### PR TITLE
fix(auth): fail fast when supabase service role key is missing

### DIFF
--- a/src/auth/utilities/supaBaseServer.ts
+++ b/src/auth/utilities/supaBaseServer.ts
@@ -37,7 +37,11 @@ export async function createClient() {
 // Create a Supabase admin client for server-side admin operations
 export async function createAdminClient() {
   const { url } = getSupabaseConfig()
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!serviceRoleKey) {
+    throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined')
+  }
 
   return createServerClient(url, serviceRoleKey, {
     cookies: {

--- a/tests/unit/auth/utilities/supaBaseServer.test.ts
+++ b/tests/unit/auth/utilities/supaBaseServer.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const createServerClientMock = vi.fn()
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: createServerClientMock,
+}))
+
+describe('createAdminClient', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+  })
+
+  it('throws a clear error when SUPABASE_SERVICE_ROLE_KEY is missing', async () => {
+    const { createAdminClient } = await import('@/auth/utilities/supaBaseServer')
+
+    await expect(createAdminClient()).rejects.toThrow('SUPABASE_SERVICE_ROLE_KEY is not defined')
+    expect(createServerClientMock).not.toHaveBeenCalled()
+  })
+
+  it('creates the client with SUPABASE_SERVICE_ROLE_KEY when present', async () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key'
+    createServerClientMock.mockReturnValueOnce({ ok: true })
+
+    const { createAdminClient } = await import('@/auth/utilities/supaBaseServer')
+    const client = await createAdminClient()
+
+    expect(client).toEqual({ ok: true })
+    expect(createServerClientMock).toHaveBeenCalledTimes(1)
+    expect(createServerClientMock).toHaveBeenCalledWith(
+      'https://example.supabase.co',
+      'service-role-key',
+      expect.objectContaining({
+        cookies: expect.objectContaining({
+          getAll: expect.any(Function),
+          setAll: expect.any(Function),
+        }),
+      }),
+    )
+  })
+})


### PR DESCRIPTION
This change prevents hidden Supabase admin misconfiguration errors by failing fast with a clear message when the required service-role key is missing.

Internal value:
- Improves operational diagnostics for auth/admin routes.
- Prevents hard-to-debug downstream Supabase client failures.

---

Expected outcome:
- Internal impact: Missing `SUPABASE_SERVICE_ROLE_KEY` now throws `SUPABASE_SERVICE_ROLE_KEY is not defined` immediately.
- Internal impact: Admin client initialization no longer proceeds with an undefined key.
- Internal impact: Regression-safe via focused unit coverage.

Summary:
- Added an explicit runtime guard in `createAdminClient`.
- Added a dedicated unit test for missing and present service-role key paths.

Changes:
- `src/auth/utilities/supaBaseServer.ts`
- `tests/unit/auth/utilities/supaBaseServer.test.ts`

Screenshots:
- N/A (no UI changes)

Why:
- Using a non-null assertion allowed `undefined` to flow into `createServerClient`, surfacing as indirect runtime/auth failures instead of a clear config error.

Testing:
- `pnpm vitest tests/unit/auth/utilities/supaBaseServer.test.ts --run` ✅
- `pnpm check` ✅
- `pnpm format` ✅
- `pnpm build` ⚠️ did not complete in previous restricted run; no functional changes since then.

Related:
- None

Breaking changes:
- No
