### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,8 @@ jobs:
   Test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/findmydoc-platform/website/security/code-scanning/3](https://github.com/findmydoc-platform/website/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `Test` job. Since the job primarily involves checking out the repository, setting up dependencies, and running tests, it only requires `contents: read` permissions. This change will explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum necessary for the job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
