### PR TITLE
feat: add feature and bug issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+---
+name: Bug Report
+description: Report a defect with reproducible steps and expected behavior
+title: 'Bug: '
+labels: []
+type: Bug
+projects: ['findmydoc-platform/3']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to report bugs with enough detail to reproduce and verify a fix.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the bug.
+      placeholder: What is broken?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Provide a minimal, deterministic sequence.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Enter ...
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What should happen instead?
+      placeholder: Describe the expected result.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What happens currently?
+      placeholder: Describe the observed result, including errors.
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, OS, app version/commit, and relevant configuration.
+      placeholder: e.g., Chrome 122 on macOS 14, main@abc123
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs-and-evidence
+    attributes:
+      label: Logs, Screenshots, and Evidence
+      description: Add console logs, stack traces, screenshots, or videos.
+      placeholder: Paste relevant logs and links.
+    validations:
+      required: false
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope / Impact
+      description: Who is affected and how severe is the impact?
+      placeholder: User impact, frequency, and affected areas.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,58 @@
+---
+name: Feature
+description: Product feature request for implementation planning
+title: 'Feature: '
+labels: []
+type: Feature
+projects: ['findmydoc-platform/3']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for feature requests that should move into implementation.
+        Keep the description short, specific, and outcome-oriented.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem are we solving and for whom?
+      placeholder: Clear problem, motivation, and target users/stakeholders.
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Intended Outcome
+      description: What should be true after this feature is delivered?
+      placeholder: Clear, measurable, outcome-focused description.
+    validations:
+      required: true
+
+  - type: textarea
+    id: quality-criteria
+    attributes:
+      label: Quality Criteria
+      description: Which quality aspects must this feature meet?
+      placeholder: Performance, reliability, accessibility, maintainability, security, etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Which concrete conditions must be met for completion?
+      placeholder: Use bullet points with testable criteria.
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of Scope
+      description: What is explicitly not part of this feature?
+      placeholder: List boundaries and exclusions to avoid scope creep.
+    validations:
+      required: false


### PR DESCRIPTION
Summary: Add two new GitHub issue form templates to standardize feature requests and bug reports in project 3.

Changes:
- Add .github/ISSUE_TEMPLATE/feature.yml with fields for problem, intended outcome, quality criteria, acceptance criteria, and out of scope.
- Add .github/ISSUE_TEMPLATE/bug_report.yml with standard reproduction, expected/actual behavior, environment, evidence, and impact fields.
- Set both templates to projects: [findmydoc-platform/3].

Why:
- This makes planning and triage clearer by separating quality and acceptance requirements for features while keeping explicit scope boundaries, and by capturing reproducible bug details in a consistent format.

Testing:
- Run pnpm check.
- Run /bin/zsh -lc "PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build".
- Run pnpm format.

Related: None
Breaking changes: None