### PR TITLE
test(integration): add collection contract gate wave 1

### DIFF
--- a/docs/testing/setup.md
+++ b/docs/testing/setup.md
@@ -50,6 +50,20 @@ pnpm tests --watch           # iterative feedback
 
 Use `pnpm tests --inspect-brk` for debugging with breakpoints.
 
+## Collection Contract Gate
+
+Integration coverage for collections is tracked via `tests/integration/contracts/collectionContractRegistry.ts`.
+
+- The hard gate test `tests/integration/contracts/collectionContractCoverage.test.ts` compares real slugs from `src/collections/**` against the registry.
+- It also verifies every registry entry points to real integration test files.
+- New collections must be added to the registry in the same change set as their baseline integration test.
+
+Recommended focused run while iterating on this gate:
+
+```bash
+pnpm vitest --project integration --run tests/integration/contracts/collectionContractCoverage.test.ts
+```
+
 ## Global Infrastructure
 
 `tests/setup/integrationGlobalSetup.ts` controls the database lifecycle:
@@ -88,3 +102,5 @@ The Playwright lane uses the same Docker + migration harness via `scripts/test-d
 ## Follow-up
 
 After the first Playwright rollout lands, the next infrastructure improvement should target DB reset speed. The current path still performs full container teardown plus `migrate:fresh`; the follow-up should evaluate a faster run reset or a snapshot/template database approach once the new E2E lane is stable.
+
+After this collection-contract rollout, keep that DB-reset optimization as the next technical step for both integration and E2E runtime. Do not bundle it into the same change set as contract coverage work.

--- a/docs/testing/strategy.md
+++ b/docs/testing/strategy.md
@@ -25,6 +25,25 @@ This page explains what we expect from the test suite and how it mirrors the per
 - **Unit** (`tests/unit`): Fast, focused suites that mock external calls. This includes access helpers, collection configs (via the permission matrix helpers), hooks, and auth utilities.
 - **Integration** (`tests/integration`): Real Payload requests against the Docker-backed Postgres instance using the fixture helpers. Use when a behaviour depends on multiple collections or Supabase interactions.
 - **Setup scripts** (`tests/setup`): Global lifecycle orchestration (database, seeds, cleanup). These are executed automatically; you rarely need to touch them.
+- **E2E** (`tests/e2e`): Keep this intentionally small and deterministic. Use it for true user journeys (admin login, dashboard smoke, key CRUD path), not for collection-internal contract depth.
+
+## Collection Contract Model (Integration-first)
+
+We use a two-tier model for collection coverage:
+
+- **Baseline contract (all collections):** at least one integration path that proves owner-role CRUD behavior plus one denied write path.
+- **Deep contract (critical domains):** additional integration scenarios for relationship integrity, duplicate guards, and hook-driven side effects.
+
+Registry and gate:
+
+- Contract registry: `tests/integration/contracts/collectionContractRegistry.ts`
+- Hard sync gate: `tests/integration/contracts/collectionContractCoverage.test.ts`
+
+The gate fails when:
+
+- a slug exists in `src/collections/**` but not in the registry
+- a registry entry points to a missing integration test file
+- a slug in a deep-domain group has no deep test references
 
 ## Core Integration Scope (Issue #297)
 
@@ -40,6 +59,7 @@ For core medical-network collections (`clinics`, `doctors`, `medical-specialties
 - You changed a collection `access` rule → update the permission matrix config, regenerate snapshots, and adjust the matching test in `tests/unit/access-matrix`.
 - You added a hook or extended an existing one → create or expand the suite under `tests/unit/hooks`.
 - You introduced a new workflow that crosses collections or relies on seeds → prefer an integration test with fixtures so behaviour remains realistic.
+- You added a new collection slug → add baseline integration coverage and register it in `collectionContractRegistry` in the same PR.
 
 ## Naming & Location
 
@@ -52,6 +72,13 @@ For core medical-network collections (`clinics`, `doctors`, `medical-specialties
 - [Access Control](./access-control.md) explains how metadata drives the permission matrix suites.
 - [Patterns & Utilities](./patterns.md) lists the reusable mocks, fixtures, and cleanup helpers.
 - [Setup](./setup.md) details the environment and commands.
+
+## Follow-up
+
+Collection contract coverage and DB reset performance are intentionally separated.
+
+- This phase adds deterministic contract coverage and a hard sync gate.
+- The next phase should optimize DB reset runtime (faster run-reset or snapshot/template approach) without coupling that refactor to collection test semantics.
 
 ## Architecture Overview
 

--- a/tests/integration/clinicApplications.approval.test.ts
+++ b/tests/integration/clinicApplications.approval.test.ts
@@ -4,6 +4,7 @@ import type { Payload } from 'payload'
 import config from '@payload-config'
 import { ensureBaseline } from '../fixtures/ensureBaseline'
 import { testSlug } from '../fixtures/testSlug'
+import { runBaselineContract } from './contracts/baselineContract'
 import type { BasicUser, ClinicApplication } from '@/payload-types'
 
 type PayloadUser = NonNullable<Parameters<Payload['create']>[0]['user']>
@@ -262,5 +263,117 @@ describe('ClinicApplications approval integration (manual provisioning era)', ()
 
     expect(updated.status).toBe('approved')
     expect(updated.linkedRecords?.processedAt).toBeTruthy()
+  })
+
+  it('matches the baseline collection contract', async () => {
+    const email = `${slugPrefix}-baseline@example.com`
+
+    await runBaselineContract<ClinicApplication>({
+      collection: 'clinicApplications',
+      createPrivileged: async () => {
+        const created = (await payload.create({
+          collection: 'clinicApplications',
+          data: buildApplicationData(email),
+          overrideAccess: true,
+          depth: 0,
+        } as PayloadCreateArgs)) as ClinicApplication
+
+        createdApplicationIds.push(created.id)
+        return created
+      },
+      getId: (doc) => doc.id,
+      readPrivileged: async (id) =>
+        (await payload.findByID({
+          collection: 'clinicApplications',
+          id,
+          overrideAccess: true,
+          depth: 0,
+        })) as ClinicApplication,
+      updatePrivileged: async (id) =>
+        (await payload.update({
+          collection: 'clinicApplications',
+          id,
+          data: { status: 'approved' },
+          overrideAccess: true,
+          depth: 0,
+        } as PayloadUpdateArgs)) as ClinicApplication,
+      assertUpdated: (doc) => {
+        expect(doc.status).toBe('approved')
+      },
+      assertDeniedWrite: async (id) => {
+        const clinicUser = await createClinicUser('baseline-denied')
+
+        await expect(
+          payload.update({
+            collection: 'clinicApplications',
+            id,
+            data: { status: 'rejected' },
+            user: asPayloadUser(clinicUser),
+            overrideAccess: false,
+            depth: 0,
+          } as PayloadUpdateArgs),
+        ).rejects.toThrow(/not allowed|perform this action/i)
+      },
+      deletePrivileged: async (id) => {
+        const platformUser = await createPlatformUser('baseline-delete')
+
+        const deleted = await payload.delete({
+          collection: 'clinicApplications',
+          id,
+          user: asPayloadUser(platformUser),
+          overrideAccess: false,
+          depth: 0,
+        })
+
+        const index = createdApplicationIds.indexOf(Number(id))
+        if (index >= 0) createdApplicationIds.splice(index, 1)
+        return deleted
+      },
+    })
+  })
+
+  it('allows platform delete and blocks clinic delete', async () => {
+    const app = (await payload.create({
+      collection: 'clinicApplications',
+      data: buildApplicationData(`${slugPrefix}-delete-access@example.com`),
+      overrideAccess: true,
+      depth: 0,
+    } as PayloadCreateArgs)) as ClinicApplication
+
+    createdApplicationIds.push(app.id)
+
+    const clinicUser = await createClinicUser('delete-denied')
+
+    await expect(
+      payload.delete({
+        collection: 'clinicApplications',
+        id: app.id,
+        user: asPayloadUser(clinicUser),
+        overrideAccess: false,
+        depth: 0,
+      }),
+    ).rejects.toThrow(/not allowed|perform this action/i)
+
+    const platformUser = await createPlatformUser('delete-allowed')
+
+    await payload.delete({
+      collection: 'clinicApplications',
+      id: app.id,
+      user: asPayloadUser(platformUser),
+      overrideAccess: false,
+      depth: 0,
+    })
+
+    const index = createdApplicationIds.indexOf(app.id)
+    if (index >= 0) createdApplicationIds.splice(index, 1)
+
+    await expect(
+      payload.findByID({
+        collection: 'clinicApplications',
+        id: app.id,
+        overrideAccess: true,
+        depth: 0,
+      }),
+    ).rejects.toThrow()
   })
 })

--- a/tests/integration/clinicGalleryEntries.lifecycle.test.ts
+++ b/tests/integration/clinicGalleryEntries.lifecycle.test.ts
@@ -6,6 +6,7 @@ import { ensureBaseline } from '../fixtures/ensureBaseline'
 import { createClinicFixture } from '../fixtures/createClinicFixture'
 import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
 import { testSlug } from '../fixtures/testSlug'
+import { runBaselineContract } from './contracts/baselineContract'
 import type { BasicUser, ClinicGalleryEntry, ClinicGalleryMedia, ClinicStaff } from '@/payload-types'
 
 vi.mock('@payloadcms/storage-s3', () => ({
@@ -266,6 +267,107 @@ describe('ClinicGalleryEntries integration - lifecycle', () => {
 
     expect(updated.status).toBe('published')
     expect(updated.publishedAt).toBeTruthy()
+  })
+
+  it('matches the baseline collection contract', async () => {
+    const { clinic } = await createClinicFixture(payload, cityId, { slugPrefix: `${slugPrefix}-baseline-contract` })
+    const { basicUser, clinicStaff } = await createClinicUser('baseline-contract')
+
+    await approveClinicStaff(clinicStaff.id, clinic.id as number)
+
+    const before = await createGalleryMedia(clinic.id as number, basicUser, 'baseline-before')
+    const after = await createGalleryMedia(clinic.id as number, basicUser, 'baseline-after')
+
+    await runBaselineContract<ClinicGalleryEntry>({
+      collection: 'clinicGalleryEntries',
+      createPrivileged: async () =>
+        createEntry({
+          clinicId: clinic.id as number,
+          user: basicUser,
+          beforeMediaId: before.id,
+          afterMediaId: after.id,
+          titleSuffix: 'baseline-create',
+        }),
+      getId: (doc) => doc.id,
+      readPrivileged: async (id) =>
+        (await payload.findByID({
+          collection: 'clinicGalleryEntries',
+          id,
+          user: asClinicUser(basicUser),
+          overrideAccess: false,
+          depth: 0,
+        })) as ClinicGalleryEntry,
+      updatePrivileged: async (id) =>
+        (await payload.update({
+          collection: 'clinicGalleryEntries',
+          id,
+          data: { title: `${slugPrefix}-baseline-updated` },
+          user: asClinicUser(basicUser),
+          overrideAccess: false,
+          depth: 0,
+        } as PayloadUpdateArgs)) as ClinicGalleryEntry,
+      assertUpdated: (doc) => {
+        expect(doc.title).toBe(`${slugPrefix}-baseline-updated`)
+      },
+      assertDeniedWrite: async () => {
+        await expect(
+          payload.create({
+            collection: 'clinicGalleryEntries',
+            data: {
+              clinic: clinic.id,
+              title: `${slugPrefix}-baseline-anon`,
+              beforeMedia: before.id,
+              afterMedia: after.id,
+            } as Partial<ClinicGalleryEntry>,
+            overrideAccess: false,
+            depth: 0,
+          } as PayloadCreateArgs),
+        ).rejects.toThrow()
+      },
+      deletePrivileged: async (id) => {
+        const deleted = await payload.delete({
+          collection: 'clinicGalleryEntries',
+          id,
+          user: asClinicUser(basicUser),
+          overrideAccess: false,
+          depth: 0,
+        })
+
+        const index = createdEntryIds.indexOf(Number(id))
+        if (index >= 0) createdEntryIds.splice(index, 1)
+        return deleted
+      },
+    })
+  })
+
+  it('rejects mixed-clinic media references in integration flow', async () => {
+    const { clinic: clinicA } = await createClinicFixture(payload, cityId, { slugPrefix: `${slugPrefix}-mixed-a` })
+    const { clinic: clinicB } = await createClinicFixture(payload, cityId, { slugPrefix: `${slugPrefix}-mixed-b` })
+
+    const { basicUser: clinicUserA, clinicStaff: staffA } = await createClinicUser('mixed-a')
+    await approveClinicStaff(staffA.id, clinicA.id as number)
+
+    const { basicUser: clinicUserB, clinicStaff: staffB } = await createClinicUser('mixed-b')
+    await approveClinicStaff(staffB.id, clinicB.id as number)
+
+    const beforeA = await createGalleryMedia(clinicA.id as number, clinicUserA, 'mixed-before-a', 'published')
+    const afterB = await createGalleryMedia(clinicB.id as number, clinicUserB, 'mixed-after-b', 'published')
+
+    await expect(
+      payload.create({
+        collection: 'clinicGalleryEntries',
+        data: {
+          clinic: clinicA.id,
+          title: `${slugPrefix}-mixed-invalid`,
+          beforeMedia: beforeA.id,
+          afterMedia: afterB.id,
+          status: 'published',
+        } as Partial<ClinicGalleryEntry>,
+        user: asClinicUser(clinicUserA),
+        overrideAccess: false,
+        depth: 0,
+      } as PayloadCreateArgs),
+    ).rejects.toThrow(/same clinic/i)
   })
 
   it('scopes reads to published for public, clinic for staff, and all for platform', async () => {

--- a/tests/integration/contracts/baselineContract.ts
+++ b/tests/integration/contracts/baselineContract.ts
@@ -1,0 +1,45 @@
+import { expect } from 'vitest'
+
+type ContractDocId = number | string
+
+export interface BaselineContractOptions<TDoc> {
+  collection: string
+  createPrivileged: () => Promise<TDoc>
+  getId: (doc: TDoc) => ContractDocId
+  readPrivileged: (id: ContractDocId) => Promise<TDoc>
+  updatePrivileged: (id: ContractDocId) => Promise<TDoc>
+  assertUpdated: (doc: TDoc) => void
+  assertDeniedWrite: (id: ContractDocId) => Promise<void>
+  deletePrivileged: (id: ContractDocId) => Promise<unknown>
+  deleteExpected?: 'allow' | 'deny'
+}
+
+/**
+ * Shared baseline contract runner for collection integration tests.
+ * Keeps CRUD + denied-write expectations consistent across collections.
+ */
+export async function runBaselineContract<TDoc>(options: BaselineContractOptions<TDoc>): Promise<void> {
+  const created = await options.createPrivileged()
+  const id = options.getId(created)
+
+  expect(id).toBeDefined()
+
+  const hydrated = await options.readPrivileged(id)
+  expect(options.getId(hydrated)).toBe(id)
+
+  const updated = await options.updatePrivileged(id)
+  options.assertUpdated(updated)
+
+  await options.assertDeniedWrite(id)
+
+  const deleteExpected = options.deleteExpected ?? 'allow'
+  if (deleteExpected === 'deny') {
+    await expect(options.deletePrivileged(id)).rejects.toThrow()
+    const stillThere = await options.readPrivileged(id)
+    expect(options.getId(stillThere)).toBe(id)
+    return
+  }
+
+  await options.deletePrivileged(id)
+  await expect(options.readPrivileged(id)).rejects.toThrow()
+}

