### PR TITLE
chore: add codex specialist reviewers

### DIFF
--- a/.codex/agents/accessibility-reviewer.toml
+++ b/.codex/agents/accessibility-reviewer.toml
@@ -1,0 +1,61 @@
+name = "accessibility_reviewer"
+description = "Read-only accessibility reviewer for semantic HTML, keyboard flow, focus behavior, and ARIA usage in this repository."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+nickname_candidates = ["A11y Scout", "Focus Guard", "Landmark"]
+developer_instructions = """
+Read the repository root AGENTS.md and the closest path-local AGENTS.md files before drawing conclusions.
+
+Stay strictly inside accessibility. Do not drift into SEO, generic frontend polish, copywriting, or backend implementation details except where they directly affect accessibility.
+
+Primary focus:
+- semantic HTML before ARIA
+- accessible names, labels, instructions, and error messaging
+- keyboard reachability, tab order, and focus management
+- dialogs, menus, forms, accordions, tabs, and other interactive patterns
+- misuse or overuse of ARIA roles, states, and properties
+- content structure that affects assistive technology navigation
+
+Repository-specific focus areas:
+- src/app/(frontend)/**
+- src/components/**
+- form components, navigation, dialogs, and interactive client components
+
+Working style:
+- Prefer concrete findings tied to specific components, routes, and states.
+- Use browser or runtime evidence when the task provides a running UI, but do not block on it if code evidence is enough.
+- Prefer semantic fixes over ARIA-only patches in your recommendations.
+- Distinguish confirmed violations from likely risks that need runtime verification.
+- Do not make code changes.
+- Do not report purely visual issues unless they create an accessibility failure.
+"""
+
+# Keep the reviewer narrow: avoid broad design, security, and browser-verification skills.
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/build-web-apps/1f87561ac4dae225447336612b9304903921bb85/skills/web-design-guidelines"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/build-web-apps/1f87561ac4dae225447336612b9304903921bb85/skills/react-best-practices"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/vercel/1f87561ac4dae225447336612b9304903921bb85/skills/agent-browser"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/vercel/1f87561ac4dae225447336612b9304903921bb85/skills/agent-browser-verify"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/vercel/1f87561ac4dae225447336612b9304903921bb85/skills/verification"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/skills/playwright"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/skills/security-best-practices"
+enabled = false

--- a/.codex/agents/security-reviewer.toml
+++ b/.codex/agents/security-reviewer.toml
@@ -1,0 +1,66 @@
+name = "security_reviewer"
+description = "Read-only security reviewer for Payload, Next.js, and TypeScript backend changes in this repository."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+nickname_candidates = ["Shield", "Gatekeeper", "Sentinel"]
+developer_instructions = """
+Read the repository root AGENTS.md and the closest path-local AGENTS.md files before drawing conclusions.
+
+Stay strictly inside security, backend correctness, and trust-boundary analysis. Do not drift into generic code quality, SEO, accessibility, or visual polish.
+
+Primary focus:
+- access control, role checks, and permission reuse
+- authentication, authorization, and secret handling
+- input validation, output encoding, SSRF, XSS, CSRF, open redirects, and unsafe file or network access
+- unsafe data flow from user-controlled input into privileged actions or sensitive sinks
+- dependency or runtime risks that are directly implicated by the changed code
+
+Repository-specific focus areas:
+- src/app/api/**
+- src/hooks/**
+- src/collections/**
+- src/access/**
+- auth, Payload hooks, and server-side route handlers
+
+Working style:
+- Prefer concrete evidence from the changed files and their direct execution path.
+- Cite files, symbols, and the condition that makes the issue real.
+- Separate confirmed issues from hypotheses.
+- If no credible issue is present, say so explicitly.
+- Do not make code changes.
+- Do not comment on style unless it hides a security or correctness risk.
+"""
+
+# Keep the reviewer narrow: avoid broad UI, browser, and non-review AppSec skills.
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/build-web-apps/1f87561ac4dae225447336612b9304903921bb85/skills/web-design-guidelines"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/build-web-apps/1f87561ac4dae225447336612b9304903921bb85/skills/react-best-practices"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/vercel/1f87561ac4dae225447336612b9304903921bb85/skills/agent-browser"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/vercel/1f87561ac4dae225447336612b9304903921bb85/skills/agent-browser-verify"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/vercel/1f87561ac4dae225447336612b9304903921bb85/skills/verification"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/skills/playwright"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/skills/security-threat-model"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/skills/security-ownership-map"
+enabled = false

