### PR TITLE
test: remove temporary lint escape hatches

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,12 +51,6 @@ const eslintConfig = [
     },
   },
   {
-    files: ['tests/**/*.{ts,tsx,js,jsx}'],
-    rules: {
-      '@typescript-eslint/no-explicit-any': 'off',
-    },
-  },
-  {
     files: ['src/stories/**/*.{ts,tsx}'],
     // Enforce correct Storybook framework imports to avoid mixing Next.js/React renderers
     rules: {

--- a/tests/integration/basicUserLifecycle.test.ts
+++ b/tests/integration/basicUserLifecycle.test.ts
@@ -36,7 +36,7 @@ describe('BasicUser lifecycle integration', () => {
 
   it('creates BasicUser -> creates Supabase user -> creates PlatformStaff profile; then deletes all', async () => {
     // Create BasicUser (platform)
-    const basic = await (payload as any).create({
+    const basic = (await payload.create({
       collection: 'basicUsers',
       data: {
         email: 'platform.staff@example.com',
@@ -45,7 +45,8 @@ describe('BasicUser lifecycle integration', () => {
         lastName: 'Staff',
       },
       overrideAccess: true,
-    })
+      depth: 0,
+    } as PayloadCreateArgs)) as BasicUser
 
     expect(basic.id).toBeDefined()
     expect(basic.supabaseUserId).toBe('sb-unit-1')
@@ -53,25 +54,26 @@ describe('BasicUser lifecycle integration', () => {
     expect(basic.lastName).toBe('Staff')
 
     // PlatformStaff profile should exist
-    const profiles = await (payload as any).find({
+    const profiles = await payload.find({
       collection: 'platformStaff',
       where: { user: { equals: basic.id } },
       limit: 1,
       overrideAccess: true,
+      depth: 0,
     })
     expect(profiles.docs.length).toBe(1)
-    // Profile no longer holds name fields
-    expect(profiles.docs[0].firstName).toBeUndefined()
-    expect(profiles.docs[0].lastName).toBeUndefined()
+    expect(profiles.docs[0]).not.toHaveProperty('firstName')
+    expect(profiles.docs[0]).not.toHaveProperty('lastName')
 
     // Now delete the BasicUser and verify cascading cleanup
-    await (payload as any).delete({ collection: 'basicUsers', id: basic.id, overrideAccess: true })
+    await payload.delete({ collection: 'basicUsers', id: basic.id, overrideAccess: true })
 
-    const profilesAfter = await (payload as any).find({
+    const profilesAfter = await payload.find({
       collection: 'platformStaff',
       where: { user: { equals: basic.id } },
       limit: 1,
       overrideAccess: true,
+      depth: 0,
     })
     expect(profilesAfter.docs.length).toBe(0)
   }, 20000)

--- a/tests/integration/clinic.test.ts
+++ b/tests/integration/clinic.test.ts
@@ -6,11 +6,12 @@ import { ensureBaseline } from '../fixtures/ensureBaseline'
 import { createClinicFixture } from '../fixtures/createClinicFixture'
 import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
 import { testSlug } from '../fixtures/testSlug'
+import type { City } from '@/payload-types'
 
 describe('Clinic Integration Tests (fixtures)', () => {
   let payload: Payload
   const slugPrefix = testSlug('clinic.test.ts')
-  let cities: any[] = []
+  let cities: City[] = []
 
   beforeAll(async () => {
     payload = await getPayload({ config })

--- a/tests/integration/clinicTreatments.creation.test.ts
+++ b/tests/integration/clinicTreatments.creation.test.ts
@@ -7,10 +7,11 @@ import { createClinicFixture } from '../fixtures/createClinicFixture'
 import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
 import { testSlug } from '../fixtures/testSlug'
 import { asClinicScopedPayloadUser, createClinicTestUser } from '../fixtures/testUsers'
-import type { Treatment } from '@/payload-types'
+import type { Clinictreatment, Treatment } from '@/payload-types'
 
 const createdClinicTreatmentIds: Array<string | number> = []
 const createdBasicUserIds: Array<number> = []
+type PayloadCreateArgs = Parameters<Payload['create']>[0]
 
 describe('ClinicTreatments Creation and Hooks Integration Tests', () => {
   let payload: Payload
@@ -100,10 +101,10 @@ describe('ClinicTreatments Creation and Hooks Integration Tests', () => {
         data: {
           clinic: clinic.id,
           // Missing required treatment and price
-        } as any,
+        } as Partial<Clinictreatment>,
         overrideAccess: true,
         depth: 0,
-      }),
+      } as PayloadCreateArgs),
     ).rejects.toThrow()
   })
 
@@ -393,16 +394,16 @@ describe('ClinicTreatments Creation and Hooks Integration Tests', () => {
     const { clinic } = await createClinicFixture(payload, cityId, { slugPrefix: `${slugPrefix}-auto-assign` })
     const clinicUser = await createClinicUser(`${slugPrefix}-auto-assign-user`, clinic.id as number)
 
-    const created = await payload.create({
+    const created = (await payload.create({
       collection: 'clinictreatments',
       data: {
         treatment: treatmentId,
         price: 1700,
-      } as any,
+      } as Partial<Clinictreatment>,
       user: clinicUser,
       overrideAccess: false,
       depth: 0,
-    })
+    } as PayloadCreateArgs)) as Clinictreatment
 
     createdClinicTreatmentIds.push(created.id)
     expect(created.clinic).toBe(clinic.id)

--- a/tests/integration/clinics.creation.test.ts
+++ b/tests/integration/clinics.creation.test.ts
@@ -13,6 +13,7 @@ vi.mock('@payloadcms/storage-s3', () => ({
 
 describe('Clinic Creation Integration Tests', () => {
   let payload: Payload
+  type PayloadCreateArgs = Parameters<Payload['create']>[0]
   const slugPrefix = testSlug('clinics.creation.test.ts')
   let cityId: number
   let tagId: number
@@ -363,11 +364,11 @@ describe('Clinic Creation Integration Tests', () => {
           supportedLanguages: ['english'],
           status: 'draft',
           slug: `${slugPrefix}-invalid-clinic`,
-        } as any,
+        } as Partial<Clinic>,
         draft: false,
         overrideAccess: true,
         depth: 0,
-      }),
+      } as PayloadCreateArgs),
     ).rejects.toThrow()
   })
 

--- a/tests/integration/doctors.titles.test.ts
+++ b/tests/integration/doctors.titles.test.ts
@@ -7,10 +7,12 @@ import { ensureBaseline } from '../fixtures/ensureBaseline'
 import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
 import { testSlug } from '../fixtures/testSlug'
 import { slugify } from '@/utilities/slugify'
+import type { Doctor } from '@/payload-types'
 
 describe('Doctor title integration', () => {
   let payload: Payload
-  let clinicId: number | string
+  type PayloadCreateArgs = Parameters<Payload['create']>[0]
+  let clinicId: number
   const slugPrefix = slugify(testSlug('doctors.titles.test.ts'))
 
   beforeAll(async () => {
@@ -24,21 +26,27 @@ describe('Doctor title integration', () => {
     } else {
       // 1. Ensure Country
       const countries = await payload.find({ collection: 'countries', limit: 1 })
-      let countryId: string | number = 'us'
+      let countryId: number
       if (countries.docs.length > 0) {
         countryId = countries.docs[0]!.id
       } else {
         const country = await payload.create({
           collection: 'countries',
-          data: { id: 'us', name: 'United States' } as any,
+          data: {
+            name: 'United States',
+            isoCode: 'US',
+            language: 'english',
+            currency: 'USD',
+          },
           overrideAccess: true,
+          depth: 0,
         })
         countryId = country.id
       }
 
       // 2. Ensure City
       const cities = await payload.find({ collection: 'cities', limit: 1 })
-      let cityId: string | number
+      let cityId: number
       if (cities.docs.length > 0) {
         cityId = cities.docs[0]!.id
       } else {
@@ -48,8 +56,9 @@ describe('Doctor title integration', () => {
             name: 'New York',
             country: countryId,
             coordinates: [40.7128, -74.006],
-          } as any,
+          },
           overrideAccess: true,
+          depth: 0,
         })
         cityId = city.id
       }
@@ -72,9 +81,10 @@ describe('Doctor title integration', () => {
           },
           supportedLanguages: ['english'],
           status: 'approved',
-          content: { root: { children: [] } },
-        } as any,
+          slug: `${slugPrefix}-fallback-clinic`,
+        },
         overrideAccess: true,
+        depth: 0,
       })
       clinicId = clinic.id
     }
@@ -89,7 +99,7 @@ describe('Doctor title integration', () => {
     const lastName = 'Doe'
 
     // Test creation with "Prof. Dr."
-    const doctor = await payload.create({
+    const doctor = (await payload.create({
       collection: 'doctors',
       data: {
         firstName,
@@ -100,9 +110,10 @@ describe('Doctor title integration', () => {
         qualifications: ['MD'],
         languages: ['english'],
         clinic: clinicId,
-      } as any,
+      },
       overrideAccess: true,
-    })
+      depth: 0,
+    } as PayloadCreateArgs)) as Doctor
 
     const capFirstName = firstName.charAt(0).toUpperCase() + firstName.slice(1)
     expect(doctor.fullName).toBe(`Prof. Dr. ${capFirstName} ${lastName}`)
@@ -113,7 +124,7 @@ describe('Doctor title integration', () => {
     const lastName = 'Smith'
 
     // Test creation with "Dr."
-    const doctor = await payload.create({
+    const doctor = (await payload.create({
       collection: 'doctors',
       data: {
         firstName,
@@ -124,9 +135,10 @@ describe('Doctor title integration', () => {
         qualifications: ['MD'],
         languages: ['english'],
         clinic: clinicId,
-      } as any,
+      },
       overrideAccess: true,
-    })
+      depth: 0,
+    } as PayloadCreateArgs)) as Doctor
 
     const capFirstName = firstName.charAt(0).toUpperCase() + firstName.slice(1)
     expect(doctor.fullName).toBe(`Dr. ${capFirstName} ${lastName}`)
@@ -136,7 +148,7 @@ describe('Doctor title integration', () => {
     const firstName = `${slugPrefix}-No`
     const lastName = 'Title'
 
-    const doctor = await payload.create({
+    const doctor = (await payload.create({
       collection: 'doctors',
       data: {
         firstName,
@@ -146,9 +158,10 @@ describe('Doctor title integration', () => {
         qualifications: ['MD'],
         languages: ['english'],
         clinic: clinicId,
-      } as any,
+      },
       overrideAccess: true,
-    })
+      depth: 0,
+    } as PayloadCreateArgs)) as Doctor
     const capFirstName = firstName.charAt(0).toUpperCase() + firstName.slice(1)
     expect(doctor.fullName).toBe(`${capFirstName} ${lastName}`)
   })

--- a/tests/integration/reviews.auditTrail.test.ts
+++ b/tests/integration/reviews.auditTrail.test.ts
@@ -6,35 +6,37 @@ import { ensureBaseline } from '../fixtures/ensureBaseline'
 import { createClinicFixture } from '../fixtures/createClinicFixture'
 import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
 import { testSlug } from '../fixtures/testSlug'
+import { asPayloadBasicUser, createPlatformTestUser } from '../fixtures/testUsers'
+import type { Review } from '@/payload-types'
 
 const createdBasicUserIds: Array<string | number> = []
+type PayloadCreateArgs = Parameters<Payload['create']>[0]
 
 async function createPlatformUser(payload: Payload, emailPrefix: string) {
-  const email = `${emailPrefix}@example.com`
-  const basicUser = await (payload as any).create({
-    collection: 'basicUsers',
-    data: {
-      email,
-      userType: 'platform',
-      firstName: 'Audit',
-      lastName: 'Tester',
-      supabaseUserId: `sb-${emailPrefix}`,
-    },
-    overrideAccess: true,
+  const basicUser = await createPlatformTestUser(payload, {
+    emailPrefix,
+    firstName: 'Audit',
+    lastName: 'Tester',
+    supabaseUserId: `sb-${emailPrefix}`,
+    createdBasicUserIds,
   })
 
-  createdBasicUserIds.push(basicUser.id)
-
-  const platformStaff = await (payload as any).find({
+  const platformStaff = await payload.find({
     collection: 'platformStaff',
     where: { user: { equals: basicUser.id } },
     limit: 1,
     overrideAccess: true,
+    depth: 0,
   })
+
+  const staffDoc = platformStaff.docs[0]
+  if (!staffDoc) {
+    throw new Error('Expected platform staff profile to be created for audit test user')
+  }
 
   // We need the platformStaff ID for the 'patient' relation on review
   // But we need the basicUser object for the 'req.user' / 'editedBy' relation
-  return { basicUser, platformStaffId: platformStaff.docs[0].id }
+  return { basicUser, platformStaffId: staffDoc.id }
 }
 
 describe('Review audit trail hooks', () => {
@@ -87,7 +89,7 @@ describe('Review audit trail hooks', () => {
     const { basicUser, platformStaffId } = await createPlatformUser(payload, 'audit.tester')
 
     // 1. Create Review (should allow creation without setting editedBy)
-    const review = await (payload as any).create({
+    const review = (await payload.create({
       collection: 'reviews',
       data: {
         patient: platformStaffId,
@@ -99,7 +101,8 @@ describe('Review audit trail hooks', () => {
         status: 'pending',
       },
       overrideAccess: true,
-    })
+      depth: 0,
+    } as PayloadCreateArgs)) as Review
 
     reviewId = review.id as number
 
@@ -109,21 +112,25 @@ describe('Review audit trail hooks', () => {
     expect(review.lastEditedAt).toBeFalsy()
 
     // 2. Update Review as Platform User
-    const updatedReview = await (payload as any).update({
+    const updatedReview = await payload.update({
       collection: 'reviews',
       id: review.id,
       data: {
         status: 'approved',
         comment: 'Moderated comment',
       },
-      user: { ...basicUser, collection: 'basicUsers' }, // This sets req.user
+      user: asPayloadBasicUser(basicUser), // This sets req.user
       overrideAccess: false, // Ensure we use the access control/hooks that utilize req.user
+      depth: 0,
     })
 
     // Assert audit trail
     // editedBy might be populated, so we check ID if it is an object
-    const editedBy = updatedReview.editedBy as any
-    expect(editedBy?.id || editedBy).toBe(basicUser.id)
+    const editedBy =
+      typeof updatedReview.editedBy === 'object' && updatedReview.editedBy !== null
+        ? updatedReview.editedBy.id
+        : updatedReview.editedBy
+    expect(editedBy).toBe(basicUser.id)
 
     expect(updatedReview.editedByName).toBe('Audit Tester')
     expect(updatedReview.lastEditedAt).toBeDefined()

--- a/tests/integration/reviews.averageRatings.test.ts
+++ b/tests/integration/reviews.averageRatings.test.ts
@@ -6,31 +6,28 @@ import { ensureBaseline } from '../fixtures/ensureBaseline'
 import { createClinicFixture } from '../fixtures/createClinicFixture'
 import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
 import { testSlug } from '../fixtures/testSlug'
+import { createPlatformTestUser } from '../fixtures/testUsers'
+import type { Review } from '@/payload-types'
 
 const createdBasicUserIds: Array<string | number> = []
+type PayloadCreateArgs = Parameters<Payload['create']>[0]
 
 async function createPlatformUser(payload: Payload) {
-  const email = 'ratings.tester@example.com'
-  const basicUser = await (payload as any).create({
-    collection: 'basicUsers',
-    data: {
-      email,
-      userType: 'platform',
-      firstName: 'Ratings',
-      lastName: 'Tester',
-      // Provide deterministic Supabase ID to bypass mocked provisioner duplicate constraint
-      supabaseUserId: 'sb-ratings-single',
-    },
-    overrideAccess: true,
+  const basicUser = await createPlatformTestUser(payload, {
+    emailPrefix: 'ratings.tester',
+    firstName: 'Ratings',
+    lastName: 'Tester',
+    // Provide deterministic Supabase ID to bypass mocked provisioner duplicate constraint
+    supabaseUserId: 'sb-ratings-single',
+    createdBasicUserIds,
   })
 
-  createdBasicUserIds.push(basicUser.id)
-
-  const platformStaff = await (payload as any).find({
+  const platformStaff = await payload.find({
     collection: 'platformStaff',
     where: { user: { equals: basicUser.id } },
     limit: 1,
     overrideAccess: true,
+    depth: 0,
   })
 
   const staffDoc = platformStaff.docs[0]
@@ -112,7 +109,7 @@ describe('Review average ratings hooks', () => {
 
     const patient = await createPlatformUser(payload)
 
-    const review = await (payload as any).create({
+    const review = (await payload.create({
       collection: 'reviews',
       data: {
         patient,
@@ -124,7 +121,8 @@ describe('Review average ratings hooks', () => {
         status: 'approved',
       },
       overrideAccess: true,
-    })
+      depth: 0,
+    } as PayloadCreateArgs)) as Review
 
     const clinicAfterCreate = await payload.findByID({ collection: 'clinics', id: clinic.id, overrideAccess: true })
     const doctorAfterCreate = await payload.findByID({ collection: 'doctors', id: doctor.id, overrideAccess: true })
@@ -138,7 +136,7 @@ describe('Review average ratings hooks', () => {
     expect(doctorAfterCreate.averageRating).toBeCloseTo(4, 5)
     expect(treatmentAfterCreate.averageRating).toBeCloseTo(4, 5)
 
-    const reviewAfterUpdate = await (payload as any).update({
+    const reviewAfterUpdate = await payload.update({
       collection: 'reviews',
       id: review.id,
       data: {
@@ -147,6 +145,7 @@ describe('Review average ratings hooks', () => {
         status: 'approved',
       },
       overrideAccess: true,
+      depth: 0,
     })
 
     expect(reviewAfterUpdate.starRating).toBe(2)

--- a/tests/integration/reviews.duplicateGuard.test.ts
+++ b/tests/integration/reviews.duplicateGuard.test.ts
@@ -6,30 +6,29 @@ import { ensureBaseline } from '../fixtures/ensureBaseline'
 import { createClinicFixture } from '../fixtures/createClinicFixture'
 import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
 import { testSlug } from '../fixtures/testSlug'
+import { createPlatformTestUser } from '../fixtures/testUsers'
+import type { Review } from '@/payload-types'
 
 const createdBasicUserIds: Array<string | number> = []
 const createdReviewIds: Array<string | number> = []
+type PayloadCreateArgs = Parameters<Payload['create']>[0]
+type PayloadUpdateArgs = Parameters<Payload['update']>[0]
 
-async function createPlatformPatient(payload: Payload, identifier: string) {
-  const basicUser = await (payload as any).create({
-    collection: 'basicUsers',
-    data: {
-      email: `${identifier}@example.com`,
-      userType: 'platform',
-      firstName: 'Review',
-      lastName: 'Patient',
-      supabaseUserId: identifier,
-    },
-    overrideAccess: true,
+async function createPlatformPatient(payload: Payload, identifier: string): Promise<number> {
+  const basicUser = await createPlatformTestUser(payload, {
+    emailPrefix: identifier,
+    firstName: 'Review',
+    lastName: 'Patient',
+    supabaseUserId: identifier,
+    createdBasicUserIds,
   })
 
-  createdBasicUserIds.push(basicUser.id)
-
-  const staffRes = await (payload as any).find({
+  const staffRes = await payload.find({
     collection: 'platformStaff',
     where: { user: { equals: basicUser.id } },
     limit: 1,
     overrideAccess: true,
+    depth: 0,
   })
 
   const staffDoc = staffRes.docs?.[0]
@@ -37,7 +36,7 @@ async function createPlatformPatient(payload: Payload, identifier: string) {
     throw new Error('Expected platform staff profile for patient user')
   }
 
-  return staffDoc.id as string | number
+  return staffDoc.id
 }
 
 describe('Review duplicate prevention', () => {
@@ -89,7 +88,10 @@ describe('Review duplicate prevention', () => {
 
     const patient = await createPlatformPatient(payload, `${slugPrefix}-patient`)
 
-    const baseReviewData = {
+    const baseReviewData: Pick<
+      Review,
+      'patient' | 'clinic' | 'doctor' | 'treatment' | 'starRating' | 'comment' | 'status'
+    > = {
       patient,
       clinic: clinic.id,
       doctor: doctor.id,
@@ -99,25 +101,27 @@ describe('Review duplicate prevention', () => {
       status: 'approved',
     }
 
-    const review = await (payload as any).create({
+    const review = (await payload.create({
       collection: 'reviews',
       data: baseReviewData,
       overrideAccess: true,
-    })
+      depth: 0,
+    } as PayloadCreateArgs)) as Review
 
     createdReviewIds.push(review.id)
 
     expect(review.reviewDate).toBeTruthy()
 
     await expect(
-      (payload as any).create({
+      payload.create({
         collection: 'reviews',
         data: { ...baseReviewData, comment: 'Trying to double dip' },
         overrideAccess: true,
-      }),
+        depth: 0,
+      } as PayloadCreateArgs),
     ).rejects.toThrow(/Duplicate review/i)
 
-    const updated = await (payload as any).update({
+    const updated = (await payload.update({
       collection: 'reviews',
       id: review.id,
       data: {
@@ -126,7 +130,8 @@ describe('Review duplicate prevention', () => {
         comment: 'Adjusted after follow-up',
       },
       overrideAccess: true,
-    })
+      depth: 0,
+    } as PayloadUpdateArgs)) as Review
 
     expect(updated.starRating).toBe(3)
     expect(updated.comment).toContain('Adjusted')

--- a/tests/integration/tags.createAndDuplicate.test.ts
+++ b/tests/integration/tags.createAndDuplicate.test.ts
@@ -7,9 +7,11 @@ import { ensureBaseline } from '../fixtures/ensureBaseline'
 import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
 import { testSlug } from '../fixtures/testSlug'
 import { slugify } from '@/utilities/slugify'
+import type { Tag } from '@/payload-types'
 
 describe('Tags integration - create and duplicate behavior', () => {
   let payload: Payload
+  type PayloadCreateArgs = Parameters<Payload['create']>[0]
   const slugPrefix = slugify(testSlug('tags.createAndDuplicate.test.ts'))
 
   beforeAll(async () => {
@@ -27,18 +29,33 @@ describe('Tags integration - create and duplicate behavior', () => {
     const nameDup = `${slugPrefix} alpha` // same as nameA
 
     // create first tag
-    const a = await payload.create({ collection: 'tags', data: { name: nameA } as any, overrideAccess: true })
+    const a = (await payload.create({
+      collection: 'tags',
+      data: { name: nameA },
+      overrideAccess: true,
+      depth: 0,
+    } as PayloadCreateArgs)) as Tag
     expect(a).toBeDefined()
     expect(a.slug).toBe(slugify(nameA))
 
     // create second tag with a different name
-    const b = await payload.create({ collection: 'tags', data: { name: nameB } as any, overrideAccess: true })
+    const b = (await payload.create({
+      collection: 'tags',
+      data: { name: nameB },
+      overrideAccess: true,
+      depth: 0,
+    } as PayloadCreateArgs)) as Tag
     expect(b).toBeDefined()
     expect(b.slug).toBe(slugify(nameB))
 
     // attempt to create duplicate - for now we expect this to fail with a slug/unique constraint error
     await expect(async () => {
-      await payload.create({ collection: 'tags', data: { name: nameDup } as any, overrideAccess: true })
+      await payload.create({
+        collection: 'tags',
+        data: { name: nameDup },
+        overrideAccess: true,
+        depth: 0,
+      } as PayloadCreateArgs)
     }).rejects.toThrowError(/slug|unique|duplicate|violates|constraint|tags_slug_idx/i)
   })
 })

--- a/tests/integration/treatments.creation.test.ts
+++ b/tests/integration/treatments.creation.test.ts
@@ -20,6 +20,7 @@ import type { Treatment } from '@/payload-types'
 describe('Treatments Creation Integration Tests', () => {
   let payload: Payload
   const slugPrefix = testSlug('treatments.creation.test.ts')
+  type PayloadCreateArgs = Parameters<Payload['create']>[0]
   let medicalSpecialtyId: number
   let tagId: number
   const createdBasicUserIds: Array<number> = []
@@ -120,9 +121,9 @@ describe('Treatments Creation Integration Tests', () => {
         data: {
           name: `${slugPrefix}-invalid-treatment`,
           // Missing required description and medicalSpecialty
-        } as any,
+        } as Partial<Treatment>,
         overrideAccess: true,
-      }),
+      } as PayloadCreateArgs),
     ).rejects.toThrow()
   })
 
@@ -373,7 +374,7 @@ describe('Treatments Creation Integration Tests', () => {
         medicalSpecialty: medicalSpecialtyId,
         averagePrice: 9999,
         averageRating: 5,
-      } as any,
+      },
       overrideAccess: true,
       depth: 0,
     })


### PR DESCRIPTION
This removes the remaining test-only lint escapes so the stricter repository-wide TypeScript rules now apply to `tests/**` as well.

## What changed
- remove the temporary `tests/**` override for `@typescript-eslint/no-explicit-any`
- replace the remaining `any`-based Payload test casts with collection-specific types and narrower `Payload` argument aliases
- tighten integration fixtures around review, tag, doctor, clinic, and treatment creation so linting stays strict without broad repo exceptions
- keep the phase split intact by stacking this PR on top of #908 instead of folding the test cleanup back into the first PR

## Validation
- `pnpm format`
- `pnpm format:check`
- `pnpm check`
- `pnpm vitest tests/integration/basicUserLifecycle.test.ts tests/integration/clinic.test.ts tests/integration/clinicTreatments.creation.test.ts tests/integration/clinics.creation.test.ts tests/integration/doctors.titles.test.ts tests/integration/reviews.auditTrail.test.ts tests/integration/reviews.averageRatings.test.ts tests/integration/reviews.duplicateGuard.test.ts tests/integration/tags.createAndDuplicate.test.ts tests/integration/treatments.creation.test.ts`

## Development
- Refs #907
- Stacked on top of #908