--- a/tests/integration/contracts/collectionContractCoverage.test.ts
+++ b/tests/integration/contracts/collectionContractCoverage.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { collectionContractRegistry, deepContractDomains } from './collectionContractRegistry'
+
+const repositoryRoot = process.cwd()
+const collectionsRoot = path.join(repositoryRoot, 'src/collections')
+
+const walkFiles = (dir: string): string[] => {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  const files: string[] = []
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(entryPath))
+      continue
+    }
+    if (entry.isFile() && entry.name.endsWith('.ts')) {
+      files.push(entryPath)
+    }
+  }
+
+  return files
+}
+
+const readCollectionSlugsFromSource = (): string[] => {
+  const slugSet = new Set<string>()
+  const files = walkFiles(collectionsRoot)
+
+  for (const filePath of files) {
+    const source = fs.readFileSync(filePath, 'utf8')
+    const matches = source.matchAll(/slug:\s*'([^']+)'/g)
+    for (const match of matches) {
+      const slug = match[1]
+      if (slug) slugSet.add(slug)
+    }
+  }
+
+  return [...slugSet].sort()
+}
+
+describe('Collection contract coverage gate', () => {
+  it('keeps registry slugs in sync with src/collections', () => {
+    const sourceSlugs = readCollectionSlugsFromSource()
+    const registrySlugs = Object.keys(collectionContractRegistry).sort()
+
+    expect(registrySlugs).toEqual(sourceSlugs)
+  })
+
+  it('references existing integration tests for each registered collection', () => {
+    for (const [slug, entry] of Object.entries(collectionContractRegistry)) {
+      expect(entry.baseline.length, `${slug} requires at least one baseline test reference`).toBeGreaterThan(0)
+
+      const deepReferences = 'deep' in entry ? entry.deep : undefined
+      for (const relativePath of [...entry.baseline, ...(deepReferences ?? [])]) {
+        const absolutePath = path.join(repositoryRoot, relativePath)
+        expect(fs.existsSync(absolutePath), `${slug} references missing test: ${relativePath}`).toBe(true)
+      }
+    }
+  })
+
+  it('keeps deep-domain slugs mapped to deep contract references', () => {
+    for (const [domain, slugs] of Object.entries(deepContractDomains)) {
+      for (const slug of slugs) {
+        const entry = collectionContractRegistry[slug]
+        const deepReferences = entry && 'deep' in entry ? entry.deep : undefined
+        expect(entry, `${domain} references unknown slug "${slug}"`).toBeDefined()
+        expect(deepReferences?.length ?? 0, `${slug} in ${domain} requires deep test references`).toBeGreaterThan(0)
+      }
+    }
+  })
+})

