### PR TITLE
feat(ci): require linked issues on pr gates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this template to report bugs with enough detail to reproduce and verify a fix.
+        Use this template for a problem that already exists in the product.
+        Describe the current behavior, how to reproduce it, and what correct behavior should look like.
 
   - type: textarea
     id: summary

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -9,8 +9,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this template for feature requests that should move into implementation.
-        Keep the description short, specific, and outcome-oriented.
+        Use this template for a product need that already exists and should be implemented next.
+        Describe the current problem, the desired outcome, and the acceptance criteria.
 
   - type: textarea
     id: problem

--- a/.github/scripts/pr-gates-linked-issue.cjs
+++ b/.github/scripts/pr-gates-linked-issue.cjs
@@ -1,0 +1,109 @@
+/**
+ * PR Gates linked issue automation.
+ *
+ * Purpose
+ * - Require every non-bot pull request, including AI-assisted PRs created
+ *   under a human GitHub account, to have at least one manually linked GitHub
+ *   Issue in the PR's Development section.
+ *
+ * How it works
+ * - Skips pull requests authored by bots.
+ * - Uses GitHub GraphQL with `closingIssuesReferences(userLinkedOnly: true)` to
+ *   read the manually linked issues only.
+ * - Returns a failure comment that points authors to the Issue templates.
+ */
+
+const STICKY_COMMENT_HEADER = 'pr-linked-issue-lint-error'
+
+const ISSUE_TEMPLATE_NAMES = ['Bug Report', 'Feature']
+
+const LINKED_ISSUES_QUERY = `
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        closingIssuesReferences(first: 1, userLinkedOnly: true) {
+          nodes {
+            id
+            number
+            title
+            url
+          }
+        }
+      }
+    }
+  }
+`
+
+function isBotAuthor(pullRequest) {
+  return pullRequest?.user?.type === 'Bot'
+}
+
+function buildMissingLinkedIssueComment() {
+  return [
+    'This pull request must be linked to at least one GitHub Issue in the `Development` section.',
+    '',
+    `Open or reuse an Issue first. If you need a new one, use the ${ISSUE_TEMPLATE_NAMES.map((name) => `\`${name}\``).join(' or ')} template.`,
+    '',
+    'AI-assisted and human-authored PRs must link an Issue; only GitHub bot-authored PRs are exempt.',
+    'PR body text and commit history do not count for this check.',
+  ].join('\n')
+}
+
+async function getLinkedIssues({ github, owner, repo, number }) {
+  const { repository } = await github.graphql(LINKED_ISSUES_QUERY, {
+    owner,
+    repo,
+    number,
+  })
+
+  return repository?.pullRequest?.closingIssuesReferences?.nodes ?? []
+}
+
+async function evaluateLinkedIssueGate({ github, context, core = undefined }) {
+  const pullRequest = context?.payload?.pull_request
+
+  if (!pullRequest) {
+    throw new Error('No pull_request payload available.')
+  }
+
+  if (isBotAuthor(pullRequest)) {
+    core?.info?.('Pull request author is a bot; skipping linked issue gate.')
+    return {
+      shouldSkip: true,
+      shouldFail: false,
+      shouldPostComment: false,
+      failureComment: '',
+      linkedIssues: [],
+    }
+  }
+
+  const owner = context.repo.owner
+  const repo = context.repo.repo
+  const number = pullRequest.number
+
+  const linkedIssues = await getLinkedIssues({ github, owner, repo, number })
+  const shouldFail = linkedIssues.length === 0
+
+  if (shouldFail) {
+    core?.info?.('No manually linked issue found for this pull request.')
+  } else {
+    const [firstLinkedIssue] = linkedIssues
+    core?.info?.(`Linked issue found: #${firstLinkedIssue.number} ${firstLinkedIssue.title}`)
+  }
+
+  return {
+    shouldSkip: false,
+    shouldFail,
+    shouldPostComment: shouldFail,
+    failureComment: shouldFail ? buildMissingLinkedIssueComment() : '',
+    linkedIssues,
+  }
+}
+
+module.exports = {
+  STICKY_COMMENT_HEADER,
+  buildMissingLinkedIssueComment,
+  evaluateLinkedIssueGate,
+  getLinkedIssues,
+  isBotAuthor,
+}

--- a/.github/workflows/pr-gates.yml
+++ b/.github/workflows/pr-gates.yml
@@ -1,27 +1,30 @@
 name: PR Gates
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
       - synchronize
 
 permissions:
