### PR TITLE
ci: update deployment workflow to deploy Storybook to Vercel

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,4 +1,4 @@
-name: Deploy Storybook to GitHub Pages
+name: Deploy Storybook to Vercel
 
 on:
   push:
@@ -12,18 +12,13 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: "pages"
+  group: "storybook-vercel"
   cancel-in-progress: true
 
 jobs:
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -46,14 +41,18 @@ jobs:
       - name: Build Storybook
         run: pnpm build-storybook
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Pull Vercel Environment Information
+        uses: vercel/actions/pull@v1
         with:
-          path: './storybook-static'
+          token: ${{ secrets.VERCEL_TOKEN }}
+          project-id: ${{ secrets.VERCEL_STORYBOOK_PROJECT_ID }}
+          org-id: ${{ secrets.VERCEL_ORG_ID }}
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Deploy Storybook to Vercel
+        uses: vercel/actions/deploy@v1
+        with:
+          token: ${{ secrets.VERCEL_TOKEN }}
+          project-id: ${{ secrets.VERCEL_STORYBOOK_PROJECT_ID }}
+          org-id: ${{ secrets.VERCEL_ORG_ID }}
+          working-directory: ./storybook-static
+          prod: true


### PR DESCRIPTION
This pull request updates the Storybook deployment workflow to use Vercel instead of GitHub Pages. The changes involve updating the workflow configuration, permissions, concurrency group, and deployment steps to align with Vercel's deployment process.

**Migration from GitHub Pages to Vercel:**

* Changed the workflow name from "Deploy Storybook to GitHub Pages" to "Deploy Storybook to Vercel" and updated the concurrency group to `storybook-vercel` for clarity and to avoid conflicts with previous deployments. [[1]](diffhunk://#diff-cb8a3745bba2af943905f89d7bec62ecb9ac5162961f5bd657a90cf43ba37155L1-R1) [[2]](diffhunk://#diff-cb8a3745bba2af943905f89d7bec62ecb9ac5162961f5bd657a90cf43ba37155L15-L26)
* Removed permissions and steps related to GitHub Pages (`pages: write`, `id-token: write`, `actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages`) and replaced them with Vercel-specific steps (`vercel/actions/pull`, `vercel/actions/deploy`), using secrets for authentication and configuration. [[1]](diffhunk://#diff-cb8a3745bba2af943905f89d7bec62ecb9ac5162961f5bd657a90cf43ba37155L15-L26) [[2]](diffhunk://#diff-cb8a3745bba2af943905f89d7bec62ecb9ac5162961f5bd657a90cf43ba37155L49-R58)