### PR TITLE
fix: include collectionSlug in beforeSync test inputs

### DIFF
--- a/tests/unit/search/beforeSync.test.ts
+++ b/tests/unit/search/beforeSync.test.ts
@@ -4,6 +4,7 @@ import { beforeSyncWithSearch } from '@/search/beforeSync'
 describe('beforeSyncWithSearch', () => {
   it('removes top-level id from search docs', async () => {
     const result = await beforeSyncWithSearch({
+      collectionSlug: 'posts',
       originalDoc: {
         id: 42,
         slug: 'sample-post',
@@ -24,6 +25,7 @@ describe('beforeSyncWithSearch', () => {
 
   it('does not inject id into post categories', async () => {
     const result = await beforeSyncWithSearch({
+      collectionSlug: 'posts',
       originalDoc: {
         id: 42,
         slug: 'sample-post',


### PR DESCRIPTION
This fixes a CI-blocking TypeScript contract mismatch in the `beforeSyncWithSearch` unit tests.

## What changed
- Added missing `collectionSlug: 'posts'` to both calls in `tests/unit/search/beforeSync.test.ts`.
- Kept test behavior unchanged; this only aligns test inputs with the current `BeforeSync` contract.

## Validation
- `pnpm vitest tests/unit/search/beforeSync.test.ts`
- `pnpm format`
- `pnpm check`