-  pull-requests: write
-  issues: write
   contents: read
 
 jobs:
   pr-label:
     name: label pr
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
 
       # Custom label logic to avoid unnecessary remove/add cycles when label unchanged
       - name: apply labels (idempotent)
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -31,8 +34,10 @@ jobs:
   pr-title-lint:
     name: lint pr title
     runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -93,7 +98,7 @@ jobs:
             didn't match the configured pattern. Please ensure that the subject
             doesn't start with an uppercase character.
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
         with:
           header: pr-title-lint-error
@@ -113,7 +118,7 @@ jobs:
             add a comment `/lint-pr` to re-run the checks.
 
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: pr-title-lint-error
           delete: true
@@ -121,12 +126,16 @@ jobs:
   pr-linked-issue:
     name: require linked issue
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: check linked issue
         id: check_linked_issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -143,7 +152,7 @@ jobs:
             core.setOutput('should_post_comment', String(result.shouldPostComment));
             core.setOutput('failure_comment', result.failureComment ?? '');
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         if: >
           always() &&
           steps.check_linked_issue.outcome == 'success' &&
@@ -152,7 +161,7 @@ jobs:
           header: ${{ steps.check_linked_issue.outputs.sticky_comment_header }}
           message: ${{ steps.check_linked_issue.outputs.failure_comment }}
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         if: >
           always() &&
           steps.check_linked_issue.outcome == 'success' &&

--- a/.github/workflows/pr-gates.yml
+++ b/.github/workflows/pr-gates.yml
@@ -117,3 +117,50 @@ jobs:
         with:
           header: pr-title-lint-error
           delete: true
