### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Feature Branch Integration & Deployment
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/findmydoc-platform/website/security/code-scanning/2](https://github.com/findmydoc-platform/website/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. This block will be added at the root level to apply to all jobs in the workflow. Based on the actions performed in the workflow (e.g., checking out code, installing dependencies, running tests, and linting), the minimal required permission is `contents: read`. This ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
