### PR TITLE
test(integration): add integration tests covering remaining collections

### DIFF
--- a/docs/testing/integration-test-tasks.md
+++ b/docs/testing/integration-test-tasks.md
@@ -1,0 +1,205 @@
+# Integration test tasks by collection
+
+This backlog converts the provided integration test plan into per-collection tasks. Each task lists existing coverage to avoid duplicate work and calls out only the scenarios that still need integration tests.
+
+## Pages
+
+**Existing coverage**: None found under `tests/integration/`.
+
+**Task**
+- Add integration tests for create/update/delete flows, including:
+  - Create pages with and without `publishedAt`; verify slug generation and `populatePublishedAt` hook behavior.
+  - Update title and validate slug changes or lock behavior, plus invalid block payloads.
+  - Delete (trash) and verify `revalidateDelete` hook side-effects via a mocked endpoint or logger hook.
+  - Access control: only platform users can create/update/delete; non-platform reads only published.
+  - Preview URL generation for live preview and preview fields.
+
+## Posts
+
+**Existing coverage**: None found under `tests/integration/`.
+
+**Task**
+- Add integration tests for create/update/delete flows, including:
+  - Create posts with tags, hero image, content, excerpt, categories, authors, and slug generation.
+  - Publish flow: set `_status` to `published` and verify `publishedAt` is set by the inline hook.
+  - After read: ensure `populateAuthors` fills `populatedAuthors` and respects privacy access.
+  - Related posts filter prevents self-referential links.
+  - Delete (trash) and verify `revalidateDelete` hook side-effects via mocked endpoint or logger hook.
+  - Access control: platform-only create/update/delete; others read published.
+
+## Categories
+
+**Existing coverage**: None found under `tests/integration/`.
+
+**Task**
+- Add integration tests for CRUD and slug behavior:
+  - Create categories and verify auto-generated slug from title.
+  - Update title and validate slug updates or remains stable if locked by Payload defaults.
+  - Delete category and verify removal.
+  - Validation: missing title should fail; duplicate titles should raise slug uniqueness errors when enforced.
+
+## PlatformContentMedia
+
+**Existing coverage**: None found under `tests/integration/`.
+
+**Task**
+- Add integration tests for upload and hook behavior:
+  - Upload an image and verify `storagePath` and `createdBy` are set by `beforeChange` hook.
+  - Update caption/alt and ensure `storagePath` and `createdBy` are stable.
+  - Delete media and confirm file removal (if storage adapter allows).
+  - Validation: reject non-image MIME types and missing `alt`.
+  - Enforce the 5MB file size limit (global upload limit).
+
+## PlatformStaff
+
+**Existing coverage**: `tests/integration/basicUserLifecycle.test.ts` validates auto-creation via BasicUsers hooks and cleanup on delete.
+
+**Task**
+- Add integration tests for access control and updates:
+  - Verify direct create requests are rejected (collection `create: false`).
+  - Update role as platform user and validate persistence; deny updates for non-platform users.
+  - Validation: duplicate `user` relationship should fail due to uniqueness.
+
+## Clinics
+
+**Existing coverage**: `tests/integration/clinics.creation.test.ts`, `tests/integration/clinic.test.ts`.
+
+**Task**
+- Add integration tests for remaining scenarios:
+  - Access control for status field: non-platform users cannot update `status`.
+  - Join behavior: create `ClinicTreatments` via clinic side and verify join visibility in clinic.
+  - Accreditation relationships and gallery entries association behavior.
+  - Access control: clinic users can only update their own clinic.
+
+## ClinicApplications
+
+**Existing coverage**: `tests/integration/clinicApplications.approval.test.ts`.
+
+**Task**
+- Add integration tests for validation and access:
+  - Required fields validation for application submissions.
+  - Public create without auth; non-platform read/update/delete should fail.
+  - `reviewNotes` update guarded by platform user access.
+  - Conditional `linkedRecords` visibility/editability when status changes from `submitted`.
+
+## Doctors
+
+**Existing coverage**: `tests/integration/doctors.titles.test.ts`.
+
+**Task**
+- Add integration tests for full CRUD and joins:
+  - Create doctors with required fields and verify `fullName` and slug generation.
+  - Validate required `qualifications` and `languages`; missing fields should fail.
+  - Update name/title and verify `fullName` recalculates.
+  - Join behavior: create `DoctorTreatments` and `DoctorSpecialties` and confirm joins.
+  - Delete access restricted to platform users.
+
+## Accreditation
+
+**Existing coverage**: None found under `tests/integration/`.
+
+**Task**
+- Add integration tests for CRUD and uploads:
+  - Create accreditation with name, abbreviation, country, description, and icon upload.
+  - Update and delete flows.
+  - Validation: missing required fields and non-image icon rejection.
+
+## MedicalSpecialties
+
+**Existing coverage**: None found under `tests/integration/`.
+
+**Task**
+- Add integration tests for hierarchy and joins:
+  - Create specialties with and without `parentSpecialty` and `icon`.
+  - Update parent-child relationships; prevent or detect self/circular references.
+  - Create `DoctorSpecialties` and verify `doctorLinks` join behavior.
+  - Delete specialty and verify join handling.
+
+## Treatments
+
+**Existing coverage**: `tests/integration/treatments.creation.test.ts`, plus review hook coverage in `tests/integration/reviews.averageRatings.test.ts`.
+
+**Task**
+- Add integration tests for join and aggregation scenarios:
+  - Verify `ClinicTreatments` creation updates `Treatments.Clinics` join list.
+  - Verify `DoctorTreatments` creation updates `Treatments.Doctors` join list.
+  - Validate tag relationships and specialty requirements in read/update flows beyond current create tests.
+
+## ClinicTreatments
+
+**Existing coverage**: `tests/integration/clinicTreatments.creation.test.ts`, `tests/integration/clinicTreatments.averagePrice.test.ts`.
+
+**Task**
+- Add integration tests for access control:
+  - Ensure non-platform users cannot delete or update others' entries.
+  - Verify unique constraint enforcement is consistent when updating existing records.
+
+## DoctorTreatments
+
+**Existing coverage**: None found under `tests/integration/`.
+
+**Task**
+- Add integration tests for CRUD and unique constraints:
+  - Create doctor-treatment links with specialization level.
+  - Prevent duplicate doctor-treatment pairs (unique index).
+  - Update specialization level and verify joins in doctor and treatment collections.
+  - Delete and verify join removal.
+
+## DoctorSpecialties
+
+**Existing coverage**: None found under `tests/integration/`.
+
+**Task**
+- Add integration tests for CRUD, certifications array, and unique constraints:
+  - Create doctor-specialty links with certifications array and specialization level.
+  - Validate unique constraints on doctor + medicalSpecialty.
+  - Update certifications array (empty and multiple values).
+  - Delete and verify join removal on `medical-specialties`.
+
+## FavoriteClinics
+
+**Existing coverage**: None found under `tests/integration/`.
+
+**Task**
+- Add integration tests for CRUD and access:
+  - Patient creates and deletes favorite clinic entries.
+  - Access control: patient can only read/update/delete their own favorites; platform can read all.
+  - Unique constraint enforcement on patient + clinic.
+
+## Reviews
+
+**Existing coverage**: `tests/integration/reviews.auditTrail.test.ts`, `tests/integration/reviews.averageRatings.test.ts`, `tests/integration/reviews.duplicateGuard.test.ts`.
+
+**Task**
+- Add integration tests for remaining validation/access scenarios:
+  - Validate required relationships (clinic, doctor, treatment) and rating bounds.
+  - Access control: patient can create, platform can update/delete; patient updates should fail.
+  - Verify `reviewDate` default and read-only behavior on create.
+
+## Countries
+
+**Existing coverage**: None found under `tests/integration/`.
+
+**Task**
+- Add integration tests for CRUD and validation:
+  - Create, update, and delete country entries with required fields.
+  - Validation for missing required fields.
+  - Optional: verify duplicate ISO codes behavior if uniqueness is enforced elsewhere.
+
+## Cities
+
+**Existing coverage**: `tests/integration/cities.creation.test.ts`.
+
+**Task**
+- Add integration tests for remaining access scenarios:
+  - Validate non-platform create/update/delete denial (access control).
+  - Confirm coordinates validation for boundary values if configured.
+
+## Tags
+
+**Existing coverage**: `tests/integration/tags.createAndDuplicate.test.ts`.
+
+**Task**
+- Add integration tests for join behavior:
+  - Add tags to posts/clinics/treatments and verify join lists on tags.
+  - Delete tags and verify disassociation or appropriate constraints.

--- a/tests/fixtures/testFiles.ts
+++ b/tests/fixtures/testFiles.ts
@@ -1,0 +1,24 @@
+import { Buffer } from 'node:buffer'
+
+const base64Png =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQI12NgYGBgAAAABQABDQottAAAAABJRU5ErkJggg=='
+
+export const createPngFile = (name = 'test.png') => {
+  const data = Buffer.from(base64Png, 'base64')
+  return {
+    data,
+    name,
+    mimetype: 'image/png',
+    size: data.length,
+  }
+}
+
+export const createLargeFile = (sizeInBytes: number, name = 'large.png') => {
+  const data = Buffer.alloc(sizeInBytes, 0)
+  return {
+    data,
+    name,
+    mimetype: 'image/png',
+    size: data.length,
+  }
+}

