### PR TITLE
fix(search): reject malformed budget values to prevent unintended matches

### DIFF
--- a/src/utilities/buildSearchWhere.ts
+++ b/src/utilities/buildSearchWhere.ts
@@ -81,7 +81,8 @@ export const buildSearchWhere = async ({
   }
 
   if (filters.budget && filters.budget.trim().length > 0) {
-    const parsedBudget = Number.parseInt(filters.budget, 10)
+    const trimmedBudget = filters.budget.trim()
+    const parsedBudget = /^\d+$/.test(trimmedBudget) ? Number.parseInt(trimmedBudget, 10) : Number.NaN
 
     if (Number.isFinite(parsedBudget)) {
       conditions.push({

--- a/tests/unit/utilities/buildSearchWhere.test.ts
+++ b/tests/unit/utilities/buildSearchWhere.test.ts
@@ -98,4 +98,18 @@ describe('buildSearchWhere', () => {
     // Should fall back to just the base condition when extra filters are unusable
     expect(result).toEqual(baseCondition)
   })
+
+  it('ignores partially numeric budget values instead of parsing a prefix', async () => {
+    const payload = { find: vi.fn() } as unknown as Payload
+
+    const result = await buildSearchWhere({
+      payload,
+      filters: {
+        budget: '5000abc',
+      },
+    })
+
+    expect(result).toEqual(baseCondition)
+    expect(payload.find).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
prevents malformed budget query strings from unintentionally widening clinic search results.

## What changed
- reject partially numeric `budget` values (for example `5000abc`) in `buildSearchWhere` instead of parsing a numeric prefix
- keep valid numeric budgets unchanged and continue applying the existing min/max price filter
- add a regression test covering partially numeric budget input to ensure invalid values are ignored

## Validation
- `pnpm check` *(fails locally: `cross-env: command not found`, `node_modules` missing)*
- `pnpm format` *(fails locally: `prettier: command not found`, `node_modules` missing)*
