### PR TITLE
ci: add sticky coverage comment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -469,7 +469,7 @@ jobs:
 
       - name: Comment combined coverage on PR
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: combined-coverage-summary
           message: ${{ steps.combined_coverage_comment.outputs.message }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -410,6 +410,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -444,6 +446,33 @@ jobs:
           else
             echo "Combined coverage summary not available." >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - name: Prepare combined coverage PR comment
+        id: combined_coverage_comment
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ -f coverage/combined/summary.md ]; then
+            {
+              echo 'message<<EOF'
+              cat coverage/combined/summary.md
+              echo EOF
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo 'message<<EOF'
+              echo '# Combined Coverage Summary'
+              echo
+              echo 'Combined coverage summary not available.'
+              echo EOF
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment combined coverage on PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: combined-coverage-summary
+          message: ${{ steps.combined_coverage_comment.outputs.message }}
 
   Deploy-Preview:
     name: Deploy Preview


### PR DESCRIPTION
The combined coverage summary is now visible as a sticky PR comment on PR runs.

## What changed
- Added a sticky pull request comment step to the combined coverage job.
- Reused `coverage/combined/summary.md` as the comment body.
- Granted the job `issues: write` and `pull-requests: write` so the comment can be updated.

## Validation
- `pnpm format`
- `pnpm check`
