### PR TITLE
chore(collections): clarify clinic copy

### DIFF
--- a/src/collections/ClinicApplications.ts
+++ b/src/collections/ClinicApplications.ts
@@ -140,7 +140,7 @@ export const ClinicApplications: CollectionConfig = {
     {
       name: 'reviewNotes',
       type: 'textarea',
-      admin: { description: 'Notes for reviewers' },
+      admin: { description: 'Internal notes for this application' },
       access: {
         update: ({ req }: { req: PayloadRequest }) => {
           const u = req.user
@@ -151,8 +151,9 @@ export const ClinicApplications: CollectionConfig = {
     {
       name: 'linkedRecords',
       type: 'group',
+      label: 'Created records',
       admin: {
-        description: 'Related records',
+        description: 'Records created from this application',
         condition: (data) => data?.status !== 'submitted',
       },
       fields: [

--- a/src/collections/Reviews.ts
+++ b/src/collections/Reviews.ts
@@ -141,21 +141,21 @@ export const Reviews: CollectionConfig = {
       label: 'Change History',
       admin: {
         initCollapsed: true,
-        description: 'Review history and notes',
+        description: 'Edit history',
       },
       fields: [
         {
           name: 'lastEditedAt',
           type: 'date',
           admin: {
-            description: 'Last edited time',
+            description: 'When this review was last edited',
             readOnly: true,
           },
         },
         {
           name: 'editedByName',
           type: 'text',
-          label: 'Edited by name',
+          label: 'Editor name',
           admin: {
             description: 'Name of the person who edited this review',
             readOnly: true,


### PR DESCRIPTION
This tightens a few collection field labels and descriptions so first-time clinic users see clearer copy in the admin.

## What changed
- Clarified the clinic application review notes and linked-records text in `src/collections/ClinicApplications.ts`.
- Simplified the review history labels in `src/collections/Reviews.ts`.

## Validation
- `pnpm format`
- `pnpm check`