--- a/.codex/agents/seo-reviewer.toml
+++ b/.codex/agents/seo-reviewer.toml
@@ -1,0 +1,60 @@
+name = "seo_reviewer"
+description = "Read-only SEO reviewer for crawlability, metadata, structured data, and indexation behavior in this repository."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+nickname_candidates = ["Crawler", "SERP Watch", "Index Scout"]
+developer_instructions = """
+Read the repository root AGENTS.md and the closest path-local AGENTS.md files before drawing conclusions.
+
+Stay strictly inside technical SEO and search-facing content structure. Do not drift into marketing strategy, generic copywriting advice, security, or accessibility unless it directly affects crawlability or indexation.
+
+Primary focus:
+- crawlability, indexation, and canonical behavior
+- route metadata, titles, descriptions, Open Graph, and canonical URLs
+- robots, sitemap, redirects, and duplicate-content risks
+- heading structure, internal linking, and rendering choices that affect search bots
+- structured data and route-level search visibility signals
+
+Repository-specific focus areas:
+- src/app/(frontend)/**
+- src/utilities/generateMeta.ts
+- sitemap, robots, redirects, and metadata-related utilities
+
+Working style:
+- Ground every finding in a real route, utility, or metadata path.
+- Prefer technical SEO issues over broad content suggestions.
+- Separate confirmed issues from opportunities or follow-up checks.
+- If no credible SEO issue is present in scope, say so explicitly.
+- Do not make code changes.
+- Do not give generic ranking advice detached from the repository.
+"""
+
+# Keep the reviewer narrow: avoid broad design, security, and browser-verification workflows.
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/build-web-apps/1f87561ac4dae225447336612b9304903921bb85/skills/web-design-guidelines"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/build-web-apps/1f87561ac4dae225447336612b9304903921bb85/skills/react-best-practices"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/vercel/1f87561ac4dae225447336612b9304903921bb85/skills/agent-browser"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/vercel/1f87561ac4dae225447336612b9304903921bb85/skills/agent-browser-verify"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/vercel/1f87561ac4dae225447336612b9304903921bb85/skills/verification"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/skills/playwright"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/skills/security-best-practices"
+enabled = false

--- a/.codex/agents/web-vitals-reviewer.toml
+++ b/.codex/agents/web-vitals-reviewer.toml
@@ -1,0 +1,48 @@
+name = "web_vitals_reviewer"
+description = "Read-only reviewer for Core Web Vitals and frontend performance regressions in this repository."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+nickname_candidates = ["Lighthouse", "Pulse", "Render Watch"]
+developer_instructions = """
+Read the repository root AGENTS.md and the closest path-local AGENTS.md files before drawing conclusions.
+
+Stay strictly inside Core Web Vitals and frontend performance. Do not drift into generic product advice, backend security, or accessibility unless it directly impacts performance behavior.
+
+Primary focus:
+- likely LCP, INP, and CLS regressions
+- unnecessary client-side rendering or hydration pressure
+- oversized images, font loading, render-blocking resources, and layout shifts
+- route-level bundle growth, repeated fetches, and cache misses
+- server versus client component boundaries that affect runtime cost
+
+Repository-specific focus areas:
+- src/app/(frontend)/**
+- src/components/**
+- metadata, media, and landing-page composition
+
+Working style:
+- Separate measured evidence from code-based inference.
+- Prefer the smallest file set that explains the performance risk.
+- Cite the exact code path, asset, or rendering choice that likely causes the regression.
+- If a concern requires browser measurement, say what should be measured and why.
+- Do not make code changes.
+- Do not report style-only issues that have no material performance consequence.
+"""
+
+# Keep the reviewer narrow: allow React performance guidance, avoid broad design and end-to-end verification drift.
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/build-web-apps/1f87561ac4dae225447336612b9304903921bb85/skills/web-design-guidelines"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/vercel/1f87561ac4dae225447336612b9304903921bb85/skills/agent-browser-verify"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/vercel/1f87561ac4dae225447336612b9304903921bb85/skills/verification"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/skills/security-best-practices"
+enabled = false

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,3 @@
+[agents]
+max_threads = 4
+max_depth = 1

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Use this index as the main entry point for project documentation.
 
 - [Setup & Development](./setup.md)
 - [Features & Integrations](./features.md)
+- [Codex Specialist Subagents](./integrations/codex-specialists.md)
 - [Deployment & Migration Runbook](./deployment-runbook.md)
 - [CI Modularization Plan](./engineering/ci-modularization-plan.md)
 - [Local Database Reset (Test Only)](./database-reset.md)

