### PR TITLE
ci: add Playwright and Storybook tests to CI workflow

### DIFF
--- a/.github/coverage/vitest.thresholds.storybook.js
+++ b/.github/coverage/vitest.thresholds.storybook.js
@@ -1,0 +1,12 @@
+export default {
+  test: {
+    coverage: {
+      thresholds: {
+        statements: 10,
+        branches: 10,
+        functions: 10,
+        lines: 10,
+      },
+    },
+  },
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -135,10 +135,11 @@ jobs:
 
       - name: Run Storybook tests
         id: storybook
-        run: pnpm vitest --project storybook --run
+        if: ${{ steps.vitest.outcome == 'success' || steps.vitest.outcome == 'failure' }}
+        run: pnpm vitest --project storybook --run --coverage
 
-      - name: Publish coverage summary
-        if: ${{ steps.vitest.outcome == 'success' }}
+      - name: Publish Unit Test coverage
+        if: ${{ steps.vitest.outcome == 'success' || steps.vitest.outcome == 'failure' }}
         uses: davelosert/vitest-coverage-report-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -147,6 +148,17 @@ jobs:
           file-coverage-mode: all
           json-summary-path: coverage/unit/coverage-summary.json
           json-final-path: coverage/unit/coverage-final.json
+
+      - name: Publish Storybook coverage
+        if: ${{ steps.storybook.outcome == 'success' || steps.storybook.outcome == 'failure' }}
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          vite-config-path: .github/coverage/vitest.thresholds.storybook.js
+          name: Storybook Tests
+          file-coverage-mode: all
+          json-summary-path: coverage/storybook/coverage-summary.json
+          json-final-path: coverage/storybook/coverage-final.json
 
       - name: Generate job summary
         if: always()


### PR DESCRIPTION
Summary: Enhance the CI workflow by integrating Playwright and Storybook tests.

Changes:

- Added Playwright browser installation step in the CI workflow.

- Included Storybook tests execution in the CI process.

- Excluded story files from deployment paths filter.

Why: This update improves testing coverage and ensures that both Playwright and Storybook tests run automatically during the CI process, enhancing the reliability of the application.

Testing:

- Verify that Playwright browsers install correctly during CI.

- Ensure that both unit tests and Storybook tests execute successfully in the CI pipeline.

Breaking changes: None.