--- a/tests/integration/contracts/collectionContractRegistry.ts
+++ b/tests/integration/contracts/collectionContractRegistry.ts
@@ -1,0 +1,152 @@
+export interface CollectionContractEntry {
+  baseline: readonly string[]
+  deep?: readonly string[]
+}
+
+export const collectionContractRegistry = {
+  accreditation: {
+    baseline: ['tests/integration/accreditation.lifecycle.test.ts'],
+    deep: ['tests/integration/accreditation.lifecycle.test.ts'],
+  },
+  basicUsers: {
+    baseline: ['tests/integration/basicUserLifecycle.test.ts'],
+  },
+  categories: {
+    baseline: ['tests/integration/categories.lifecycle.test.ts'],
+  },
+  cities: {
+    baseline: ['tests/integration/cities.creation.test.ts'],
+  },
+  clinicApplications: {
+    baseline: ['tests/integration/clinicApplications.approval.test.ts'],
+    deep: ['tests/integration/clinicApplications.approval.test.ts'],
+  },
+  clinicGalleryEntries: {
+    baseline: ['tests/integration/clinicGalleryEntries.lifecycle.test.ts'],
+    deep: [
+      'tests/integration/clinicGalleryEntries.lifecycle.test.ts',
+      'tests/integration/clinicGalleryEntries.validation.test.ts',
+    ],
+  },
+  clinicGalleryMedia: {
+    baseline: ['tests/integration/clinicGalleryMedia.lifecycle.test.ts'],
+    deep: ['tests/integration/clinicGalleryMedia.lifecycle.test.ts'],
+  },
+  clinicMedia: {
+    baseline: ['tests/integration/clinicMedia.lifecycle.test.ts'],
+    deep: ['tests/integration/clinicMedia.lifecycle.test.ts'],
+  },
+  clinicStaff: {
+    baseline: ['tests/integration/clinicStaff.lifecycle.test.ts'],
+    deep: ['tests/integration/clinicStaff.lifecycle.test.ts', 'tests/integration/access/clinicStaff-access.test.ts'],
+  },
+  clinictreatments: {
+    baseline: ['tests/integration/clinicTreatments.creation.test.ts'],
+    deep: [
+      'tests/integration/clinicTreatments.creation.test.ts',
+      'tests/integration/clinicTreatments.averagePrice.test.ts',
+    ],
+  },
+  clinics: {
+    baseline: ['tests/integration/clinics.creation.test.ts'],
+    deep: ['tests/integration/clinics.creation.test.ts', 'tests/integration/access/clinics-access.test.ts'],
+  },
+  countries: {
+    baseline: ['tests/integration/countries.lifecycle.test.ts'],
+  },
+  doctorMedia: {
+    baseline: ['tests/integration/doctorMedia.lifecycle.test.ts'],
+    deep: ['tests/integration/doctorMedia.lifecycle.test.ts'],
+  },
+  doctors: {
+    baseline: ['tests/integration/doctors.lifecycle.test.ts'],
+    deep: ['tests/integration/doctors.lifecycle.test.ts', 'tests/integration/doctors.titles.test.ts'],
+  },
+  doctorspecialties: {
+    baseline: ['tests/integration/doctorSpecialties.lifecycle.test.ts'],
+    deep: ['tests/integration/doctorSpecialties.lifecycle.test.ts'],
+  },
+  doctortreatments: {
+    baseline: ['tests/integration/doctorTreatments.lifecycle.test.ts'],
+    deep: ['tests/integration/doctorTreatments.lifecycle.test.ts'],
+  },
+  favoriteclinics: {
+    baseline: ['tests/integration/favoriteClinics.lifecycle.test.ts'],
+    deep: [
+      'tests/integration/favoriteClinics.lifecycle.test.ts',
+      'tests/integration/access/favoriteClinics-access.test.ts',
+    ],
+  },
+  'medical-specialties': {
+    baseline: ['tests/integration/medicalSpecialties.lifecycle.test.ts'],
+    deep: [
+      'tests/integration/medicalSpecialties.lifecycle.test.ts',
+      'tests/integration/medicalSpecialties.upsert.integration.test.ts',
+    ],
+  },
+  pages: {
+    baseline: ['tests/integration/pages.lifecycle.test.ts'],
+  },
+  patients: {
+    baseline: ['tests/integration/patientLifecycle.test.ts'],
+    deep: ['tests/integration/patientLifecycle.test.ts'],
+  },
+  platformContentMedia: {
+    baseline: ['tests/integration/platformContentMedia.lifecycle.test.ts'],
+    deep: ['tests/integration/platformContentMedia.lifecycle.test.ts', 'tests/integration/access/media-access.test.ts'],
+  },
+  platformStaff: {
+    baseline: ['tests/integration/platformStaff.lifecycle.test.ts'],
+    deep: ['tests/integration/platformStaff.lifecycle.test.ts'],
+  },
+  posts: {
+    baseline: ['tests/integration/posts.lifecycle.test.ts'],
+  },
+  reviews: {
+    baseline: ['tests/integration/reviews.lifecycle.test.ts'],
+    deep: [
+      'tests/integration/reviews.lifecycle.test.ts',
+      'tests/integration/reviews.auditTrail.test.ts',
+      'tests/integration/reviews.duplicateGuard.test.ts',
+      'tests/integration/reviews.averageRatings.test.ts',
+    ],
+  },
+  tags: {
+    baseline: ['tests/integration/tags.associations.test.ts'],
+  },
+  treatments: {
+    baseline: ['tests/integration/treatments.creation.test.ts'],
+  },
+  userProfileMedia: {
+    baseline: ['tests/integration/userProfileMedia.lifecycle.test.ts'],
+    deep: ['tests/integration/userProfileMedia.lifecycle.test.ts'],
+  },
+} as const satisfies Record<string, CollectionContractEntry>
+
+export const prioritizedBaselineContractSlugs = [
+  'clinicApplications',
+  'clinicGalleryEntries',
+  'doctorMedia',
+  'doctortreatments',
+  'userProfileMedia',
+] as const
+
+export const deepContractDomains = {
+  clinicDoctorRelations: [
+    'clinics',
+    'doctors',
+    'clinicStaff',
+    'doctorspecialties',
+    'doctortreatments',
+    'clinictreatments',
+  ],
+  contentMediaRelations: [
+    'clinicGalleryMedia',
+    'clinicGalleryEntries',
+    'platformContentMedia',
+    'clinicMedia',
+    'doctorMedia',
+    'userProfileMedia',
+  ],
+  trustWorkflow: ['reviews', 'favoriteclinics', 'accreditation', 'clinicApplications', 'patients', 'platformStaff'],
+} as const

