### PR TITLE
Implement Slack release notifier

### DIFF
--- a/.github/workflows/slack-release-notification.yml
+++ b/.github/workflows/slack-release-notification.yml
@@ -1,81 +1,22 @@
 name: Slack Release Notification
-permissions:
-  contents: read
-
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 jobs:
   notify-slack:
-    name: Notify Slack on Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - name: Get release info (manual or event)
-        id: release
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            gh release view --json tagName,url,body -q '.tagName + "||" + .url + "||" + .body' > out.txt
-            IFS='||' read -r TAG URL BODY < out.txt
-            echo "tag_name=$TAG" >> $GITHUB_OUTPUT
-            echo "url=$URL" >> $GITHUB_OUTPUT
-            echo "body<<EOF" >> $GITHUB_OUTPUT
-            echo "$BODY" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          else
-            echo "tag_name=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
-            echo "url=${{ github.event.release.url }}" >> $GITHUB_OUTPUT
-            echo "body<<EOF" >> $GITHUB_OUTPUT
-            echo "${{ github.event.release.body }}" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          fi
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Post release to Slack
+        run: node scripts/postReleaseSlack.js
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Convert release notes markdown to Slack mrkdwn
-        uses: LoveToKnow/slackify-markdown-action@v1.0.0
-        id: markdown
-        with:
-          text: "${{ steps.release.outputs.body }}"
-
-      - name: Post Release to Slack
-        uses: slackapi/slack-github-action@v2.1.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {
-              "channel": "CHSJYJR8C",
-              "icon_emoji": ":rocket:",
-              "text": "🚀 Release ${{ steps.release.outputs.tag_name }}. See details on GitHub.",
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "🚀 Release ${{ steps.release.outputs.tag_name }}"
-                  }
-                },
-                {
-                  "type": "context",
-                  "elements": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "<${{ steps.release.outputs.html_url }}|View on GitHub>"
-                    }
-                  ]
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "${{ steps.markdown.outputs.text }}"
-                  }
-                }
-              ]
-            }
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL: CHSJYJR8C

--- a/scripts/postReleaseSlack.js
+++ b/scripts/postReleaseSlack.js
@@ -1,0 +1,132 @@
+import { readFileSync } from 'fs'
+
+const MAX_SECTION = 3000
+
+/**
+ * Convert a subset of GitHub flavored Markdown to Slack mrkdwn.
+ * Supports headings, links, strikethrough, inline/code blocks and tables.
+ * @param {string} md - Markdown text
+ * @returns {string[]} Array of mrkdwn sections
+ */
+export function githubMarkdownToSlack(md) {
+  let text = md.replace(/\r\n/g, '\n').trim()
+
+  // Extract fenced code blocks
+  const codeBlocks = []
+  text = text.replace(/```([\w-]*)\n([\s\S]*?)```/g, (_m, _l, body) => {
+    const token = `@@CODE_${codeBlocks.length}@@`
+    codeBlocks.push('```' + body.replace(/\n+$/, '') + '```')
+    return token
+  })
+
+  // Tables to code blocks
+  text = text.replace(/((?:^\s*\|.*\|\s*\n)+)/gm, (block) => {
+    const lines = block
+      .trim()
+      .split('\n')
+      .filter((l) => /\|/.test(l))
+    const clean = lines.filter((l) => !/^\s*\|?\s*:?-+:?\s*\|/.test(l))
+    const rows = clean.map((l) =>
+      l
+        .replace(/^\s*\|/, '')
+        .replace(/\|\s*$/, '')
+        .split(/\s*\|\s*/),
+    )
+    const widths = []
+    rows.forEach((r) =>
+      r.forEach((c, i) => {
+        widths[i] = Math.max(widths[i] || 0, c.length)
+      }),
+    )
+    const formatted = rows.map((r) => r.map((c, i) => c.padEnd(widths[i])).join('  ')).join('\n')
+    const token = `@@CODE_${codeBlocks.push('```' + formatted + '```') - 1}@@`
+    return token
+  })
+
+  text = text.replace(/^#{1,6}\s+(.+)$/gm, (_m, t) => `*${t.trim()}*`)
+  text = text.replace(/~~(.+?)~~/g, '~$1~')
+  text = text.replace(/\[([^\]]+)]\((https?:\/\/[^\s)]+)\)/g, '<$2|$1>')
+  text = text.replace(/!\[([^\]]*)]\((https?:\/\/[^\s)]+)\)/g, '<$2|$1>')
+
+  text = text.replace(/@@CODE_(\d+)@@/g, (_m, i) => codeBlocks[Number(i)])
+  text = text.replace(/\n{3,}/g, '\n\n')
+
+  const sections = []
+  let buffer = ''
+  for (const part of text.split(/\n\n/)) {
+    const candidate = (buffer ? buffer + '\n\n' : '') + part
+    if (candidate.length > MAX_SECTION) {
+      if (buffer) sections.push(buffer)
+      buffer = part
+      if (buffer.length > MAX_SECTION) {
+        while (buffer.length > MAX_SECTION) {
+          sections.push(buffer.slice(0, MAX_SECTION - 1))
+          buffer = buffer.slice(MAX_SECTION - 1)
+        }
+      }
+    } else {
+      buffer = candidate
+    }
+  }
+  if (buffer) sections.push(buffer)
+  return sections
+}
+
+/**
+ * Post release notes to Slack using chat.postMessage.
+ */
+export async function postReleaseToSlack() {
+  const eventPath = process.env.GITHUB_EVENT_PATH
+  if (!eventPath) throw new Error('Missing GITHUB_EVENT_PATH')
+  const event = JSON.parse(readFileSync(eventPath, 'utf8'))
+  const release = event.release
+  if (!release) throw new Error('No release data found')
+  const sections = githubMarkdownToSlack(release.body || '')
+  const blocks = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: `${release.tag_name} – ${release.name || ''}`.slice(0, 150) },
+    },
+    {
+      type: 'context',
+      elements: [
+        { type: 'mrkdwn', text: `*Repo:* ${process.env.GITHUB_REPOSITORY}` },
+        { type: 'mrkdwn', text: `*Author:* ${release.author.login}` },
+        { type: 'mrkdwn', text: `*Published:* ${release.published_at}` },
+      ],
+    },
+  ]
+  sections.forEach((s) => blocks.push({ type: 'section', text: { type: 'mrkdwn', text: s } }))
+  blocks.push({
+    type: 'actions',
+    elements: [
+      {
+        type: 'button',
+        text: { type: 'plain_text', text: 'Open Release' },
+        url: release.html_url,
+      },
+    ],
+  })
+
+  const response = await fetch('https://slack.com/api/chat.postMessage', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      Authorization: `Bearer ${process.env.SLACK_TOKEN}`,
+    },
+    body: JSON.stringify({ channel: process.env.SLACK_CHANNEL, text: `${release.tag_name} released`, blocks }),
+  })
+
+  const json = await response.json()
+  if (!json.ok) {
+    throw new Error(`Slack API error: ${JSON.stringify(json)}`)
+  }
+  console.log('Posted to Slack')
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  postReleaseToSlack().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary
- replace markdown action with simple Node script
- post release body as Slack blocks
- add converter for GitHub Markdown

## Testing
- `pnpm install`
- `npm test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_b_687b95a125e4833280b4019ba88b47e4