### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,8 @@ jobs:
     name: Build for Vercel
     runs-on: ubuntu-latest
     needs: [check-migrations, Lint, Test]
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/findmydoc-platform/website/security/code-scanning/4](https://github.com/findmydoc-platform/website/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the `Build` job in the workflow file. Based on the operations performed in the `Build` job, the minimal required permission is `contents: read`, which allows the job to read the repository contents without granting unnecessary `write` access. This change ensures that the `GITHUB_TOKEN` used in the `Build` job adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