--- a/tests/integration/doctorMedia.lifecycle.test.ts
+++ b/tests/integration/doctorMedia.lifecycle.test.ts
@@ -9,6 +9,7 @@ import { testSlug } from '../fixtures/testSlug'
 import { cleanupTrackedDocs } from '../fixtures/cleanupTrackedDocs'
 import { createTinyPngFile } from '../fixtures/mediaFile'
 import { approveClinicStaff, asBasicUserPayload, createClinicUserWithStaff } from '../fixtures/clinicUserFixtures'
+import { runBaselineContract } from './contracts/baselineContract'
 import type { DoctorMedia } from '@/payload-types'
 
 vi.mock('@payloadcms/storage-s3', () => ({
@@ -204,6 +205,83 @@ describe('DoctorMedia integration - lifecycle', () => {
     } as PayloadUpdateArgs)) as DoctorMedia
 
     expect(updated.storagePath).toBe(created.storagePath)
+  })
+
+  it('matches the baseline collection contract', async () => {
+    const { clinic, doctor } = await createClinicFixture(payload, cityId, { slugPrefix: `${slugPrefix}-baseline` })
+    const { basicUser, clinicStaff } = await createClinicUserWithStaff(payload, {
+      slugPrefix,
+      suffix: 'baseline',
+      createdBasicUserIds,
+      createdClinicStaffIds,
+    })
+
+    await approveClinicStaff(payload, clinicStaff.id, clinic.id as number)
+
+    await runBaselineContract<DoctorMedia>({
+      collection: 'doctorMedia',
+      createPrivileged: async () => {
+        const created = (await payload.create({
+          collection: 'doctorMedia',
+          data: {
+            alt: 'Doctor baseline',
+            doctor: doctor.id,
+          } as Partial<DoctorMedia>,
+          file: createTinyPngFile(`${slugPrefix}-baseline.png`),
+          user: asBasicUserPayload(basicUser),
+          overrideAccess: false,
+          depth: 0,
+        } as PayloadCreateArgs)) as DoctorMedia
+
+        createdMediaIds.push(created.id)
+        return created
+      },
+      getId: (doc) => doc.id,
+      readPrivileged: async (id) =>
+        (await payload.findByID({
+          collection: 'doctorMedia',
+          id,
+          user: asBasicUserPayload(basicUser),
+          overrideAccess: false,
+          depth: 0,
+        })) as DoctorMedia,
+      updatePrivileged: async (id) =>
+        (await payload.update({
+          collection: 'doctorMedia',
+          id,
+          data: { alt: 'Doctor baseline updated' },
+          user: asBasicUserPayload(basicUser),
+          overrideAccess: false,
+          depth: 0,
+        } as PayloadUpdateArgs)) as DoctorMedia,
+      assertUpdated: (doc) => {
+        expect(doc.alt).toBe('Doctor baseline updated')
+      },
+      assertDeniedWrite: async (id) => {
+        await expect(
+          payload.update({
+            collection: 'doctorMedia',
+            id,
+            data: { alt: 'blocked-anon-update' },
+            overrideAccess: false,
+            depth: 0,
+          } as PayloadUpdateArgs),
+        ).rejects.toThrow()
+      },
+      deletePrivileged: async (id) => {
+        const deleted = await payload.delete({
+          collection: 'doctorMedia',
+          id,
+          user: asBasicUserPayload(basicUser),
+          overrideAccess: false,
+          depth: 0,
+        })
+
+        const index = createdMediaIds.indexOf(Number(id))
+        if (index >= 0) createdMediaIds.splice(index, 1)
+        return deleted
+      },
+    })
   })
 
   it('allows clinic users to delete doctor media', async () => {

--- a/tests/integration/doctorTreatments.lifecycle.test.ts
+++ b/tests/integration/doctorTreatments.lifecycle.test.ts
@@ -7,6 +7,7 @@ import { createClinicFixture } from '../fixtures/createClinicFixture'
 import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
 import { buildRichText } from '../fixtures/richText'
 import { testSlug } from '../fixtures/testSlug'
+import { runBaselineContract } from './contracts/baselineContract'
 import {
   asClinicScopedPayloadUser,
   asPayloadBasicUser,
@@ -280,6 +281,77 @@ describe('DoctorTreatments lifecycle integration', () => {
     )
 
     expect(treatmentJoinIds).toContain(doctorTreatment.id)
+  })
+
+  it('matches the baseline collection contract', async () => {
+    const { clinic, doctor } = await createClinicFixture(payload, cityId, { slugPrefix: `${slugPrefix}-baseline` })
+    const clinicUser = await createClinicUser(`${slugPrefix}-baseline-clinic`, clinic.id as number)
+
+    await runBaselineContract<Doctortreatment>({
+      collection: 'doctortreatments',
+      createPrivileged: async () => {
+        const created = (await payload.create({
+          collection: 'doctortreatments',
+          data: {
+            doctor: doctor.id,
+            treatment: treatmentId,
+            specializationLevel: 'specialist',
+          } as unknown as Doctortreatment,
+          user: clinicUser,
+          overrideAccess: false,
+          depth: 0,
+        })) as Doctortreatment
+
+        createdDoctorTreatmentIds.push(created.id)
+        return created
+      },
+      getId: (doc) => doc.id,
+      readPrivileged: async (id) =>
+        (await payload.findByID({
+          collection: 'doctortreatments',
+          id,
+          user: clinicUser,
+          overrideAccess: false,
+          depth: 0,
+        })) as Doctortreatment,
+      updatePrivileged: async (id) =>
+        (await payload.update({
+          collection: 'doctortreatments',
+          id,
+          data: { specializationLevel: 'sub_specialist' } as unknown as Doctortreatment,
+          user: clinicUser,
+          overrideAccess: false,
+          depth: 0,
+        })) as Doctortreatment,
+      assertUpdated: (doc) => {
+        expect(doc.specializationLevel).toBe('sub_specialist')
+      },
+      assertDeniedWrite: async (id) => {
+        await expect(
+          payload.update({
+            collection: 'doctortreatments',
+            id,
+            data: { specializationLevel: 'general_practice' } as unknown as Doctortreatment,
+            overrideAccess: false,
+            depth: 0,
+          }),
+        ).rejects.toThrow()
+      },
+      deletePrivileged: async (id) => {
+        const platformUser = await createPlatformUser(`${slugPrefix}-baseline-platform-delete`)
+
+        const deleted = await payload.delete({
+          collection: 'doctortreatments',
+          id,
+          user: platformUser,
+          overrideAccess: false,
+        })
+
+        const index = createdDoctorTreatmentIds.indexOf(Number(id))
+        if (index >= 0) createdDoctorTreatmentIds.splice(index, 1)
+        return deleted
+      },
+    })
   })
 
   it('allows platform users to delete doctor treatments', async () => {

--- a/tests/integration/userProfileMedia.lifecycle.test.ts
+++ b/tests/integration/userProfileMedia.lifecycle.test.ts
@@ -6,6 +6,7 @@ import { ensureBaseline } from '../fixtures/ensureBaseline'
 import { testSlug } from '../fixtures/testSlug'
 import { cleanupTrackedDocs } from '../fixtures/cleanupTrackedDocs'
 import { createTinyPngFile } from '../fixtures/mediaFile'
+import { runBaselineContract } from './contracts/baselineContract'
 import type { BasicUser, Patient, UserProfileMedia } from '@/payload-types'
 
 vi.mock('@payloadcms/storage-s3', () => ({
@@ -297,5 +298,77 @@ describe('UserProfileMedia integration - lifecycle', () => {
         overrideAccess: true,
       }),
     ).rejects.toThrow()
+  })
+
+  it('matches the baseline collection contract', async () => {
+    const patient = await createPatient('baseline')
+    const otherPatient = await createPatient('baseline-other')
+
+    await runBaselineContract<UserProfileMedia>({
+      collection: 'userProfileMedia',
+      createPrivileged: async () => {
+        const created = (await payload.create({
+          collection: 'userProfileMedia',
+          data: {
+            user: { relationTo: 'patients', value: patient.id },
+          } as Partial<UserProfileMedia>,
+          file: createTinyPngFile(`${slugPrefix}-baseline-create.png`),
+          user: asPatientUser(patient),
+          overrideAccess: false,
+          depth: 0,
+        } as PayloadCreateArgs)) as UserProfileMedia
+
+        createdMediaIds.push(created.id)
+        return created
+      },
+      getId: (doc) => doc.id,
+      readPrivileged: async (id) =>
+        (await payload.findByID({
+          collection: 'userProfileMedia',
+          id,
+          user: asPatientUser(patient),
+          overrideAccess: false,
+          depth: 0,
+        })) as UserProfileMedia,
+      updatePrivileged: async (id) =>
+        (await payload.update({
+          collection: 'userProfileMedia',
+          id,
+          data: {},
+          file: createTinyPngFile(`${slugPrefix}-baseline-update.png`),
+          user: asPatientUser(patient),
+          overrideAccess: false,
+          depth: 0,
+        } as PayloadUpdateArgs)) as UserProfileMedia,
+      assertUpdated: (doc) => {
+        expect(doc.user.relationTo).toBe('patients')
+        expect(getRelationValueId(doc.user)).toBe(patient.id)
+      },
+      assertDeniedWrite: async (id) => {
+        await expect(
+          payload.update({
+            collection: 'userProfileMedia',
+            id,
+            data: {},
+            user: asPatientUser(otherPatient),
+            overrideAccess: false,
+            depth: 0,
+          } as PayloadUpdateArgs),
+        ).rejects.toThrow()
+      },
+      deletePrivileged: async (id) => {
+        const deleted = await payload.delete({
+          collection: 'userProfileMedia',
+          id,
+          user: asPatientUser(patient),
+          overrideAccess: false,
+          depth: 0,
+        })
+
+        const index = createdMediaIds.indexOf(Number(id))
+        if (index >= 0) createdMediaIds.splice(index, 1)
+        return deleted
+      },
+    })
   })
 })


### PR DESCRIPTION
Adds a hard collection contract gate and baseline contract coverage so new collection slugs cannot land without mapped integration coverage.

## What changed
- Added a reusable baseline contract runner for integration suites.
- Added a central collection contract registry covering all 27 collection slugs.
- Added a hard meta-test that:
  - compares `src/collections` slugs against the registry
  - verifies every referenced test file exists
  - ensures deep-domain groups have deep references
- Extended prioritized integration suites with executable baseline contract tests:
  - `clinicApplications`
  - `clinicGalleryEntries`
  - `doctorMedia`
  - `doctortreatments`
  - `userProfileMedia`
- Added additional relation/access deep checks in those suites.
- Updated testing docs with the integration-first contract model and DB-reset performance follow-up note.

## Validation
- `pnpm format`
- `pnpm check`
- `pnpm vitest --project integration --run tests/integration/contracts/collectionContractCoverage.test.ts tests/integration/clinicApplications.approval.test.ts tests/integration/clinicGalleryEntries.lifecycle.test.ts tests/integration/doctorMedia.lifecycle.test.ts tests/integration/doctorTreatments.lifecycle.test.ts tests/integration/userProfileMedia.lifecycle.test.ts`
- `pnpm vitest --project integration --run`