--- a/docs/integrations/codex-specialists.md
+++ b/docs/integrations/codex-specialists.md
@@ -1,0 +1,99 @@
+# Codex Specialist Subagents
+
+This repository defines project-scoped Codex subagents for narrow review work that should not pollute the main task context.
+
+## Why this split exists
+
+Use the two Codex layers for different jobs:
+
+- `AGENTS.md`: repository and path-scoped baseline rules that should always apply.
+- `.codex/agents/*.toml`: explicit specialist subagents for delegated ownership of one concern.
+
+This setup keeps specialist instructions narrow and opt-in instead of pushing SEO, accessibility, performance, or security guidance into every task.
+
+The relevant Codex docs are:
+
+- [Subagents](https://developers.openai.com/codex/subagents)
+- [Agents SDK orchestration and handoffs](https://developers.openai.com/api/docs/guides/agents/orchestration)
+
+## Repository configuration
+
+Project-level subagent defaults live in [`/.codex/config.toml`](../../.codex/config.toml):
+
+- `max_threads = 4`
+- `max_depth = 1`
+
+This allows parallel review across the four specialists while preventing recursive fan-out.
+
+The specialist files under [`/.codex/agents`](../../.codex/agents) also disable a small set of broad skills per reviewer through `skills.config` so the reviewers stay narrow.
+
+Important:
+
+- Some disabled skills live under the Codex plugin cache.
+- Those cache paths are versioned. After a plugin refresh, the hash segment in the path may change.
+- If a reviewer suddenly starts drifting again after a Codex/plugin update, refresh the affected `skills.config.path` entries.
+
+## Available specialists
+
+- `security_reviewer`
+  - Read-only reviewer for auth, access control, unsafe input or output handling, trust boundaries, and backend security risks.
+- `accessibility_reviewer`
+  - Read-only reviewer for semantic HTML, keyboard behavior, focus management, form accessibility, and ARIA usage.
+- `web_vitals_reviewer`
+  - Read-only reviewer for LCP, INP, CLS, hydration cost, asset loading, and route-level frontend performance risks.
+- `seo_reviewer`
+  - Read-only reviewer for crawlability, indexation, metadata, structured data, and search-facing rendering behavior.
+
+All four agents are intentionally read-only. They gather evidence and findings; they do not edit code.
+
+## How to use them
+
+Use direct prompts when you want one specialist:
+
+```text
+Have accessibility_reviewer audit the affected frontend files only and report concrete findings with file references.
+```
+
+```text
+Have security_reviewer review src/app/api and src/hooks for privilege-boundary or input-validation risks only.
+```
+
+Use a direct orchestration prompt when you want multiple specialists:
+
+```text
+Review this branch against origin/main.
+Spawn security_reviewer, accessibility_reviewer, web_vitals_reviewer, and seo_reviewer in parallel.
+Keep them read-only, wait for all of them, and summarize the findings by severity.
+```
+
+Limit scope aggressively when possible:
+
+- the current diff versus `origin/main`
+- a named route such as `src/app/(frontend)/clinics/[slug]`
+- a named component subtree such as `src/components/organisms/Form`
+- a backend area such as `src/app/api` or `src/hooks`
+
+## Recommended operating model
+
+For review-only work:
+
+1. Run the specialist or specialists.
+2. Consolidate findings.
+3. Decide whether a fix is needed.
+
+For review plus implementation:
+
+1. Run the specialists first.
+2. Let the parent agent decide which findings are real and in scope.
+3. Apply the fix in the main thread or a dedicated implementation agent.
+4. Re-run only the relevant specialists to verify the changed concern.
+
+## Why not put this in `AGENTS.md`
+
+Putting all four specialties into the repository-wide `AGENTS.md` would make them part of nearly every task. That increases context size, causes instruction conflicts, and weakens specialist quality.
+
+Subagents are the right layer when:
+
+- a concern is narrow and expert-driven
+- the review can run in parallel
+- the result should come back as findings, not silently alter the main task behavior


### PR DESCRIPTION
Adds repo-scoped Codex specialist reviewers so targeted SEO, accessibility, performance, and security audits can run without broadening normal task context.

Closes #914

## What changed
- add project-level Codex subagent defaults in `.codex/config.toml`
- add four read-only specialist reviewers under `.codex/agents` for security, accessibility, Core Web Vitals, and SEO
- document how to invoke the specialists and why they live outside `AGENTS.md`
- narrow each reviewer with `skills.config` deny lists to reduce drift from broad design, browser, and non-review skills

## Validation
- `pnpm format`
