### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,6 +157,8 @@ jobs:
     name: Deploy to preview environment
     runs-on: ubuntu-latest
     needs: [Build]
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/findmydoc-platform/website/security/code-scanning/5](https://github.com/findmydoc-platform/website/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the `Deploy-Preview` job. Since this job primarily interacts with external services (e.g., Vercel) and downloads artifacts, it does not require write access to the repository. The minimal permissions required are `contents: read` to allow the job to read repository contents if necessary. No additional permissions are needed unless explicitly required by the job's steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
