### PR TITLE
refactor(collections): extract shared media scaffolding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,13 @@
 - When sharing screenshots in chat responses, embed them inline as Markdown images using absolute filesystem paths; avoid plain linked file paths unless explicitly requested.
 - Install hooks once with `pnpm hooks:install` to enable the pre-push AI-slop gate.
 
+## External Service Access
+
+- For GitHub, Vercel, and Supabase tasks in this repository, use the native CLI first: `gh`, `vercel`, `supabase`.
+- For Vercel, use `findmydoc-portal` as the project name when the CLI needs an explicit project reference.
+- Do not use Playwright, browser-based login flows, or MCP as authentication workarounds for those services.
+- If CLI access or authentication is unavailable, stop and report the required setup instead of trying alternative login methods.
+
 ## Payload Migration Workflow
 
 - Run Payload migration commands only when schema or data-model code changes.

--- a/src/collections/ClinicGalleryMedia/index.ts
+++ b/src/collections/ClinicGalleryMedia/index.ts
@@ -12,6 +12,15 @@ import { beforeChangeCreatedBy } from '@/hooks/createdBy'
 import { beforeChangeComputeStorage } from '@/hooks/media/computeStorage'
 import { beforeChangePublishedAt } from '@/hooks/publishedAt'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
+import {
+  buildMediaAltField,
+  buildMediaCaptionField,
+  buildMediaCreatedByField,
+  buildMediaPrefixField,
+  buildMediaStoragePathField,
+  buildMediaUploadConfig,
+  galleryMediaImageMimeTypes,
+} from '@/collections/common/mediaCollection'
 
 const STORAGE_KEY_PREFIX = 'cgmedia'
 
@@ -22,8 +31,6 @@ const generateStorageKey = (): string => {
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-
-const imageMimeTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/avif', 'image/gif']
 
 export const ClinicGalleryMedia: CollectionConfig = {
   slug: 'clinicGalleryMedia',
@@ -71,23 +78,14 @@ export const ClinicGalleryMedia: CollectionConfig = {
     ],
   },
   fields: [
-    {
-      name: 'alt',
+    buildMediaAltField({
       label: 'Alt Text',
-      type: 'text',
-      required: true,
-      admin: {
-        description: 'Screen-reader alternative text',
-      },
-    },
-    {
+    }),
+    buildMediaCaptionField({
       name: 'description',
       label: 'Description',
-      type: 'richText',
-      admin: {
-        description: 'Optional context displayed with the media asset',
-      },
-    },
+      description: 'Optional context displayed with the media asset',
+    }),
     {
       name: 'clinic',
       label: 'Clinic',
@@ -125,19 +123,12 @@ export const ClinicGalleryMedia: CollectionConfig = {
         position: 'sidebar',
       },
     },
-    {
-      name: 'createdBy',
-      label: 'Created By',
-      type: 'relationship',
+    buildMediaCreatedByField({
       relationTo: 'basicUsers',
-      required: true,
-      admin: {
-        description: 'Who performed the upload (auto-set)',
-        readOnly: true,
-        position: 'sidebar',
-        condition: () => false,
-      },
-    },
+      label: 'Created By',
+      readOnly: true,
+      position: 'sidebar',
+    }),
     {
       name: 'storageKey',
       label: 'Storage Key',
@@ -150,45 +141,15 @@ export const ClinicGalleryMedia: CollectionConfig = {
         hidden: true,
       },
     },
-    {
-      name: 'storagePath',
+    buildMediaStoragePathField({
       label: 'Storage Path',
-      type: 'text',
-      required: true,
-      admin: {
-        description: 'Resolved storage path used in storage',
-        readOnly: true,
-        hidden: true,
-      },
-    },
-    {
-      name: 'prefix',
+    }),
+    buildMediaPrefixField({
       label: 'Storage Prefix',
-      type: 'text',
-      admin: {
-        hidden: true,
-        readOnly: true,
-        description: 'S3 storage prefix (managed by plugin)',
-      },
-      access: {
-        read: () => true,
-        update: () => false,
-      },
-    },
+    }),
   ],
-  upload: {
+  upload: buildMediaUploadConfig({
     staticDir: path.resolve(dirname, '../../public/clinic-gallery-media'),
-    adminThumbnail: 'thumbnail',
-    focalPoint: true,
-    mimeTypes: imageMimeTypes,
-    imageSizes: [
-      { name: 'thumbnail', width: 300 },
-      { name: 'square', width: 500, height: 500 },
-      { name: 'small', width: 600 },
-      { name: 'medium', width: 900 },
-      { name: 'large', width: 1400 },
-      { name: 'xlarge', width: 1920 },
-      { name: 'og', width: 1200, height: 630, crop: 'center' },
-    ],
-  },
+    mimeTypes: galleryMediaImageMimeTypes,
+  }),
 }

