### PR TITLE
fix: pin workflow actions for zizmor compliance

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -30,15 +30,15 @@ jobs:
       NEXT_TELEMETRY_DISABLED: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -18,11 +18,11 @@ jobs:
       docs_changed: ${{ steps.filter.outputs.docs }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Detect README/docs changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         with:
           filters: |
             docs:
@@ -36,13 +36,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 

--- a/.github/workflows/reset-database.yml
+++ b/.github/workflows/reset-database.yml
@@ -23,13 +23,13 @@ jobs:
     environment: Preview
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -41,4 +41,5 @@ jobs:
         env:
           DATABASE_URI: ${{ secrets.DATABASE_URI }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
-        run: bash ./.github/scripts/ci/reset-preview-database.sh "${{ github.event.inputs.confirmation }}"
+          RESET_CONFIRMATION: ${{ github.event.inputs.confirmation }}
+        run: bash ./.github/scripts/ci/reset-preview-database.sh "$RESET_CONFIRMATION"


### PR DESCRIPTION
This update makes CI checks more stable and avoids security-gate failures that block unrelated work.

The workflows now use pinned action SHAs and safer variable handling in shell commands, so security scanning can pass consistently.

Internal value:

- Stable and enforceable workflow security gating in CI.
- Fewer manual reruns caused by workflow policy drift.

---

Expected outcome:

- User impact: Pull requests fail less often for workflow-policy reasons unrelated to product code.
- Internal impact: Security checks remain strict while being predictable across branches.
- Internal impact: Reset workflow input handling follows safer shell execution patterns.

Summary: Pin workflow action references and harden reset-workflow command interpolation so zizmor passes reliably.

Changes:

- Pin `actions/checkout`, `pnpm/action-setup`, and `actions/setup-node` in `.github/workflows/deploy-storybook.yml`.
- Pin `actions/checkout`, `dorny/paths-filter`, `pnpm/action-setup`, and `actions/setup-node` in `.github/workflows/docs-check.yml`.
- Pin `actions/checkout`, `pnpm/action-setup`, and `actions/setup-node` in `.github/workflows/reset-database.yml`.
- Replace direct expression interpolation in the reset command with a dedicated `RESET_CONFIRMATION` environment variable.

Why:

CI run `22718151266` failed in the `✅ Check & Unit Tests` job because `zizmor` flagged unpinned actions and template expansion risk. These changes align the workflows with the repository's security-gate policy.

Testing:

- `pnpm check`
- `PAYLOAD_SECRET=dev-secret pnpm build`
- `pnpm format`
- `pnpm tests`
- `docker run --rm -v "$PWD:/work" -w /work ghcr.io/zizmorcore/zizmor:latest --config zizmor.yml --persona regular --min-severity medium --min-confidence medium .github/workflows/deploy-storybook.yml .github/workflows/docs-check.yml .github/workflows/reset-database.yml`

Related: https://github.com/findmydoc-platform/website/actions/runs/22718151266/job/65873027646, #673

Breaking changes: None
