### PR TITLE
fix: ensure fill media has positioned wrapper

### DIFF
--- a/src/components/molecules/SectionBackground/index.tsx
+++ b/src/components/molecules/SectionBackground/index.tsx
@@ -182,6 +182,7 @@ export const SectionBackground: React.FC<SectionBackgroundProps> = ({
         >
           {media && (
             <Media
+              className="relative h-full w-full"
               fill
               priority={media.priority}
               imgClassName={cn('object-cover', media.imgClassName)}


### PR DESCRIPTION
This fixes a background image rendering bug that could cause visual glitches in sections using full-bleed media.

Internal value:
- Removes noisy Next/Image runtime warnings in Storybook/tests.
- Makes `SectionBackground` media behavior predictable for `fill` images.

---
Expected outcome:
- User impact: Background media in section wrappers consistently fills its container.
- User impact: No invalid `fill` parent positioning warnings for this component path.
- Internal impact: Better signal/noise in UI test logs and Storybook runs.

Summary:
`SectionBackground` passed `fill` to `Media`, but `Media` renders a default wrapper `div` with static positioning. Next/Image requires a positioned parent for `fill`, so rendering produced warnings and could compute incorrect dimensions.

Changes:
- Add `className="relative h-full w-full"` to `Media` in `SectionBackground`.

Screenshots:
- N/A (no visual redesign; behavioral rendering fix in existing component).

Why:
- `fill` images need a positioned parent and explicit size context.
- This is the smallest safe change at the bug origin without broad side effects.

Testing:
- `pnpm tests src/stories/molecules/SectionBackground.stories.tsx`
- `pnpm check`
- `pnpm format`
- `pnpm build` (blocked in this environment by persistent `.next/lock` from an existing build process)
- `detect-secrets-hook --baseline .secrets.baseline` (command unavailable locally; `pnpm dlx` fallback blocked due restricted npm network)

Related:
- None

Breaking changes:
- None