--- a/tests/integration/accreditation.integration.test.ts
+++ b/tests/integration/accreditation.integration.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { testSlug } from '../fixtures/testSlug'
+import { createPngFile } from '../fixtures/testFiles'
+
+describe('Accreditation integration', () => {
+  let payload: Payload
+  const slugPrefix = testSlug('accreditation.integration.test.ts')
+  const createdMediaIds: Array<number | string> = []
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+  })
+
+  afterEach(async () => {
+    while (createdMediaIds.length) {
+      const id = createdMediaIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'platformContentMedia', id, overrideAccess: true })
+    }
+
+    const { docs } = await payload.find({
+      collection: 'accreditation',
+      where: { name: { like: `${slugPrefix}%` } },
+      limit: 100,
+      overrideAccess: true,
+    })
+    for (const doc of docs) {
+      await payload.delete({ collection: 'accreditation', id: doc.id, overrideAccess: true })
+    }
+  })
+
+  it('creates accreditation with an icon upload', async () => {
+    const icon = await payload.create({
+      collection: 'platformContentMedia',
+      data: { alt: 'Accreditation icon' },
+      file: createPngFile(`${slugPrefix}-icon.png`),
+      overrideAccess: true,
+    })
+    createdMediaIds.push(icon.id)
+
+    const accreditation = await payload.create({
+      collection: 'accreditation',
+      data: {
+        name: `${slugPrefix} Accreditation`,
+        abbreviation: 'ACC',
+        country: 'Turkey',
+        description: {
+          root: {
+            type: 'root',
+            children: [{ type: 'paragraph', children: [{ type: 'text', text: 'Accreditation details' }] }],
+            direction: 'ltr',
+            format: '',
+            indent: 0,
+            version: 1,
+          },
+        },
+        icon: icon.id,
+      },
+      overrideAccess: true,
+    })
+
+    expect(accreditation.id).toBeDefined()
+    expect(accreditation.icon).toBe(icon.id)
+  })
+
+  it('rejects missing required fields', async () => {
+    await expect(
+      payload.create({
+        collection: 'accreditation',
+        data: { name: `${slugPrefix}-invalid` },
+        overrideAccess: true,
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/tests/integration/categories.integration.test.ts
+++ b/tests/integration/categories.integration.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
+import { testSlug } from '../fixtures/testSlug'
+import { slugify } from '@/utilities/slugify'
+
+describe('Categories integration', () => {
+  let payload: Payload
+  const slugPrefix = testSlug('categories.integration.test.ts')
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+  })
+
+  afterEach(async () => {
+    await cleanupTestEntities(payload, 'categories', slugPrefix)
+  })
+
+  it('creates a category with an auto-generated slug', async () => {
+    const title = `${slugPrefix} Category`
+    const category = await payload.create({
+      collection: 'categories',
+      data: { title },
+      overrideAccess: true,
+    })
+
+    expect(category.id).toBeDefined()
+    expect(category.slug).toBe(slugify(title))
+  })
+
+  it('updates a category title and slug', async () => {
+    const category = await payload.create({
+      collection: 'categories',
+      data: { title: `${slugPrefix} Original` },
+      overrideAccess: true,
+    })
+
+    const updatedTitle = `${slugPrefix} Updated`
+    const updated = await payload.update({
+      collection: 'categories',
+      id: category.id,
+      data: { title: updatedTitle },
+      overrideAccess: true,
+    })
+
+    expect(updated.title).toBe(updatedTitle)
+    expect(updated.slug).toBe(slugify(updatedTitle))
+  })
+
+  it('rejects missing title', async () => {
+    await expect(
+      payload.create({
+        collection: 'categories',
+        data: {},
+        overrideAccess: true,
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/tests/integration/cities.access.test.ts
+++ b/tests/integration/cities.access.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { testSlug } from '../fixtures/testSlug'
+import type { BasicUser } from '@/payload-types'
+
+describe('Cities access integration', () => {
+  let payload: Payload
+  let countryId: number
+  const slugPrefix = testSlug('cities.access.test.ts')
+  const createdBasicUserIds: Array<number | string> = []
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+
+    const countryRes = await payload.find({ collection: 'countries', limit: 1, overrideAccess: true })
+    const countryDoc = countryRes.docs[0]
+    if (!countryDoc) throw new Error('Expected baseline country for city access tests')
+    countryId = countryDoc.id as number
+  })
+
+  afterEach(async () => {
+    while (createdBasicUserIds.length) {
+      const id = createdBasicUserIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'basicUsers', id, overrideAccess: true })
+    }
+
+    const { docs } = await payload.find({
+      collection: 'cities',
+      where: { name: { like: `${slugPrefix}%` } },
+      limit: 100,
+      overrideAccess: true,
+    })
+    for (const doc of docs) {
+      await payload.delete({ collection: 'cities', id: doc.id, overrideAccess: true })
+    }
+  })
+
+  it('blocks non-platform create and update', async () => {
+    await expect(
+      payload.create({
+        collection: 'cities',
+        data: {
+          name: `${slugPrefix}-city`,
+          coordinates: [40, 29],
+          country: countryId,
+        },
+        overrideAccess: false,
+      }),
+    ).rejects.toThrow()
+
+    const city = await payload.create({
+      collection: 'cities',
+      data: {
+        name: `${slugPrefix}-platform`,
+        coordinates: [40, 29],
+        country: countryId,
+      },
+      overrideAccess: true,
+    })
+
+    const clinicUser = (await payload.create({
+      collection: 'basicUsers',
+      data: {
+        email: `${slugPrefix}-clinic-user@example.com`,
+        userType: 'clinic',
+        firstName: 'Clinic',
+        lastName: 'User',
+        supabaseUserId: `sb-${slugPrefix}-clinic`,
+      },
+      overrideAccess: true,
+    })) as BasicUser
+    createdBasicUserIds.push(clinicUser.id)
+
+    await expect(
+      payload.update({
+        collection: 'cities',
+        id: city.id,
+        data: { name: `${slugPrefix}-updated` },
+        overrideAccess: false,
+        user: { ...clinicUser, collection: 'basicUsers' },
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/tests/integration/clinicApplications.validation.test.ts
+++ b/tests/integration/clinicApplications.validation.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { testSlug } from '../fixtures/testSlug'
+import type { BasicUser } from '@/payload-types'
+
+describe('ClinicApplications validation and access', () => {
+  let payload: Payload
+  const slugPrefix = testSlug('clinicApplications.validation.test.ts')
+  const createdBasicUserIds: Array<number | string> = []
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+  })
+
+  afterEach(async () => {
+    while (createdBasicUserIds.length) {
+      const id = createdBasicUserIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'basicUsers', id, overrideAccess: true })
+    }
+
+    const { docs } = await payload.find({
+      collection: 'clinicApplications',
+      where: { clinicName: { like: `${slugPrefix}%` } },
+      limit: 100,
+      overrideAccess: true,
+    })
+    for (const doc of docs) {
+      await payload.delete({ collection: 'clinicApplications', id: doc.id, overrideAccess: true })
+    }
+  })
+
+  it('allows public creation and enforces required fields', async () => {
+    await expect(
+      payload.create({
+        collection: 'clinicApplications',
+        data: { clinicName: `${slugPrefix}-invalid` },
+        overrideAccess: false,
+      }),
+    ).rejects.toThrow()
+
+    const app = await payload.create({
+      collection: 'clinicApplications',
+      data: {
+        clinicName: `${slugPrefix}-clinic`,
+        contactFirstName: 'Public',
+        contactLastName: 'Applicant',
+        contactEmail: `${slugPrefix}@example.com`,
+        address: {
+          street: 'Main',
+          houseNumber: '1',
+          zipCode: 34000,
+          city: 'Istanbul',
+          country: 'Turkey',
+        },
+      },
+      overrideAccess: false,
+    })
+
+    expect(app.status).toBe('submitted')
+  })
+
+  it('blocks non-platform read access', async () => {
+    const app = await payload.create({
+      collection: 'clinicApplications',
+      data: {
+        clinicName: `${slugPrefix}-access`,
+        contactFirstName: 'Access',
+        contactLastName: 'Tester',
+        contactEmail: `${slugPrefix}-access@example.com`,
+        address: {
+          street: 'Main',
+          houseNumber: '2',
+          zipCode: 34000,
+          city: 'Istanbul',
+          country: 'Turkey',
+        },
+      },
+      overrideAccess: false,
+    })
+
+    await expect(
+      payload.findByID({
+        collection: 'clinicApplications',
+        id: app.id,
+        overrideAccess: false,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it('allows platform staff to update review notes and linked records', async () => {
+    const app = await payload.create({
+      collection: 'clinicApplications',
+      data: {
+        clinicName: `${slugPrefix}-review`,
+        contactFirstName: 'Review',
+        contactLastName: 'Notes',
+        contactEmail: `${slugPrefix}-review@example.com`,
+        address: {
+          street: 'Main',
+          houseNumber: '3',
+          zipCode: 34000,
+          city: 'Istanbul',
+          country: 'Turkey',
+        },
+      },
+      overrideAccess: false,
+    })
+
+    const basicUser = (await payload.create({
+      collection: 'basicUsers',
+      data: {
+        email: `${slugPrefix}-platform@example.com`,
+        userType: 'platform',
+        firstName: 'Platform',
+        lastName: 'Reviewer',
+        supabaseUserId: `sb-${slugPrefix}-reviewer`,
+      },
+      overrideAccess: true,
+    })) as BasicUser
+    createdBasicUserIds.push(basicUser.id)
+
+    const updated = await payload.update({
+      collection: 'clinicApplications',
+      id: app.id,
+      data: {
+        status: 'approved',
+        reviewNotes: 'Approved for onboarding.',
+        linkedRecords: {
+          processedAt: new Date().toISOString(),
+        },
+      },
+      overrideAccess: false,
+      user: { ...basicUser, collection: 'basicUsers' },
+    })
+
+    expect(updated.status).toBe('approved')
+    expect(updated.reviewNotes).toBe('Approved for onboarding.')
+    expect(updated.linkedRecords?.processedAt).toBeTruthy()
+  })
+})

--- a/tests/integration/clinicTreatments.access.test.ts
+++ b/tests/integration/clinicTreatments.access.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { testSlug } from '../fixtures/testSlug'
+import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
+import type { BasicUser, ClinicStaff } from '@/payload-types'
+
+describe('ClinicTreatments access integration', () => {
+  let payload: Payload
+  let cityId: number
+  let treatmentId: number
+  const slugPrefix = testSlug('clinicTreatments.access.test.ts')
+  const createdBasicUserIds: Array<number | string> = []
+  const createdClinicTreatmentIds: Array<number | string> = []
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+
+    const cityRes = await payload.find({ collection: 'cities', limit: 1, overrideAccess: true })
+    const cityDoc = cityRes.docs[0]
+    if (!cityDoc) throw new Error('Expected baseline city for clinic treatment access tests')
+    cityId = cityDoc.id as number
+
+    const treatmentRes = await payload.find({ collection: 'treatments', limit: 1, overrideAccess: true })
+    const treatmentDoc = treatmentRes.docs[0]
+    if (!treatmentDoc) throw new Error('Expected baseline treatment for clinic treatment access tests')
+    treatmentId = treatmentDoc.id as number
+  }, 60000)
+
+  afterEach(async () => {
+    while (createdBasicUserIds.length) {
+      const id = createdBasicUserIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'basicUsers', id, overrideAccess: true })
+    }
+
+    while (createdClinicTreatmentIds.length) {
+      const id = createdClinicTreatmentIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'clinictreatments', id, overrideAccess: true })
+    }
+    await cleanupTestEntities(payload, 'clinics', slugPrefix)
+  })
+
+  it('allows clinic staff to update own clinic treatment but not delete', async () => {
+    const clinic = await payload.create({
+      collection: 'clinics',
+      data: {
+        name: `${slugPrefix}-clinic`,
+        address: {
+          street: 'Access Street',
+          houseNumber: '1',
+          zipCode: 12000,
+          country: 'Turkey',
+          city: cityId,
+        },
+        contact: {
+          phoneNumber: '+90 555 1111111',
+          email: `${slugPrefix}@example.com`,
+        },
+        supportedLanguages: ['english'],
+        status: 'approved',
+      },
+      overrideAccess: true,
+    })
+
+    const clinicTreatment = await payload.create({
+      collection: 'clinictreatments',
+      data: {
+        clinic: clinic.id,
+        treatment: treatmentId,
+        price: 1000,
+      },
+      overrideAccess: true,
+    })
+    createdClinicTreatmentIds.push(clinicTreatment.id)
+
+    const basicUser = (await payload.create({
+      collection: 'basicUsers',
+      data: {
+        email: `${slugPrefix}-clinic-user@example.com`,
+        userType: 'clinic',
+        firstName: 'Clinic',
+        lastName: 'Updater',
+        supabaseUserId: `sb-${slugPrefix}-clinic`,
+      },
+      overrideAccess: true,
+    })) as BasicUser
+    createdBasicUserIds.push(basicUser.id)
+
+    const staffRes = await payload.find({
+      collection: 'clinicStaff',
+      where: { user: { equals: basicUser.id } },
+      limit: 1,
+      overrideAccess: true,
+    })
+    const staffDoc = staffRes.docs[0] as ClinicStaff | undefined
+    if (!staffDoc) throw new Error('Expected clinic staff profile')
+
+    await payload.update({
+      collection: 'clinicStaff',
+      id: staffDoc.id,
+      data: { clinic: clinic.id },
+      overrideAccess: true,
+    })
+
+    const updated = await payload.update({
+      collection: 'clinictreatments',
+      id: clinicTreatment.id,
+      data: { price: 1200 },
+      overrideAccess: false,
+      user: { ...basicUser, collection: 'basicUsers' },
+    })
+
+    expect(updated.price).toBe(1200)
+
+    await expect(
+      payload.delete({
+        collection: 'clinictreatments',
+        id: clinicTreatment.id,
+        overrideAccess: false,
+        user: { ...basicUser, collection: 'basicUsers' },
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/tests/integration/clinics.access.test.ts
+++ b/tests/integration/clinics.access.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { testSlug } from '../fixtures/testSlug'
+import type { BasicUser, ClinicStaff } from '@/payload-types'
+import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
+
+describe('Clinics access integration', () => {
+  let payload: Payload
+  let cityId: number
+  const slugPrefix = testSlug('clinics.access.test.ts')
+  const createdBasicUserIds: Array<number | string> = []
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+
+    const cityRes = await payload.find({ collection: 'cities', limit: 1, overrideAccess: true })
+    const cityDoc = cityRes.docs[0]
+    if (!cityDoc) throw new Error('Expected baseline city for clinic access tests')
+    cityId = cityDoc.id as number
+  })
+
+  afterEach(async () => {
+    while (createdBasicUserIds.length) {
+      const id = createdBasicUserIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'basicUsers', id, overrideAccess: true })
+    }
+
+    await cleanupTestEntities(payload, 'clinics', slugPrefix)
+  })
+
+  it('allows clinic staff to update their own clinic but not status', async () => {
+    const clinic = await payload.create({
+      collection: 'clinics',
+      data: {
+        name: `${slugPrefix}-clinic`,
+        address: {
+          street: 'Access Street',
+          houseNumber: '10',
+          zipCode: 12000,
+          country: 'Turkey',
+          city: cityId,
+        },
+        contact: {
+          phoneNumber: '+90 555 1111111',
+          email: `${slugPrefix}@example.com`,
+        },
+        supportedLanguages: ['english'],
+        status: 'draft',
+      },
+      overrideAccess: true,
+    })
+
+    const basicUser = (await payload.create({
+      collection: 'basicUsers',
+      data: {
+        email: `${slugPrefix}-clinic-user@example.com`,
+        userType: 'clinic',
+        firstName: 'Clinic',
+        lastName: 'Staff',
+        supabaseUserId: `sb-${slugPrefix}-clinic`,
+      },
+      overrideAccess: true,
+    })) as BasicUser
+    createdBasicUserIds.push(basicUser.id)
+
+    const staffRes = await payload.find({
+      collection: 'clinicStaff',
+      where: { user: { equals: basicUser.id } },
+      limit: 1,
+      overrideAccess: true,
+    })
+    const staffDoc = staffRes.docs[0] as ClinicStaff | undefined
+    if (!staffDoc) throw new Error('Expected clinic staff profile')
+
+    await payload.update({
+      collection: 'clinicStaff',
+      id: staffDoc.id,
+      data: { clinic: clinic.id },
+      overrideAccess: true,
+    })
+
+    const updated = await payload.update({
+      collection: 'clinics',
+      id: clinic.id,
+      data: { name: `${slugPrefix}-updated` },
+      overrideAccess: false,
+      user: { ...basicUser, collection: 'basicUsers' },
+    })
+
+    expect(updated.name).toBe(`${slugPrefix}-updated`)
+
+    await expect(
+      payload.update({
+        collection: 'clinics',
+        id: clinic.id,
+        data: { status: 'approved' },
+        overrideAccess: false,
+        user: { ...basicUser, collection: 'basicUsers' },
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/tests/integration/countries.integration.test.ts
+++ b/tests/integration/countries.integration.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { testSlug } from '../fixtures/testSlug'
+
+describe('Countries integration', () => {
+  let payload: Payload
+  const slugPrefix = testSlug('countries.integration.test.ts')
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+  })
+
+  afterEach(async () => {
+    const { docs } = await payload.find({
+      collection: 'countries',
+      where: { name: { like: `${slugPrefix}%` } },
+      limit: 100,
+      overrideAccess: true,
+    })
+    for (const doc of docs) {
+      await payload.delete({ collection: 'countries', id: doc.id, overrideAccess: true })
+    }
+  })
+
+  it('creates and updates a country', async () => {
+    const country = await payload.create({
+      collection: 'countries',
+      data: {
+        name: `${slugPrefix}-Country`,
+        isoCode: 'TC',
+        language: 'Testish',
+        currency: 'TST',
+      },
+      overrideAccess: true,
+    })
+
+    const updated = await payload.update({
+      collection: 'countries',
+      id: country.id,
+      data: {
+        currency: 'TSC',
+      },
+      overrideAccess: true,
+    })
+
+    expect(updated.currency).toBe('TSC')
+  })
+
+  it('rejects missing required fields', async () => {
+    await expect(
+      payload.create({
+        collection: 'countries',
+        data: { name: `${slugPrefix}-Invalid` },
+        overrideAccess: true,
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/tests/integration/doctorSpecialties.integration.test.ts
+++ b/tests/integration/doctorSpecialties.integration.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
+import { testSlug } from '../fixtures/testSlug'
+
+describe('DoctorSpecialties integration', () => {
+  let payload: Payload
+  let cityId: number
+  let specialtyId: number
+  const slugPrefix = testSlug('doctorSpecialties.integration.test.ts')
+  const createdDoctorSpecialtyIds: Array<number | string> = []
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+
+    const cityRes = await payload.find({ collection: 'cities', limit: 1, overrideAccess: true })
+    const cityDoc = cityRes.docs[0]
+    if (!cityDoc) throw new Error('Expected baseline city for doctor specialty tests')
+    cityId = cityDoc.id as number
+
+    const specialtyRes = await payload.find({
+      collection: 'medical-specialties',
+      limit: 1,
+      overrideAccess: true,
+    })
+    const specialtyDoc = specialtyRes.docs[0]
+    if (!specialtyDoc) throw new Error('Expected baseline specialty for doctor specialty tests')
+    specialtyId = specialtyDoc.id as number
+  }, 60000)
+
+  afterEach(async () => {
+    while (createdDoctorSpecialtyIds.length) {
+      const id = createdDoctorSpecialtyIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'doctorspecialties', id, overrideAccess: true })
+    }
+    await cleanupTestEntities(payload, 'doctors', slugPrefix)
+    await cleanupTestEntities(payload, 'clinics', slugPrefix)
+  })
+
+  it('creates doctor specialties with certifications and enforces uniqueness', async () => {
+    const clinic = await payload.create({
+      collection: 'clinics',
+      data: {
+        name: `${slugPrefix}-clinic`,
+        address: {
+          street: 'Specialty Street',
+          houseNumber: '1',
+          zipCode: 11111,
+          country: 'Turkey',
+          city: cityId,
+        },
+        contact: {
+          phoneNumber: '+90 555 1111111',
+          email: `${slugPrefix}@example.com`,
+        },
+        supportedLanguages: ['english'],
+        status: 'approved',
+      },
+      overrideAccess: true,
+    })
+
+    const doctor = await payload.create({
+      collection: 'doctors',
+      data: {
+        firstName: `${slugPrefix}-Doc`,
+        lastName: 'Specialty',
+        clinic: clinic.id,
+        qualifications: ['MD'],
+        languages: ['english'],
+      },
+      overrideAccess: true,
+    })
+
+    const link = await payload.create({
+      collection: 'doctorspecialties',
+      data: {
+        doctor: doctor.id,
+        medicalSpecialty: specialtyId,
+        specializationLevel: 'expert',
+        certifications: [{ certification: 'Board Certified' }],
+      },
+      overrideAccess: true,
+    })
+    createdDoctorSpecialtyIds.push(link.id)
+
+    const updated = await payload.update({
+      collection: 'doctorspecialties',
+      id: link.id,
+      data: { certifications: [] },
+      overrideAccess: true,
+    })
+
+    expect(updated.certifications).toHaveLength(0)
+
+    await expect(
+      payload.create({
+        collection: 'doctorspecialties',
+        data: {
+          doctor: doctor.id,
+          medicalSpecialty: specialtyId,
+          specializationLevel: 'expert',
+        },
+        overrideAccess: true,
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/tests/integration/doctorTreatments.integration.test.ts
+++ b/tests/integration/doctorTreatments.integration.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
+import { testSlug } from '../fixtures/testSlug'
+
+describe('DoctorTreatments integration', () => {
+  let payload: Payload
+  let cityId: number
+  let treatmentId: number
+  const slugPrefix = testSlug('doctorTreatments.integration.test.ts')
+  const createdDoctorTreatmentIds: Array<number | string> = []
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+
+    const cityRes = await payload.find({ collection: 'cities', limit: 1, overrideAccess: true })
+    const cityDoc = cityRes.docs[0]
+    if (!cityDoc) throw new Error('Expected baseline city for doctor treatment tests')
+    cityId = cityDoc.id as number
+
+    const treatmentRes = await payload.find({ collection: 'treatments', limit: 1, overrideAccess: true })
+    const treatmentDoc = treatmentRes.docs[0]
+    if (!treatmentDoc) throw new Error('Expected baseline treatment for doctor treatment tests')
+    treatmentId = treatmentDoc.id as number
+  }, 60000)
+
+  afterEach(async () => {
+    while (createdDoctorTreatmentIds.length) {
+      const id = createdDoctorTreatmentIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'doctortreatments', id, overrideAccess: true })
+    }
+    await cleanupTestEntities(payload, 'doctors', slugPrefix)
+    await cleanupTestEntities(payload, 'clinics', slugPrefix)
+  })
+
+  it('creates and updates doctor treatments, enforcing uniqueness', async () => {
+    const clinic = await payload.create({
+      collection: 'clinics',
+      data: {
+        name: `${slugPrefix}-clinic`,
+        address: {
+          street: 'Doctor Street',
+          houseNumber: '2',
+          zipCode: 11111,
+          country: 'Turkey',
+          city: cityId,
+        },
+        contact: {
+          phoneNumber: '+90 555 1111111',
+          email: `${slugPrefix}@example.com`,
+        },
+        supportedLanguages: ['english'],
+        status: 'approved',
+      },
+      overrideAccess: true,
+    })
+
+    const doctor = await payload.create({
+      collection: 'doctors',
+      data: {
+        firstName: `${slugPrefix}-Doc`,
+        lastName: 'Treatment',
+        clinic: clinic.id,
+        qualifications: ['MD'],
+        languages: ['english'],
+      },
+      overrideAccess: true,
+    })
+
+    const link = await payload.create({
+      collection: 'doctortreatments',
+      data: {
+        doctor: doctor.id,
+        treatment: treatmentId,
+        specializationLevel: 'expert',
+      },
+      overrideAccess: true,
+    })
+    createdDoctorTreatmentIds.push(link.id)
+
+    const updated = await payload.update({
+      collection: 'doctortreatments',
+      id: link.id,
+      data: { specializationLevel: 'advanced' },
+      overrideAccess: true,
+    })
+
+    expect(updated.specializationLevel).toBe('advanced')
+
+    await expect(
+      payload.create({
+        collection: 'doctortreatments',
+        data: {
+          doctor: doctor.id,
+          treatment: treatmentId,
+          specializationLevel: 'expert',
+        },
+        overrideAccess: true,
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/tests/integration/doctors.integration.test.ts
+++ b/tests/integration/doctors.integration.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
+import { testSlug } from '../fixtures/testSlug'
+
+const createdDoctorTreatmentIds: Array<number | string> = []
+const createdDoctorSpecialtyIds: Array<number | string> = []
+
+describe('Doctors integration', () => {
+  let payload: Payload
+  let cityId: number
+  let clinicId: number | string
+  let treatmentId: number
+  let specialtyId: number
+  const slugPrefix = testSlug('doctors.integration.test.ts')
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+
+    const cityRes = await payload.find({ collection: 'cities', limit: 1, overrideAccess: true })
+    const cityDoc = cityRes.docs[0]
+    if (!cityDoc) throw new Error('Expected baseline city for doctor tests')
+    cityId = cityDoc.id as number
+
+    const clinic = await payload.create({
+      collection: 'clinics',
+      data: {
+        name: `${slugPrefix}-clinic`,
+        address: {
+          street: 'Doctor Street',
+          houseNumber: '9',
+          zipCode: 12345,
+          country: 'Turkey',
+          city: cityId,
+        },
+        contact: {
+          phoneNumber: '+90 555 1234567',
+          email: `${slugPrefix}@example.com`,
+        },
+        supportedLanguages: ['english'],
+        status: 'approved',
+      },
+      overrideAccess: true,
+    })
+    clinicId = clinic.id
+
+    const treatmentRes = await payload.find({ collection: 'treatments', limit: 1, overrideAccess: true })
+    const treatmentDoc = treatmentRes.docs[0]
+    if (!treatmentDoc) throw new Error('Expected baseline treatment for doctor tests')
+    treatmentId = treatmentDoc.id as number
+
+    const specialtyRes = await payload.find({
+      collection: 'medical-specialties',
+      limit: 1,
+      overrideAccess: true,
+    })
+    const specialtyDoc = specialtyRes.docs[0]
+    if (!specialtyDoc) throw new Error('Expected baseline specialty for doctor tests')
+    specialtyId = specialtyDoc.id as number
+  }, 60000)
+
+  afterEach(async () => {
+    while (createdDoctorTreatmentIds.length) {
+      const id = createdDoctorTreatmentIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'doctortreatments', id, overrideAccess: true })
+    }
+
+    while (createdDoctorSpecialtyIds.length) {
+      const id = createdDoctorSpecialtyIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'doctorspecialties', id, overrideAccess: true })
+    }
+
+    await cleanupTestEntities(payload, 'doctors', slugPrefix)
+    await cleanupTestEntities(payload, 'clinics', slugPrefix)
+  })
+
+  it('creates a doctor and generates fullName and slug', async () => {
+    const doctor = await payload.create({
+      collection: 'doctors',
+      data: {
+        firstName: `${slugPrefix}-John`,
+        lastName: 'Doe',
+        title: 'dr',
+        clinic: clinicId,
+        qualifications: ['MD'],
+        languages: ['english'],
+      },
+      overrideAccess: true,
+    })
+
+    expect(doctor.fullName).toContain('Dr.')
+    expect(doctor.slug).toContain(`${slugPrefix}-john-doe`)
+  })
+
+  it('rejects missing qualifications', async () => {
+    await expect(
+      payload.create({
+        collection: 'doctors',
+        data: {
+          firstName: `${slugPrefix}-NoQual`,
+          lastName: 'Doctor',
+          clinic: clinicId,
+          languages: ['english'],
+        },
+        overrideAccess: true,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it('creates doctor treatment and specialty joins', async () => {
+    const doctor = await payload.create({
+      collection: 'doctors',
+      data: {
+        firstName: `${slugPrefix}-Join`,
+        lastName: 'Doctor',
+        clinic: clinicId,
+        qualifications: ['MD'],
+        languages: ['english'],
+      },
+      overrideAccess: true,
+    })
+
+    const doctorTreatment = await payload.create({
+      collection: 'doctortreatments',
+      data: {
+        doctor: doctor.id,
+        treatment: treatmentId,
+        specializationLevel: 'expert',
+      },
+      overrideAccess: true,
+    })
+    createdDoctorTreatmentIds.push(doctorTreatment.id)
+
+    const doctorSpecialty = await payload.create({
+      collection: 'doctorspecialties',
+      data: {
+        doctor: doctor.id,
+        medicalSpecialty: specialtyId,
+        specializationLevel: 'expert',
+        certifications: [{ certification: 'Board Certified' }],
+      },
+      overrideAccess: true,
+    })
+    createdDoctorSpecialtyIds.push(doctorSpecialty.id)
+
+    const updatedDoctor = await payload.findByID({
+      collection: 'doctors',
+      id: doctor.id,
+      overrideAccess: true,
+    })
+
+    expect(updatedDoctor.treatments).toBeDefined()
+    expect(updatedDoctor.specialties).toBeDefined()
+  })
+})

--- a/tests/integration/favoriteClinics.integration.test.ts
+++ b/tests/integration/favoriteClinics.integration.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
+import { testSlug } from '../fixtures/testSlug'
+import type { Patient } from '@/payload-types'
+
+describe('FavoriteClinics integration', () => {
+  let payload: Payload
+  let cityId: number
+  const slugPrefix = testSlug('favoriteClinics.integration.test.ts')
+  const createdPatientIds: Array<number | string> = []
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+
+    const cityRes = await payload.find({ collection: 'cities', limit: 1, overrideAccess: true })
+    const cityDoc = cityRes.docs[0]
+    if (!cityDoc) throw new Error('Expected baseline city for favorite clinic tests')
+    cityId = cityDoc.id as number
+  })
+
+  afterEach(async () => {
+    for (const patientId of createdPatientIds.splice(0)) {
+      const { docs: favorites } = await payload.find({
+        collection: 'favoriteclinics',
+        where: { patient: { equals: patientId } },
+        limit: 100,
+        overrideAccess: true,
+      })
+      for (const doc of favorites) {
+        await payload.delete({ collection: 'favoriteclinics', id: doc.id, overrideAccess: true })
+      }
+    }
+    await cleanupTestEntities(payload, 'clinics', slugPrefix)
+
+    const { docs } = await payload.find({
+      collection: 'patients',
+      where: { email: { like: `${slugPrefix}%` } },
+      limit: 100,
+      overrideAccess: true,
+    })
+    for (const doc of docs) {
+      await payload.delete({ collection: 'patients', id: doc.id, overrideAccess: true })
+    }
+  })
+
+  it('allows patients to create and delete favorites with unique constraint', async () => {
+    const clinic = await payload.create({
+      collection: 'clinics',
+      data: {
+        name: `${slugPrefix}-clinic`,
+        address: {
+          street: 'Favorite Street',
+          houseNumber: '1',
+          zipCode: 12000,
+          country: 'Turkey',
+          city: cityId,
+        },
+        contact: {
+          phoneNumber: '+90 555 1111111',
+          email: `${slugPrefix}@example.com`,
+        },
+        supportedLanguages: ['english'],
+        status: 'approved',
+      },
+      overrideAccess: true,
+    })
+
+    const patient = (await payload.create({
+      collection: 'patients',
+      data: {
+        email: `${slugPrefix}@patient.com`,
+        firstName: 'Favorite',
+        lastName: 'Patient',
+        supabaseUserId: `sb-${slugPrefix}-patient`,
+      },
+      overrideAccess: true,
+    })) as Patient
+    createdPatientIds.push(patient.id)
+
+    const favorite = await payload.create({
+      collection: 'favoriteclinics',
+      data: {
+        patient: patient.id,
+        clinic: clinic.id,
+      },
+      overrideAccess: false,
+      user: { ...patient, collection: 'patients' },
+    })
+
+    expect(favorite.patient).toBe(patient.id)
+
+    await expect(
+      payload.create({
+        collection: 'favoriteclinics',
+        data: {
+          patient: patient.id,
+          clinic: clinic.id,
+        },
+        overrideAccess: false,
+        user: { ...patient, collection: 'patients' },
+      }),
+    ).rejects.toThrow()
+
+    await payload.delete({
+      collection: 'favoriteclinics',
+      id: favorite.id,
+      overrideAccess: false,
+      user: { ...patient, collection: 'patients' },
+    })
+
+    const result = await payload.find({
+      collection: 'favoriteclinics',
+      where: { id: { equals: favorite.id } },
+      overrideAccess: true,
+    })
+
+    expect(result.docs).toHaveLength(0)
+  })
+})

--- a/tests/integration/medicalSpecialties.integration.test.ts
+++ b/tests/integration/medicalSpecialties.integration.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
+import { testSlug } from '../fixtures/testSlug'
+
+describe('MedicalSpecialties integration', () => {
+  let payload: Payload
+  let cityId: number
+  const slugPrefix = testSlug('medicalSpecialties.integration.test.ts')
+  const createdDoctorSpecialtyIds: Array<number | string> = []
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+
+    const cityRes = await payload.find({ collection: 'cities', limit: 1, overrideAccess: true })
+    const cityDoc = cityRes.docs[0]
+    if (!cityDoc) throw new Error('Expected baseline city for specialty tests')
+    cityId = cityDoc.id as number
+  })
+
+  afterEach(async () => {
+    while (createdDoctorSpecialtyIds.length) {
+      const id = createdDoctorSpecialtyIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'doctorspecialties', id, overrideAccess: true })
+    }
+
+    const { docs } = await payload.find({
+      collection: 'medical-specialties',
+      where: { name: { like: `${slugPrefix}%` } },
+      limit: 100,
+      overrideAccess: true,
+    })
+    for (const doc of docs) {
+      await payload.delete({ collection: 'medical-specialties', id: doc.id, overrideAccess: true })
+    }
+    await cleanupTestEntities(payload, 'doctors', slugPrefix)
+    await cleanupTestEntities(payload, 'clinics', slugPrefix)
+  })
+
+  it('creates specialties with parent relationship and doctor links', async () => {
+    const parent = await payload.create({
+      collection: 'medical-specialties',
+      data: {
+        name: `${slugPrefix}-parent`,
+      },
+      overrideAccess: true,
+    })
+
+    const child = await payload.create({
+      collection: 'medical-specialties',
+      data: {
+        name: `${slugPrefix}-child`,
+        parentSpecialty: parent.id,
+      },
+      overrideAccess: true,
+    })
+
+    const clinic = await payload.create({
+      collection: 'clinics',
+      data: {
+        name: `${slugPrefix}-clinic`,
+        address: {
+          street: 'Spec Street',
+          houseNumber: '1',
+          zipCode: 12345,
+          country: 'Turkey',
+          city: cityId,
+        },
+        contact: {
+          phoneNumber: '+90 555 1111111',
+          email: `${slugPrefix}@example.com`,
+        },
+        supportedLanguages: ['english'],
+        status: 'approved',
+      },
+      overrideAccess: true,
+    })
+
+    const doctor = await payload.create({
+      collection: 'doctors',
+      data: {
+        firstName: `${slugPrefix}-Doc`,
+        lastName: 'Specialist',
+        clinic: clinic.id,
+        qualifications: ['MD'],
+        languages: ['english'],
+      },
+      overrideAccess: true,
+    })
+
+    const doctorSpecialty = await payload.create({
+      collection: 'doctorspecialties',
+      data: {
+        doctor: doctor.id,
+        medicalSpecialty: child.id,
+        specializationLevel: 'expert',
+      },
+      overrideAccess: true,
+    })
+    createdDoctorSpecialtyIds.push(doctorSpecialty.id)
+
+    const updatedChild = await payload.findByID({
+      collection: 'medical-specialties',
+      id: child.id,
+      overrideAccess: true,
+    })
+
+    expect(updatedChild.parentSpecialty).toBe(parent.id)
+    expect(updatedChild.doctorLinks).toBeDefined()
+  })
+})

--- a/tests/integration/pages.integration.test.ts
+++ b/tests/integration/pages.integration.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
+import { testSlug } from '../fixtures/testSlug'
+
+const layoutBlock = {
+  blockType: 'content',
+  columns: [],
+}
+
+describe('Pages integration', () => {
+  let payload: Payload
+  const slugPrefix = testSlug('pages.integration.test.ts')
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+  })
+
+  afterEach(async () => {
+    await cleanupTestEntities(payload, 'pages', slugPrefix)
+  })
+
+  it('creates a page and generates a slug', async () => {
+    const page = await payload.create({
+      collection: 'pages',
+      data: {
+        title: `${slugPrefix}-page`,
+        layout: [layoutBlock],
+      },
+      overrideAccess: true,
+    })
+
+    expect(page.id).toBeDefined()
+    expect(page.slug).toContain(`${slugPrefix}-page`)
+  })
+
+  it('auto-populates publishedAt when publishing without a date', async () => {
+    const page = await payload.create({
+      collection: 'pages',
+      data: {
+        title: `${slugPrefix}-publish`,
+        layout: [layoutBlock],
+      },
+      overrideAccess: true,
+    })
+
+    const updated = await payload.update({
+      collection: 'pages',
+      id: page.id,
+      data: {
+        _status: 'published',
+      },
+      overrideAccess: true,
+    })
+
+    expect(updated.publishedAt).toBeTruthy()
+  })
+
+  it('rejects missing title', async () => {
+    await expect(
+      payload.create({
+        collection: 'pages',
+        data: {
+          layout: [layoutBlock],
+        },
+        overrideAccess: true,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it('blocks create for anonymous users', async () => {
+    await expect(
+      payload.create({
+        collection: 'pages',
+        data: {
+          title: `${slugPrefix}-no-access`,
+          layout: [layoutBlock],
+        },
+        overrideAccess: false,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it('rejects invalid block data', async () => {
+    await expect(
+      payload.create({
+        collection: 'pages',
+        data: {
+          title: `${slugPrefix}-invalid-block`,
+          layout: [{ blockType: 'content' }],
+        },
+        overrideAccess: true,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it('soft deletes a page', async () => {
+    const page = await payload.create({
+      collection: 'pages',
+      data: {
+        title: `${slugPrefix}-trash`,
+        layout: [layoutBlock],
+      },
+      overrideAccess: true,
+    })
+
+    await payload.delete({
+      collection: 'pages',
+      id: page.id,
+      overrideAccess: true,
+    })
+
+    const findResult = await payload.find({
+      collection: 'pages',
+      where: { id: { equals: page.id } },
+      overrideAccess: true,
+    })
+
+    expect(findResult.docs).toHaveLength(0)
+  })
+})

--- a/tests/integration/platformContentMedia.integration.test.ts
+++ b/tests/integration/platformContentMedia.integration.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { testSlug } from '../fixtures/testSlug'
+import { createLargeFile, createPngFile } from '../fixtures/testFiles'
+import type { BasicUser } from '@/payload-types'
+
+describe('PlatformContentMedia integration', () => {
+  let payload: Payload
+  const slugPrefix = testSlug('platformContentMedia.integration.test.ts')
+  const createdBasicUserIds: Array<string | number> = []
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+  })
+
+  afterEach(async () => {
+    while (createdBasicUserIds.length) {
+      const id = createdBasicUserIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'basicUsers', id, overrideAccess: true })
+    }
+
+    const { docs } = await payload.find({
+      collection: 'platformContentMedia',
+      where: { alt: { like: `${slugPrefix}%` } },
+      limit: 100,
+      overrideAccess: true,
+    })
+    for (const doc of docs) {
+      await payload.delete({ collection: 'platformContentMedia', id: doc.id, overrideAccess: true })
+    }
+  })
+
+  it('uploads media and sets storagePath and createdBy', async () => {
+    const basicUser = (await payload.create({
+      collection: 'basicUsers',
+      data: {
+        email: `${slugPrefix}@example.com`,
+        userType: 'platform',
+        firstName: 'Media',
+        lastName: 'Uploader',
+        supabaseUserId: `sb-${slugPrefix}`,
+      },
+      overrideAccess: true,
+    })) as BasicUser
+    createdBasicUserIds.push(basicUser.id)
+
+    const media = await payload.create({
+      collection: 'platformContentMedia',
+      data: {
+        alt: `${slugPrefix} Integration media`,
+      },
+      file: createPngFile(`${slugPrefix}.png`),
+      overrideAccess: false,
+      user: { ...basicUser, collection: 'basicUsers' },
+    })
+
+    expect(media.id).toBeDefined()
+    expect(media.storagePath).toContain('platform')
+    expect(media.createdBy).toBe(basicUser.id)
+  })
+
+  it('rejects missing alt text', async () => {
+    await expect(
+      payload.create({
+        collection: 'platformContentMedia',
+        data: {},
+        file: createPngFile(`${slugPrefix}-no-alt.png`),
+        overrideAccess: true,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it('rejects uploads over the file size limit', async () => {
+    const largeFile = createLargeFile(5 * 1024 * 1024 + 1024, `${slugPrefix}-large.png`)
+
+    await expect(
+      payload.create({
+        collection: 'platformContentMedia',
+        data: {
+          alt: 'Too large',
+        },
+        file: largeFile,
+        overrideAccess: true,
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/tests/integration/platformStaff.integration.test.ts
+++ b/tests/integration/platformStaff.integration.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import type { BasicUser, PlatformStaff } from '@/payload-types'
+
+describe('PlatformStaff integration', () => {
+  let payload: Payload
+  const createdBasicUserIds: Array<number | string> = []
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+  })
+
+  afterEach(async () => {
+    while (createdBasicUserIds.length) {
+      const id = createdBasicUserIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'basicUsers', id, overrideAccess: true })
+    }
+  })
+
+  it('blocks direct create requests', async () => {
+    const basicUser = (await payload.create({
+      collection: 'basicUsers',
+      data: {
+        email: 'platform.staff.create@example.com',
+        userType: 'platform',
+        firstName: 'Platform',
+        lastName: 'User',
+        supabaseUserId: 'sb-platform-staff-create',
+      },
+      overrideAccess: true,
+    })) as BasicUser
+    createdBasicUserIds.push(basicUser.id)
+
+    await expect(
+      payload.create({
+        collection: 'platformStaff',
+        data: {
+          user: basicUser.id,
+          role: 'support',
+        },
+        overrideAccess: false,
+        user: { ...basicUser, collection: 'basicUsers' },
+      }),
+    ).rejects.toThrow()
+  })
+
+  it('allows platform user to update role', async () => {
+    const basicUser = (await payload.create({
+      collection: 'basicUsers',
+      data: {
+        email: 'platform.staff.update@example.com',
+        userType: 'platform',
+        firstName: 'Role',
+        lastName: 'Updater',
+        supabaseUserId: 'sb-platform-staff-update',
+      },
+      overrideAccess: true,
+    })) as BasicUser
+    createdBasicUserIds.push(basicUser.id)
+
+    const staffRes = await payload.find({
+      collection: 'platformStaff',
+      where: { user: { equals: basicUser.id } },
+      limit: 1,
+      overrideAccess: true,
+    })
+    const staffDoc = staffRes.docs[0] as PlatformStaff | undefined
+    if (!staffDoc) throw new Error('Expected platform staff profile')
+
+    const updated = await payload.update({
+      collection: 'platformStaff',
+      id: staffDoc.id,
+      data: { role: 'content-manager' },
+      overrideAccess: false,
+      user: { ...basicUser, collection: 'basicUsers' },
+    })
+
+    expect(updated.role).toBe('content-manager')
+  })
+})

--- a/tests/integration/posts.integration.test.ts
+++ b/tests/integration/posts.integration.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
+import { testSlug } from '../fixtures/testSlug'
+import { createPngFile } from '../fixtures/testFiles'
+import type { BasicUser, PlatformStaff } from '@/payload-types'
+
+const richTextValue = {
+  root: {
+    type: 'root',
+    children: [
+      {
+        type: 'paragraph',
+        children: [{ type: 'text', text: 'Post content' }],
+      },
+    ],
+    direction: 'ltr',
+    format: '',
+    indent: 0,
+    version: 1,
+  },
+}
+
+type PlatformStaffResult = { staff: PlatformStaff; basicUserId: number | string }
+
+async function createPlatformStaff(payload: Payload, email: string): Promise<PlatformStaffResult> {
+  const basicUser = (await payload.create({
+    collection: 'basicUsers',
+    data: {
+      email,
+      userType: 'platform',
+      firstName: 'Post',
+      lastName: 'Author',
+      supabaseUserId: `sb-${email}`,
+    },
+    overrideAccess: true,
+  })) as BasicUser
+
+  const staffRes = await payload.find({
+    collection: 'platformStaff',
+    where: { user: { equals: basicUser.id } },
+    limit: 1,
+    overrideAccess: true,
+  })
+
+  const staffDoc = staffRes.docs[0] as PlatformStaff | undefined
+  if (!staffDoc) {
+    throw new Error('Expected platform staff profile for post author')
+  }
+
+  return { staff: staffDoc, basicUserId: basicUser.id }
+}
+
+describe('Posts integration', () => {
+  let payload: Payload
+  const slugPrefix = testSlug('posts.integration.test.ts')
+  const createdBasicUserIds: Array<number | string> = []
+  const createdMediaIds: Array<number | string> = []
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+  })
+
+  afterEach(async () => {
+    while (createdMediaIds.length) {
+      const id = createdMediaIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'platformContentMedia', id, overrideAccess: true })
+    }
+
+    while (createdBasicUserIds.length) {
+      const id = createdBasicUserIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'basicUsers', id, overrideAccess: true })
+    }
+
+    await cleanupTestEntities(payload, 'posts', slugPrefix)
+  })
+
+  it('creates a post with slug, relationships, and content', async () => {
+    const { staff, basicUserId } = await createPlatformStaff(payload, `${slugPrefix}-author@example.com`)
+    createdBasicUserIds.push(basicUserId)
+
+    const media = await payload.create({
+      collection: 'platformContentMedia',
+      data: {
+        alt: 'Post hero',
+      },
+      file: createPngFile(`${slugPrefix}-hero.png`),
+      overrideAccess: true,
+    })
+    createdMediaIds.push(media.id)
+
+    const tagRes = await payload.find({ collection: 'tags', limit: 1, overrideAccess: true })
+    const tagId = tagRes.docs[0]?.id
+
+    const categoryRes = await payload.find({ collection: 'categories', limit: 1, overrideAccess: true })
+    const categoryId = categoryRes.docs[0]?.id
+
+    const post = await payload.create({
+      collection: 'posts',
+      data: {
+        title: `${slugPrefix}-post`,
+        tags: tagId ? [tagId] : [],
+        heroImage: media.id,
+        content: richTextValue,
+        excerpt: 'Summary',
+        categories: categoryId ? [categoryId] : [],
+        authors: [staff.id],
+      },
+      overrideAccess: true,
+    })
+
+    expect(post.id).toBeDefined()
+    expect(post.slug).toContain(`${slugPrefix}-post`)
+    expect(post.authors).toContain(staff.id)
+  })
+
+  it('auto-sets publishedAt when publishing without a date', async () => {
+    const post = await payload.create({
+      collection: 'posts',
+      data: {
+        title: `${slugPrefix}-publish`,
+        content: richTextValue,
+        excerpt: 'Publish summary',
+      },
+      overrideAccess: true,
+    })
+
+    const updated = await payload.update({
+      collection: 'posts',
+      id: post.id,
+      data: {
+        _status: 'published',
+      },
+      overrideAccess: true,
+    })
+
+    expect(updated.publishedAt).toBeTruthy()
+  })
+
+  it('populates authors after read', async () => {
+    const { staff, basicUserId } = await createPlatformStaff(payload, `${slugPrefix}-author2@example.com`)
+    createdBasicUserIds.push(basicUserId)
+
+    const post = await payload.create({
+      collection: 'posts',
+      data: {
+        title: `${slugPrefix}-authors`,
+        content: richTextValue,
+        excerpt: 'Authors summary',
+        authors: [staff.id],
+      },
+      overrideAccess: true,
+    })
+
+    const fetched = await payload.findByID({
+      collection: 'posts',
+      id: post.id,
+      overrideAccess: true,
+    })
+
+    expect(fetched.populatedAuthors?.[0]?.id).toBe(staff.id)
+    expect(fetched.populatedAuthors?.[0]?.name).toContain('Post Author')
+  })
+
+  it('blocks create for anonymous users', async () => {
+    await expect(
+      payload.create({
+        collection: 'posts',
+        data: {
+          title: `${slugPrefix}-no-access`,
+          content: richTextValue,
+          excerpt: 'No access',
+        },
+        overrideAccess: false,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it('soft deletes a post', async () => {
+    const post = await payload.create({
+      collection: 'posts',
+      data: {
+        title: `${slugPrefix}-trash`,
+        content: richTextValue,
+        excerpt: 'Trash',
+      },
+      overrideAccess: true,
+    })
+
+    await payload.delete({
+      collection: 'posts',
+      id: post.id,
+      overrideAccess: true,
+    })
+
+    const findResult = await payload.find({
+      collection: 'posts',
+      where: { id: { equals: post.id } },
+      overrideAccess: true,
+    })
+
+    expect(findResult.docs).toHaveLength(0)
+  })
+})

--- a/tests/integration/reviews.validationAccess.test.ts
+++ b/tests/integration/reviews.validationAccess.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
+import { testSlug } from '../fixtures/testSlug'
+import type { BasicUser, Patient, PlatformStaff } from '@/payload-types'
+
+async function createPlatformStaff(payload: Payload, email: string) {
+  const basicUser = (await payload.create({
+    collection: 'basicUsers',
+    data: {
+      email,
+      userType: 'platform',
+      firstName: 'Review',
+      lastName: 'Owner',
+      supabaseUserId: `sb-${email}`,
+    },
+    overrideAccess: true,
+  })) as BasicUser
+
+  const staffRes = await payload.find({
+    collection: 'platformStaff',
+    where: { user: { equals: basicUser.id } },
+    limit: 1,
+    overrideAccess: true,
+  })
+
+  const staffDoc = staffRes.docs[0] as PlatformStaff | undefined
+  if (!staffDoc) throw new Error('Expected platform staff profile for review')
+
+  return { basicUser, staffDoc }
+}
+
+describe('Reviews validation and access', () => {
+  let payload: Payload
+  let cityId: number
+  let treatmentId: number
+  const slugPrefix = testSlug('reviews.validationAccess.test.ts')
+  const createdBasicUserIds: Array<number | string> = []
+  const createdReviewIds: Array<number | string> = []
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+
+    const cityRes = await payload.find({ collection: 'cities', limit: 1, overrideAccess: true })
+    const cityDoc = cityRes.docs[0]
+    if (!cityDoc) throw new Error('Expected baseline city for review validation tests')
+    cityId = cityDoc.id as number
+
+    const treatmentRes = await payload.find({ collection: 'treatments', limit: 1, overrideAccess: true })
+    const treatmentDoc = treatmentRes.docs[0]
+    if (!treatmentDoc) throw new Error('Expected baseline treatment for review validation tests')
+    treatmentId = treatmentDoc.id as number
+  }, 60000)
+
+  afterEach(async () => {
+    while (createdBasicUserIds.length) {
+      const id = createdBasicUserIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'basicUsers', id, overrideAccess: true })
+    }
+
+    while (createdReviewIds.length) {
+      const id = createdReviewIds.pop()
+      if (!id) continue
+      await payload.delete({ collection: 'reviews', id, overrideAccess: true })
+    }
+    await cleanupTestEntities(payload, 'clinics', slugPrefix)
+    await cleanupTestEntities(payload, 'doctors', slugPrefix)
+
+    const { docs } = await payload.find({
+      collection: 'patients',
+      where: { email: { like: `${slugPrefix}%` } },
+      limit: 100,
+      overrideAccess: true,
+    })
+    for (const doc of docs) {
+      await payload.delete({ collection: 'patients', id: doc.id, overrideAccess: true })
+    }
+  })
+
+  it('validates required relationships and rating bounds', async () => {
+    const { basicUser, staffDoc } = await createPlatformStaff(payload, `${slugPrefix}-reviewer@example.com`)
+    createdBasicUserIds.push(basicUser.id)
+
+    await expect(
+      payload.create({
+        collection: 'reviews',
+        data: {
+          patient: staffDoc.id,
+          starRating: 5,
+          comment: 'Missing relations',
+        },
+        overrideAccess: true,
+      }),
+    ).rejects.toThrow()
+
+    const clinic = await payload.create({
+      collection: 'clinics',
+      data: {
+        name: `${slugPrefix}-clinic`,
+        address: {
+          street: 'Review Street',
+          houseNumber: '1',
+          zipCode: 12000,
+          country: 'Turkey',
+          city: cityId,
+        },
+        contact: {
+          phoneNumber: '+90 555 1111111',
+          email: `${slugPrefix}@example.com`,
+        },
+        supportedLanguages: ['english'],
+        status: 'approved',
+      },
+      overrideAccess: true,
+    })
+
+    const doctor = await payload.create({
+      collection: 'doctors',
+      data: {
+        firstName: `${slugPrefix}-Doc`,
+        lastName: 'Review',
+        clinic: clinic.id,
+        qualifications: ['MD'],
+        languages: ['english'],
+      },
+      overrideAccess: true,
+    })
+
+    await expect(
+      payload.create({
+        collection: 'reviews',
+        data: {
+          patient: staffDoc.id,
+          clinic: clinic.id,
+          doctor: doctor.id,
+          treatment: treatmentId,
+          starRating: 6,
+          comment: 'Invalid rating',
+          status: 'pending',
+        },
+        overrideAccess: true,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it('sets reviewDate by default and blocks patient updates', async () => {
+    const { basicUser, staffDoc } = await createPlatformStaff(payload, `${slugPrefix}-editor@example.com`)
+    createdBasicUserIds.push(basicUser.id)
+
+    const clinic = await payload.create({
+      collection: 'clinics',
+      data: {
+        name: `${slugPrefix}-clinic-update`,
+        address: {
+          street: 'Review Street',
+          houseNumber: '2',
+          zipCode: 12000,
+          country: 'Turkey',
+          city: cityId,
+        },
+        contact: {
+          phoneNumber: '+90 555 1111111',
+          email: `${slugPrefix}-update@example.com`,
+        },
+        supportedLanguages: ['english'],
+        status: 'approved',
+      },
+      overrideAccess: true,
+    })
+
+    const doctor = await payload.create({
+      collection: 'doctors',
+      data: {
+        firstName: `${slugPrefix}-Doc`,
+        lastName: 'Review',
+        clinic: clinic.id,
+        qualifications: ['MD'],
+        languages: ['english'],
+      },
+      overrideAccess: true,
+    })
+
+    const review = await payload.create({
+      collection: 'reviews',
+      data: {
+        patient: staffDoc.id,
+        clinic: clinic.id,
+        doctor: doctor.id,
+        treatment: treatmentId,
+        starRating: 4,
+        comment: `${slugPrefix} review content`,
+        status: 'pending',
+      },
+      overrideAccess: true,
+    })
+    createdReviewIds.push(review.id)
+
+    expect(review.reviewDate).toBeTruthy()
+
+    const patientUser = (await payload.create({
+      collection: 'patients',
+      data: {
+        email: `${slugPrefix}@patient.com`,
+        firstName: 'Patient',
+        lastName: 'Reviewer',
+        supabaseUserId: `sb-${slugPrefix}-patient`,
+      },
+      overrideAccess: true,
+    })) as Patient
+
+    await expect(
+      payload.update({
+        collection: 'reviews',
+        id: review.id,
+        data: { comment: 'Patient edit attempt' },
+        overrideAccess: false,
+        user: { ...patientUser, collection: 'patients' },
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/tests/integration/tags.joins.test.ts
+++ b/tests/integration/tags.joins.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { getPayload } from 'payload'
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
+import { testSlug } from '../fixtures/testSlug'
+
+const richTextValue = {
+  root: {
+    type: 'root',
+    children: [
+      {
+        type: 'paragraph',
+        children: [{ type: 'text', text: 'Tag content' }],
+      },
+    ],
+    direction: 'ltr',
+    format: '',
+    indent: 0,
+    version: 1,
+  },
+}
+
+describe('Tags join integration', () => {
+  let payload: Payload
+  let cityId: number
+  let specialtyId: number
+  const slugPrefix = testSlug('tags.joins.test.ts')
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+
+    const cityRes = await payload.find({ collection: 'cities', limit: 1, overrideAccess: true })
+    const cityDoc = cityRes.docs[0]
+    if (!cityDoc) throw new Error('Expected baseline city for tags join tests')
+    cityId = cityDoc.id as number
+
+    const specialtyRes = await payload.find({
+      collection: 'medical-specialties',
+      limit: 1,
+      overrideAccess: true,
+    })
+    const specialtyDoc = specialtyRes.docs[0]
+    if (!specialtyDoc) throw new Error('Expected baseline specialty for tags join tests')
+    specialtyId = specialtyDoc.id as number
+  })
+
+  afterEach(async () => {
+    await cleanupTestEntities(payload, 'tags', slugPrefix)
+    await cleanupTestEntities(payload, 'clinics', slugPrefix)
+    await cleanupTestEntities(payload, 'posts', slugPrefix)
+    await cleanupTestEntities(payload, 'treatments', slugPrefix)
+  })
+
+  it('populates tag join lists for posts, clinics, and treatments', async () => {
+    const tag = await payload.create({
+      collection: 'tags',
+      data: { name: `${slugPrefix}-tag` },
+      overrideAccess: true,
+    })
+
+    const clinic = await payload.create({
+      collection: 'clinics',
+      data: {
+        name: `${slugPrefix}-clinic`,
+        address: {
+          street: 'Tag Street',
+          houseNumber: '1',
+          zipCode: 12000,
+          country: 'Turkey',
+          city: cityId,
+        },
+        contact: {
+          phoneNumber: '+90 555 1111111',
+          email: `${slugPrefix}@example.com`,
+        },
+        supportedLanguages: ['english'],
+        status: 'approved',
+        tags: [tag.id],
+      },
+      overrideAccess: true,
+    })
+
+    const treatment = await payload.create({
+      collection: 'treatments',
+      data: {
+        name: `${slugPrefix}-treatment`,
+        description: richTextValue,
+        medicalSpecialty: specialtyId,
+        tags: [tag.id],
+      },
+      overrideAccess: true,
+    })
+
+    const post = await payload.create({
+      collection: 'posts',
+      data: {
+        title: `${slugPrefix}-post`,
+        content: richTextValue,
+        excerpt: 'Tagged post',
+        tags: [tag.id],
+      },
+      overrideAccess: true,
+    })
+
+    const updatedTag = await payload.findByID({
+      collection: 'tags',
+      id: tag.id,
+      overrideAccess: true,
+    })
+
+    expect(updatedTag.posts?.length).toBeGreaterThanOrEqual(1)
+    expect(updatedTag.clinics?.length).toBeGreaterThanOrEqual(1)
+    expect(updatedTag.treatments?.length).toBeGreaterThanOrEqual(1)
+
+    expect(updatedTag.posts?.[0]).toBeDefined()
+    expect(updatedTag.clinics?.[0]).toBeDefined()
+    expect(updatedTag.treatments?.[0]).toBeDefined()
+
+    await payload.delete({ collection: 'posts', id: post.id, overrideAccess: true })
+    await payload.delete({ collection: 'clinics', id: clinic.id, overrideAccess: true })
+    await payload.delete({ collection: 'treatments', id: treatment.id, overrideAccess: true })
+  })
+})


### PR DESCRIPTION
### Motivation

- Fill gaps identified in the integration test backlog (`docs/testing/integration-test-tasks.md`) by adding end-to-end coverage for collection behaviors, hooks, joins, and access rules.
- Provide deterministic fixtures for file uploads and consistent cleanup helpers so integration tests can create and remove test artifacts safely.
- Protect critical access and validation logic (publishing hooks, joins, file limits, unique constraints) with real Payload API calls rather than only unit mocks.

### Description

- Add a new upload fixture `tests/fixtures/testFiles.ts` and a suite of Vitest integration tests under `tests/integration/` for pages, posts, categories, platform content media, platform staff, clinics, clinic applications, countries, cities, accreditation, doctors, doctor treatments/specialties, medical specialties, clinic treatments, favorite clinics, reviews, tags joins, and treatments joins.
- Tests exercise create/update/delete flows, access control (anonymous vs platform/clinic), validation (required fields and bounds), join list population, hook-driven fields (`publishedAt`, `storagePath`, `reviewDate`), and file size limits for uploads.
- Improve test cleanup patterns by adding per-collection targeted deletions (using slug/email/alt prefixes) and tracking created helper IDs so tests remove artifacts they create.
- Keep tests consistent with repo patterns: use `getPayload({ config })`, `ensureBaseline`, `cleanupTestEntities`, and override/access/user parameters to exercise both privileged and unprivileged paths.

### Testing

- No automated test runner was executed as part of this change; the PR only adds Vitest integration tests (no `vitest` run was performed here).