### PR TITLE
fix(frontend): correct read-time labels for empty and short posts

### DIFF
--- a/src/utilities/blog/calculateReadTime.ts
+++ b/src/utilities/blog/calculateReadTime.ts
@@ -37,10 +37,12 @@ export function calculateReadTime(content: SerializedEditorState | undefined | n
     const text = extractText(content)
     const wordCount = text.split(/\s+/).filter((word) => word.length > 0).length
 
-    // Average reading speed: 200 words per minute
-    const minutes = Math.ceil(wordCount / 200)
+    if (wordCount === 0) return ''
 
-    if (minutes < 1) return '< 1 min read'
+    // Average reading speed: 200 words per minute
+    if (wordCount < 200) return '< 1 min read'
+
+    const minutes = Math.ceil(wordCount / 200)
 
     return `${minutes} min read`
   } catch (error) {

--- a/tests/unit/utilities/calculateReadTime.test.ts
+++ b/tests/unit/utilities/calculateReadTime.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
+
+import { calculateReadTime } from '@/utilities/blog/calculateReadTime'
+
+type LexicalState = {
+  root: {
+    type: 'root'
+    children: Array<{ type: 'paragraph'; children: Array<{ type: 'text'; text: string }> }>
+  }
+}
+
+const buildState = (text: string): LexicalState => ({
+  root: {
+    type: 'root',
+    children: [
+      {
+        type: 'paragraph',
+        children: [{ type: 'text', text }],
+      },
+    ],
+  },
+})
+
+describe('calculateReadTime', () => {
+  it('returns an empty string for empty lexical content', () => {
+    expect(calculateReadTime(buildState('') as unknown as SerializedEditorState)).toBe('')
+  })
+
+  it('returns less than one minute for short content with words', () => {
+    expect(calculateReadTime(buildState('A short post body') as unknown as SerializedEditorState)).toBe('< 1 min read')
+  })
+})


### PR DESCRIPTION
This prevents misleading read-time metadata for empty and very short blog posts.

## What changed
- fixed `calculateReadTime` to return an empty string when lexical content has zero words
- fixed `calculateReadTime` to return `< 1 min read` when content has fewer than 200 words
- added focused unit tests for empty and short lexical content cases

## Validation
- `pnpm vitest tests/unit/utilities/calculateReadTime.test.ts --run`
- `pnpm format`
- `pnpm check`

## Development
- closes #915
