### PR TITLE
refactor(forms): move form submission into block adapter

### DIFF
--- a/src/blocks/Form/Component.tsx
+++ b/src/blocks/Form/Component.tsx
@@ -1,12 +1,15 @@
 'use client'
 
 import type { Form as FormType } from '@payloadcms/plugin-form-builder/types'
+import { useRouter } from 'next/navigation'
 import React from 'react'
+import { useCallback, useState } from 'react'
 import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
 
 import { fields } from './fields'
-import { Form, type FormConfig } from '@/components/organisms/Form'
+import { Form, type FormConfig, type FormSubmitError, type FormValues } from '@/components/organisms/Form'
 import RichText from '@/blocks/_shared/RichText'
+import { FormSubmissionError, submitFormData } from '@/utilities/submitForm'
 
 export type FormBlockType = {
   blockName?: string
@@ -23,11 +26,55 @@ export const FormBlock: React.FC<
   } & FormBlockType
 > = (props) => {
   const { enableIntro, form, introContent, background, id } = props
+  const router = useRouter()
 
   const introContentNode = introContent ? <RichText data={introContent} enableGutter={false} /> : undefined
   const confirmationMessageNode = form.confirmationMessage ? (
     <RichText data={form.confirmationMessage} enableGutter={false} />
   ) : undefined
+  const [isLoading, setIsLoading] = useState(false)
+  const [hasSubmitted, setHasSubmitted] = useState(false)
+  const [error, setError] = useState<FormSubmitError | undefined>()
+
+  const handleSubmit = useCallback(
+    async (values: FormValues) => {
+      const loadingTimer = setTimeout(() => {
+        setIsLoading(true)
+      }, 1000)
+
+      setError(undefined)
+
+      try {
+        await submitFormData({
+          formId: form.id,
+          values,
+        })
+
+        clearTimeout(loadingTimer)
+        setIsLoading(false)
+        setHasSubmitted(true)
+
+        if (form.confirmationType === 'redirect' && form.redirect?.url) {
+          router.push(form.redirect.url)
+        }
+      } catch (submissionError) {
+        clearTimeout(loadingTimer)
+        setIsLoading(false)
+
+        if (submissionError instanceof FormSubmissionError) {
+          setError({
+            message: submissionError.message,
+            status: String(submissionError.status),
+          })
+          return
+        }
+
+        console.warn(submissionError)
+        setError({ message: 'Something went wrong.' })
+      }
+    },
+    [form.confirmationType, form.id, form.redirect?.url, router],
+  )
 
   return (
     <Form
@@ -38,6 +85,10 @@ export const FormBlock: React.FC<
       introContent={introContentNode}
       confirmationMessage={confirmationMessageNode}
       fields={fields}
+      isLoading={isLoading}
+      hasSubmitted={hasSubmitted}
+      error={error}
+      onSubmit={handleSubmit}
     />
   )
 }

--- a/src/components/organisms/Form/index.tsx
+++ b/src/components/organisms/Form/index.tsx
@@ -1,12 +1,10 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
 import type { Control, FieldErrors, UseFormRegister } from 'react-hook-form'
 import { Button } from '@/components/atoms/button'
 
-import { getClientSideURL } from '@/utilities/getURL'
 import { cn } from '@/utilities/ui'
 import { Container } from '@/components/molecules/Container'
 
@@ -31,9 +29,14 @@ export type FormProps = {
   introContent?: React.ReactNode
   confirmationMessage?: React.ReactNode
   fields?: Record<string, React.ComponentType<never>>
+  isLoading?: boolean
+  hasSubmitted?: boolean
+  error?: FormSubmitError
+  onSubmit?: (data: FormValues) => void | Promise<void>
 }
 