--- a/src/collections/ClinicMedia/index.ts
+++ b/src/collections/ClinicMedia/index.ts
@@ -10,11 +10,17 @@ import { beforeChangeCreatedBy } from '@/hooks/createdBy'
 import { beforeChangeComputeStorage } from '@/hooks/media/computeStorage'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
 import { stableIdBeforeChangeHook, stableIdField } from '@/collections/common/stableIdField'
+import {
+  buildMediaAltField,
+  buildMediaCaptionField,
+  buildMediaCreatedByField,
+  buildMediaPrefixField,
+  buildMediaStoragePathField,
+  buildMediaUploadConfig,
+} from '@/collections/common/mediaCollection'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-
-const imageMimeTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/avif', 'image/gif', 'image/svg+xml']
 
 export const ClinicMedia: CollectionConfig = {
   slug: 'clinicMedia',
@@ -55,18 +61,8 @@ export const ClinicMedia: CollectionConfig = {
   },
   fields: [
     stableIdField(),
-    {
-      name: 'alt',
-      type: 'text',
-      required: true,
-      admin: { description: 'Screen-reader alternative text' },
-    },
-    {
-      name: 'caption',
-      type: 'richText',
-      required: false,
-      admin: { description: 'Optional caption displayed with the media' },
-    },
+    buildMediaAltField(),
+    buildMediaCaptionField(),
     {
       name: 'clinic',
       type: 'relationship',
@@ -79,49 +75,13 @@ export const ClinicMedia: CollectionConfig = {
           !(user && user.collection === 'basicUsers' && user.userType === 'clinic'),
       },
     },
-    {
-      name: 'createdBy',
-      type: 'relationship',
+    buildMediaCreatedByField({
       relationTo: 'basicUsers',
-      required: true,
-      admin: {
-        description: 'Who performed the upload (auto-set)',
-        condition: () => false,
-      },
-    },
-    {
-      name: 'storagePath',
-      type: 'text',
-      required: true,
-      admin: { description: 'Resolved storage path used in storage', readOnly: true, hidden: true },
-    },
-    {
-      name: 'prefix',
-      type: 'text',
-      admin: {
-        hidden: true,
-        readOnly: true,
-        description: 'S3 storage prefix (managed by plugin)',
-      },
-      access: {
-        read: () => true,
-        update: () => false,
-      },
-    },
+    }),
+    buildMediaStoragePathField(),
+    buildMediaPrefixField(),
   ],
-  upload: {
+  upload: buildMediaUploadConfig({
     staticDir: path.resolve(dirname, '../../public/clinic-media'),
-    adminThumbnail: 'thumbnail',
-    focalPoint: true,
-    mimeTypes: imageMimeTypes,
-    imageSizes: [
-      { name: 'thumbnail', width: 300 },
-      { name: 'square', width: 500, height: 500 },
-      { name: 'small', width: 600 },
-      { name: 'medium', width: 900 },
-      { name: 'large', width: 1400 },
-      { name: 'xlarge', width: 1920 },
-      { name: 'og', width: 1200, height: 630, crop: 'center' },
-    ],
-  },
+  }),
 }

--- a/src/collections/DoctorMedia/index.ts
+++ b/src/collections/DoctorMedia/index.ts
@@ -11,11 +11,17 @@ import { extractRelationId } from '@/collections/common/mediaPathHelpers'
 import { beforeChangeDoctorMedia } from './hooks/beforeChangeDoctorMedia'
 import type { DoctorMedia as DoctorMediaType } from '@/payload-types'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
