### PR TITLE
fix(ui): refresh animated count-up on value changes

### DIFF
--- a/src/components/organisms/TrustQualitySection/AnimatedCountUp.tsx
+++ b/src/components/organisms/TrustQualitySection/AnimatedCountUp.tsx
@@ -61,6 +61,12 @@ export function AnimatedCountUp({
       return
     }
 
+    if (hasAnimatedRef.current) {
+      tweenRef.current?.kill()
+      setText(value)
+      return
+    }
+
     const start = () => {
       if (hasAnimatedRef.current) return
 

--- a/src/stories/organisms/TrustQualitySection.stories.tsx
+++ b/src/stories/organisms/TrustQualitySection.stories.tsx
@@ -1,7 +1,8 @@
+import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect, within } from '@storybook/test'
+import { expect, userEvent, waitFor, within } from '@storybook/test'
 
-import { TrustQualitySection } from '@/components/organisms/TrustQualitySection'
+import { TrustQualitySection, type TrustQualitySectionProps } from '@/components/organisms/TrustQualitySection'
 import { formatTrustQualityStatValue } from '@/components/organisms/TrustQualitySection'
 import { clinicTrust } from '@/stories/fixtures'
 
@@ -18,6 +19,35 @@ const meta = {
 export default meta
 
 type Story = StoryObj<typeof meta>
+
+const renderMetricUpdatePreview = (args: Story['args']) => {
+  const resolvedArgs = args as TrustQualitySectionProps
+  const [stats, setStats] = React.useState(resolvedArgs.stats)
+
+  return (
+    <div className="space-y-4">
+      <button
+        type="button"
+        className="rounded-md border border-border px-4 py-2 text-sm font-medium"
+        onClick={() => {
+          setStats((currentStats) =>
+            currentStats.map((stat, index) =>
+              index === 0 && 'value' in stat
+                ? {
+                    ...stat,
+                    value: stat.value + 200,
+                  }
+                : stat,
+            ),
+          )
+        }}
+      >
+        Update metrics
+      </button>
+      <TrustQualitySection {...resolvedArgs} stats={stats} />
+    </div>
+  )
+}
 
 export const Default: Story = {
   play: async ({ canvasElement, args }) => {
@@ -40,4 +70,55 @@ export const Default: Story = {
       })
     }
   },
+}
+
+export const UpdatesMetricValues: Story = {
+  args: {
+    title: 'Trust proven quality',
+    numberLocale: 'en-US',
+    stats: [
+      {
+        value: 1200,
+        suffix: '+',
+        label: 'Treatment types',
+        Icon: clinicTrust.stats[1]!.Icon,
+      },
+    ],
+  },
+  render: renderMetricUpdatePreview,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const statLabel = await canvas.findByText('Treatment types')
+    const statCard = statLabel.closest('li')
+
+    if (!statCard) {
+      throw new Error('Unable to locate the metric card for Treatment types.')
+    }
+
+    const visibleValue = statCard.querySelector('span[aria-hidden="true"]')
+
+    if (!visibleValue) {
+      throw new Error('Unable to locate the visible animated value.')
+    }
+
+    await waitFor(
+      () => {
+        expect(visibleValue).toHaveTextContent('1,200+')
+      },
+      { timeout: 2000 },
+    )
+    await userEvent.click(canvas.getByRole('button', { name: /update metrics/i }))
+    await waitFor(
+      () => {
+        expect(visibleValue).toHaveTextContent('1,400+')
+      },
+      { timeout: 2000 },
+    )
+  },
+}
+
+export const MetricUpdatePreview: Story = {
+  args: UpdatesMetricValues.args,
+  render: renderMetricUpdatePreview,
 }


### PR DESCRIPTION
Fixes #898

This keeps trust metrics visually in sync when their numeric values change after the first count-up animation.

## What changed
- update `AnimatedCountUp` so subsequent `value` changes replace the visible text instead of bailing out after the first animation
- add a Storybook regression story that exercises a metric update through the rendered UI
- assert against the visible animated span so the regression test covers the user-facing value, not only the screen-reader text

## Validation
- `pnpm vitest --project storybook --run src/stories/organisms/TrustQualitySection.stories.tsx`
- `pnpm check`
- `PAYLOAD_SECRET=dev-secret pnpm build`
- `pnpm format`

## Screenshots
- `output/playwright/review/trust-quality-section-metric-update-final.png`

## Development
- Fixes #898
