### PR TITLE
Organize admin groups for collections and plugins

### DIFF
--- a/src/collections/Accredition.ts
+++ b/src/collections/Accredition.ts
@@ -1,6 +1,6 @@
 import { CollectionConfig } from 'payload'
 
-export const Accredition: CollectionConfig = {
+export const Accreditation: CollectionConfig = {
   slug: 'accreditation',
   admin: {
     group: 'Platform Management',

--- a/src/collections/Accredition.ts
+++ b/src/collections/Accredition.ts
@@ -3,6 +3,7 @@ import { CollectionConfig } from 'payload'
 export const Accredition: CollectionConfig = {
   slug: 'accreditation',
   admin: {
+    group: 'Platform Management',
     useAsTitle: 'name',
     defaultColumns: ['name', 'abbreviation'],
   },

--- a/src/collections/Categories.ts
+++ b/src/collections/Categories.ts
@@ -13,6 +13,7 @@ export const Categories: CollectionConfig = {
     update: authenticated,
   },
   admin: {
+    group: 'Content & Media',
     useAsTitle: 'title',
   },
   fields: [

--- a/src/collections/Cities.ts
+++ b/src/collections/Cities.ts
@@ -3,6 +3,7 @@ import { CollectionConfig } from 'payload'
 export const Cities: CollectionConfig = {
   slug: 'cities',
   admin: {
+    group: 'Location Data',
     useAsTitle: 'name',
     defaultColumns: ['name', 'airportcode', 'coordinates', 'country'],
   },

--- a/src/collections/Clinics.ts
+++ b/src/collections/Clinics.ts
@@ -5,6 +5,7 @@ import { languageOptions } from './common/selectionOptions'
 export const Clinics: CollectionConfig = {
   slug: 'clinics',
   admin: {
+    group: 'Medical Network',
     useAsTitle: 'name',
     defaultColumns: ['name', 'status', 'country'],
   },

--- a/src/collections/Countries.ts
+++ b/src/collections/Countries.ts
@@ -3,6 +3,7 @@ import { CollectionConfig } from 'payload'
 export const Countries: CollectionConfig = {
   slug: 'countries',
   admin: {
+    group: 'Location Data',
     useAsTitle: 'name',
     defaultColumns: ['name', 'isoCode'],
   },

--- a/src/collections/Doctors.ts
+++ b/src/collections/Doctors.ts
@@ -5,6 +5,7 @@ import { languageOptions } from './common/selectionOptions'
 export const Doctors: CollectionConfig = {
   slug: 'doctors',
   admin: {
+    group: 'Medical Network',
     useAsTitle: 'fullName',
     defaultColumns: ['fullName', 'specialization', 'clinic', 'active'],
   },

--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -16,6 +16,9 @@ const dirname = path.dirname(filename)
 
 export const Media: CollectionConfig = {
   slug: 'media',
+  admin: {
+    group: 'Content & Media',
+  },
   access: {
     create: authenticated,
     delete: authenticated,

--- a/src/collections/MedicalSpecialities.ts
+++ b/src/collections/MedicalSpecialities.ts
@@ -3,6 +3,7 @@ import { CollectionConfig } from 'payload'
 export const MedicalSpecialties: CollectionConfig = {
   slug: 'medical-specialties',
   admin: {
+    group: 'Medical Network',
     useAsTitle: 'name',
     defaultColumns: ['name', 'description'],
   },

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -37,6 +37,7 @@ export const Pages: CollectionConfig<'pages'> = {
     slug: true,
   },
   admin: {
+    group: 'Content & Media',
     defaultColumns: ['title', 'slug', 'updatedAt'],
     livePreview: {
       url: ({ data, req }) => {

--- a/src/collections/PlattformStaff/index.ts
+++ b/src/collections/PlattformStaff/index.ts
@@ -9,6 +9,7 @@ export const PlattformStaff: CollectionConfig = {
     strategies: [createSupabaseStrategy({ collection: 'plattformStaff', defaultRole: 'admin' })],
   },
   admin: {
+    group: 'Platform Management',
     useAsTitle: 'email',
     defaultColumns: ['email', 'firstName', 'lastName', 'role'],
   },

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -48,6 +48,7 @@ export const Posts: CollectionConfig<'posts'> = {
     },
   },
   admin: {
+    group: 'Content & Media',
     defaultColumns: ['title', 'slug', 'updatedAt'],
     livePreview: {
       url: ({ data, req }) => {

--- a/src/collections/Reviews.ts
+++ b/src/collections/Reviews.ts
@@ -3,6 +3,7 @@ import { CollectionConfig } from 'payload'
 export const Reviews: CollectionConfig = {
   slug: 'review',
   admin: {
+    group: 'Platform Management',
     useAsTitle: 'title',
     defaultColumns: ['title', 'rating', 'user', 'createdAt'],
   },

--- a/src/collections/Tags.ts
+++ b/src/collections/Tags.ts
@@ -8,6 +8,7 @@ export const Tags: CollectionConfig = {
     plural: 'Tags',
   },
   admin: {
+    group: 'Content & Media',
     useAsTitle: 'name',
     defaultColumns: ['name', 'slug'],
   },

--- a/src/collections/Treatments.ts
+++ b/src/collections/Treatments.ts
@@ -3,6 +3,7 @@ import { CollectionConfig } from 'payload'
 export const Treatments: CollectionConfig = {
   slug: 'treatments',
   admin: {
+    group: 'Medical Network',
     useAsTitle: 'name',
     defaultColumns: ['name', 'description', 'averagePrice'],
   },

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -18,7 +18,7 @@ import { defaultLexical } from '@/fields/defaultLexical'
 import { getServerSideURL } from './utilities/getURL'
 import { Clinics } from './collections/Clinics'
 import { Doctors } from './collections/Doctors'
-import { Accredition } from './collections/Accredition'
+import { Accreditation } from './collections/Accredition'
 import { MedicalSpecialties } from './collections/MedicalSpecialities'
 import { Treatments } from './collections/Treatments'
 import { Reviews } from './collections/Reviews'
@@ -82,7 +82,7 @@ export default buildConfig({
     PlattformStaff,
     Clinics,
     Doctors,
-    Accredition,
+    Accreditation,
     MedicalSpecialties,
     Treatments,
     Reviews,

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -15,7 +15,7 @@ import { Page, Post } from '@/payload-types'
 import { getServerSideURL } from '@/utilities/getURL'
 
 const generateTitle: GenerateTitle<Post | Page> = ({ doc }) => {
-  return doc?.title ? `${doc.title} | Payload Website Template` : 'Payload Website Template'
+  return doc?.title ? `${doc.title} | findmydoc` : 'findmydoc'
 }
 
 const generateURL: GenerateURL<Post | Page> = ({ doc }) => {
@@ -28,6 +28,9 @@ export const plugins: Plugin[] = [
   redirectsPlugin({
     collections: ['pages', 'posts'],
     overrides: {
+      admin: {
+        group: 'Settings',
+      },
       // @ts-expect-error - This is a valid override, mapped fields don't resolve to the same type
       fields: ({ defaultFields }) => {
         return defaultFields.map((field) => {
@@ -61,6 +64,9 @@ export const plugins: Plugin[] = [
       payment: false,
     },
     formOverrides: {
+      admin: {
+        group: 'Settings',
+      },
       fields: ({ defaultFields }) => {
         return defaultFields.map((field) => {
           if ('name' in field && field.name === 'confirmationMessage') {
@@ -86,6 +92,9 @@ export const plugins: Plugin[] = [
     collections: ['posts'],
     beforeSync: beforeSyncWithSearch,
     searchOverrides: {
+      admin: {
+        group: 'Settings',
+      },
       fields: ({ defaultFields }) => {
         return [...defaultFields, ...searchFields]
       },


### PR DESCRIPTION
Introduce structured grouping for admin interfaces across various collections and plugins to enhance organization and usability.