### PR TITLE
fix(auth): accept case-insensitive bearer auth scheme

### DIFF
--- a/src/auth/utilities/jwtValidation.ts
+++ b/src/auth/utilities/jwtValidation.ts
@@ -20,11 +20,12 @@ export function extractTokenFromHeader(headers?: Headers): string | undefined {
   if (!headers) return undefined
 
   const authHeader = headers.get('authorization') || headers.get('Authorization')
-  if (authHeader && authHeader.startsWith('Bearer ')) {
-    return authHeader.replace('Bearer ', '')
-  }
+  if (!authHeader) return undefined
 
-  return undefined
+  const [scheme, ...rest] = authHeader.trim().split(/\s+/)
+  if (scheme?.toLowerCase() !== 'bearer' || rest.length === 0) return undefined
+
+  return rest.join(' ')
 }
 
 /**

--- a/tests/unit/auth/utilities/jwtValidation.test.ts
+++ b/tests/unit/auth/utilities/jwtValidation.test.ts
@@ -42,6 +42,13 @@ describe('jwtValidation utilities', () => {
       const result = extractTokenFromHeader()
       expect(result).toBeUndefined()
     })
+
+    it('should extract token when bearer scheme casing differs', () => {
+      const headers = new Headers([['authorization', 'bearer test-token-123']])
+
+      const result = extractTokenFromHeader(headers)
+      expect(result).toBe('test-token-123')
+    })
   })
 
   describe('validateSupabaseUser', () => {


### PR DESCRIPTION
Authentication no longer fails when clients send lowercase `bearer` in the Authorization header.

Internal value:
- Restores RFC-compliant token parsing for mixed client implementations.
- Prevents false unauthenticated fallbacks in Supabase user extraction.

---

Expected outcome:
- User impact: API and admin auth paths accept `Bearer` and `bearer` schemes.
- Internal impact: fewer false negatives in JWT extraction logic.

Summary:
Normalize Authorization scheme parsing in `extractTokenFromHeader` to be case-insensitive and token-safe.

Changes:
- Updated `src/auth/utilities/jwtValidation.ts` to parse scheme/token via whitespace split and lowercase scheme check.
- Added regression test in `tests/unit/auth/utilities/jwtValidation.test.ts` for lowercase `bearer`.

Why:
Authorization scheme names are case-insensitive; strict `Bearer` matching rejected valid requests from some clients.

Testing:
- ✅ `pnpm check`
- ✅ `pnpm build`
- ✅ `pnpm format`
- ✅ `pnpm tests --project unit`
- ⚠️ `pnpm tests --project integration` (existing beforeAll hook timeouts in 7 suites; unrelated to this change)
- ✅ `pnpm tests --project storybook`

Related:
- None

Breaking changes:
- None
