### PR TITLE
fix: normalize fractional page params to avoid page 0

### DIFF
--- a/src/utilities/listingComparison/queryState.ts
+++ b/src/utilities/listingComparison/queryState.ts
@@ -104,7 +104,8 @@ export function parseListingComparisonQueryState(
   const priceMaxInput = parseFiniteNumber(parseSingleParam(params, 'priceMax'))
   const budgetInput = parseFiniteNumber(parseSingleParam(params, 'budget'))
 
-  const page = pageInput && pageInput > 0 ? Math.floor(pageInput) : 1
+  const normalizedPage = pageInput !== null ? Math.floor(pageInput) : null
+  const page = normalizedPage !== null && normalizedPage >= 1 ? normalizedPage : 1
   const ratingMin =
     ratingInput === null ? null : clamp(Math.round(ratingInput * 10) / 10, LISTING_COMPARISON_RATING_MIN_DEFAULT, 5)
   const priceMin =

--- a/tests/unit/utilities/listingComparisonQueryState.test.ts
+++ b/tests/unit/utilities/listingComparisonQueryState.test.ts
@@ -78,6 +78,14 @@ describe('parseListingComparisonQueryState', () => {
 
     expect(parsed.state.priceMax).toBe(4200)
   })
+
+  it('normalizes fractional page numbers below 1 to first page', () => {
+    const parsed = parseListingComparisonQueryState({
+      page: '0.5',
+    })
+
+    expect(parsed.state.page).toBe(1)
+  })
 })
 
 describe('buildListingComparisonSearchParams', () => {


### PR DESCRIPTION
## Summary
- fix query parsing so fractional `page` values below 1 (e.g. `0.5`) normalize to page `1`
- add a focused unit test for the regression in listing comparison query parsing

## Why
`parseListingComparisonQueryState` previously used `Math.floor` directly after checking `> 0`, which turned `0.5` into `0` and produced an invalid pagination state.

## Validation
- pnpm tests tests/unit/utilities/listingComparisonQueryState.test.ts
- pnpm check
- pnpm build
- pnpm format
