### PR TITLE
chore: tighten mobile-first review guidance

### DIFF
--- a/.codex/agents/accessibility-reviewer.toml
+++ b/.codex/agents/accessibility-reviewer.toml
@@ -27,6 +27,8 @@ Working style:
 - Use browser or runtime evidence when the task provides a running UI, but do not block on it if code evidence is enough.
 - Prefer semantic fixes over ARIA-only patches in your recommendations.
 - Distinguish confirmed violations from likely risks that need runtime verification.
+- Score each finding on the repository's absolute `1-10` severity scale instead of using relative labels such as high, medium, or low.
+- Use `7-10` only for issues with clear accessibility failure or major user impact; use `3-4` for polish or weaker consistency gaps.
 - Do not make code changes.
 - Do not report purely visual issues unless they create an accessibility failure.
 """

--- a/.codex/agents/mobile-ui-reviewer.toml
+++ b/.codex/agents/mobile-ui-reviewer.toml
@@ -1,0 +1,69 @@
+name = "mobile_ui_reviewer"
+description = "Read-only reviewer for mobile-first UI behavior, responsive layout failures, and touch-first interaction risks in this repository."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+nickname_candidates = ["Viewport Scout", "Pocket Audit", "Thumb Zone"]
+developer_instructions = """
+Read the repository root AGENTS.md, the closest path-local AGENTS.md files, and docs/frontend/mobile-ai-playbook.md before drawing conclusions.
+
+Stay strictly inside mobile-first UI and responsive behavior. Do not drift into backend implementation, generic product strategy, or broad desktop polish unless it directly explains a mobile failure.
+
+Primary focus:
+- broken or fragile layout at narrow widths
+- touch-first interaction failures, including drawers, accordions, sticky UI, and scroll containment
+- poor mobile content hierarchy, CTA placement, or reading flow
+- horizontal overflow, clipped text, and unstable wrapping
+- responsive image sizing and layout choices that likely hurt mobile UX or runtime cost
+
+Repository-specific focus areas:
+- src/app/(frontend)/**
+- src/components/**
+- src/stories/**
+- mobile nav, landing sections, listing/filter/comparison flows, and image-heavy route sections
+
+Working style:
+- Prioritize findings in this order: broken layout, touch interaction failure, hierarchy/readability, mobile performance smell.
+- Use the canonical mobile matrix from `docs/frontend/mobile-ai-playbook.md`, including the additional `1280px` check when the playbook marks it as required.
+- Always name the viewport or breakpoint where the issue appears or is most likely.
+- Separate confirmed issues from likely risks that still need runtime verification.
+- Score each finding on the repository's absolute `1-10` severity scale instead of using relative labels such as high, medium, or low.
+- Use `7-10` only for issues with clear user-flow breakage or severe mobile failure; use `3-4` for instruction polish or weaker consistency gaps.
+- Cite the exact component, story, route, or UI state that supports the finding, and include the evidence used for each finding.
+- Treat a finding as confirmed only when it is reproducible in Playwright, reproducible in Storybook with the relevant state, or directly provable from code without runtime ambiguity.
+- Treat sticky overlap, scroll containment, touch reachability, safe-area, browser-chrome resize, virtual-keyboard overlap, and other runtime-sensitive issues as likely risks unless runtime or story evidence confirms them.
+- For route-level or other runtime-sensitive mobile risks, use Playwright to attempt runtime verification before leaving the issue as `Likely`; use code evidence first only for static layout proof or when runtime verification is not available.
+- Treat browser-engine-sensitive evidence as partial unless the engine limitation is stated explicitly or matching runtime evidence exists for the affected engine.
+- Treat long labels, validation errors, empty states, loading states, error states, dense CMS content, and responsive image sizing as first-class mobile review inputs, not optional follow-up checks.
+- If a browser check is needed, say which viewport and interaction path should be verified.
+- Do not make code changes.
+- Do not report generic desktop polish issues unless they block a mobile-first design outcome.
+"""
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/build-web-apps/1f87561ac4dae225447336612b9304903921bb85/skills/web-design-guidelines"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/build-web-apps/1f87561ac4dae225447336612b9304903921bb85/skills/react-best-practices"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/vercel/1f87561ac4dae225447336612b9304903921bb85/skills/agent-browser"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/vercel/1f87561ac4dae225447336612b9304903921bb85/skills/agent-browser-verify"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/plugins/cache/openai-curated/vercel/1f87561ac4dae225447336612b9304903921bb85/skills/verification"
+enabled = false
+
+[[skills.config]]
+path = "~/.codex/skills/playwright"
+enabled = true
+
+[[skills.config]]
+path = "~/.codex/skills/security-best-practices"
+enabled = false

--- a/.codex/agents/security-reviewer.toml
+++ b/.codex/agents/security-reviewer.toml
@@ -27,6 +27,8 @@ Working style:
 - Prefer concrete evidence from the changed files and their direct execution path.
 - Cite files, symbols, and the condition that makes the issue real.
 - Separate confirmed issues from hypotheses.
+- Score each finding on the repository's absolute `1-10` severity scale instead of using relative labels such as high, medium, or low.
+- Use `8-10` only for clear trust-boundary, auth, data exposure, or exploitability problems; use `3-4` for weaker hardening opportunities.
 - If no credible issue is present, say so explicitly.
 - Do not make code changes.
 - Do not comment on style unless it hides a security or correctness risk.

--- a/.codex/agents/seo-reviewer.toml
+++ b/.codex/agents/seo-reviewer.toml
@@ -25,6 +25,8 @@ Working style:
 - Ground every finding in a real route, utility, or metadata path.
 - Prefer technical SEO issues over broad content suggestions.
 - Separate confirmed issues from opportunities or follow-up checks.
+- Score each finding on the repository's absolute `1-10` severity scale instead of using relative labels such as high, medium, or low.
+- Use `7-10` only for clear crawlability, indexation, canonical, or metadata failures with meaningful search impact; use `3-4` for softer opportunities.
 - If no credible SEO issue is present in scope, say so explicitly.
 - Do not make code changes.
 - Do not give generic ranking advice detached from the repository.

--- a/.codex/agents/web-vitals-reviewer.toml
+++ b/.codex/agents/web-vitals-reviewer.toml
@@ -25,6 +25,8 @@ Working style:
 - Separate measured evidence from code-based inference.
 - Prefer the smallest file set that explains the performance risk.
 - Cite the exact code path, asset, or rendering choice that likely causes the regression.
+- Score each finding on the repository's absolute `1-10` severity scale instead of using relative labels such as high, medium, or low.
+- Use `7-10` only for likely material regressions to user-perceived performance or Core Web Vitals; use `3-4` for softer optimization ideas.
 - If a concern requires browser measurement, say what should be measured and why.
 - Do not make code changes.
 - Do not report style-only issues that have no material performance consequence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@
 - Keep `detect-secrets` in sync with the branch before push. If secret scanning updates `.secrets.baseline`, include that file in the same change set.
 - Treat `.secrets.baseline` drift as required maintenance so CI `Detect secrets` does not fail on baseline updates.
 - AI-slop enforcement mode is `pre-commit + pre-push + deep-quality-lane`; AI-slop itself remains intentionally non-blocking in the main PR CI workflow.
-- When changing instruction sources (`AGENTS.md`, `**/AGENTS.md`, `**/AGENTS.override.md`), run `pnpm ai:slop-check` locally.
+- When changing instruction sources (`AGENTS.md`, `**/AGENTS.md`, `**/AGENTS.override.md`, `docs/frontend/mobile-ai-playbook.md`), run `pnpm ai:slop-check` locally.
 - For UI changes, always save Playwright screenshots in an ignored Playwright artifacts folder, review the change via those screenshots and runtime logs, and fix it immediately if the result is not correct or not good enough.
 - For frontend UI work, treat mobile as the primary design and verification target; widen to tablet and desktop only after the narrowest supported viewport is coherent.
 - For frontend UI work, verify the canonical mobile matrix from `docs/frontend/mobile-ai-playbook.md`; include the additional `1280px` check when the playbook marks it as required.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,12 +10,18 @@
 - Repository-local Codex skills can live under `.codex/skills/`.
 - Use `.codex/skills/gh-release-publish` when the task is to compute the next semantic release, publish a GitHub release, dispatch the production deploy workflow, or send the release announcement to Google Chat.
 
+## Repo-Local Agents
+
+- Read-only specialist agents can live under `.codex/agents/`.
+- Use `.codex/agents/mobile-ui-reviewer.toml` when the task is to review mobile-first UI behavior, responsive layout risks, or touch-first interaction issues in the frontend.
+
 ## Layered Instruction Map
 
 - Repository-wide routing and execution constraints: `AGENTS.md`
 - Usage guides and operator documentation: `docs/guides/AGENTS.md`
 - Application-wide engineering defaults: `src/AGENTS.md`
 - UI components and frontend architecture: `src/components/AGENTS.md`, `src/app/(frontend)/AGENTS.md`
+- Mobile-first frontend heuristics and prompt scaffolding: `docs/frontend/mobile-ai-playbook.md`
 - UI and CMS boundary mapping: `src/blocks/AGENTS.md`, `src/app/AGENTS.md`, `src/stories/AGENTS.md`
 - Payload/API/hooks/seeds: `src/collections/AGENTS.md`, `src/hooks/AGENTS.md`, `src/endpoints/seed/AGENTS.md`, `src/app/api/AGENTS.md`
 - Payload admin UI design: `src/app/(payload)/AGENTS.md`, `src/components/organisms/AdminBranding/AGENTS.md`, `src/components/organisms/DeveloperDashboard/AGENTS.md`, `src/dashboard/adminDashboard/AGENTS.md`
@@ -46,6 +52,12 @@
 - AI-slop enforcement mode is `pre-commit + pre-push + deep-quality-lane`; AI-slop itself remains intentionally non-blocking in the main PR CI workflow.
 - When changing instruction sources (`AGENTS.md`, `**/AGENTS.md`, `**/AGENTS.override.md`), run `pnpm ai:slop-check` locally.
 - For UI changes, always save Playwright screenshots in an ignored Playwright artifacts folder, review the change via those screenshots and runtime logs, and fix it immediately if the result is not correct or not good enough.
+- For frontend UI work, treat mobile as the primary design and verification target; widen to tablet and desktop only after the narrowest supported viewport is coherent.
+- For frontend UI work, verify the canonical mobile matrix from `docs/frontend/mobile-ai-playbook.md`; include the additional `1280px` check when the playbook marks it as required.
+- For frontend UI work, explicitly check for horizontal overflow, clipped text, obstructive sticky elements, unstable CTA placement, touch-target crowding, hover-only interactions, and short-height mobile failures such as safe-area collisions, browser-chrome resize, dynamic viewport height issues, and virtual-keyboard overlap when relevant.
+- For frontend UI work, include a brief mobile QA note in the final handoff covering checked viewports, checked interaction paths or states, confirmed findings or verified states, likely risks, remaining assumptions, and the screenshot, Storybook, or Playwright evidence used.
+- For runtime-sensitive route-level mobile risks, do not treat code inference alone as confirmation; use Playwright or equivalent route-level runtime evidence for confirmed findings.
+- For browser-engine-sensitive mobile risks such as safe-area, browser-chrome resize, dynamic viewport height, or virtual-keyboard behavior, treat single-engine evidence as partial unless the engine limitation is stated explicitly.
 - When local Playwright verification needs authenticated admin access, prefer the shared session file `output/playwright/sessions/admin.local.json`; refresh it with `pnpm playwright:session:record -- --persona admin` and validate it with `pnpm playwright:session:check -- --persona admin` using an existing local or test platform admin account.
 - When sharing screenshots in chat responses, embed them inline as Markdown images using absolute filesystem paths; avoid plain linked file paths unless explicitly requested.
 - `pnpm install` configures `.githooks` automatically in local Git worktrees; rerun `pnpm hooks:install` manually if hook setup drifts.
@@ -127,6 +139,22 @@ Rule budget:
 - Rule 1: State concrete facts with references (files, commands, logs, or links).
 - Rule 2: Separate facts from recommendations.
 - Rule 3: Keep responses concise and implementation-oriented.
+
+## Review Severity Scale
+
+Use an absolute `1-10` severity scale for review findings across all agents and review tasks. Do not use relative labels such as `high`, `medium`, or `low` unless the user explicitly asks for them.
+
+- `9-10`: production-critical or trust-critical issue; likely to break primary flows, create security exposure, or cause severe user failure
+- `7-8`: important issue with clear user, business, or reliability impact; should usually be fixed before merge
+- `5-6`: meaningful issue worth fixing soon; real risk exists but the impact is narrower or more conditional
+- `3-4`: quality or maintainability gap; useful to improve but not urgent on its own
+- `1-2`: minor polish, wording, or consistency issue with low standalone impact
+
+For review outputs:
+
+- score findings on this absolute scale, not relative to the other findings in the same review
+- prefer fewer findings with calibrated scores over long lists of weak observations
+- if nothing credibly reaches `5/10`, say that explicitly instead of inflating weaker issues
 
 ## Uncertainty & Evidence
 

--- a/docs/frontend/mobile-ai-playbook.md
+++ b/docs/frontend/mobile-ai-playbook.md
@@ -1,7 +1,6 @@
 # Mobile-First AI Playbook
 
-This document is the canonical mobile-first reference for Codex tasks that touch frontend UI in this repository. Keep hard rules in the relevant `AGENTS.md` files and use this playbook for the working heuristics, viewport matrix, prompt scaffolding, and review checklist.
-Path-local `AGENTS.md` files should reference this playbook instead of restating the full matrix or `Confirmed` versus `Likely` thresholds unless they need a narrower local exception.
+This document is the canonical mobile-first reference for Codex tasks that touch frontend UI in this repository. Keep hard rules in the relevant `AGENTS.md` files and use this playbook for heuristics, viewport matrix, prompt scaffolding, and review checklists. Path-local `AGENTS.md` files should reference it instead of restating the full matrix or `Confirmed` versus `Likely` thresholds unless they need a narrow local exception.
 
 ## Mobile-First Default
 
@@ -72,25 +71,13 @@ For browser-engine-sensitive risks such as safe-area, browser-chrome resize, dyn
 
 ### Severity Scale
 
-Use the repository's absolute `1-10` severity scale for review findings:
-
-- `9-10`: production-critical or trust-critical issue
-- `7-8`: important issue with clear user-flow, business, or reliability impact
-- `5-6`: meaningful issue worth fixing soon
-- `3-4`: quality or consistency gap with limited standalone impact
-- `1-2`: minor polish issue
-
-Do not use relative `high`, `medium`, or `low` labels unless the user explicitly asks for them.
+Use the repository's absolute `1-10` severity scale from `AGENTS.md`. Do not use relative `high`, `medium`, or `low` labels unless the user explicitly asks for them.
 
 ### Confirmed vs. Likely
 
-Use this threshold consistently:
-
 - `Confirmed`: reproducible in Playwright, reproducible in Storybook with the relevant state, or directly provable from code without runtime ambiguity
 - `Likely`: plausible from code or layout structure but still dependent on runtime behavior, browser chrome, content volume, or touch interaction to verify
-
-For sticky overlap, scroll traps, touch reachability, safe-area issues, virtual-keyboard overlap, and similar runtime-sensitive behavior, default to `Likely` unless a runtime or story reproduction exists.
-For browser-engine-sensitive risks such as safe-area, browser-chrome resize, dynamic viewport height, or virtual-keyboard behavior, treat single-engine runtime evidence as partial unless the engine limitation is stated explicitly.
+- Default sticky overlap, scroll traps, touch reachability, safe-area issues, and virtual-keyboard overlap to `Likely` unless runtime or story evidence confirms them. Treat single-engine evidence as partial unless the engine limitation is stated explicitly.
 
 ## Prompt Scaffolding
 
@@ -115,11 +102,7 @@ For route-level work:
 - require composed-route Playwright or equivalent runtime verification for runtime-sensitive risks
 - if shared mobile UI spans multiple route types, sample at least two representative routes or content densities
 
-Example:
-
-```text
-Implement this section mobile-first. Start at 320px, verify 320/375/640/768/1024, verify the composed route directly with Playwright, sample two representative routes if the same mobile header or drawer is shared, verify the mobile nav open/use/scroll/close cycle and the filter drawer open/apply/clear/close cycle, verify short-height states and one worst-case content state, preserve the current visual language, and return a short mobile QA note covering checked interaction cycles, overflow, CTA placement, sticky behavior, short-height mobile risks, confirmed findings, likely risks, and any remaining assumptions.
-```
+Example prompt: `Implement this section mobile-first. Start at 320px, verify 320/375/640/768/1024, verify the composed route directly with Playwright, sample two representative routes if the same mobile header or drawer is shared, verify the mobile nav open/use/scroll/close cycle and the filter drawer open/apply/clear/close cycle, verify short-height states and one worst-case content state, preserve the current visual language, and return a short mobile QA note covering checked interaction cycles, overflow, CTA placement, sticky behavior, short-height mobile risks, confirmed findings, likely risks, and remaining assumptions.`
 
 ### Review Prompt Shape
 
@@ -141,11 +124,7 @@ For route-level or shared mobile UI:
 - require composed-route Playwright or equivalent runtime verification for runtime-sensitive risks
 - require sampling at least two representative routes or content densities when the same mobile UI spans multiple route types
 
-Example:
-
-```text
-Review this UI for mobile-first issues at 320/375/640/768/1024. Score each finding on an absolute 1-10 severity scale. Prioritize broken layout, touch interaction failures, and content hierarchy problems. Use composed-route Playwright for route-level runtime risks, sample two representative routes when shared mobile UI spans multiple route types, separate confirmed issues from likely risks, name the triggering viewport for each finding, verify and name the interaction cycle when runtime verification is needed, check short-height states and worst-case content states when relevant, and include evidence per finding.
-```
+Example prompt: `Review this UI for mobile-first issues at 320/375/640/768/1024. Score each finding on an absolute 1-10 severity scale. Prioritize broken layout, touch interaction failures, and content hierarchy problems. Use composed-route Playwright for route-level runtime risks, sample two representative routes when shared mobile UI spans multiple route types, separate confirmed issues from likely risks, name the triggering viewport for each finding, verify and name the interaction cycle when runtime verification is needed, check short-height states and worst-case content states when relevant, and include evidence per finding.`
 
 ## Reviewer Routing
 
@@ -168,26 +147,5 @@ Pay extra attention to these patterns in this repository:
 
 ## Good vs. Weak Instructions
 
-Good:
-
-```text
-Update the mobile nav behavior first. Verify 320/375/640/768/1024, verify the composed route with Playwright, check the nav open/use/close cycle, avoid hover-only affordances, and include a mobile QA note describing any remaining drawer-height, short-height viewport, or scroll-lock risks.
-```
-
-Weak:
-
-```text
-Make it responsive and nice on mobile.
-```
-
-Good:
-
-```text
-Review this landing section for mobile hierarchy problems. Focus on CTA placement, text wrapping, sticky overlap, short-height viewport behavior, and image sizing on 320/375/640/768/1024 widths before discussing desktop polish.
-```
-
-Weak:
-
-```text
-Check whether the layout could be improved.
-```
+- Strong request: `Update the mobile nav behavior first. Verify 320/375/640/768/1024, verify the composed route with Playwright, check the nav open/use/close cycle, avoid hover-only affordances, and include a mobile QA note describing any remaining drawer-height, short-height viewport, or scroll-lock risks.`
+- Weak request: `Make it responsive and nice on mobile.`

--- a/docs/frontend/mobile-ai-playbook.md
+++ b/docs/frontend/mobile-ai-playbook.md
@@ -1,0 +1,193 @@
+# Mobile-First AI Playbook
+
+This document is the canonical mobile-first reference for Codex tasks that touch frontend UI in this repository. Keep hard rules in the relevant `AGENTS.md` files and use this playbook for the working heuristics, viewport matrix, prompt scaffolding, and review checklist.
+Path-local `AGENTS.md` files should reference this playbook instead of restating the full matrix or `Confirmed` versus `Likely` thresholds unless they need a narrower local exception.
+
+## Mobile-First Default
+
+- Design and verify the narrow viewport first.
+- Expand to tablet and desktop only after the mobile hierarchy and interaction model are coherent.
+- Prioritize content order, CTA clarity, text wrapping, and touch reachability before decorative density.
+- Prefer vertical flow before introducing multi-column layouts.
+- Prefer touch-first interactions before hover enhancements.
+
+## Standard Viewport Matrix
+
+Use this matrix unless the task explicitly defines a different one:
+
+- `320px`: smallest hard constraint
+- `375px`: default smartphone width
+- `640px`: repository `sm`
+- `768px`: repository `md`
+- `>=1024px`: desktop verification width
+
+If a task affects image behavior, dense dashboards, or wide comparison layouts, include one additional large-screen check at `1280px`.
+
+This same matrix applies to route, component, story, and review work. Do not collapse it to `320px` plus one generic mobile state and one desktop state.
+
+## Short-Height Mobile Checks
+
+Width checks are not enough for sticky and full-height UI. When relevant, also verify:
+
+- browser-chrome or address-bar resize on mobile browsers
+- safe-area inset collisions near the top or bottom edge
+- dynamic viewport height behavior for full-height panels
+- virtual-keyboard overlap for forms, drawers, and bottom sheets
+- landscape or other reduced-height mobile states
+
+These short-height checks apply to route, component, story, and review work for drawers, sheets, sticky bars, dialogs, fixed navigation, and full-height panels.
+
+## Mobile Failure Modes
+
+Review these before and after editing:
+
+- horizontal overflow or clipped containers
+- text overflow in buttons, pills, cards, tables, and badges
+- CTA groups that wrap into ambiguous order or overlap key content
+- sticky headers, jump bars, or drawers that hide content or trap scrolling
+- dialogs and sheets that exceed the viewport without internal scroll containment
+- bottom sheets, sticky CTAs, or full-height panels that break under short-height mobile states
+- carousels, tab bars, comparison views, and filters that are hard to use on touch
+- hover-only or pointer-precision interactions for essential actions
+- image `sizes` hints that do not match the real mobile layout
+- mobile layouts that bury the primary action below decorative content
+- long labels, validation errors, empty states, loading states, and CMS-realistic content that reorder or clip mobile UI
+
+## Task Output Contract
+
+For frontend UI tasks, the final handoff should include a short mobile QA note with:
+
+- checked viewports
+- checked interaction paths or UI states
+- checked short-height mobile states when relevant
+- confirmed findings or verified states
+- remaining mobile risks or follow-up checks
+- evidence used: Storybook stories, Playwright evidence, or code-based inference for static layout checks or likely risks
+
+For review tasks, include evidence per finding, not just once for the whole review.
+
+For runtime-sensitive route risks, confirm on the composed route with Playwright or equivalent runtime evidence instead of code inference alone.
+For shared mobile UI such as header, navigation, drawers, or sticky bars, sample at least two representative routes or content densities when the same UI spans multiple route types.
+For browser-engine-sensitive risks such as safe-area, browser-chrome resize, dynamic viewport height, or virtual-keyboard behavior, treat single-engine runtime evidence as partial unless the engine limitation is stated explicitly.
+
+### Severity Scale
+
+Use the repository's absolute `1-10` severity scale for review findings:
+
+- `9-10`: production-critical or trust-critical issue
+- `7-8`: important issue with clear user-flow, business, or reliability impact
+- `5-6`: meaningful issue worth fixing soon
+- `3-4`: quality or consistency gap with limited standalone impact
+- `1-2`: minor polish issue
+
+Do not use relative `high`, `medium`, or `low` labels unless the user explicitly asks for them.
+
+### Confirmed vs. Likely
+
+Use this threshold consistently:
+
+- `Confirmed`: reproducible in Playwright, reproducible in Storybook with the relevant state, or directly provable from code without runtime ambiguity
+- `Likely`: plausible from code or layout structure but still dependent on runtime behavior, browser chrome, content volume, or touch interaction to verify
+
+For sticky overlap, scroll traps, touch reachability, safe-area issues, virtual-keyboard overlap, and similar runtime-sensitive behavior, default to `Likely` unless a runtime or story reproduction exists.
+For browser-engine-sensitive risks such as safe-area, browser-chrome resize, dynamic viewport height, or virtual-keyboard behavior, treat single-engine runtime evidence as partial unless the engine limitation is stated explicitly.
+
+## Prompt Scaffolding
+
+Use these ingredients when prompting Codex for mobile UI work:
+
+### Build Prompt Shape
+
+Include:
+
+- the exact route, block, or component in scope
+- the primary mobile user goal
+- the viewport matrix to verify
+- the exact mobile interaction cycles or failure states to verify
+- the short-height mobile states to verify when the UI uses drawers, sheets, sticky bars, fixed navigation, dialogs, or full-height panels
+- the worst-case content states to verify when the layout depends on content shape
+- any relevant repo-specific hotspots from the list below
+- any fixed constraints, such as keeping Payload boundaries or preserving existing visual language
+- the required output, including a mobile QA note and screenshots or stories when relevant
+
+For route-level work:
+
+- require composed-route Playwright or equivalent runtime verification for runtime-sensitive risks
+- if shared mobile UI spans multiple route types, sample at least two representative routes or content densities
+
+Example:
+
+```text
+Implement this section mobile-first. Start at 320px, verify 320/375/640/768/1024, verify the composed route directly with Playwright, sample two representative routes if the same mobile header or drawer is shared, verify the mobile nav open/use/scroll/close cycle and the filter drawer open/apply/clear/close cycle, verify short-height states and one worst-case content state, preserve the current visual language, and return a short mobile QA note covering checked interaction cycles, overflow, CTA placement, sticky behavior, short-height mobile risks, confirmed findings, likely risks, and any remaining assumptions.
+```
+
+### Review Prompt Shape
+
+Include:
+
+- exact scope
+- required viewport matrix
+- requested absolute `1-10` severity scoring
+- request to separate confirmed issues from likely risks
+- request to name the triggering viewport for each finding
+- request to verify and name the interaction cycle when runtime verification is needed
+- request short-height state checks when the UI uses drawers, sheets, sticky bars, fixed navigation, dialogs, or full-height panels
+- request worst-case content-state checks when the layout depends on content shape
+- any relevant repo-specific hotspots from the list below
+- request to call out touch, overflow, and content-hierarchy problems explicitly
+
+For route-level or shared mobile UI:
+
+- require composed-route Playwright or equivalent runtime verification for runtime-sensitive risks
+- require sampling at least two representative routes or content densities when the same mobile UI spans multiple route types
+
+Example:
+
+```text
+Review this UI for mobile-first issues at 320/375/640/768/1024. Score each finding on an absolute 1-10 severity scale. Prioritize broken layout, touch interaction failures, and content hierarchy problems. Use composed-route Playwright for route-level runtime risks, sample two representative routes when shared mobile UI spans multiple route types, separate confirmed issues from likely risks, name the triggering viewport for each finding, verify and name the interaction cycle when runtime verification is needed, check short-height states and worst-case content states when relevant, and include evidence per finding.
+```
+
+## Reviewer Routing
+
+Use specialist reviewers in this order when the task is primarily mobile UI quality work:
+
+1. `.codex/agents/mobile-ui-reviewer.toml`
+2. `.codex/agents/accessibility-reviewer.toml`
+3. `.codex/agents/web-vitals-reviewer.toml` for image-heavy, animation-heavy, or landing-page work
+
+Use the SEO reviewer only when the mobile change also affects crawlable route metadata, headings, or indexation behavior.
+
+## Repo-Specific Hotspots
+
+Pay extra attention to these patterns in this repository:
+
+- header and navigation states that switch between desktop dropdowns and mobile accordions
+- landing-page sections with sticky or scrollytelling behavior
+- listing, comparison, and filter layouts that become dense quickly on narrow screens
+- image-heavy clinic detail and blog layouts where `sizes` hints must match real breakpoints
+
+## Good vs. Weak Instructions
+
+Good:
+
+```text
+Update the mobile nav behavior first. Verify 320/375/640/768/1024, verify the composed route with Playwright, check the nav open/use/close cycle, avoid hover-only affordances, and include a mobile QA note describing any remaining drawer-height, short-height viewport, or scroll-lock risks.
+```
+
+Weak:
+
+```text
+Make it responsive and nice on mobile.
+```
+
+Good:
+
+```text
+Review this landing section for mobile hierarchy problems. Focus on CTA placement, text wrapping, sticky overlap, short-height viewport behavior, and image sizing on 320/375/640/768/1024 widths before discussing desktop polish.
+```
+
+Weak:
+
+```text
+Check whether the layout could be improved.
+```

--- a/scripts/ai-slop-policy-check.mjs
+++ b/scripts/ai-slop-policy-check.mjs
@@ -16,6 +16,7 @@ import { pathToFileURL } from 'node:url'
 
 const ROUTER_RELATIVE_PATH = 'AGENTS.md'
 const AGENT_FILE_NAMES = new Set(['AGENTS.md', 'AGENTS.override.md'])
+const SCOPED_INSTRUCTION_RELATIVE_PATHS = new Set(['docs/frontend/mobile-ai-playbook.md'])
 const AGENT_SCAN_IGNORED_DIRS = new Set([
   '.git',
   '.next',
@@ -115,7 +116,11 @@ function getRouterPath(rootDir) {
 }
 
 function collectFilesToScan(rootDir) {
-  return [...new Set(walkAgentInstructionFiles(rootDir))]
+  const scopedInstructionFiles = [...SCOPED_INSTRUCTION_RELATIVE_PATHS]
+    .map((relativePath) => path.join(rootDir, relativePath))
+    .filter((filePath) => fs.existsSync(filePath))
+
+  return [...new Set([...walkAgentInstructionFiles(rootDir), ...scopedInstructionFiles])]
 }
 
 function isScopedMarkdownFile(rootDir, filePath) {
@@ -123,6 +128,7 @@ function isScopedMarkdownFile(rootDir, filePath) {
 
   const normalizedRelativePath = toRelative(rootDir, filePath)
   if (/(?:^|\/)AGENTS(?:\.override)?\.md$/u.test(normalizedRelativePath)) return true
+  if (SCOPED_INSTRUCTION_RELATIVE_PATHS.has(normalizedRelativePath)) return true
   return false
 }
 

--- a/scripts/ai-slop-pre-push-check.mjs
+++ b/scripts/ai-slop-pre-push-check.mjs
@@ -3,7 +3,10 @@ import { writeFileSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-const AI_SLOP_RELEVANT_FILE_PATTERNS = [/(?:^|\/)AGENTS(?:\.override)?\.md$/]
+const AI_SLOP_RELEVANT_FILE_PATTERNS = [
+  /(?:^|\/)AGENTS(?:\.override)?\.md$/,
+  /^docs\/frontend\/mobile-ai-playbook\.md$/,
+]
 
 const runGit = (args) => {
   try {

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -51,6 +51,7 @@ This guide defines shared defaults for `src/**`. Nested `AGENTS.md` files overri
 - Keep UI components Payload-free; map CMS shapes in block adapters.
 - Use Tailwind + shadcn atoms in `src/components/atoms`.
 - Story metadata must comply with `docs/frontend/story-governance.md`.
+- Treat mobile-first layout and interaction behavior as the default frontend design mode; see `docs/frontend/mobile-ai-playbook.md` for the canonical viewport matrix, review checklist, and prompt scaffolding.
 
 ### Domain Routing
 

--- a/src/app/(frontend)/AGENTS.md
+++ b/src/app/(frontend)/AGENTS.md
@@ -18,6 +18,9 @@
 - Do not place business logic or data fetching inside reusable UI components.
 - Favor parent-controlled inputs (`value/onValueChange`, `checked/onCheckedChange`).
 - Keep molecules router-agnostic; pass navigation callbacks as props.
+- Start route and page composition from the narrow viewport first, then widen to tablet and desktop once hierarchy, spacing, and primary actions are stable.
+- Prefer vertical flow, clear content priority, and compact CTA grouping over early multi-column density.
+- Do not rely on hover-only disclosure, pointer-precision affordances, or side-by-side layouts that collapse into ambiguous mobile order.
 
 ## Boundary Reminder
 
@@ -28,6 +31,8 @@
 
 - New or changed reusable UI components should include or update stories in `src/stories/**`.
 - Keep stories isolated and deterministic.
+- Use `docs/frontend/mobile-ai-playbook.md` when defining mobile states, viewport expectations, and responsive QA notes for route-level UI work.
+- For route-level mobile work, verify the composed route directly; use Playwright or equivalent route-level runtime evidence for runtime-sensitive risks such as sticky overlap, drawers, sheets, filters, forms, or scroll containment, and use screenshots or route-level stories only as supporting evidence or for static layout checks.
 
 ## Styling Protocol
 
@@ -47,6 +52,13 @@
 - Prefer server-side data fetching in App Router unless client reactivity is required.
 - If frontend route changes alter user-facing flows documented in `docs/guides/**`, update the affected guide and refresh stale screenshots in the same change.
 - For local verification of authenticated admin-facing routes under `src/app/(frontend)/admin/**`, prefer the shared Playwright session `output/playwright/sessions/admin.local.json` instead of redoing login in each browser run.
+- For route-level mobile work, apply the canonical mobile matrix from `docs/frontend/mobile-ai-playbook.md`; include the additional `1280px` check only when the playbook marks it as required.
+- Review sticky headers, drawers, accordions, carousels, filter bars, and modal heights for touch reachability and scroll containment on small screens.
+- When the route uses sticky CTAs, sticky bars, fixed navigation, drawers, sheets, dialogs, or full-height panels, apply the playbook short-height checks and name the reduced-height states you verified.
+- When reporting route-level mobile verification, name the exact interaction cycles checked per viewport, for example open/use/scroll/close for mobile nav or drawers, apply/clear filters, or invalid-submit/error/fix/submit for forms.
+- When shared mobile UI such as header, navigation, or sticky bars spans multiple route types, sample at least two representative routes or content densities.
+- When route layout depends on real content shape, also verify at least one worst-case content state with long labels, dense CMS content, or empty/loading/error states.
+- For image-heavy routes, verify composed-route image sizing and `sizes` assumptions at mobile widths instead of relying only on component-level checks.
 
 ## Animation Stack
 

--- a/src/components/AGENTS.md
+++ b/src/components/AGENTS.md
@@ -19,6 +19,10 @@
 - Favor parent-controlled inputs (`value/onValueChange`, `checked/onCheckedChange`).
 - Use context only for local compound-component coordination when necessary.
 - Keep molecules router-agnostic; pass navigation callbacks as props.
+- Design component APIs so mobile state is explicit and testable; avoid hidden responsive behavior that cannot be previewed or asserted in isolation.
+- Do not introduce hover-only interactions for essential actions or navigation.
+- Avoid component layouts that depend on horizontal scrolling unless the component is explicitly a scrollable pattern and provides clear touch affordances.
+- Keep touch targets, spacing, and text wrapping resilient at narrow widths before layering larger-screen enhancements.
 
 ## Boundary Rules
 
@@ -34,6 +38,9 @@
 - Keep stories isolated and deterministic.
 - Follow detailed story rules in `.github/instructions/stories.instructions.md`.
 - Story metadata must follow `docs/frontend/story-governance.md`.
+- For responsive components, use the canonical mobile matrix from `docs/frontend/mobile-ai-playbook.md`; include the additional `1280px` check only when the playbook marks it as required.
+- If a shared mobile component such as header, navigation, drawer, or sticky bar can affect multiple route types, pair component-level verification with composed-route checks on at least two representative routes or content densities.
+- If a route-critical mobile component such as a filter sheet, sticky CTA, full-height dialog, or overlay can create runtime risk on the composed route, pair component-level verification with composed-route checks even when the component is not shared.
 
 ## Styling Protocol
 
@@ -41,6 +48,7 @@
 - Keep component variants in code (CVA), not semantic global CSS classes.
 - Avoid inline styles unless no other option exists.
 - Use design tokens and utility composition before arbitrary values.
+- Prefer mobile-first utilities and widen deliberately instead of patching desktop layouts downward.
 
 ## Heading Rule
 
@@ -51,6 +59,11 @@
 
 - Business validation belongs in Payload hooks/access logic.
 - Prefer server-side data fetching in App Router unless client reactivity is required.
+- Review responsive components for CTA order and wrapping, sticky overlap, dialog or sheet height containment, and image `sizes` hints when media layout changes across breakpoints.
+- For sheets, drawers, sticky bars, dialogs, fixed navigation, and full-height panels, apply the playbook short-height checks instead of inventing a local subset.
+- When component layout depends on content shape, add at least one worst-case story or fixture covering long labels, dense CMS-like content, validation errors, empty states, loading states, or error states.
+- When documenting runtime-sensitive mobile risks for a component, follow the playbook `Confirmed` versus `Likely` threshold instead of redefining it locally.
+- For interactive mobile components, verify at least one full interaction cycle, not only a single click state, for example open/use/scroll/close, apply/clear/close, or invalid-submit/error/fix/submit.
 
 ## Animation Stack
 

--- a/src/stories/AGENTS.md
+++ b/src/stories/AGENTS.md
@@ -12,6 +12,9 @@
 - Mock missing dependencies in story scope (router/auth/fetch) when required.
 - Keep stories compatible with Vitest Storybook runs.
 - Story metadata must comply with `docs/frontend/story-governance.md`.
+- Use `docs/frontend/mobile-ai-playbook.md` as the canonical source for the mobile matrix, short-height checks, and `Confirmed` versus `Likely` thresholds.
+- For interactive mobile patterns, add `play` assertions for at least one full interaction cycle, not only a single open state.
+- Treat stories as supporting evidence for route-level runtime risks; use composed-route runtime verification to confirm those risks.
 
 ## Frontend Consistency Rules
 

--- a/tests/unit/scripts/ai-slop-policy-check.test.ts
+++ b/tests/unit/scripts/ai-slop-policy-check.test.ts
@@ -194,6 +194,23 @@ describe('runAiSlopPolicyCheck', () => {
     expect(result.failures.some((failure) => failure.includes('banned filler phrase found'))).toBe(true)
   })
 
+  it('treats the mobile playbook as relevant in changed-files mode', () => {
+    const rootDir = createRepo({
+      extraFiles: {
+        'docs/frontend/mobile-ai-playbook.md': 'Great question\n',
+      },
+    })
+
+    const result = runAiSlopPolicyCheck({
+      rootDir,
+      changedFiles: ['docs/frontend/mobile-ai-playbook.md'],
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.failures.some((failure) => failure.includes('banned filler phrase found'))).toBe(true)
+    expect(result.scannedPaths).toContain('docs/frontend/mobile-ai-playbook.md')
+  })
+
   it('keeps changed-files mode scoped to relevant files', () => {
     const rootDir = createRepo({
       extraFiles: {


### PR DESCRIPTION
Improve how Codex handles mobile-first frontend review work without changing runtime UI behavior.

## What changed
- add a canonical mobile-first playbook and a dedicated mobile UI reviewer agent
- align root and path-local frontend instructions around the shared mobile policy without duplicating the full rule set
- calibrate specialist reviewers to use the repository-wide absolute 1-10 severity scale

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm format`
- `pnpm ai:slop-check`

## Development
- Closes #943
