### PR TITLE
build: allow manual runs to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -167,7 +167,7 @@ jobs:
 
   Deploy-Production:
     name: Deploy Production
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: build
     environment:


### PR DESCRIPTION
This pull request updates the deployment workflow to allow manual triggering of the production deployment job via the GitHub Actions interface.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L170-R170): Modified the `if` condition for the `Deploy-Production` job to include the `workflow_dispatch` event, enabling manual triggering in addition to automatic deployment on pushes to the `main` branch.