### PR TITLE
fix: potential fix for code scanning alert no. 10: Information exposure through a stack trace

### DIFF
--- a/src/endpoints/seed/seedEndpoint.ts
+++ b/src/endpoints/seed/seedEndpoint.ts
@@ -115,7 +115,7 @@ export const seedPostHandler = async (req: PayloadRequest, res?: unknown) => {
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e)
     payloadInstance.logger.error(`Seed endpoint error: ${msg}`)
-    return respond(500, { error: 'Seed failed', detail: msg })
+    return respond(500, { error: 'Seed failed', detail: 'An internal error occurred' })
   }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/findmydoc-platform/website/security/code-scanning/10](https://github.com/findmydoc-platform/website/security/code-scanning/10)

In general, to fix this issue we should avoid sending raw exception information (messages or stacks) to the client. Instead, we should log the detailed error on the server, and send a generic error response to the caller (for example, a stable error code and human-readable but non-sensitive message). This prevents accidental leakage of internal state or implementation details.

The best fix here without changing functionality elsewhere is to keep logging the detailed `msg` using `payloadInstance.logger.error`, but modify the HTTP response so that it no longer includes `msg` in the `detail` field. Instead, respond with a generic, constant message such as `"An internal error occurred"` or re-use the existing `"Seed failed"` message, and optionally add a non-sensitive, static `errorCode` if you want clients to distinguish cases. This change should be made only in the `catch` block in `seedPostHandler` (lines 115–118). No changes are needed to `respond`, to imports, or to `seedGetHandler`.

Concretely:
- Keep line 116 computing `msg` so that logging remains informative.
- Keep line 117 logging `msg`.
- Change line 118 from `return respond(500, { error: 'Seed failed', detail: msg })` to something like `return respond(500, { error: 'Seed failed' })`, or `return respond(500, { error: 'Seed failed', detail: 'An internal error occurred' })`. The important part is that the client no longer receives the tainted `msg`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
