### PR TITLE
fix: fail gracefully for invalid share URLs

### DIFF
--- a/src/utilities/blog/sharePostUrl.ts
+++ b/src/utilities/blog/sharePostUrl.ts
@@ -112,8 +112,16 @@ export const sharePostUrl = async (
 ): Promise<'shared' | 'copied' | 'unavailable' | 'failed' | 'canceled'> => {
   if (!environment) return 'unavailable'
 
-  const resolvedInput = resolveShareInput(input, environment)
-  const sharePayload = buildSharePayload(resolvedInput)
+  let resolvedInput: { url: string; title?: string; description?: string }
+  let sharePayload: SharePayload
+
+  try {
+    resolvedInput = resolveShareInput(input, environment)
+    sharePayload = buildSharePayload(resolvedInput)
+  } catch (error) {
+    environment.logger?.error('Invalid share input:', error)
+    return 'failed'
+  }
 
   if (environment.share) {
     try {

--- a/tests/unit/utilities/sharePostUrl.test.ts
+++ b/tests/unit/utilities/sharePostUrl.test.ts
@@ -133,4 +133,16 @@ describe('sharePostUrl', () => {
     await expect(sharePostUrl('/posts/example', environment)).resolves.toBe('canceled')
     expect(logger.error).not.toHaveBeenCalled()
   })
+
+  it('returns failed and logs when share input URL is invalid', async () => {
+    const logger = { error: vi.fn() }
+    const environment = createEnvironment({
+      share: undefined,
+      clipboard: { writeText: vi.fn(async () => {}) },
+      logger,
+    })
+
+    await expect(sharePostUrl({ url: 'https://[invalid-url' }, environment)).resolves.toBe('failed')
+    expect(logger.error).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## User impact
Sharing a post no longer crashes when malformed URL input is passed to the share utility.

## What was fixed
- Guard URL normalization in `sharePostUrl` with `try/catch`
- Return `failed` instead of throwing on invalid URL input
- Keep explicit logging (`Invalid share input`) for debugging
- Add regression test for malformed URL input

## Why this fix
`new URL(...)` can throw synchronously for malformed input. Without a guard, this bypasses the intended status-based flow (`shared` / `copied` / `failed`) and creates a runtime crash path.

## Validation notes
I could not run local test/check/build/format in the prior run because DNS access to npm registry was unavailable in that environment.
