### PR TITLE
refactor(ui): split landing categories client shell

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -4,7 +4,7 @@ import { CheckCircle, TrendingUp, Eye } from 'lucide-react'
 
 import { LandingHero } from '@/components/organisms/Heroes/LandingHero'
 import { LandingTestimonials } from '@/components/organisms/Landing/LandingTestimonials'
-import { LandingCategoriesClient } from '@/components/organisms/Landing'
+import { LandingCategories } from '@/components/organisms/Landing'
 import { LandingFeatures } from '@/components/organisms/Landing/LandingFeatures'
 import { LandingProcess } from '@/components/organisms/Landing/LandingProcess'
 import { LandingContact } from '@/components/organisms/Landing/LandingContact'
@@ -93,7 +93,7 @@ export default async function Home({
         description="Perspectives from healthcare and product experts who reviewed the patient decision flow."
       />
 
-      <LandingCategoriesClient
+      <LandingCategories
         title="Categories"
         description="Explore verified clinics by specialty and compare the best options for your needs."
         categories={landingSpecialtyCategories.categories}

--- a/src/app/(frontend)/partners/clinics/page.tsx
+++ b/src/app/(frontend)/partners/clinics/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from 'next'
 
 import { Heading } from '@/components/atoms/Heading'
 import {
-  LandingCategoriesClient,
+  LandingCategories,
   LandingContact,
   LandingFeatures,
   LandingPricing,
@@ -72,7 +72,7 @@ export default async function ClinicLandingPage() {
         stepPercentages={[0, 33.33, 66.67, 100]}
         stepActivationOffsetPx={[0, 28, 48, 0]}
       />
-      <LandingCategoriesClient
+      <LandingCategories
         title="Our Categories"
         description="Showcase your clinic under the categories patients search most."
         categories={landingSpecialtyCategories.categories}

--- a/src/components/organisms/Landing/LandingCategories.shared.ts
+++ b/src/components/organisms/Landing/LandingCategories.shared.ts
@@ -1,0 +1,123 @@
+import type { ImageProps } from 'next/image'
+
+export type LandingCategory = {
+  label: string
+  value: string
+}
+
+export type LandingCategoryItem = {
+  id: string
+  title: string
+  subtitle?: string | null
+  categories: string[]
+  href?: string
+  newTab?: boolean
+  image: {
+    src: ImageProps['src']
+    alt: string
+  }
+}
+
+export type LandingCategoriesProps = {
+  title: string
+  description: string
+  categories: LandingCategory[]
+  items: LandingCategoryItem[]
+  featuredIds?: string[]
+  defaultActiveFilter?: string
+  moreCategoriesLink?: {
+    href: string
+    label?: string | null
+    newTab?: boolean
+  }
+}
+
+export const ALL_CATEGORY_VALUE = 'all'
+const ALL_CATEGORY_LABEL = 'All'
+
+// Slot layout definitions for the 4-card collage.
+// Grid model:
+// - Slot 0: left half, full height (primary card)
+// - Slot 1: right half, top half
+// - Slot 2: right half, bottom-left quarter
+// - Slot 3: right half, bottom-right quarter
+// Items not assigned to one of these slots are moved to a hidden 0×0 slot.
+export const SLOT_LARGE_LEFT = 'top-0 left-0 h-full w-1/2'
+export const SLOT_TOP_RIGHT_HALF = 'top-0 left-1/2 h-1/2 w-1/2'
+export const SLOT_BOTTOM_RIGHT_LEFT_QUARTER = 'top-1/2 left-1/2 h-1/2 w-1/4'
+export const SLOT_BOTTOM_RIGHT_RIGHT_QUARTER = 'top-1/2 left-3/4 h-1/2 w-1/4'
+export const SLOT_HIDDEN = 'top-1/2 left-1/2 h-0 w-0'
+
+const PARKING_SLOTS = [
+  'top-[-18%] left-[-16%] h-2/5 w-2/5',
+  'top-[-8%] left-[-24%] h-1/3 w-1/3',
+  'top-[18%] left-[-20%] h-1/3 w-1/3',
+  'top-[-18%] left-[76%] h-2/5 w-2/5',
+  'top-[-10%] left-[88%] h-1/3 w-1/3',
+  'top-[18%] left-[92%] h-1/3 w-1/3',
+  'top-[70%] left-[76%] h-2/5 w-2/5',
+  'top-[84%] left-[88%] h-1/3 w-1/3',
+  'top-[54%] left-[92%] h-1/3 w-1/3',
+  'top-[72%] left-[-18%] h-2/5 w-2/5',
+  'top-[84%] left-[-24%] h-1/3 w-1/3',
+  'top-[54%] left-[-22%] h-1/3 w-1/3',
+] as const
+
+function hashString(value: string): number {
+  let hash = 2166136261
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+
+  return hash >>> 0
+}
+
+function createSeededRandom(seedText: string): () => number {
+  let state = hashString(seedText) || 1
+
+  return () => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0
+    return state / 2 ** 32
+  }
+}
+
+export function createParkingSlotOrder(seedText: string): string[] {
+  const slots: string[] = [...PARKING_SLOTS]
+  const random = createSeededRandom(seedText)
+  const fallbackSlot = PARKING_SLOTS[0] ?? SLOT_HIDDEN
+
+  for (let index = slots.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(random() * (index + 1))
+    const currentSlot = slots[index] ?? fallbackSlot
+    slots[index] = slots[swapIndex] ?? currentSlot
+    slots[swapIndex] = currentSlot
+  }
+
+  return slots
+}
+
+export function buildCategoryTabs(categories: LandingCategory[]): LandingCategory[] {
+  const specialtyTabs = categories.filter((category) => category.value !== ALL_CATEGORY_VALUE)
+  return [{ label: ALL_CATEGORY_LABEL, value: ALL_CATEGORY_VALUE }, ...specialtyTabs]
+}
+
+export function withSpecialtyQuery(href: string, specialtyId: string | null) {
+  if (!href.startsWith('/')) return href
+
+  const [pathAndQuery, hash] = href.split('#')
+  const [pathnameValue = '/', query = ''] = (pathAndQuery ?? '/').split('?')
+  const pathname = pathnameValue.length > 0 ? pathnameValue : '/'
+  const params = new URLSearchParams(query)
+
+  if (specialtyId) {
+    params.set('specialty', specialtyId)
+  } else {
+    params.delete('specialty')
+  }
+
+  const serializedParams = params.toString()
+  const next = serializedParams ? `${pathname}?${serializedParams}` : pathname
+  return hash ? `${next}#${hash}` : next
+}

--- a/src/components/organisms/Landing/LandingCategories.tsx
+++ b/src/components/organisms/Landing/LandingCategories.tsx
@@ -1,237 +1,45 @@
-'use client'
-
-import React, { useEffect, useMemo, useState } from 'react'
-import Image, { type ImageProps } from 'next/image'
+import React from 'react'
+import Image from 'next/image'
 import { ArrowRight } from 'lucide-react'
 
 import { Heading } from '@/components/atoms/Heading'
 import { Container } from '@/components/molecules/Container'
-import { SectionHeading } from '@/components/molecules/SectionHeading'
 import { UiLink } from '@/components/molecules/Link'
+import { SectionHeading } from '@/components/molecules/SectionHeading'
 import { cn } from '@/utilities/ui'
 
-export type LandingCategory = {
-  label: string
-  value: string
-}
+import { LandingCategoriesShell } from './LandingCategoriesShell'
+import { buildCategoryTabs, type LandingCategoriesProps, withSpecialtyQuery } from './LandingCategories.shared'
 
-export type LandingCategoryItem = {
-  id: string
-  title: string
-  subtitle?: string | null
-  categories: string[]
-  href?: string
-  newTab?: boolean
-  image: {
-    src: ImageProps['src']
-    alt: string
-  }
-}
+export type { LandingCategory, LandingCategoriesProps, LandingCategoryItem } from './LandingCategories.shared'
 
-export type LandingCategoriesProps = {
-  title: string
-  description: string
-  categories: LandingCategory[]
-  items: LandingCategoryItem[]
-  activeFilter: string
-  onActiveFilterChange: (nextValue: string) => void
-  featuredIds?: string[]
-  moreCategoriesLink?: {
-    href: string
-    label?: string | null
-    newTab?: boolean
-  }
-}
-
-const ALL_CATEGORY_VALUE = 'all'
-const ALL_CATEGORY_LABEL = 'All'
-
-// Slot layout definitions for the 4-card collage.
-// Grid model:
-// - Slot 0: left half, full height (primary card)
-// - Slot 1: right half, top half
-// - Slot 2: right half, bottom-left quarter
-// - Slot 3: right half, bottom-right quarter
-// Items not assigned to one of these slots are moved to a hidden 0×0 slot.
-const SLOT_LARGE_LEFT = 'top-0 left-0 h-full w-1/2'
-const SLOT_TOP_RIGHT_HALF = 'top-0 left-1/2 h-1/2 w-1/2'
-const SLOT_BOTTOM_RIGHT_LEFT_QUARTER = 'top-1/2 left-1/2 h-1/2 w-1/4'
-const SLOT_BOTTOM_RIGHT_RIGHT_QUARTER = 'top-1/2 left-3/4 h-1/2 w-1/4'
-const SLOT_HIDDEN = 'top-1/2 left-1/2 h-0 w-0'
-const PARKING_SLOTS = [
-  'top-[-18%] left-[-16%] h-2/5 w-2/5',
-  'top-[-8%] left-[-24%] h-1/3 w-1/3',
-  'top-[18%] left-[-20%] h-1/3 w-1/3',
-  'top-[-18%] left-[76%] h-2/5 w-2/5',
-  'top-[-10%] left-[88%] h-1/3 w-1/3',
-  'top-[18%] left-[92%] h-1/3 w-1/3',
-  'top-[70%] left-[76%] h-2/5 w-2/5',
-  'top-[84%] left-[88%] h-1/3 w-1/3',
-  'top-[54%] left-[92%] h-1/3 w-1/3',
-  'top-[72%] left-[-18%] h-2/5 w-2/5',
-  'top-[84%] left-[-24%] h-1/3 w-1/3',
-  'top-[54%] left-[-22%] h-1/3 w-1/3',
-] as const
-
-function hashString(value: string): number {
-  let hash = 2166136261
-
-  for (let index = 0; index < value.length; index += 1) {
-    hash ^= value.charCodeAt(index)
-    hash = Math.imul(hash, 16777619)
-  }
-
-  return hash >>> 0
-}
-
-function createSeededRandom(seedText: string): () => number {
-  let state = hashString(seedText) || 1
-
-  return () => {
-    state = (Math.imul(state, 1664525) + 1013904223) >>> 0
-    return state / 2 ** 32
-  }
-}
-
-function createParkingSlotOrder(seedText: string): string[] {
-  const slots: string[] = [...PARKING_SLOTS]
-  const random = createSeededRandom(seedText)
-  const fallbackSlot = PARKING_SLOTS[0] ?? SLOT_HIDDEN
-
-  for (let index = slots.length - 1; index > 0; index -= 1) {
-    const swapIndex = Math.floor(random() * (index + 1))
-    const currentSlot = slots[index] ?? fallbackSlot
-    slots[index] = slots[swapIndex] ?? currentSlot
-    slots[swapIndex] = currentSlot
-  }
-
-  return slots
-}
-
-function buildCategoryTabs(categories: LandingCategory[]): LandingCategory[] {
-  const specialtyTabs = categories.filter((category) => category.value !== ALL_CATEGORY_VALUE)
-  return [{ label: ALL_CATEGORY_LABEL, value: ALL_CATEGORY_VALUE }, ...specialtyTabs]
-}
-
-export const LandingCategories: React.FC<LandingCategoriesProps> = ({
+export function LandingCategories({
   title,
   description,
   categories,
   items,
-  activeFilter,
-  onActiveFilterChange,
   featuredIds,
+  defaultActiveFilter,
   moreCategoriesLink,
-}) => {
+}: LandingCategoriesProps) {
   const baseHref = moreCategoriesLink?.href ?? '/listing-comparison'
+  const categoryLabelMap = new Map(buildCategoryTabs(categories).map((category) => [category.value, category.label]))
 
-  const categoryTabs = useMemo<LandingCategory[]>(() => {
-    return buildCategoryTabs(categories)
-  }, [categories])
-
-  const categoryValueSet = useMemo(() => {
-    return new Set(
-      categoryTabs.filter((category) => category.value !== ALL_CATEGORY_VALUE).map((category) => category.value),
-    )
-  }, [categoryTabs])
-
-  const scopedItems = useMemo(() => {
-    if (categoryValueSet.size === 0) return items
-    return items.filter((item) => item.categories.some((category) => categoryValueSet.has(category)))
-  }, [categoryValueSet, items])
-
-  const panelId = 'landing-categories-panel'
-  const resolvedFilter = categoryTabs.some((category) => category.value === activeFilter)
-    ? activeFilter
-    : ALL_CATEGORY_VALUE
-  const activeTabId = `landing-categories-tab-${resolvedFilter}`
-
-  const withSpecialtyQuery = (href: string, specialtyId: string | null) => {
-    if (!href.startsWith('/')) return href
-
-    const [pathAndQuery, hash] = href.split('#')
-    const [pathnameValue = '/', query = ''] = (pathAndQuery ?? '/').split('?')
-    const pathname = pathnameValue.length > 0 ? pathnameValue : '/'
-    const params = new URLSearchParams(query)
-
-    if (specialtyId) {
-      params.set('specialty', specialtyId)
-    } else {
-      params.delete('specialty')
-    }
-
-    const serializedParams = params.toString()
-    const next = serializedParams ? `${pathname}?${serializedParams}` : pathname
-    return hash ? `${next}#${hash}` : next
-  }
-
-  const categoryLabelMap = useMemo(() => {
-    return new Map(categoryTabs.map((category) => [category.value, category.label]))
-  }, [categoryTabs])
-
-  const parkingSlotMap = useMemo(() => {
-    const map = new Map<string, string>()
-    const orderedParkingSlots = createParkingSlotOrder(resolvedFilter)
-    const sortedItems = [...scopedItems].sort((left, right) =>
-      left.id.localeCompare(right.id, 'en', { sensitivity: 'base' }),
-    )
-
-    sortedItems.forEach((item, index) => {
-      map.set(item.id, orderedParkingSlots[index % orderedParkingSlots.length] ?? SLOT_HIDDEN)
-    })
-
-    for (const item of scopedItems) {
-      if (!map.has(item.id)) {
-        map.set(item.id, SLOT_HIDDEN)
-      }
-    }
-
-    return map
-  }, [resolvedFilter, scopedItems])
-
-  const curatedItems = useMemo(() => {
-    if (!featuredIds?.length) return scopedItems
-    return featuredIds
-      .map((id) => scopedItems.find((item) => item.id === id))
-      .filter((item): item is LandingCategoryItem => Boolean(item))
-  }, [featuredIds, scopedItems])
-
-  const visibleItems = useMemo(() => {
-    const curatedMatches =
-      resolvedFilter === ALL_CATEGORY_VALUE
-        ? curatedItems
-        : curatedItems.filter((item) => item.categories.includes(resolvedFilter))
-
-    const pool =
-      resolvedFilter === ALL_CATEGORY_VALUE
-        ? scopedItems
-        : scopedItems.filter((item) => item.categories.includes(resolvedFilter))
-    const poolSet = new Set(curatedMatches.map((item) => item.id))
-    const filler = pool.filter((item) => !poolSet.has(item.id))
-
-    return [...curatedMatches, ...filler].slice(0, 4)
-  }, [curatedItems, resolvedFilter, scopedItems])
-
-  const slotItems = useMemo(() => {
-    return Array.from({ length: 4 }).map((_, index) => visibleItems[index])
-  }, [visibleItems])
-
-  const slotMap = useMemo(() => {
-    const map = new Map<string, number>()
-    slotItems.forEach((item, index) => {
-      if (item) map.set(item.id, index)
-    })
-    return map
-  }, [slotItems])
-
-  const activeLabel = categoryLabelMap.get(resolvedFilter)
-  const ctaLabel =
-    moreCategoriesLink?.label ??
-    (resolvedFilter === ALL_CATEGORY_VALUE ? 'View all clinics' : `More clinics in ${activeLabel ?? 'specialty'}`)
-  const ctaHref = withSpecialtyQuery(baseHref, resolvedFilter === ALL_CATEGORY_VALUE ? null : resolvedFilter)
-
-  const slots = [SLOT_LARGE_LEFT, SLOT_TOP_RIGHT_HALF, SLOT_BOTTOM_RIGHT_LEFT_QUARTER, SLOT_BOTTOM_RIGHT_RIGHT_QUARTER]
-  const hiddenSlot = SLOT_HIDDEN
+  const shellItems = items.map((item) => ({
+    id: item.id,
+    categories: item.categories,
+    card: (
+      <LandingCategoryCard
+        key={item.id}
+        label={categoryLabelMap.get(item.categories[0] ?? '') ?? item.categories[0] ?? 'Category'}
+        title={item.title}
+        subtitle={item.subtitle}
+        href={item.href ?? withSpecialtyQuery(baseHref, item.id)}
+        newTab={item.newTab}
+        image={item.image}
+      />
+    ),
+  }))
 
   return (
     <section className="bg-muted/30 py-20">
@@ -244,179 +52,57 @@ export const LandingCategories: React.FC<LandingCategoriesProps> = ({
             align="center"
             titleClassName="font-semibold"
           />
-
-          <nav role="tablist" aria-label="Category filters" className="flex flex-wrap justify-center gap-x-8 gap-y-3">
-            {categoryTabs.map((category) => {
-              const isActive = resolvedFilter === category.value
-              const tabId = `landing-categories-tab-${category.value}`
-
-              return (
-                <button
-                  key={category.value}
-                  id={tabId}
-                  type="button"
-                  onClick={() => onActiveFilterChange(category.value)}
-                  role="tab"
-                  aria-selected={isActive}
-                  aria-pressed={isActive}
-                  aria-controls={panelId}
-                  tabIndex={isActive ? 0 : -1}
-                  className={cn(
-                    'relative cursor-pointer text-base font-medium transition-colors md:text-lg',
-                    isActive ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
-                  )}
-                >
-                  {category.label}
-                  <span
-                    className={cn(
-                      'absolute -bottom-2 left-0 h-0.5 bg-foreground transition-all duration-300',
-                      isActive ? 'w-full' : 'w-0',
-                    )}
-                  />
-                </button>
-              )
-            })}
-          </nav>
         </header>
 
-        <div id={panelId} role="tabpanel" aria-labelledby={activeTabId} className="relative mb-12 h-140 w-full">
-          {scopedItems.map((item) => {
-            const slotIndex = slotMap.get(item.id)
-            const hasSlot = slotIndex !== undefined && slotIndex >= 0 && slotIndex < slots.length
-            const isVisible = hasSlot
-            const slotClass = hasSlot ? slots[slotIndex] : (parkingSlotMap.get(item.id) ?? hiddenSlot)
-
-            return (
-              <div
-                key={item.id}
-                aria-hidden={!isVisible}
-                className={cn(
-                  'absolute p-3 transition-all duration-700 ease-in-out',
-                  slotClass,
-                  isVisible ? 'pointer-events-auto scale-100 opacity-100' : 'pointer-events-none scale-90 opacity-0',
-                  isVisible ? 'z-10' : 'z-0',
-                )}
-              >
-                <div className="relative h-full w-full overflow-hidden rounded-2xl border border-border/60 bg-muted/40 shadow-sm">
-                  <LandingCategoryCard
-                    item={item}
-                    categories={categoryLabelMap}
-                    sizes="(min-width: 1024px) 45vw, (min-width: 768px) 50vw, 100vw"
-                    showContent={isVisible}
-                    href={item.href ?? withSpecialtyQuery(baseHref, item.id)}
-                    newTab={item.newTab}
-                  />
-                </div>
-              </div>
-            )
-          })}
-        </div>
-
-        <div className="mt-10 flex justify-center">
-          <UiLink
-            href={ctaHref}
-            label={ctaLabel}
-            newTab={moreCategoriesLink?.newTab}
-            appearance="secondary"
-            hoverEffect="slideFill"
-            size="lg"
-            className="rounded-full border border-black text-base font-bold text-black"
-          />
-        </div>
+        <LandingCategoriesShell
+          baseHref={baseHref}
+          categories={categories}
+          defaultActiveFilter={defaultActiveFilter}
+          featuredIds={featuredIds}
+          items={shellItems}
+          moreCategoriesLink={moreCategoriesLink}
+        />
       </Container>
     </section>
   )
 }
 
-export type LandingCategoriesClientProps = Omit<LandingCategoriesProps, 'activeFilter' | 'onActiveFilterChange'> & {
-  defaultActiveFilter?: string
-}
-
-export const LandingCategoriesClient: React.FC<LandingCategoriesClientProps> = ({
-  defaultActiveFilter,
-  categories,
-  ...rest
-}) => {
-  const categoryFilters = useMemo(() => {
-    return new Set(buildCategoryTabs(categories).map((category) => category.value))
-  }, [categories])
-
-  const preferredDefault =
-    typeof defaultActiveFilter === 'string' && categoryFilters.has(defaultActiveFilter)
-      ? defaultActiveFilter
-      : ALL_CATEGORY_VALUE
-
-  const [activeFilter, setActiveFilter] = useState<string>(preferredDefault)
-
-  useEffect(() => {
-    if (!categoryFilters.has(activeFilter)) {
-      setActiveFilter(ALL_CATEGORY_VALUE)
-    }
-  }, [activeFilter, categoryFilters])
-
-  return (
-    <LandingCategories
-      {...rest}
-      categories={categories}
-      activeFilter={activeFilter}
-      onActiveFilterChange={setActiveFilter}
-    />
-  )
-}
-
 type LandingCategoryCardProps = {
-  item?: LandingCategoryItem
-  categories: Map<string, string>
-  sizes: string
-  showContent?: boolean
   href?: string
+  image: LandingCategoriesProps['items'][number]['image']
+  label: string
   newTab?: boolean
+  subtitle?: string | null
+  title: string
 }
 
-const LandingCategoryCard: React.FC<LandingCategoryCardProps> = ({
-  item,
-  categories,
-  sizes,
-  showContent = true,
-  href,
-  newTab,
-}) => {
-  if (!item) {
-    return <div className="h-full w-full rounded-2xl bg-muted/40" aria-hidden="true" />
-  }
-
-  const label = categories.get(item.categories[0] ?? '') ?? item.categories[0] ?? 'Category'
-
+const LandingCategoryCard: React.FC<LandingCategoryCardProps> = ({ href, image, label, newTab, subtitle, title }) => {
   return (
     <div className="group relative h-full w-full overflow-hidden">
       <Image
-        src={item.image.src}
-        alt={item.image.alt}
+        src={image.src}
+        alt={image.alt}
         fill
-        sizes={sizes}
+        sizes="(min-width: 1024px) 45vw, (min-width: 768px) 50vw, 100vw"
         className="object-cover transition-transform duration-700 group-hover:scale-105"
       />
       <div className="absolute inset-0 bg-linear-to-t from-black/70 via-black/20 to-transparent opacity-70 transition-opacity duration-300 group-hover:opacity-60" />
-      {showContent ? (
-        <>
-          <div className="absolute bottom-0 left-0 w-full p-6 text-left text-white md:p-8">
-            <div className="translate-y-2 transition-all duration-500 group-hover:translate-y-0">
-              <p className="text-xs font-bold tracking-widest text-white/80 uppercase">{label}</p>
-              <Heading as="h3" size="h5" align="left" className="mt-2 text-2xl font-semibold text-white md:text-2xl">
-                {item.title}
-              </Heading>
-              <p className="mt-2 max-h-0 overflow-hidden text-sm text-white/90 opacity-0 transition-all duration-500 group-hover:max-h-20 group-hover:opacity-100">
-                {item.subtitle}
-              </p>
-            </div>
-          </div>
-          <div className="absolute top-6 right-6 translate-y-2 opacity-0 transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100">
-            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-foreground shadow-lg">
-              <ArrowRight className="h-4 w-4 -rotate-45" />
-            </div>
-          </div>
-        </>
-      ) : null}
+      <div className="absolute bottom-0 left-0 w-full p-6 text-left text-white md:p-8">
+        <div className="translate-y-2 transition-all duration-500 group-hover:translate-y-0">
+          <p className="text-xs font-bold tracking-widest text-white/80 uppercase">{label}</p>
+          <Heading as="h3" size="h5" align="left" className="mt-2 text-2xl font-semibold text-white md:text-2xl">
+            {title}
+          </Heading>
+          <p className="mt-2 max-h-0 overflow-hidden text-sm text-white/90 opacity-0 transition-all duration-500 group-hover:max-h-20 group-hover:opacity-100">
+            {subtitle}
+          </p>
+        </div>
+      </div>
+      <div className="absolute top-6 right-6 translate-y-2 opacity-0 transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-foreground shadow-lg">
+          <ArrowRight className="h-4 w-4 -rotate-45" />
+        </div>
+      </div>
       {href ? (
         <UiLink
           href={href}
@@ -426,7 +112,7 @@ const LandingCategoryCard: React.FC<LandingCategoryCardProps> = ({
             'cursor-pointer focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none',
           )}
         >
-          <span className="sr-only">Explore {item.title}</span>
+          <span className="sr-only">Explore {title}</span>
         </UiLink>
       ) : null}
     </div>

--- a/src/components/organisms/Landing/LandingCategoriesShell.tsx
+++ b/src/components/organisms/Landing/LandingCategoriesShell.tsx
@@ -1,0 +1,223 @@
+'use client'
+
+import React, { useEffect, useMemo, useState } from 'react'
+
+import { UiLink } from '@/components/molecules/Link'
+import { cn } from '@/utilities/ui'
+
+import {
+  ALL_CATEGORY_VALUE,
+  SLOT_BOTTOM_RIGHT_LEFT_QUARTER,
+  SLOT_BOTTOM_RIGHT_RIGHT_QUARTER,
+  SLOT_HIDDEN,
+  SLOT_LARGE_LEFT,
+  SLOT_TOP_RIGHT_HALF,
+  buildCategoryTabs,
+  createParkingSlotOrder,
+  type LandingCategory,
+  type LandingCategoriesProps,
+  withSpecialtyQuery,
+} from './LandingCategories.shared'
+
+type LandingCategoriesShellItem = {
+  id: string
+  categories: string[]
+  card: React.ReactNode
+}
+
+type LandingCategoriesShellProps = {
+  baseHref: string
+  categories: LandingCategory[]
+  defaultActiveFilter?: string
+  featuredIds?: string[]
+  items: LandingCategoriesShellItem[]
+  moreCategoriesLink?: LandingCategoriesProps['moreCategoriesLink']
+}
+
+export function LandingCategoriesShell({
+  baseHref,
+  categories,
+  defaultActiveFilter,
+  featuredIds,
+  items,
+  moreCategoriesLink,
+}: LandingCategoriesShellProps) {
+  const categoryTabs = useMemo(() => {
+    return buildCategoryTabs(categories)
+  }, [categories])
+
+  const categoryFilters = useMemo(() => {
+    return new Set(categoryTabs.map((category) => category.value))
+  }, [categoryTabs])
+
+  const preferredDefault =
+    typeof defaultActiveFilter === 'string' && categoryFilters.has(defaultActiveFilter)
+      ? defaultActiveFilter
+      : ALL_CATEGORY_VALUE
+
+  const [activeFilter, setActiveFilter] = useState(preferredDefault)
+
+  useEffect(() => {
+    if (!categoryFilters.has(activeFilter)) {
+      setActiveFilter(ALL_CATEGORY_VALUE)
+    }
+  }, [activeFilter, categoryFilters])
+
+  const categoryValueSet = useMemo(() => {
+    return new Set(
+      categoryTabs.filter((category) => category.value !== ALL_CATEGORY_VALUE).map((category) => category.value),
+    )
+  }, [categoryTabs])
+
+  const scopedItems = useMemo(() => {
+    if (categoryValueSet.size === 0) return items
+    return items.filter((item) => item.categories.some((category) => categoryValueSet.has(category)))
+  }, [categoryValueSet, items])
+
+  const resolvedFilter = categoryTabs.some((category) => category.value === activeFilter)
+    ? activeFilter
+    : ALL_CATEGORY_VALUE
+  const panelId = 'landing-categories-panel'
+  const activeTabId = `landing-categories-tab-${resolvedFilter}`
+  const categoryLabelMap = useMemo(() => {
+    return new Map(categoryTabs.map((category) => [category.value, category.label]))
+  }, [categoryTabs])
+
+  const parkingSlotMap = useMemo(() => {
+    const map = new Map<string, string>()
+    const orderedParkingSlots = createParkingSlotOrder(resolvedFilter)
+    const sortedItems = [...scopedItems].sort((left, right) =>
+      left.id.localeCompare(right.id, 'en', { sensitivity: 'base' }),
+    )
+
+    sortedItems.forEach((item, index) => {
+      map.set(item.id, orderedParkingSlots[index % orderedParkingSlots.length] ?? SLOT_HIDDEN)
+    })
+
+    for (const item of scopedItems) {
+      if (!map.has(item.id)) {
+        map.set(item.id, SLOT_HIDDEN)
+      }
+    }
+
+    return map
+  }, [resolvedFilter, scopedItems])
+
+  const curatedItems = useMemo(() => {
+    if (!featuredIds?.length) return scopedItems
+    return featuredIds
+      .map((id) => scopedItems.find((item) => item.id === id))
+      .filter((item): item is LandingCategoriesShellItem => Boolean(item))
+  }, [featuredIds, scopedItems])
+
+  const visibleItems = useMemo(() => {
+    const curatedMatches =
+      resolvedFilter === ALL_CATEGORY_VALUE
+        ? curatedItems
+        : curatedItems.filter((item) => item.categories.includes(resolvedFilter))
+
+    const pool =
+      resolvedFilter === ALL_CATEGORY_VALUE
+        ? scopedItems
+        : scopedItems.filter((item) => item.categories.includes(resolvedFilter))
+    const poolSet = new Set(curatedMatches.map((item) => item.id))
+    const filler = pool.filter((item) => !poolSet.has(item.id))
+
+    return [...curatedMatches, ...filler].slice(0, 4)
+  }, [curatedItems, resolvedFilter, scopedItems])
+
+  const slotItems = useMemo(() => {
+    return Array.from({ length: 4 }).map((_, index) => visibleItems[index])
+  }, [visibleItems])
+
+  const slotMap = useMemo(() => {
+    const map = new Map<string, number>()
+    slotItems.forEach((item, index) => {
+      if (item) map.set(item.id, index)
+    })
+    return map
+  }, [slotItems])
+
+  const activeLabel = categoryLabelMap.get(resolvedFilter)
+  const ctaLabel =
+    moreCategoriesLink?.label ??
+    (resolvedFilter === ALL_CATEGORY_VALUE ? 'View all clinics' : `More clinics in ${activeLabel ?? 'specialty'}`)
+  const ctaHref = withSpecialtyQuery(baseHref, resolvedFilter === ALL_CATEGORY_VALUE ? null : resolvedFilter)
+
+  const slots = [SLOT_LARGE_LEFT, SLOT_TOP_RIGHT_HALF, SLOT_BOTTOM_RIGHT_LEFT_QUARTER, SLOT_BOTTOM_RIGHT_RIGHT_QUARTER]
+
+  return (
+    <React.Fragment>
+      <nav role="tablist" aria-label="Category filters" className="mb-12 flex flex-wrap justify-center gap-x-8 gap-y-3">
+        {categoryTabs.map((category) => {
+          const isActive = resolvedFilter === category.value
+          const tabId = `landing-categories-tab-${category.value}`
+
+          return (
+            <button
+              key={category.value}
+              id={tabId}
+              type="button"
+              onClick={() => setActiveFilter(category.value)}
+              role="tab"
+              aria-selected={isActive}
+              aria-pressed={isActive}
+              aria-controls={panelId}
+              tabIndex={isActive ? 0 : -1}
+              className={cn(
+                'relative cursor-pointer text-base font-medium transition-colors md:text-lg',
+                isActive ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {category.label}
+              <span
+                className={cn(
+                  'absolute -bottom-2 left-0 h-0.5 bg-foreground transition-all duration-300',
+                  isActive ? 'w-full' : 'w-0',
+                )}
+              />
+            </button>
+          )
+        })}
+      </nav>
+
+      <div id={panelId} role="tabpanel" aria-labelledby={activeTabId} className="relative mb-12 h-140 w-full">
+        {scopedItems.map((item) => {
+          const slotIndex = slotMap.get(item.id)
+          const hasSlot = slotIndex !== undefined && slotIndex >= 0 && slotIndex < slots.length
+          const isVisible = hasSlot
+          const slotClass = hasSlot ? slots[slotIndex] : (parkingSlotMap.get(item.id) ?? SLOT_HIDDEN)
+
+          return (
+            <div
+              key={item.id}
+              aria-hidden={!isVisible}
+              className={cn(
+                'absolute p-3 transition-all duration-700 ease-in-out',
+                slotClass,
+                isVisible ? 'pointer-events-auto scale-100 opacity-100' : 'pointer-events-none scale-90 opacity-0',
+                isVisible ? 'z-10' : 'z-0',
+              )}
+            >
+              <div className="relative h-full w-full overflow-hidden rounded-2xl border border-border/60 bg-muted/40 shadow-sm">
+                {item.card}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="mt-10 flex justify-center">
+        <UiLink
+          href={ctaHref}
+          label={ctaLabel}
+          newTab={moreCategoriesLink?.newTab}
+          appearance="secondary"
+          hoverEffect="slideFill"
+          size="lg"
+          className="rounded-full border border-black text-base font-bold text-black"
+        />
+      </div>
+    </React.Fragment>
+  )
+}

--- a/src/stories/organisms/Landing/LandingCategories.stories.tsx
+++ b/src/stories/organisms/Landing/LandingCategories.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, userEvent, within } from '@storybook/test'
 
-import { LandingCategoriesClient } from '@/components/organisms/Landing'
+import { LandingCategories } from '@/components/organisms/Landing'
 import { clinicCategoriesData, clinicCategoryFeaturedIds, clinicCategoryItems } from '@/stories/fixtures/listings'
 
 const meta = {
   title: 'Domain/Landing/Organisms/LandingCategories',
-  component: LandingCategoriesClient,
+  component: LandingCategories,
   parameters: {
     layout: 'fullscreen',
   },
@@ -18,7 +18,7 @@ const meta = {
     items: clinicCategoryItems,
     featuredIds: clinicCategoryFeaturedIds,
   },
-} satisfies Meta<typeof LandingCategoriesClient>
+} satisfies Meta<typeof LandingCategories>
 
 export default meta
 

--- a/src/stories/templates/Landing.stories.tsx
+++ b/src/stories/templates/Landing.stories.tsx
@@ -3,7 +3,7 @@ import { SiInstagram, SiMeta, SiX } from 'react-icons/si'
 
 import { Heading } from '@/components/atoms/Heading'
 import {
-  LandingCategoriesClient,
+  LandingCategories,
   LandingContact,
   LandingFeatures,
   LandingPricing,
@@ -80,7 +80,7 @@ export const FullPage: StoryObj = {
         steps={clinicProcessData}
         stepImages={landingProcessPlaceholderStepImages}
       />
-      <LandingCategoriesClient
+      <LandingCategories
         title="Top Treatment Categories"
         description="Showcase your clinic under the categories patients search most."
         categories={clinicCategoriesData}
@@ -188,9 +188,9 @@ export const Process: StoryObj<typeof LandingProcess> = {
   ),
 }
 
-export const Categories: StoryObj<typeof LandingCategoriesClient> = {
+export const Categories: StoryObj<typeof LandingCategories> = {
   render: () => (
-    <LandingCategoriesClient
+    <LandingCategories
       title="Top Treatment Categories"
       description="Showcase your clinic under the categories patients search most."
       categories={clinicCategoriesData}

--- a/tests/unit/components/landingCategories.test.tsx
+++ b/tests/unit/components/landingCategories.test.tsx
@@ -21,7 +21,7 @@ vi.mock('next/image', () => ({
   },
 }))
 
-import { LandingCategoriesClient, type LandingCategoryItem } from '@/components/organisms/Landing/LandingCategories'
+import { LandingCategories, type LandingCategoryItem } from '@/components/organisms/Landing/LandingCategories'
 
 const items: LandingCategoryItem[] = [
   {
@@ -66,7 +66,7 @@ const items: LandingCategoryItem[] = [
   },
 ]
 
-describe('LandingCategoriesClient', () => {
+describe('LandingCategories', () => {
   const findAnimatedContainer = (node: HTMLElement): HTMLElement => {
     let current: HTMLElement | null = node
 
@@ -90,12 +90,7 @@ describe('LandingCategoriesClient', () => {
 
   it('renders All as first tab and shows every available specialty tab', () => {
     render(
-      <LandingCategoriesClient
-        title="Categories"
-        description="Explore specialties"
-        categories={categories}
-        items={items}
-      />,
+      <LandingCategories title="Categories" description="Explore specialties" categories={categories} items={items} />,
     )
 
     const tabs = screen.getAllByRole('tab')
@@ -104,12 +99,7 @@ describe('LandingCategoriesClient', () => {
 
   it('shows the clinic-focused default CTA in All view', () => {
     render(
-      <LandingCategoriesClient
-        title="Categories"
-        description="Explore specialties"
-        categories={categories}
-        items={items}
-      />,
+      <LandingCategories title="Categories" description="Explore specialties" categories={categories} items={items} />,
     )
 
     const ctaLink = screen.getByRole('link', { name: 'View all clinics' })
@@ -119,12 +109,7 @@ describe('LandingCategoriesClient', () => {
 
   it('filters cards when a specialty tab is selected', () => {
     render(
-      <LandingCategoriesClient
-        title="Categories"
-        description="Explore specialties"
-        categories={categories}
-        items={items}
-      />,
+      <LandingCategories title="Categories" description="Explore specialties" categories={categories} items={items} />,
     )
 
     const noseTab = screen.getByRole('tab', { name: 'Nose' })
@@ -140,12 +125,7 @@ describe('LandingCategoriesClient', () => {
 
   it('parks hidden specialties in category-specific offstage slots instead of the shared center slot', () => {
     render(
-      <LandingCategoriesClient
-        title="Categories"
-        description="Explore specialties"
-        categories={categories}
-        items={items}
-      />,
+      <LandingCategories title="Categories" description="Explore specialties" categories={categories} items={items} />,
     )
 
     fireEvent.click(screen.getByRole('tab', { name: 'Nose' }))
@@ -193,7 +173,7 @@ describe('LandingCategoriesClient', () => {
     ]
 
     render(
-      <LandingCategoriesClient
+      <LandingCategories
         title="Categories"
         description="Explore specialties"
         categories={[
@@ -221,12 +201,7 @@ describe('LandingCategoriesClient', () => {
 
   it('keeps the parking layout stable when item order changes', () => {
     const firstRender = render(
-      <LandingCategoriesClient
-        title="Categories"
-        description="Explore specialties"
-        categories={categories}
-        items={items}
-      />,
+      <LandingCategories title="Categories" description="Explore specialties" categories={categories} items={items} />,
     )
 
     fireEvent.click(screen.getByRole('tab', { name: 'Nose' }))
@@ -239,7 +214,7 @@ describe('LandingCategoriesClient', () => {
     firstRender.unmount()
 
     render(
-      <LandingCategoriesClient
+      <LandingCategories
         title="Categories"
         description="Explore specialties"
         categories={categories}


### PR DESCRIPTION
Fixes #897

This moves the interactive filter state for landing categories into a small client shell while keeping the heavy collage cards and page composition server-rendered.

## What changed
- split `LandingCategories` into shared slot helpers, a server-rendered section/card composition, and a client shell that only owns active-filter state and item positioning
- switch the homepage, partner-clinic page, and stories to the server `LandingCategories` export
- keep the existing tab/parking-slot behavior covered through Storybook plus the focused landing categories unit test

## Validation
- `pnpm stories:governance:check`
- `pnpm vitest --project storybook --run src/stories/organisms/Landing/LandingCategories.stories.tsx`
- `pnpm vitest --run tests/unit/components/landingCategories.test.tsx`
- `pnpm check`
- `PAYLOAD_SECRET=dev-secret pnpm build`
- `pnpm format`

## Screenshots
- `output/playwright/review/landing-categories-hair-filter.png`

## Development
- Fixes #897
