### PR TITLE
chore: clarify collection field copy

### DIFF
--- a/src/collections/ClinicGalleryEntries/index.ts
+++ b/src/collections/ClinicGalleryEntries/index.ts
@@ -13,7 +13,7 @@ export const ClinicGalleryEntries: CollectionConfig = {
   admin: {
     group: 'Clinics',
     defaultColumns: ['clinic', 'status', 'title', 'createdBy'],
-    description: 'Before-and-after stories built from clinic media',
+    description: 'Before-and-after stories',
     useAsTitle: 'title',
   },
   access: {
@@ -86,7 +86,7 @@ export const ClinicGalleryEntries: CollectionConfig = {
       label: 'Description',
       type: 'richText',
       admin: {
-        description: 'Short story shown with this entry',
+        description: 'Short story for this entry',
       },
     },
     {

--- a/src/collections/ClinicGalleryMedia/index.ts
+++ b/src/collections/ClinicGalleryMedia/index.ts
@@ -84,7 +84,7 @@ export const ClinicGalleryMedia: CollectionConfig = {
     buildMediaCaptionField({
       name: 'description',
       label: 'Description',
-      description: 'Short note shown with the media',
+      description: 'Short note for this media',
     }),
     {
       name: 'clinic',

--- a/src/collections/Doctors.ts
+++ b/src/collections/Doctors.ts
@@ -96,7 +96,7 @@ export const Doctors: CollectionConfig<'doctors'> = {
           required: true,
           admin: {
             width: '30%',
-            description: 'Fallback avatar when no photo is uploaded',
+            description: 'Doctor gender',
           },
         },
       ],

--- a/src/collections/Reviews.ts
+++ b/src/collections/Reviews.ts
@@ -138,10 +138,10 @@ export const Reviews: CollectionConfig = {
     },
     {
       type: 'collapsible',
-      label: 'Change History',
+      label: 'Edit History',
       admin: {
         initCollapsed: true,
-        description: 'Changes made to this review',
+        description: 'Last edits to this review',
       },
       fields: [
         {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1161,7 +1161,7 @@ export interface Doctor {
   firstName: string;
   lastName: string;
   /**
-   * Fallback avatar when no photo is uploaded
+   * Doctor gender
    */
   gender: 'female' | 'male';
   /**
@@ -1512,7 +1512,7 @@ export interface ClinicMedia {
   };
 }
 /**
- * Before-and-after stories built from clinic media
+ * Before-and-after stories
  *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "clinicGalleryEntries".
@@ -1536,7 +1536,7 @@ export interface ClinicGalleryEntry {
    */
   afterMedia: number | ClinicGalleryMedia;
   /**
-   * Short story shown with this entry
+   * Short story for this entry
    */
   description?: {
     root: {
@@ -1581,7 +1581,7 @@ export interface ClinicGalleryMedia {
    */
   alt: string;
   /**
-   * Short note shown with the media
+   * Short note for this media
    */
   description?: {
     root: {


### PR DESCRIPTION
This trims a few unclear collection field labels and descriptions so first-time clinic users see shorter, plainer copy.

## What changed
- Clarified a few collection labels and descriptions in `src/collections/**`.
- Kept the edits local and conservative.
- Regenerated `src/payload-types.ts` so the collection metadata stays in sync.

## Validation
- `pnpm format`
- `pnpm check`

## Development
- Fixes #948
