### PR TITLE
fix(auth): prevent crash on malformed user_type

### DIFF
--- a/src/features/previewGuard/index.ts
+++ b/src/features/previewGuard/index.ts
@@ -38,7 +38,8 @@ export const isPreviewGuardExemptPath = (pathname: string): boolean =>
   PREVIEW_GUARD_EXEMPT_PATHS.has(normalizePathname(pathname))
 
 export const isAllowedPreviewUser = (user: UserTypeCarrier): boolean => {
-  return user?.app_metadata?.user_type?.trim().toLowerCase() === 'platform'
+  const userType = user?.app_metadata?.user_type
+  return typeof userType === 'string' && userType.trim().toLowerCase() === 'platform'
 }
 
 export const buildPreviewGuardLoginRedirect = (url: URL): string => {

--- a/tests/unit/features/previewGuard/index.test.ts
+++ b/tests/unit/features/previewGuard/index.test.ts
@@ -107,6 +107,14 @@ describe('previewGuard feature', () => {
     expect(isAllowedPreviewUser(null)).toBe(false)
   })
 
+  it('returns false for malformed user_type values without throwing', () => {
+    const malformedUser = {
+      app_metadata: { user_type: 42 },
+    } as unknown as Pick<User, 'app_metadata'>
+
+    expect(isAllowedPreviewUser(malformedUser)).toBe(false)
+  })
+
   it('builds preview guard login redirect with message and next path', () => {
     const redirectPath = buildPreviewGuardLoginRedirect(new URL('https://example.com/posts/a?foo=bar'))
     const url = new URL(redirectPath, 'https://example.com')


### PR DESCRIPTION
users can no longer hit a preview-login crash when account metadata is malformed.

## What changed
- guard isAllowedPreviewUser against non-string app_metadata.user_type
- keep strict platform check using normalized string values
- add regression test for malformed numeric user_type

## Validation
- pnpm tests tests/unit/features/previewGuard/index.test.ts (pass)
- pnpm build (pass)
- pnpm format (pass)
- pnpm check (fails due pre-existing unrelated TypeScript errors in tests/integration/access/*)
