### PR TITLE
fix: normalize full-name spacing when name parts are missing

### DIFF
--- a/src/utilities/nameUtils.ts
+++ b/src/utilities/nameUtils.ts
@@ -34,8 +34,9 @@ export const generateFullName = (
   firstName: string | null | undefined,
   lastName: string | null | undefined,
 ): string => {
-  const trimmedTitle = title ? capitalizeFirstLetter(title) : ''
-  const capFirstName = capitalizeFirstLetter(firstName)
-  const capLastName = capitalizeFirstLetter(lastName)
-  return `${trimmedTitle} ${capFirstName} ${capLastName}`.trim()
+  const parts = [title, firstName, lastName]
+    .map((value) => capitalizeFirstLetter(value?.trim()))
+    .filter((value) => value.length > 0)
+
+  return parts.join(' ')
 }

--- a/tests/unit/utilities/nameUtils.test.ts
+++ b/tests/unit/utilities/nameUtils.test.ts
@@ -84,11 +84,9 @@ describe('nameUtils', () => {
     })
 
     it('should work with only last name', () => {
-      // When firstName is null/undefined, capitalizeFirstLetter returns '',
-      // so we get extra spaces that trim handles
-      expect(generateFullName('dr', null, 'doe')).toBe('Dr  Doe')
-      expect(generateFullName('dr', undefined, 'smith')).toBe('Dr  Smith')
-      expect(generateFullName('dr', '', 'johnson')).toBe('Dr  Johnson') // Empty string also returns '', so same behavior
+      expect(generateFullName('dr', null, 'doe')).toBe('Dr Doe')
+      expect(generateFullName('dr', undefined, 'smith')).toBe('Dr Smith')
+      expect(generateFullName('dr', '', 'johnson')).toBe('Dr Johnson')
     })
 
     it('should handle all null/undefined values', () => {
@@ -98,10 +96,9 @@ describe('nameUtils', () => {
     })
 
     it('should trim extra whitespace at the end', () => {
-      // The function trims the final result, so leading/trailing spaces are removed
-      expect(generateFullName('', 'john', 'doe')).toBe('John Doe') // Empty title gets trimmed
-      expect(generateFullName('dr', '', 'doe')).toBe('Dr  Doe') // Empty firstName leaves double space
-      expect(generateFullName('dr', 'john', '')).toBe('Dr John') // Empty lastName gets trimmed
+      expect(generateFullName('', 'john', 'doe')).toBe('John Doe')
+      expect(generateFullName('dr', '', 'doe')).toBe('Dr Doe')
+      expect(generateFullName('dr', 'john', '')).toBe('Dr John')
     })
 
     it('should handle names with spaces and special characters', () => {
@@ -117,9 +114,13 @@ describe('nameUtils', () => {
     })
 
     it('should handle edge cases with mixed null and valid values', () => {
-      expect(generateFullName('dr', null, 'doe')).toBe('Dr  Doe')
-      expect(generateFullName(null, 'john', null)).toBe('John') // Spaces get trimmed
-      expect(generateFullName(null, null, 'doe')).toBe('Doe') // Leading spaces get trimmed
+      expect(generateFullName('dr', null, 'doe')).toBe('Dr Doe')
+      expect(generateFullName(null, 'john', null)).toBe('John')
+      expect(generateFullName(null, null, 'doe')).toBe('Doe')
+    })
+
+    it('should normalize surrounding whitespace in all parts', () => {
+      expect(generateFullName('  dr  ', '  john', 'doe  ')).toBe('Dr John Doe')
     })
 
     it('should capitalize only the first letter of each component', () => {


### PR DESCRIPTION
## Summary
- fix `generateFullName` to join only non-empty name parts
- trim each input part before capitalization to avoid whitespace artifacts
- update unit tests to assert normalized spacing and add a whitespace-normalization case

## Why
The previous implementation produced double spaces like `Dr  Doe` when a middle part was empty, which leaked into UI output and contradicted the function contract.

## Validation
- `pnpm tests tests/unit/utilities/nameUtils.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm format`