-type FormValues = Record<string, unknown>
+export type FormValues = Record<string, unknown>
+export type FormSubmitError = { message: string; status?: string }
 
 type FormFieldRenderProps = {
   form: FormConfig
@@ -46,10 +49,14 @@ export const Form: React.FC<FormProps> = (props) => {
   const {
     enableIntro,
     form: formFromProps,
-    form: { id: formID, confirmationType, redirect, submitButtonLabel } = {},
+    form: { id: formID, confirmationType, submitButtonLabel } = {},
     introContent,
     confirmationMessage,
     fields: fieldsComponents,
+    isLoading = false,
+    hasSubmitted = false,
+    error,
+    onSubmit,
   } = props
 
   const formMethods = useForm<FormValues>({ defaultValues: {} })
@@ -60,71 +67,15 @@ export const Form: React.FC<FormProps> = (props) => {
     register,
   } = formMethods
 
-  const [isLoading, setIsLoading] = useState(false)
-  const [hasSubmitted, setHasSubmitted] = useState<boolean>()
-  const [error, setError] = useState<{ message: string; status?: string } | undefined>()
-  const router = useRouter()
-
   const background = props.background ?? 'primary'
   const buttonVariant =
     background === 'secondary' || background === 'accent' || background === 'accent-2' ? 'secondary' : 'primary'
 
-  const onSubmit = useCallback(
+  const handleFormSubmit = useCallback(
     (data: FormValues) => {
-      let loadingTimerID: ReturnType<typeof setTimeout>
-      const submitForm = async () => {
-        setError(undefined)
-
-        const dataToSend = Object.entries(data).map(([name, value]) => ({
-          field: name,
-          value,
-        }))
-
-        loadingTimerID = setTimeout(() => {
-          setIsLoading(true)
-        }, 1000)
-
-        try {
-          const req = await fetch(`${getClientSideURL()}/api/form-submissions`, {
-            body: JSON.stringify({
-              form: formID,
-              submissionData: dataToSend,
-            }),
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            method: 'POST',
-          })
-
-          const res = await req.json()
-
-          clearTimeout(loadingTimerID)
-
-          if (req.status >= 400) {
-            setIsLoading(false)
-            setError({
-              message: res.errors?.[0]?.message || 'Internal Server Error',
-              status: res.status,
-            })
-            return
-          }
-
-          setIsLoading(false)
-          setHasSubmitted(true)
-
-          if (confirmationType === 'redirect' && redirect?.url) {
-            router.push(redirect.url)
-          }
-        } catch (err) {
-          console.warn(err)
-          setIsLoading(false)
-          setError({ message: 'Something went wrong.' })
-        }
-      }
-
-      void submitForm()
+      void onSubmit?.(data)
     },
-    [router, formID, redirect, confirmationType],
+    [onSubmit],
   )
 
   return (
@@ -136,7 +87,7 @@ export const Form: React.FC<FormProps> = (props) => {
           {isLoading && !hasSubmitted && <p>Loading, please wait...</p>}
           {error && <div>{`${error.status || '500'}: ${error.message || ''}`}</div>}
           {!hasSubmitted && (
-            <form id={formID} onSubmit={handleSubmit(onSubmit)}>
+            <form id={formID} onSubmit={handleSubmit(handleFormSubmit)}>
               <div className="mb-6 grid grid-cols-1 gap-6 md:grid-cols-2">
                 {formFromProps?.fields?.map((field, index) => {
                   const blockType = (field as { blockType?: string }).blockType

--- a/src/stories/organisms/Form.stories.tsx
+++ b/src/stories/organisms/Form.stories.tsx
@@ -1,18 +1,18 @@
+import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { Form, type FormConfig } from '@/components/organisms/Form'
-import { withMockRouter } from '../utils/routerDecorator'
+import { expect, userEvent, waitFor, within } from '@storybook/test'
+import { Form, type FormConfig, type FormProps } from '@/components/organisms/Form'
 import type { UseFormRegister } from 'react-hook-form'
 
 const meta = {
   title: 'Shared/Organisms/Form',
   component: Form,
-  decorators: [withMockRouter],
   parameters: {
     layout: 'fullscreen',
     docs: {
       description: {
         component:
-          'Dynamic form builder that renders fields from configuration object. Supports text, email, textarea, select, and checkbox fields with validation and submission handling.',
+          'Dynamic form builder that renders fields from configuration and delegates submission state to the parent adapter.',
       },
     },
   },
@@ -22,6 +22,31 @@ const meta = {
 export default meta
 
 type Story = StoryObj<typeof meta>
+
+const renderSuccessfulSubmissionStory = (args: Story['args']) => {
+  const resolvedArgs = args as FormProps
+  const [isLoading, setIsLoading] = React.useState(false)
+  const [hasSubmitted, setHasSubmitted] = React.useState(false)
+  const [error, setError] = React.useState<FormProps['error']>(undefined)
+
+  return (
+    <Form
+      {...resolvedArgs}
+      isLoading={isLoading}
+      hasSubmitted={hasSubmitted}
+      error={error}
+      onSubmit={async () => {
+        setError(undefined)
+        setIsLoading(true)
+        await new Promise((resolve) => {
+          window.setTimeout(resolve, 50)
+        })
+        setIsLoading(false)
+        setHasSubmitted(true)
+      }}
+    />
+  )
+}
 
 const sampleForm: FormConfig = {
   id: 'sample-form',
@@ -64,30 +89,39 @@ type MockFieldProps = {
 const mockFields = {
   text: ({ label, register, name, required }: MockFieldProps) => (
     <div className="flex flex-col gap-2">
-      <label className="text-sm font-medium">{label}</label>
+      <label className="text-sm font-medium" htmlFor={name}>
+        {label}
+      </label>
       <input
         {...register(name, { required })}
         className="rounded-md border border-input bg-background px-3 py-2"
+        id={name}
         type="text"
       />
     </div>
   ),
   email: ({ label, register, name, required }: MockFieldProps) => (
     <div className="flex flex-col gap-2">
-      <label className="text-sm font-medium">{label}</label>
+      <label className="text-sm font-medium" htmlFor={name}>
+        {label}
+      </label>
       <input
         {...register(name, { required })}
         className="rounded-md border border-input bg-background px-3 py-2"
+        id={name}
         type="email"
       />
     </div>
   ),
   textarea: ({ label, register, name, required }: MockFieldProps) => (
     <div className="flex flex-col gap-2">
-      <label className="text-sm font-medium">{label}</label>
+      <label className="text-sm font-medium" htmlFor={name}>
+        {label}
+      </label>
       <textarea
         {...register(name, { required })}
         className="rounded-md border border-input bg-background px-3 py-2"
+        id={name}
         rows={4}
       />
     </div>
@@ -126,5 +160,36 @@ export const SecondaryButton: Story = {
     enableIntro: false,
     background: 'secondary',
     fields: mockFields,
+  },
+}
+
+export const SuccessfulSubmission: Story = {
+  args: {
+    form: sampleForm,
+    enableIntro: true,
+    introContent: (
+      <div className="prose">
+        <p>findmydoc connects patients with trusted clinics across specialties.</p>
+      </div>
+    ),
+    confirmationMessage: (
+      <div className="prose">
+        <p>Thank you for your submission!</p>
+      </div>
+    ),
+    fields: mockFields,
+  },
+  render: renderSuccessfulSubmissionStory,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await userEvent.type(canvas.getByLabelText('Full Name'), 'Ada Lovelace')
+    await userEvent.type(canvas.getByLabelText('Email Address'), 'ada@example.com')
+    await userEvent.type(canvas.getByLabelText('Message'), 'Please tell me more.')
+    await userEvent.click(canvas.getByRole('button', { name: 'Submit' }))
+
+    await waitFor(() => {
+      expect(canvas.getByText('Thank you for your submission!')).toBeInTheDocument()
+    })
   },
 }


### PR DESCRIPTION
Fixes #896

This keeps the shared form organism presentational and moves network + navigation side effects back into the Payload-aware block adapter.

## What changed
- strip fetch, redirect, and local submission state out of `src/components/organisms/Form`
- let `src/blocks/Form/Component.tsx` own form submission, redirect handling, and API error mapping through `submitFormData`
- add an interactive Storybook regression story that submits the rendered form and verifies the confirmation state

## Validation
- `pnpm stories:governance:check`
- `pnpm vitest --project storybook --run src/stories/organisms/Form.stories.tsx`
- `pnpm check`
- `PAYLOAD_SECRET=dev-secret pnpm build`
- `pnpm format`

## Screenshots
- `output/playwright/review/form-successful-submission-debug.png`

## Development
- Fixes #896
