### PR TITLE
fix(ci): harden dependabot auto-merge security gates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -33,5 +33,6 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: gh pr merge --auto --squash "$PR_NUMBER"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,7 @@
 name: Dependabot Auto-Merge
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -15,12 +15,15 @@ permissions:
 jobs:
   auto-merge:
     name: enable auto-merge for safe dependabot updates
-    if: github.actor == 'dependabot[bot]'
+    if: |
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -30,4 +33,5 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr merge --auto --squash "$PR_NUMBER"


### PR DESCRIPTION
Scheduled `Workflow Security` runs on `main` stop failing on known dependabot workflow hardening findings.

## What changed
- switched `.github/workflows/dependabot-auto-merge.yml` trigger from `pull_request_target` to `pull_request`
- replaced spoofable actor-only gate with stricter PR trust checks:
  - PR author must be `dependabot[bot]`
  - head repository must match `github.repository`
  - base branch must be `main`
- pinned `dependabot/fetch-metadata` to commit SHA `21025c705c08248db411dc16f3619e6b5f9ea21a`
- removed template-expanded PR URL from shell command and merged by validated PR number env var instead

## Development
- Closes #938

## Validation
- `pnpm check`
- `pnpm format`
