### PR TITLE
refactor(ui): import blog card variant directly

### DIFF
--- a/src/components/organisms/CollectionArchive/index.tsx
+++ b/src/components/organisms/CollectionArchive/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { BlogCard } from '@/components/organisms/Blog/BlogCard'
+import { Simple as BlogCardSimple } from '@/components/organisms/Blog/BlogCard/Simple'
 import type { BlogCardBaseProps } from '@/utilities/blog/normalizePost'
 import { Container } from '@/components/molecules/Container'
 
@@ -27,7 +27,7 @@ export const CollectionArchive: React.FC<Props> = (props) => {
             if (typeof result === 'object' && result !== null && result.title && result.href) {
               return (
                 <div className="col-span-4" key={index}>
-                  <BlogCard.Simple
+                  <BlogCardSimple
                     title={result.title}
                     excerpt={result.excerpt}
                     href={result.href}


### PR DESCRIPTION
Fixes #895

This removes the namespace import path that eagerly pulls every `BlogCard` variant into `CollectionArchive` when it only renders the simple card.

## What changed
- swap `BlogCard.Simple` namespace usage in `CollectionArchive` for a direct import from `BlogCard/Simple`
- keep the rendered archive output unchanged while trimming the import graph for this path

## Validation
- `pnpm check`
- `PAYLOAD_SECRET=dev-secret pnpm build`
- `pnpm format`

## Screenshots
- `output/playwright/review/collection-archive-three-posts.png`

## Development
- Fixes #895