+import {
+  buildMediaAltField,
+  buildMediaCaptionField,
+  buildMediaCreatedByField,
+  buildMediaPrefixField,
+  buildMediaStoragePathField,
+  buildMediaUploadConfig,
+} from '@/collections/common/mediaCollection'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-
-const imageMimeTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/avif', 'image/gif', 'image/svg+xml']
 
 export const DoctorMedia: CollectionConfig = {
   slug: 'doctorMedia',
@@ -65,18 +71,8 @@ export const DoctorMedia: CollectionConfig = {
     ],
   },
   fields: [
-    {
-      name: 'alt',
-      type: 'text',
-      required: true,
-      admin: { description: 'Screen-reader alternative text' },
-    },
-    {
-      name: 'caption',
-      type: 'richText',
-      required: false,
-      admin: { description: 'Optional caption displayed with the media' },
-    },
+    buildMediaAltField(),
+    buildMediaCaptionField(),
     {
       name: 'doctor',
       type: 'relationship',
@@ -93,49 +89,13 @@ export const DoctorMedia: CollectionConfig = {
       index: true,
       admin: { description: 'Clinic derived from the doctor', readOnly: true },
     },
-    {
-      name: 'createdBy',
-      type: 'relationship',
+    buildMediaCreatedByField({
       relationTo: 'basicUsers',
-      required: true,
-      admin: {
-        description: 'Who performed the upload (auto-set)',
-        condition: () => false,
-      },
-    },
-    {
-      name: 'storagePath',
-      type: 'text',
-      required: true,
-      admin: { description: 'Resolved storage path used in storage', readOnly: true, hidden: true },
-    },
-    {
-      name: 'prefix',
-      type: 'text',
-      admin: {
-        hidden: true,
-        readOnly: true,
-        description: 'S3 storage prefix (managed by plugin)',
-      },
-      access: {
-        read: () => true,
-        update: () => false,
-      },
-    },
+    }),
+    buildMediaStoragePathField(),
+    buildMediaPrefixField(),
   ],
-  upload: {
+  upload: buildMediaUploadConfig({
     staticDir: path.resolve(dirname, '../../public/doctor-media'),
-    adminThumbnail: 'thumbnail',
-    focalPoint: true,
-    mimeTypes: imageMimeTypes,
-    imageSizes: [
-      { name: 'thumbnail', width: 300 },
-      { name: 'square', width: 500, height: 500 },
-      { name: 'small', width: 600 },
-      { name: 'medium', width: 900 },
-      { name: 'large', width: 1400 },
-      { name: 'xlarge', width: 1920 },
-      { name: 'og', width: 1200, height: 630, crop: 'center' },
-    ],
-  },
+  }),
 }

--- a/src/collections/PlatformContentMedia/index.ts
+++ b/src/collections/PlatformContentMedia/index.ts
@@ -6,12 +6,18 @@ import { anyone } from '@/access/anyone'
 import { isPlatformBasicUser } from '@/access/isPlatformBasicUser'
 import { beforeChangePlatformContentMedia } from './hooks/beforeChangePlatformContentMedia'
 import { stableIdBeforeChangeHook, stableIdField } from '@/collections/common/stableIdField'
+import {
+  buildMediaAltField,
+  buildMediaCaptionField,
+  buildMediaCreatedByField,
+  buildMediaPrefixField,
+  buildMediaStoragePathField,
+  buildMediaUploadConfig,
+} from '@/collections/common/mediaCollection'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-
-const imageMimeTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/avif', 'image/gif', 'image/svg+xml']
 
 export const PlatformContentMedia: CollectionConfig = {
   slug: 'platformContentMedia',
@@ -38,61 +44,15 @@ export const PlatformContentMedia: CollectionConfig = {
   },
   fields: [
     stableIdField(),
-    {
-      name: 'alt',
-      type: 'text',
-      required: true,
-      admin: { description: 'Screen-reader alternative text' },
-    },
-    {
-      name: 'caption',
-      type: 'richText',
-      required: false,
-      admin: { description: 'Optional caption displayed with the media' },
-    },
-    {
-      name: 'createdBy',
-      type: 'relationship',
+    buildMediaAltField(),
+    buildMediaCaptionField(),
+    buildMediaCreatedByField({
       relationTo: 'basicUsers',
-      required: true,
-      admin: {
-        description: 'Who performed the upload (auto-set)',
-        condition: () => false,
-      },
-    },
-    {
-      name: 'storagePath',
-      type: 'text',
-      required: true,
-      admin: { description: 'Resolved storage path used in storage', readOnly: true, hidden: true },
-    },
-    {
-      name: 'prefix',
-      type: 'text',
-      admin: {
-        hidden: true,
-        readOnly: true,
-        description: 'S3 storage prefix (managed by plugin)',
-      },
-      access: {
-        read: () => true,
-        update: () => false,
-      },
-    },
+    }),
+    buildMediaStoragePathField(),
+    buildMediaPrefixField(),
   ],
-  upload: {
+  upload: buildMediaUploadConfig({
     staticDir: path.resolve(dirname, '../../public/platform-media'),
-    adminThumbnail: 'thumbnail',
-    focalPoint: true,
-    mimeTypes: imageMimeTypes,
-    imageSizes: [
-      { name: 'thumbnail', width: 300 },
-      { name: 'square', width: 500, height: 500 },
-      { name: 'small', width: 600 },
-      { name: 'medium', width: 900 },
-      { name: 'large', width: 1400 },
-      { name: 'xlarge', width: 1920 },
-      { name: 'og', width: 1200, height: 630, crop: 'center' },
-    ],
-  },
+  }),
 }

