### PR TITLE
fix: repair combined coverage merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -607,7 +607,6 @@ jobs:
         with:
           pattern: coverage-*
           path: coverage-artifacts
-          merge-multiple: true
 
       - name: Merge coverage summaries
         run: node scripts/coverage/merge-coverage.mjs --input-root coverage-artifacts --output-root coverage/combined

--- a/scripts/coverage/merge-coverage.mjs
+++ b/scripts/coverage/merge-coverage.mjs
@@ -56,7 +56,13 @@ const detectSourceName = (filePath) => {
   if (normalized.includes('/unit/')) return 'unit'
   if (normalized.includes('/storybook/')) return 'storybook'
   if (normalized.includes('/integration/')) return 'integration'
-  return path.basename(path.dirname(filePath))
+
+  const parentDir = path.basename(path.dirname(filePath))
+  if (parentDir.startsWith('coverage-')) {
+    return parentDir.slice('coverage-'.length)
+  }
+
+  return parentDir
 }
 
 const buildMarkdown = (sources, total) => {


### PR DESCRIPTION
fixes the combined coverage job so successful test runs no longer fail during artifact aggregation.

## What changed
- stop flattening all `coverage-*` artifacts into a single download directory in the CI workflow
- keep artifact namespaced directories so `coverage-summary.json` files no longer collide
- teach `scripts/coverage/merge-coverage.mjs` to normalize downloaded artifact folder names like `coverage-unit` back to `unit`, `storybook`, and `integration`

## Validation
- `pnpm format`
- `pnpm check`
- local reproduction of the failed GitHub Actions run by downloading artifacts `6394628746`, `6394636442`, and `6394703808` from run `24313568371` and running `node scripts/coverage/merge-coverage.mjs --input-root <tmp>/coverage-artifacts --output-root <tmp>/coverage/combined`
