### PR TITLE
fix: use first page when current page is missing

### DIFF
--- a/src/components/molecules/PageRange/index.tsx
+++ b/src/components/molecules/PageRange/index.tsx
@@ -25,10 +25,13 @@ export const PageRange: React.FC<{
 }> = (props) => {
   const { className, collection, collectionLabels: collectionLabelsFromProps, currentPage, limit, totalDocs } = props
 
-  let indexStart = (currentPage ? currentPage - 1 : 1) * (limit || 1) + 1
+  const resolvedPage = currentPage ?? 1
+  const resolvedLimit = limit ?? 1
+
+  let indexStart = (resolvedPage - 1) * resolvedLimit + 1
   if (totalDocs && indexStart > totalDocs) indexStart = 0
 
-  let indexEnd = (currentPage || 1) * (limit || 1)
+  let indexEnd = resolvedPage * resolvedLimit
   if (totalDocs && indexEnd > totalDocs) indexEnd = totalDocs
 
   const { plural, singular } =

--- a/tests/unit/components/molecules.test.ts
+++ b/tests/unit/components/molecules.test.ts
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 
 import { LocationLine } from '@/components/molecules/LocationLine'
+import { PageRange } from '@/components/molecules/PageRange'
 import { PriceSummary } from '@/components/molecules/PriceSummary'
 import { RatingSummary } from '@/components/molecules/RatingSummary'
 import { TagList } from '@/components/molecules/TagList'
@@ -51,5 +52,16 @@ describe('summary molecules', () => {
     tags.forEach((tag) => {
       expect(markup).toContain(tag)
     })
+  })
+
+  it('renders PageRange from page 1 when currentPage is missing', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(PageRange, {
+        limit: 12,
+        totalDocs: 24,
+      }),
+    )
+
+    expect(markup).toContain('Showing 1 - 12 of 24 Docs')
   })
 })


### PR DESCRIPTION
Users now see the correct page range when pagination defaults are used without an explicit current page.

## What changed
- fix `PageRange` default pagination math to treat missing `currentPage` as page 1 consistently for start and end indices
- reuse resolved `currentPage` and `limit` values to keep index calculations aligned
- add a regression test covering missing `currentPage` (`Showing 1 - 12 of 24 Docs`)

## Validation
- `pnpm vitest run tests/unit/components/molecules.test.ts`
- `pnpm check`
- `pnpm format`

## Development
- Closes #932