+
+  pr-linked-issue:
+    name: require linked issue
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: check linked issue
+        id: check_linked_issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const {
+              STICKY_COMMENT_HEADER,
+              evaluateLinkedIssueGate,
+            } = require('./.github/scripts/pr-gates-linked-issue.cjs');
+
+            const result = await evaluateLinkedIssueGate({ github, context, core });
+
+            core.setOutput('sticky_comment_header', STICKY_COMMENT_HEADER);
+            core.setOutput('should_skip', String(result.shouldSkip));
+            core.setOutput('should_fail', String(result.shouldFail));
+            core.setOutput('should_post_comment', String(result.shouldPostComment));
+            core.setOutput('failure_comment', result.failureComment ?? '');
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: >
+          always() &&
+          steps.check_linked_issue.outcome == 'success' &&
+          steps.check_linked_issue.outputs.should_post_comment == 'true'
+        with:
+          header: ${{ steps.check_linked_issue.outputs.sticky_comment_header }}
+          message: ${{ steps.check_linked_issue.outputs.failure_comment }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: >
+          always() &&
+          steps.check_linked_issue.outcome == 'success' &&
+          steps.check_linked_issue.outputs.should_post_comment != 'true'
+        with:
+          header: ${{ steps.check_linked_issue.outputs.sticky_comment_header }}
+          delete: true
+
+      - name: fail when no linked issue is present
+        if: ${{ steps.check_linked_issue.outputs.should_fail == 'true' }}
+        run: exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,15 @@
 - Never pass multiline PR bodies inline through shell quoting, and never rely on literal `\n` sequences to create paragraph breaks.
 - Verify the rendered PR body with `gh pr view --json body` before sharing the link.
 
+## Issue Workflow
+
+- Open or reuse a GitHub Issue before creating a PR.
+- Write the Issue as an existing problem, need, or opportunity; avoid future-tense implementation wording.
+- Prefer `.github/ISSUE_TEMPLATE/bug_report.yml` and `.github/ISSUE_TEMPLATE/feature.yml` for new work.
+- Link the Issue in the PR `Development` section before requesting review or merge.
+- AI-assisted and human-authored PRs count as non-bot and must have at least one linked Issue.
+- Only GitHub bot-authored PRs, such as Dependabot, are exempt.
+
 ## Language Policy
 
 - Chat and explanations in German unless the user asks otherwise.

--- a/tests/unit/scripts/pr-gates-linked-issue.test.ts
+++ b/tests/unit/scripts/pr-gates-linked-issue.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  buildMissingLinkedIssueComment,
+  evaluateLinkedIssueGate,
+  isBotAuthor,
+  STICKY_COMMENT_HEADER,
+} from '../../../.github/scripts/pr-gates-linked-issue.cjs'
+
+type PullRequestLike = {
+  number: number
+  body?: string | null
+  url: string
+  user?: {
+    login: string
+    type: 'Bot' | 'User' | 'Organization'
+  } | null
+}
+
+function createPullRequest(overrides: Partial<PullRequestLike> = {}): PullRequestLike {
+  return {
+    number: 42,
+    body: 'Default body',
+    url: 'https://github.com/findmydoc-platform/website/pull/42',
+    user: {
+      login: 'jane-doe',
+      type: 'User',
+    },
+    ...overrides,
+  }
+}
+
+function createContext(pullRequest: PullRequestLike) {
+  return {
+    repo: {
+      owner: 'findmydoc-platform',
+      repo: 'website',
+    },
+    payload: {
+      pull_request: pullRequest,
+    },
+  }
+}
+
+describe('pr gates linked issue helper', () => {
+  it('detects bot authors', () => {
+    expect(isBotAuthor(createPullRequest({ user: { login: 'dependabot[bot]', type: 'Bot' } }))).toBe(true)
+    expect(isBotAuthor(createPullRequest())).toBe(false)
+  })
+
+  it('skips bot-authored pull requests', async () => {
+    const github = {
+      graphql: vi.fn(),
+    }
+    const context = createContext(
+      createPullRequest({
+        body: 'Fixes #123',
+        user: { login: 'dependabot[bot]', type: 'Bot' },
+      }),
+    )
+
+    const result = await evaluateLinkedIssueGate({ github, context })
+
+    expect(result).toEqual({
+      shouldSkip: true,
+      shouldFail: false,
+      shouldPostComment: false,
+      failureComment: '',
+      linkedIssues: [],
+    })
+    expect(github.graphql).not.toHaveBeenCalled()
+  })
+
+  it('passes when a non-bot pull request has a manually linked issue', async () => {
+    const github = {
+      graphql: vi.fn().mockResolvedValue({
+        repository: {
+          pullRequest: {
+            closingIssuesReferences: {
+              nodes: [
+                {
+                  id: 'issue-node-1',
+                  number: 123,
+                  title: 'Example issue',
+                  url: 'https://github.com/findmydoc-platform/website/issues/123',
+                },
+              ],
+            },
+          },
+        },
+      }),
+    }
+    const context = createContext(createPullRequest({ body: 'Closes #123' }))
+
+    const result = await evaluateLinkedIssueGate({ github, context })
+
+    expect(result.shouldSkip).toBe(false)
+    expect(result.shouldFail).toBe(false)
+    expect(result.shouldPostComment).toBe(false)
+    expect(result.failureComment).toBe('')
+    expect(result.linkedIssues).toHaveLength(1)
+    expect(github.graphql).toHaveBeenCalledWith(expect.stringContaining('closingIssuesReferences'), {
+      owner: 'findmydoc-platform',
+      repo: 'website',
+      number: 42,
+    })
+  })
+
+  it('fails when a non-bot pull request has no manually linked issue', async () => {
+    const github = {
+      graphql: vi.fn().mockResolvedValue({
+        repository: {
+          pullRequest: {
+            closingIssuesReferences: {
+              nodes: [],
+            },
+          },
+        },
+      }),
+    }
+    const context = createContext(
+      createPullRequest({
+        body: 'Fixes #123',
+      }),
+    )
+
+    const result = await evaluateLinkedIssueGate({ github, context })
+
+    expect(result.shouldSkip).toBe(false)
+    expect(result.shouldFail).toBe(true)
+    expect(result.shouldPostComment).toBe(true)
+    expect(result.linkedIssues).toEqual([])
+    expect(result.failureComment).toContain('Development')
+    expect(result.failureComment).toContain('Bug Report')
+    expect(result.failureComment).toContain('Feature')
+    expect(result.failureComment).toContain('PR body text and commit history do not count')
+  })
+
+  it('builds a stable sticky comment header', () => {
+    expect(STICKY_COMMENT_HEADER).toBe('pr-linked-issue-lint-error')
+    expect(buildMissingLinkedIssueComment()).toContain('Development')
+  })
+})


### PR DESCRIPTION
This keeps PRs tied to real work items so AI-assisted and human-authored changes must link an Issue, while bot PRs stay exempt.

## What changed
- Added a PR gate that checks GitHub GraphQL `closingIssuesReferences(userLinkedOnly: true)` so only manually linked Issues in the PR `Development` section count.
- Exempted bot-authored PRs, including Dependabot.
- Tightened the existing Bug and Feature issue templates and added repo instructions that require an Issue before PR creation.
- Added unit coverage for the linked-issue gate helper.

## Validation
- `pnpm format`
- `pnpm check`
- `pnpm ai:slop-check`
- `pnpm vitest run tests/unit/scripts/pr-gates-linked-issue.test.ts`


## Linked issue

Closes #885.


Linked issue added via the PR Development section.


Linked issue confirmed.


Branch linked to issue #885.