--- a/src/collections/UserProfileMedia/index.ts
+++ b/src/collections/UserProfileMedia/index.ts
@@ -8,11 +8,15 @@ import { beforeChangeComputeStorage } from '@/hooks/media/computeStorage'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
 import { beforeChangeFreezeRelation } from '@/hooks/ownership'
 import type { UserProfileMedia as UserProfileMediaType } from '@/payload-types'
+import {
+  buildMediaCreatedByField,
+  buildMediaPrefixField,
+  buildMediaStoragePathField,
+  buildMediaUploadConfig,
+} from '@/collections/common/mediaCollection'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
-
-const imageMimeTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/avif', 'image/gif', 'image/svg+xml']
 
 const normalizeUserId = (value: unknown): number | null => {
   if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) return value
@@ -211,49 +215,13 @@ export const UserProfileMedia: CollectionConfig = {
       },
       admin: { description: 'Owning user (clinic staff or patient)' },
     },
-    {
-      name: 'createdBy',
-      type: 'relationship',
+    buildMediaCreatedByField({
       relationTo: ['basicUsers', 'patients'],
-      required: true,
-      admin: {
-        description: 'Who performed the upload (auto-set)',
-        condition: () => false,
-      },
-    },
-    {
-      name: 'storagePath',
-      type: 'text',
-      required: true,
-      admin: { description: 'Resolved storage path used in storage', readOnly: true, hidden: true },
-    },
-    {
-      name: 'prefix',
-      type: 'text',
-      admin: {
-        hidden: true,
-        readOnly: true,
-        description: 'S3 storage prefix (managed by plugin)',
-      },
-      access: {
-        read: () => true,
-        update: () => false,
-      },
-    },
+    }),
+    buildMediaStoragePathField(),
+    buildMediaPrefixField(),
   ],
-  upload: {
+  upload: buildMediaUploadConfig({
     staticDir: path.resolve(dirname, '../../public/user-profile-media'),
-    adminThumbnail: 'thumbnail',
-    focalPoint: true,
-    mimeTypes: imageMimeTypes,
-    imageSizes: [
-      { name: 'thumbnail', width: 300 },
-      { name: 'square', width: 500, height: 500 },
-      { name: 'small', width: 600 },
-      { name: 'medium', width: 900 },
-      { name: 'large', width: 1400 },
-      { name: 'xlarge', width: 1920 },
-      { name: 'og', width: 1200, height: 630, crop: 'center' },
-    ],
-  },
+  }),
 }

