### PR TITLE
fix: preserve full hash fragments in specialty links

### DIFF
--- a/src/components/organisms/Landing/LandingCategories.shared.ts
+++ b/src/components/organisms/Landing/LandingCategories.shared.ts
@@ -106,7 +106,9 @@ export function buildCategoryTabs(categories: LandingCategory[]): LandingCategor
 export function withSpecialtyQuery(href: string, specialtyId: string | null) {
   if (!href.startsWith('/')) return href
 
-  const [pathAndQuery, hash] = href.split('#')
+  const hashIndex = href.indexOf('#')
+  const pathAndQuery = hashIndex >= 0 ? href.slice(0, hashIndex) : href
+  const hash = hashIndex >= 0 ? href.slice(hashIndex + 1) : ''
   const [pathnameValue = '/', query = ''] = (pathAndQuery ?? '/').split('?')
   const pathname = pathnameValue.length > 0 ? pathnameValue : '/'
   const params = new URLSearchParams(query)
@@ -119,5 +121,5 @@ export function withSpecialtyQuery(href: string, specialtyId: string | null) {
 
   const serializedParams = params.toString()
   const next = serializedParams ? `${pathname}?${serializedParams}` : pathname
-  return hash ? `${next}#${hash}` : next
+  return hash.length > 0 ? `${next}#${hash}` : next
 }

--- a/tests/unit/components/landingCategoriesShared.test.ts
+++ b/tests/unit/components/landingCategoriesShared.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { withSpecialtyQuery } from '@/components/organisms/Landing/LandingCategories.shared'
+
+describe('withSpecialtyQuery', () => {
+  it('keeps full hash fragments when a specialty is added', () => {
+    const href = withSpecialtyQuery('/listing-comparison#overview#details', 'nose')
+
+    expect(href).toBe('/listing-comparison?specialty=nose#overview#details')
+  })
+
+  it('keeps full hash fragments when a specialty is removed', () => {
+    const href = withSpecialtyQuery('/listing-comparison?specialty=eyes#overview#details', null)
+
+    expect(href).toBe('/listing-comparison#overview#details')
+  })
+})


### PR DESCRIPTION
Specialty links now preserve full hash fragments so anchor navigation remains stable.

## What changed
- fix `withSpecialtyQuery` to split URL fragments only at the first `#` and preserve the entire fragment tail
- keep existing behavior for adding/removing the `specialty` query parameter
- add regression tests for add/remove flows with multi-hash fragments

## Validation
- `pnpm vitest run tests/unit/components/landingCategoriesShared.test.ts --project unit --project '!integration' --project '!storybook'`
- `pnpm check`
- `pnpm format`

## Development
- Closes #950
