### PR TITLE
ci(db): update database reset command to use Vercel build

### DIFF
--- a/.github/workflows/reset-database.yml
+++ b/.github/workflows/reset-database.yml
@@ -96,7 +96,7 @@ jobs:
           echo "⚠️  This will drop all tables and recreate the schema!"
           
           # Execute the reset command with automatic confirmation
-          printf "y" | DB_FRESH="true" pnpm run ci
+          printf "y" | DB_FRESH="true" vercel build --target=${{ github.event.inputs.environment }} --yes --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Verify Database State
         run: |


### PR DESCRIPTION
This pull request updates the database reset process in the GitHub Actions workflow to integrate with Vercel's build system. The most important change involves replacing the previous reset command with a Vercel build command to ensure the database is reset in the appropriate environment.

### Workflow updates:

* [`.github/workflows/reset-database.yml`](diffhunk://#diff-7d37fd56e81dba9341f95d59c4896a2fdfd6207b0051a78e290dd1c1696bc53eL99-R99): Replaced the `pnpm run ci` command with a `vercel build` command that targets the specified environment and uses a Vercel token for authentication. This ensures compatibility with Vercel's deployment process.