### PR TITLE
chore(collections): clarify clinic copy

### DIFF
--- a/src/collections/ClinicApplications.ts
+++ b/src/collections/ClinicApplications.ts
@@ -140,7 +140,7 @@ export const ClinicApplications: CollectionConfig = {
     {
       name: 'reviewNotes',
       type: 'textarea',
-      admin: { description: 'Internal notes for this application' },
+      admin: { description: 'Notes about this application' },
       access: {
         update: ({ req }: { req: PayloadRequest }) => {
           const u = req.user
@@ -151,7 +151,7 @@ export const ClinicApplications: CollectionConfig = {
     {
       name: 'linkedRecords',
       type: 'group',
-      label: 'Created records',
+      label: 'Created clinic records',
       admin: {
         description: 'Records created from this application',
         condition: (data) => data?.status !== 'submitted',

--- a/src/collections/Clinics.ts
+++ b/src/collections/Clinics.ts
@@ -225,7 +225,7 @@ export const Clinics: CollectionConfig = {
               relationTo: 'accreditation',
               hasMany: true,
               admin: {
-                description: 'Accreditations this clinic holds',
+                description: 'Clinic accreditations',
               },
             },
             {

--- a/src/collections/DoctorMedia/index.ts
+++ b/src/collections/DoctorMedia/index.ts
@@ -87,7 +87,7 @@ export const DoctorMedia: CollectionConfig = {
       relationTo: 'clinics',
       required: true,
       index: true,
-      admin: { description: 'Clinic linked to the doctor', readOnly: true },
+      admin: { description: 'Clinic where the doctor works', readOnly: true },
     },
     buildMediaCreatedByField({
       relationTo: 'basicUsers',

--- a/src/collections/Reviews.ts
+++ b/src/collections/Reviews.ts
@@ -141,7 +141,7 @@ export const Reviews: CollectionConfig = {
       label: 'Change History',
       admin: {
         initCollapsed: true,
-        description: 'Edit history',
+        description: 'Changes made to this review',
       },
       fields: [
         {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -597,7 +597,7 @@ export interface Clinic {
     website?: string | null;
   };
   /**
-   * Accreditations this clinic holds
+   * Clinic accreditations
    */
   accreditations?: (number | Accreditation)[] | null;
   /**
@@ -1279,7 +1279,7 @@ export interface DoctorMedia {
    */
   doctor: number | Doctor;
   /**
-   * Clinic linked to the doctor
+   * Clinic where the doctor works
    */
   clinic: number | Clinic;
   /**
@@ -2206,7 +2206,7 @@ export interface ClinicApplication {
    */
   status: 'submitted' | 'approved' | 'rejected';
   /**
-   * Internal notes for this application
+   * Notes about this application
    */
   reviewNotes?: string | null;
   /**


### PR DESCRIPTION
This keeps clinic-related field copy easier to understand for first-time users.

## What changed
- Reworded a few unclear collection field labels and descriptions in `src/collections/**`.
- Kept the edits local and conservative.
- Regenerated `src/payload-types.ts` so generated copy matches the collection text.

## Validation
- `pnpm format`
- `pnpm check`

## Development
- Fixes #911