--- a/src/collections/common/mediaCollection.ts
+++ b/src/collections/common/mediaCollection.ts
@@ -1,0 +1,148 @@
+import type { CollectionSlug, Field } from 'payload'
+
+type MediaUploadImageSize = {
+  crop?: 'center'
+  height?: number
+  name: string
+  width: number
+}
+
+export type MediaUploadConfig = {
+  adminThumbnail: string
+  focalPoint: boolean
+  imageSizes: MediaUploadImageSize[]
+  mimeTypes: string[]
+  staticDir: string
+}
+
+export const standardMediaImageMimeTypes = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/avif',
+  'image/gif',
+  'image/svg+xml',
+]
+
+export const galleryMediaImageMimeTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/avif', 'image/gif']
+
+export const standardMediaImageSizes: MediaUploadImageSize[] = [
+  { name: 'thumbnail', width: 300 },
+  { name: 'square', width: 500, height: 500 },
+  { name: 'small', width: 600 },
+  { name: 'medium', width: 900 },
+  { name: 'large', width: 1400 },
+  { name: 'xlarge', width: 1920 },
+  { name: 'og', width: 1200, height: 630, crop: 'center' },
+]
+
+export function buildMediaUploadConfig(options: {
+  staticDir: string
+  mimeTypes?: string[]
+  adminThumbnail?: string
+  focalPoint?: boolean
+  imageSizes?: MediaUploadImageSize[]
+}): MediaUploadConfig {
+  return {
+    staticDir: options.staticDir,
+    adminThumbnail: options.adminThumbnail ?? 'thumbnail',
+    focalPoint: options.focalPoint ?? true,
+    mimeTypes: options.mimeTypes ?? standardMediaImageMimeTypes,
+    imageSizes: options.imageSizes ?? standardMediaImageSizes,
+  }
+}
+
+export function buildMediaAltField(options?: { label?: string; description?: string }): Field {
+  return {
+    ...(options?.label ? { label: options.label } : {}),
+    name: 'alt',
+    type: 'text',
+    required: true,
+    admin: {
+      description: options?.description ?? 'Screen-reader alternative text',
+    },
+  }
+}
+
+export function buildMediaCaptionField(options?: { name?: string; label?: string; description?: string }): Field {
+  return {
+    ...(options?.label ? { label: options.label } : {}),
+    name: options?.name ?? 'caption',
+    type: 'richText',
+    required: false,
+    admin: {
+      description: options?.description ?? 'Optional caption displayed with the media',
+    },
+  }
+}
+
+export function buildMediaCreatedByField(options: {
+  relationTo: CollectionSlug
+  label?: string
+  description?: string
+  readOnly?: boolean
+  hidden?: boolean
+  position?: 'sidebar'
+}): Field
+export function buildMediaCreatedByField(options: {
+  relationTo: CollectionSlug[]
+  label?: string
+  description?: string
+  readOnly?: boolean
+  hidden?: boolean
+  position?: 'sidebar'
+}): Field
+export function buildMediaCreatedByField(options: {
+  relationTo: CollectionSlug | CollectionSlug[]
+  label?: string
+  description?: string
+  readOnly?: boolean
+  hidden?: boolean
+  position?: 'sidebar'
+}): Field {
+  return {
+    ...(options.label ? { label: options.label } : {}),
+    name: 'createdBy',
+    type: 'relationship',
+    relationTo: options.relationTo,
+    required: true,
+    admin: {
+      description: options.description ?? 'Who performed the upload (auto-set)',
+      ...(options.readOnly !== undefined ? { readOnly: options.readOnly } : {}),
+      ...(options.hidden !== undefined ? { hidden: options.hidden } : {}),
+      ...(options.position ? { position: options.position } : {}),
+      condition: () => false,
+    },
+  } as Field
+}
+
+export function buildMediaStoragePathField(options?: { label?: string; description?: string }): Field {
+  return {
+    ...(options?.label ? { label: options.label } : {}),
+    name: 'storagePath',
+    type: 'text',
+    required: true,
+    admin: {
+      description: options?.description ?? 'Resolved storage path used in storage',
+      readOnly: true,
+      hidden: true,
+    },
+  }
+}
+
+export function buildMediaPrefixField(options?: { label?: string; description?: string }): Field {
+  return {
+    ...(options?.label ? { label: options.label } : {}),
+    name: 'prefix',
+    type: 'text',
+    admin: {
+      hidden: true,
+      readOnly: true,
+      description: options?.description ?? 'S3 storage prefix (managed by plugin)',
+    },
+    access: {
+      read: () => true,
+      update: () => false,
+    },
+  }
+}


### PR DESCRIPTION
This reduces duplicate media collection boilerplate without changing domain logic.

## What changed
- extracted shared media upload and field helpers into `src/collections/common/mediaCollection.ts`
- updated `ClinicMedia`, `DoctorMedia`, `PlatformContentMedia`, `ClinicGalleryMedia`, and `UserProfileMedia` to use the shared helpers
- kept collection-specific access, hooks, and ownership logic local

## Development
- closes #676

## Validation
- `pnpm format`
- `pnpm check`
- `PAYLOAD_SECRET=dev-secret pnpm build`
