### PR TITLE
Set up Slack release notifications via node script

### DIFF
--- a/.github/scripts/github-to-slack.js
+++ b/.github/scripts/github-to-slack.js
@@ -1,0 +1,59 @@
+import { WebClient } from '@slack/web-api';
+import slackifyMarkdown from 'slackify-markdown';
+
+/**
+ * Convert GitHub flavored markdown to Slack's mrkdwn.
+ * @param {string} markdown
+ * @returns {string} Slack-formatted text
+ */
+export function githubMarkdownToSlack(markdown) {
+  return slackifyMarkdown(markdown ?? '');
+}
+
+/**
+ * Post a release announcement to Slack.
+ * Reads SLACK_BOT_TOKEN and SLACK_CHANNEL from environment variables.
+ * @param {{tagName: string; url: string; body: string}} options
+ */
+export async function postReleaseToSlack({ tagName, url, body }) {
+  const token = process.env.SLACK_BOT_TOKEN;
+  const channel = process.env.SLACK_CHANNEL;
+
+  if (!token) throw new Error('SLACK_BOT_TOKEN is required');
+  if (!channel) throw new Error('SLACK_CHANNEL is required');
+
+  const client = new WebClient(token);
+  const text = `🚀 Release ${tagName}. See details on GitHub.`;
+  const blocks = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: `🚀 Release ${tagName}` },
+    },
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: githubMarkdownToSlack(body) },
+    },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: 'View on GitHub' },
+          url,
+        },
+      ],
+    },
+  ];
+
+  await client.chat.postMessage({ channel, icon_emoji: ':rocket:', text, blocks });
+}
+
+if (require.main === module) {
+  const [tagName, url] = process.argv.slice(2);
+  const body = process.env.RELEASE_BODY ?? '';
+
+  postReleaseToSlack({ tagName, url, body }).catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/.github/workflows/slack-release-notification.yml
+++ b/.github/workflows/slack-release-notification.yml
@@ -37,45 +37,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Convert release notes markdown to Slack mrkdwn
-        uses: LoveToKnow/slackify-markdown-action@v1.0.0
-        id: markdown
+      - uses: actions/setup-node@v4
         with:
-          text: "${{ steps.release.outputs.body }}"
+          node-version: '20'
+
+      - name: Install dependencies
+        run: pnpm add --no-save @slack/web-api slackify-markdown
 
       - name: Post Release to Slack
-        uses: slackapi/slack-github-action@v2.1.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {
-              "channel": "CHSJYJR8C",
-              "icon_emoji": ":rocket:",
-              "text": "🚀 Release ${{ steps.release.outputs.tag_name }}. See details on GitHub.",
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "🚀 Release ${{ steps.release.outputs.tag_name }}"
-                  }
-                },
-                {
-                  "type": "context",
-                  "elements": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "<${{ steps.release.outputs.html_url }}|View on GitHub>"
-                    }
-                  ]
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "${{ steps.markdown.outputs.text }}"
-                  }
-                }
-              ]
-            }
+        run: |
+          node .github/scripts/github-to-slack.js \
+            "${{ steps.release.outputs.tag_name }}" \
+            "${{ steps.release.outputs.url }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+          RELEASE_BODY: ${{ steps.release.outputs.body }}


### PR DESCRIPTION
## Summary
- replace Slack workflow step with a custom node script
- convert GitHub markdown to Slack mrkdwn and post to Slack

## Testing
- `pnpm install`
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_b_687b9760f0748332b879197db9f3477b