### PR TITLE
refactor(ui): keep image media server-rendered

### DIFF
--- a/src/components/molecules/Media/ImageMedia/index.tsx
+++ b/src/components/molecules/Media/ImageMedia/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { cn } from '@/utilities/ui'
 import NextImage from 'next/image'
 import React from 'react'


### PR DESCRIPTION
Fixes #894

This keeps plain image rendering in the server component graph instead of forcing a client boundary for every `Media` image usage.

## What changed
- remove the unnecessary `'use client'` directive from `ImageMedia`
- keep the shared `Media` molecule server-compatible for image cases while leaving `VideoMedia` client-only

## Validation
- `pnpm check`
- `PAYLOAD_SECRET=dev-secret pnpm build`
- `pnpm format`

## Screenshots
- `output/playwright/review/media-image-resource.png`

## Development
- Fixes #894
