### PR TITLE
fix: preserve cmd-click new-tab behavior

### DIFF
--- a/src/utilities/useClickableCard.ts
+++ b/src/utilities/useClickableCard.ts
@@ -91,7 +91,7 @@ function useClickableCard<T extends HTMLElement>({
         const difference = timeNow - timeDown.current
 
         if (linkRef.current?.href && difference <= 250) {
-          if (!hasActiveParent.current && pressedButton.current === 0 && !e.ctrlKey) {
+          if (!hasActiveParent.current && pressedButton.current === 0 && !e.ctrlKey && !e.metaKey) {
             if (external) {
               const target = newTab ? '_blank' : '_self'
               window.open(linkRef.current.href, target)

--- a/tests/unit/utilities/useClickableCard.test.tsx
+++ b/tests/unit/utilities/useClickableCard.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Link from 'next/link'
 
 import useClickableCard from '@/utilities/useClickableCard'
 
@@ -19,9 +20,9 @@ function ClickableCardHarness() {
 
   return (
     <div data-testid="card" ref={cardRef}>
-      <a href="/target" ref={linkRef}>
+      <Link href="/target" ref={linkRef}>
         Open target
-      </a>
+      </Link>
     </div>
   )
 }
@@ -39,7 +40,10 @@ describe('useClickableCard', () => {
     fireEvent.mouseDown(card, { button: 0 })
     fireEvent.mouseUp(card, { button: 0 })
 
-    expect(pushMock).toHaveBeenCalledWith('http://localhost/target', { scroll: true })
+    const [href, options] = pushMock.mock.calls[0] ?? []
+    expect(typeof href).toBe('string')
+    expect(href).toMatch(/^http:\/\/localhost(?::\d+)?\/target$/)
+    expect(options).toEqual({ scroll: true })
   })
 
   it('does not intercept meta key card clicks', () => {

--- a/tests/unit/utilities/useClickableCard.test.tsx
+++ b/tests/unit/utilities/useClickableCard.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import useClickableCard from '@/utilities/useClickableCard'
+
+const pushMock = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+}))
+
+function ClickableCardHarness() {
+  const { cardRef, linkRef } = useClickableCard<HTMLDivElement>({
+    external: false,
+  })
+
+  return (
+    <div data-testid="card" ref={cardRef}>
+      <a href="/target" ref={linkRef}>
+        Open target
+      </a>
+    </div>
+  )
+}
+
+describe('useClickableCard', () => {
+  beforeEach(() => {
+    pushMock.mockReset()
+  })
+
+  it('navigates with left click on the card', () => {
+    render(<ClickableCardHarness />)
+
+    const card = screen.getByTestId('card')
+
+    fireEvent.mouseDown(card, { button: 0 })
+    fireEvent.mouseUp(card, { button: 0 })
+
+    expect(pushMock).toHaveBeenCalledWith('http://localhost/target', { scroll: true })
+  })
+
+  it('does not intercept meta key card clicks', () => {
+    render(<ClickableCardHarness />)
+
+    const card = screen.getByTestId('card')
+
+    fireEvent.mouseDown(card, { button: 0 })
+    fireEvent.mouseUp(card, { button: 0, metaKey: true })
+
+    expect(pushMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Users on macOS can now use Cmd+Click on clickable cards to open links in a new tab without unwanted in-app navigation.

## What changed
- Added a guard in `useClickableCard` to skip `router.push` when the `metaKey` is pressed.
- Added a unit test to lock behavior for normal left click and for Cmd+Click (`metaKey`) interactions.

## Validation
- `pnpm tests -- tests/unit/utilities/useClickableCard.test.tsx` *(blocked: `node_modules` missing and registry access unavailable in this environment)*
- `pnpm check` *(blocked: `node_modules` missing and registry access unavailable in this environment)*
- `pnpm format` *(blocked: `node_modules` missing and registry access unavailable in this environment)*

## Squash commit message
fix(clickable-card): preserve cmd-click new-tab behavior on macOS by avoiding router interception
