### PR TITLE
fix: fix deepMerge isObject null check

### DIFF
--- a/src/utilities/deepMerge.ts
+++ b/src/utilities/deepMerge.ts
@@ -7,7 +7,7 @@
  * @returns {boolean}
  */
 export function isObject(item: unknown): item is object {
-  return typeof item === 'object' && !Array.isArray(item)
+  return typeof item === 'object' && item !== null && !Array.isArray(item)
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure `isObject` guards against `null` before doing deep merge

## Testing
- `pnpm run check`
- `npx vitest run tests/unit`
- `pnpm test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc55f70348331ab900c17cf385f55