### PR TITLE
test(ui): add Banner story play assertions

### DIFF
--- a/src/stories/organisms/Banner.stories.tsx
+++ b/src/stories/organisms/Banner.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { expect } from '@storybook/jest'
+import { within } from '@storybook/testing-library'
 import { Banner } from '@/components/organisms/Banner'
 
 const meta = {
@@ -19,12 +21,36 @@ export const Info: Story = {
     content: <p>findmydoc connects patients with trusted clinics across specialties.</p>,
     style: 'info',
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const message = canvas.getByText(
+      'findmydoc connects patients with trusted clinics across specialties.',
+    )
+
+    await expect(message).toBeInTheDocument()
+    await expect(message.closest('div')).toHaveClass(
+      'border-primary',
+      'bg-primary/15',
+      'text-primary',
+    )
+  },
 }
 
 export const Success: Story = {
   args: {
     content: <p>Your appointment has been successfully booked!</p>,
     style: 'success',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const message = canvas.getByText('Your appointment has been successfully booked!')
+
+    await expect(message).toBeInTheDocument()
+    await expect(message.closest('div')).toHaveClass(
+      'border-success',
+      'bg-success/30',
+      'text-success',
+    )
   },
 }
 
@@ -33,11 +59,33 @@ export const Warning: Story = {
     content: <p>Please review your information before submitting.</p>,
     style: 'warning',
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const message = canvas.getByText('Please review your information before submitting.')
+
+    await expect(message).toBeInTheDocument()
+    await expect(message.closest('div')).toHaveClass(
+      'border-warning',
+      'bg-warning/30',
+      'text-warning',
+    )
+  },
 }
 
 export const Error: Story = {
   args: {
     content: <p>An error occurred while processing your request.</p>,
     style: 'error',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const message = canvas.getByText('An error occurred while processing your request.')
+
+    await expect(message).toBeInTheDocument()
+    await expect(message.closest('div')).toHaveClass(
+      'border-error',
+      'bg-error/30',
+      'text-error',
+    )
   },
 }


### PR DESCRIPTION
### Motivation
- Ensure each `Banner` variant is covered by Storybook interaction tests that validate visible, user-facing differences.
- Catch regressions in variant styling or copy by asserting rendered text and variant-specific classes.

### Description
- Update `src/stories/organisms/Banner.stories.tsx` to import `expect` and `within` for play tests. 
- Add `play` functions for `Info`, `Success`, `Warning`, and `Error` stories that assert the banner text is visible and that the nearest `div` contains the expected variant classes. 
- Keep assertions focused on user-facing output (visible copy and styling classes) rather than implementation details.

### Testing
- No automated tests were run locally against this change.
- The added story `play` functions will be exercised by Storybook interaction tests in CI via `pnpm tests` when Storybook stories are run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957cd958de083318602e0d3fcec34c9)