### PR TITLE
fix(auth): handle clinic registration success without redirect

### DIFF
--- a/src/components/organisms/Auth/ClinicRegistrationForm.tsx
+++ b/src/components/organisms/Auth/ClinicRegistrationForm.tsx
@@ -25,7 +25,7 @@ export function ClinicRegistrationForm() {
     <RegistrationForm
       title="Register Clinic"
       description="Register your clinic"
-      successRedirect="" //TODO: redirect to a success registration page needed
+      successMessage="Thanks, your clinic registration has been submitted. We will review it and get back to you soon."
       submitButtonText="Submit Registration"
       fields={[
         { name: 'clinicName', label: 'Clinic Name', type: 'text', required: true },

--- a/src/components/organisms/Auth/RegistrationForm.tsx
+++ b/src/components/organisms/Auth/RegistrationForm.tsx
@@ -23,7 +23,8 @@ interface FormField {
 interface RegistrationFormProps {
   title: string
   description: string
-  successRedirect: string
+  successRedirect?: string
+  successMessage?: string
   fields: FormField[]
   submitButtonText: string
   links?: {
@@ -37,18 +38,21 @@ export function RegistrationForm({
   title,
   description,
   successRedirect,
+  successMessage = 'Your registration was submitted successfully.',
   fields,
   submitButtonText,
   links,
   onSubmit,
 }: RegistrationFormProps) {
   const [isLoading, setIsLoading] = useState(false)
+  const [hasSubmitted, setHasSubmitted] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const router = useRouter()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsLoading(true)
+    setHasSubmitted(false)
     setError(null)
 
     try {
@@ -68,7 +72,12 @@ export function RegistrationForm({
 
       await onSubmit(submissionData)
 
-      router.push(successRedirect)
+      if (typeof successRedirect === 'string' && successRedirect.trim().length > 0) {
+        router.push(successRedirect)
+        return
+      }
+
+      setHasSubmitted(true)
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error)
       setError(msg || 'Registration failed')
@@ -105,17 +114,21 @@ export function RegistrationForm({
         <CardContent className="pt-6">
           <div className="space-y-4">
             {error && <Alert variant="error">{error}</Alert>}
-            <form onSubmit={handleSubmit} className="space-y-4">
-              {/* Grid fields (2 columns) */}
-              {gridFields.length > 0 && <div className="grid grid-cols-2 gap-4">{gridFields.map(renderField)}</div>}
+            {hasSubmitted ? (
+              <Alert variant="success">{successMessage}</Alert>
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                {/* Grid fields (2 columns) */}
+                {gridFields.length > 0 && <div className="grid grid-cols-2 gap-4">{gridFields.map(renderField)}</div>}
 
-              {/* Single column fields */}
-              {singleFields.map(renderField)}
+                {/* Single column fields */}
+                {singleFields.map(renderField)}
 
-              <Button type="submit" className="w-full" disabled={isLoading}>
-                {isLoading ? 'Creating Account...' : submitButtonText}
-              </Button>
-            </form>
+                <Button type="submit" className="w-full" disabled={isLoading}>
+                  {isLoading ? 'Creating Account...' : submitButtonText}
+                </Button>
+              </form>
+            )}
 
             {links && (
               <div className="space-y-2 text-center">

--- a/src/stories/organisms/Auth/ClinicRegistrationForm.stories.tsx
+++ b/src/stories/organisms/Auth/ClinicRegistrationForm.stories.tsx
@@ -7,9 +7,15 @@ import { withMockRouter } from '../../utils/routerDecorator'
 import { createDelayedJsonResponse } from '../../utils/mockHelpers'
 import { createMockFetchDecorator } from '../../utils/fetchDecorator'
 
+let clinicRegistrationResponseMode: 'error' | 'success' = 'error'
+
 const mockFetch: typeof fetch = async (input) => {
   const url = typeof input === 'string' ? input : input instanceof Request ? input.url : input.toString()
   if (url.includes('/api/auth/register/clinic')) {
+    if (clinicRegistrationResponseMode === 'success') {
+      return createDelayedJsonResponse({ success: true }, 200)
+    }
+
     return createDelayedJsonResponse({ error: 'Please review clinic details before submitting.' }, 400)
   }
 
@@ -38,6 +44,11 @@ export default meta
 type Story = StoryObj<typeof ClinicRegistrationForm>
 
 export const Default: Story = {
+  decorators: [
+    createMockFetchDecorator(mockFetch, () => {
+      clinicRegistrationResponseMode = 'error'
+    }),
+  ],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
@@ -62,5 +73,32 @@ export const Default: Story = {
       expect(canvas.getByText(/please review clinic details/i)).toBeInTheDocument()
     })
     consoleSpy.mockRestore()
+  },
+}
+
+export const SuccessfulSubmission: Story = {
+  decorators: [
+    createMockFetchDecorator(mockFetch, () => {
+      clinicRegistrationResponseMode = 'success'
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await userEvent.type(canvas.getByLabelText(/clinic name/i), 'Bright Smiles Clinic')
+    await userEvent.type(canvas.getByLabelText('First Name'), 'Jordan')
+    await userEvent.type(canvas.getByLabelText('Last Name'), 'Lee')
+    await userEvent.type(canvas.getByLabelText(/street/i), 'Main Street')
+    await userEvent.type(canvas.getByLabelText(/house number/i), '12A')
+    await userEvent.type(canvas.getByLabelText(/postal code/i), '10115')
+    await userEvent.type(canvas.getByLabelText(/city/i), 'Berlin')
+    await userEvent.type(canvas.getByLabelText(/country/i), 'Germany')
+    await userEvent.type(canvas.getByLabelText(/email/i), 'clinic@findmydoc.com')
+
+    await userEvent.click(canvas.getByRole('button', { name: /submit registration/i }))
+
+    await waitFor(() => {
+      expect(canvas.getByText(/submitted\. we will review it/i)).toBeInTheDocument()
+    })
   },
 }

--- a/src/stories/organisms/Auth/RegistrationForm.stories.tsx
+++ b/src/stories/organisms/Auth/RegistrationForm.stories.tsx
@@ -43,6 +43,29 @@ export const ClinicRegistration: Story = {
   },
 }
 
+export const SubmittedWithoutRedirect: Story = {
+  args: {
+    ...ClinicRegistration.args,
+    successRedirect: undefined,
+    successMessage: 'Thanks, your clinic registration has been submitted for review.',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await userEvent.type(canvas.getByLabelText('Clinic Name'), 'Aurora Dental')
+    await userEvent.type(canvas.getByLabelText('Email'), 'hello@auroradental.com')
+    await userEvent.type(canvas.getByLabelText('Password'), 'Secret123')
+    await userEvent.type(canvas.getByLabelText('Confirm Password'), 'Secret123')
+    await userEvent.type(canvas.getByLabelText('Country'), 'Germany')
+
+    await userEvent.click(canvas.getByRole('button', { name: /submit registration/i }))
+
+    await waitFor(() => {
+      expect(canvas.getByText(/submitted for review/i)).toBeInTheDocument()
+    })
+  },
+}
+
 export const PasswordMismatch: Story = {
   args: {
     ...ClinicRegistration.args,


### PR DESCRIPTION
Clinic registration now stays on a valid success state instead of navigating to an empty path after submit.

## What changed
- made `RegistrationForm` support successful submissions without a redirect by rendering a success alert in-place
- updated `ClinicRegistrationForm` to use explicit success copy instead of passing an empty redirect target
- added Storybook interaction coverage for the no-redirect success path and the clinic registration success flow

## Validation
- `pnpm format`
- `pnpm check`
- `pnpm vitest --project storybook --run src/stories/organisms/Auth/RegistrationForm.stories.tsx src/stories/organisms/Auth/ClinicRegistrationForm.stories.tsx`
- `PAYLOAD_SECRET=dev-secret pnpm build`
- manual Playwright review on `http://127.0.0.1:3000/register/clinic` with the clinic registration POST stubbed to success

Screenshots:
- Clinic registration success state reviewed locally via `output/playwright/review/clinic-registration-page-success.png`

## Development
- Fixes #892
