### PR TITLE
fix(admin): use transparent favicon

### DIFF
--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -85,16 +85,8 @@ export default buildConfig({
       icons: [
         {
           rel: 'icon',
-          type: 'image/png',
-          sizes: '32x32',
-          url: '/fmd-icon-1-dark.png?v=20260313',
-        },
-        {
-          rel: 'icon',
-          type: 'image/png',
-          sizes: '32x32',
-          media: '(prefers-color-scheme: dark)',
-          url: '/fmd-icon-1-white.png?v=20260313',
+          type: 'image/svg+xml',
+          url: '/favicon.svg?v=20260319',
         },
       ],
     },


### PR DESCRIPTION
User-facing impact: the admin browser tab icon no longer shows a white box behind the brand mark.

This switches the Payload admin favicon to the transparent SVG asset so the tab icon blends into the browser chrome and matches the light-only admin branding.

Validation:
- pnpm format
- pnpm build

Screenshots:
- Admin login: playwright-report/admin-favicon/admin-login-svg.png
- Admin app shell: playwright-report/admin-favicon/admin-page.png