### PR TITLE
test: trigger storybook advisory failure

### DIFF
--- a/src/stories/organisms/Banner.stories.tsx
+++ b/src/stories/organisms/Banner.stories.tsx
@@ -39,7 +39,7 @@ export const Success: Story = {
     const message = canvas.getByText('Your appointment has been successfully booked!')
 
     await expect(message).toBeInTheDocument()
-    await expect(message.closest('div')).toHaveClass('border-success', 'bg-success/30', 'text-success')
+    await expect(message.closest('div')).toHaveClass('border-error', 'bg-error/30', 'text-error')
   },
 }
 


### PR DESCRIPTION
verifies that a Storybook-only failure does not need to block merges after the CI split.

## What changed
- intentionally changed one Storybook expectation in `src/stories/organisms/Banner.stories.tsx` so the `Storybook Tests` job should fail
- left application code and workflow configuration untouched to isolate the advisory-check behavior

## Validation
- `pnpm format`
- `pnpm check` currently fails on `main` because `@playwright/test` types are missing from the existing checkout; that issue is unrelated to this throwaway Storybook-only probe
