### PR TITLE
fix(ci): filter post-release issue comments

### DIFF
--- a/.github/scripts/post-release-issue-commenter.cjs
+++ b/.github/scripts/post-release-issue-commenter.cjs
@@ -1,0 +1,40 @@
+/**
+ * Post-release issue commenter helpers.
+ *
+ * The workflow should only comment on issues that were actually completed
+ * in the release window. GitHub's `state_reason` gives us the explicit
+ * closure reason so we can exclude `not_planned`, `duplicate`, and similar
+ * closures.
+ */
+
+function isEligibleClosedIssueForRelease({ issue, previousReleaseDate, releaseDate }) {
+  if (!issue || issue.pull_request || !issue.closed_at) {
+    return false
+  }
+
+  if (issue.state_reason !== 'completed') {
+    return false
+  }
+
+  const closedAt = new Date(issue.closed_at)
+  if (Number.isNaN(closedAt.getTime())) {
+    return false
+  }
+
+  return closedAt >= previousReleaseDate && closedAt <= releaseDate
+}
+
+function filterEligibleClosedIssuesForRelease(issues, { previousReleaseDate, releaseDate }) {
+  return issues.filter((issue) =>
+    isEligibleClosedIssueForRelease({
+      issue,
+      previousReleaseDate,
+      releaseDate,
+    }),
+  )
+}
+
+module.exports = {
+  filterEligibleClosedIssuesForRelease,
+  isEligibleClosedIssueForRelease,
+}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment on issues included in release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const {
+              filterEligibleClosedIssuesForRelease,
+            } = require('./.github/scripts/post-release-issue-commenter.cjs');
+
             const releaseTag = context.payload.release.tag_name;
             const releaseUrl = context.payload.release.html_url;
             const releaseDate = new Date(context.payload.release.published_at);
@@ -55,13 +59,9 @@ jobs:
 
             console.log(`Found ${issues.data.length} closed issues since ${previousReleaseDate}`);
 
-            const closedIssues = issues.data.filter(issue => {
-              // Filter out pull requests and issues closed before the previous release
-              const closedAt = new Date(issue.closed_at);
-              return !issue.pull_request && 
-                     issue.closed_at && 
-                     closedAt >= previousReleaseDate && 
-                     closedAt <= releaseDate;
+            const closedIssues = filterEligibleClosedIssuesForRelease(issues.data, {
+              previousReleaseDate,
+              releaseDate,
             });
 
             console.log(`Found ${closedIssues.length} issues to comment on`);

--- a/tests/unit/scripts/post-release-issue-commenter.test.ts
+++ b/tests/unit/scripts/post-release-issue-commenter.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  filterEligibleClosedIssuesForRelease,
+  isEligibleClosedIssueForRelease,
+} from '../../../.github/scripts/post-release-issue-commenter.cjs'
+
+type GitHubIssueLike = {
+  number: number
+  title: string
+  closed_at: string
+  state_reason?: string | null
+  pull_request?: { url: string }
+}
+
+function createIssue(overrides: Partial<GitHubIssueLike> = {}): GitHubIssueLike {
+  return {
+    number: 42,
+    title: 'Example issue',
+    closed_at: '2026-04-05T12:00:00.000Z',
+    state_reason: 'completed',
+    ...overrides,
+  }
+}
+
+describe('post-release issue commenter', () => {
+  const previousReleaseDate = new Date('2026-04-01T00:00:00.000Z')
+  const releaseDate = new Date('2026-04-10T00:00:00.000Z')
+
+  it('accepts completed issues within the release window', () => {
+    const issue = createIssue()
+
+    expect(
+      isEligibleClosedIssueForRelease({
+        issue,
+        previousReleaseDate,
+        releaseDate,
+      }),
+    ).toBe(true)
+  })
+
+  it.each([
+    ['not_planned', false],
+    ['duplicate', false],
+    [undefined, false],
+  ])('rejects issues with state_reason %s', (stateReason, expected) => {
+    const issue = createIssue({ state_reason: stateReason })
+
+    expect(
+      isEligibleClosedIssueForRelease({
+        issue,
+        previousReleaseDate,
+        releaseDate,
+      }),
+    ).toBe(expected)
+  })
+
+  it('rejects pull requests even if they were completed', () => {
+    const issue = createIssue({
+      pull_request: { url: 'https://example.com/pull/1' },
+    })
+
+    expect(
+      isEligibleClosedIssueForRelease({
+        issue,
+        previousReleaseDate,
+        releaseDate,
+      }),
+    ).toBe(false)
+  })
+
+  it('rejects issues closed outside the release window', () => {
+    const issue = createIssue({ closed_at: '2026-04-11T00:00:00.000Z' })
+
+    expect(
+      isEligibleClosedIssueForRelease({
+        issue,
+        previousReleaseDate,
+        releaseDate,
+      }),
+    ).toBe(false)
+  })
+
+  it('filters only eligible issues from the release batch', () => {
+    const issues: GitHubIssueLike[] = [
+      createIssue({ number: 1 }),
+      createIssue({ number: 2, state_reason: 'not_planned' }),
+      createIssue({ number: 3, pull_request: { url: 'https://example.com/pull/3' } }),
+      createIssue({ number: 4, closed_at: '2026-04-11T00:00:00.000Z' }),
+    ]
+
+    const eligibleIssues: GitHubIssueLike[] = filterEligibleClosedIssuesForRelease(issues, {
+      previousReleaseDate,
+      releaseDate,
+    })
+
+    expect(eligibleIssues.map((issue) => issue.number)).toEqual([1])
+  })
+})


### PR DESCRIPTION
This prevents the post-release job from commenting on closed issues that were not actually completed.

## What changed
- Added a small helper for the post-release issue filter.
- Limited release comments to issues with `state_reason === 'completed'`.
- Kept pull requests and the release time window checks intact.
- Added unit coverage for completed, not planned, duplicate, PR, and out-of-window cases.

## Validation
- `pnpm format`
- `pnpm vitest tests/unit/scripts/post-release-issue-commenter.test.ts`
- `pnpm check`
