### PR TITLE
feat: refine public mobile shell and holding page

### DIFF
--- a/scripts/test-env.mjs
+++ b/scripts/test-env.mjs
@@ -50,6 +50,8 @@ export function applyE2ERuntimeDefaults(env = process.env) {
   env.DEPLOYMENT_ENV = 'test'
   env.NEXT_PUBLIC_DEPLOYMENT_ENV = 'test'
   env.NEXT_PUBLIC_SERVER_URL = baseUrl
+  // Route-level E2E runs should exercise the public app surface, not the temporary landing gate from local .env.
+  env.TEMPORARY_LANDING_MODE_ENABLED = 'false'
   env.NEXT_PUBLIC_SUPABASE_URL ??= 'http://127.0.0.1:54321'
   env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= 'e2e-anon-key'
 

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -49,24 +49,25 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <link href="/favicon.ico" rel="icon" sizes="32x32" />
         <link href="/favicon.svg" rel="icon" type="image/svg+xml" />
       </head>
-      <body>
-        <AdminBar adminBarProps={{ preview: isEnabled }} />
+      <body className="min-h-screen bg-background text-foreground antialiased">
+        <div className="flex min-h-screen min-h-svh flex-col">
+          <AdminBar adminBarProps={{ preview: isEnabled }} />
 
-        {showSiteChrome ? (
-          <div className="full-width">
-            <Header navItems={headerNavItems} logoSrc={headerLogoSrc} showPreviewBadge={showPreviewBadge} />
-          </div>
-        ) : null}
+          {showSiteChrome ? (
+            <div className="full-width">
+              <Header navItems={headerNavItems} logoSrc={headerLogoSrc} showPreviewBadge={showPreviewBadge} />
+            </div>
+          ) : null}
 
-        {/* Content-Area: Full width, pages handle containment */}
-        <main className="flex-1">{children}</main>
+          {/* Content-Area: Full width, pages handle containment */}
+          <main className="min-w-0 flex-1">{children}</main>
 
-        {showSiteChrome ? (
-          <div className="full-width">
-            <Footer footerGroups={footerGroups} logoSrc={footerLogoSrc} showPreviewBadge={showPreviewBadge} />
-          </div>
-        ) : null}
-
+          {showSiteChrome ? (
+            <div className="full-width">
+              <Footer footerGroups={footerGroups} logoSrc={footerLogoSrc} showPreviewBadge={showPreviewBadge} />
+            </div>
+          ) : null}
+        </div>
         <CookieConsentManager
           config={cookieConsentContext.config}
           initialConsent={cookieConsentContext.initialConsent}

--- a/src/app/(frontend)/register/clinic/page.tsx
+++ b/src/app/(frontend)/register/clinic/page.tsx
@@ -2,7 +2,7 @@ import { ClinicRegistrationForm } from '@/components/organisms/Auth/ClinicRegist
 
 export default function ClinicRegistrationPage() {
   return (
-    <div className="flex flex-col items-center justify-center gap-6 p-6 md:p-10">
+    <div className="flex flex-col items-center justify-center gap-6 p-6 pb-48 md:p-10 md:pb-56">
       <ClinicRegistrationForm />
     </div>
   )

--- a/src/app/(frontend)/register/patient/page.tsx
+++ b/src/app/(frontend)/register/patient/page.tsx
@@ -2,7 +2,7 @@ import { PatientRegistrationForm } from '@/components/organisms/Auth/PatientRegi
 
 export default async function PatientRegistrationPage() {
   return (
-    <div className="my-12 flex flex-col items-center justify-center gap-6 p-6 md:p-10">
+    <div className="my-12 flex flex-col items-center justify-center gap-6 p-6 pb-48 md:p-10 md:pb-56">
       <PatientRegistrationForm />
     </div>
   )

--- a/src/components/molecules/ImmersiveVideoHero/index.tsx
+++ b/src/components/molecules/ImmersiveVideoHero/index.tsx
@@ -166,7 +166,7 @@ export function ImmersiveVideoHero({
     <div
       data-testid="immersive-video-hero"
       className={cn(
-        'relative min-h-[88vh] w-full overflow-hidden rounded-[38px] border border-white/80 bg-slate-950 shadow-[0_44px_130px_-62px_rgba(2,6,23,0.72)] sm:min-h-[92vh]',
+        'relative min-h-[max(31rem,82svh)] w-full overflow-hidden rounded-[38px] border border-white/80 bg-slate-950 shadow-[0_44px_130px_-62px_rgba(2,6,23,0.72)] sm:min-h-[88svh] lg:min-h-[92vh]',
         className,
       )}
     >
@@ -282,27 +282,37 @@ export function ImmersiveVideoHero({
 
       <div
         className={cn(
-          'relative z-10 flex min-h-[88vh] flex-col items-center justify-center px-6 py-14 text-center sm:min-h-[92vh] sm:px-10',
+          'relative z-10 flex min-h-[max(31rem,82svh)] flex-col items-center justify-start px-5 pt-18 pb-16 text-center sm:min-h-[88svh] sm:justify-center sm:px-10 sm:py-16 lg:min-h-[92vh]',
           contentClassName,
         )}
       >
         {showLogo ? (
           <Logo
             variant="white"
-            className="h-12 drop-shadow-[0_10px_24px_rgba(2,6,23,0.45)] sm:h-14"
+            className="h-9 drop-shadow-[0_10px_24px_rgba(2,6,23,0.45)] sm:h-14"
             loading="eager"
             priority="high"
           />
         ) : null}
 
         {eyebrowText ? (
-          <p className={cn('mt-6 text-xs font-semibold tracking-[0.24em] text-white/75 uppercase', eyebrowClassName)}>
+          <p
+            className={cn(
+              'mt-4 text-[10px] font-semibold tracking-[0.22em] text-white/75 uppercase sm:mt-6 sm:text-xs',
+              eyebrowClassName,
+            )}
+          >
             {eyebrowText}
           </p>
         ) : null}
 
         {subheadlineText ? (
-          <p className={cn('mt-4 max-w-3xl text-sm leading-6 text-white/84 sm:text-base', subheadlineClassName)}>
+          <p
+            className={cn(
+              'mt-2 max-w-[17rem] text-[11px] leading-[1.35] text-white/84 sm:mt-4 sm:max-w-3xl sm:text-base sm:leading-6',
+              subheadlineClassName,
+            )}
+          >
             {subheadlineText}
           </p>
         ) : null}
@@ -313,7 +323,7 @@ export function ImmersiveVideoHero({
             align="center"
             variant="default"
             className={cn(
-              'mt-4 max-w-5xl text-4xl leading-[1.02] font-semibold text-white [text-shadow:0_8px_28px_rgba(2,6,23,0.58)] sm:text-6xl lg:text-[6.2rem]',
+              'mt-3 max-w-[15rem] text-[clamp(2.35rem,14vw,3.95rem)] leading-[0.98] font-semibold text-white [text-shadow:0_8px_28px_rgba(2,6,23,0.58)] sm:mt-4 sm:max-w-5xl sm:text-6xl sm:leading-[1.02] lg:text-[6.2rem]',
               headlineClassName,
             )}
           >
@@ -324,7 +334,7 @@ export function ImmersiveVideoHero({
         {descriptionText ? (
           <p
             className={cn(
-              'mt-6 max-w-2xl text-base leading-7 text-white/90 [text-shadow:0_4px_18px_rgba(2,6,23,0.5)] sm:text-lg',
+              'mt-3 max-w-[16rem] text-[13px] leading-5 text-white/90 [text-shadow:0_4px_18px_rgba(2,6,23,0.5)] sm:mt-6 sm:max-w-2xl sm:text-lg sm:leading-7',
               descriptionClassName,
             )}
           >
@@ -333,7 +343,13 @@ export function ImmersiveVideoHero({
         ) : null}
 
         {shouldRenderButton ? (
-          <Button asChild type="button" variant="primary" hoverEffect="wave" className="mt-8 rounded-full px-8 py-6">
+          <Button
+            asChild
+            type="button"
+            variant="primary"
+            hoverEffect="wave"
+            className="mt-5 w-full max-w-[12.5rem] rounded-full px-6 py-5 sm:mt-8 sm:w-auto sm:max-w-none sm:px-8 sm:py-6"
+          >
             <a href={ctaHref} onClick={(event) => handleInPageNavigation(event, ctaHref)}>
               {ctaLabel}
             </a>
@@ -346,7 +362,7 @@ export function ImmersiveVideoHero({
           href={scrollHintHref}
           aria-label="Scroll down"
           onClick={(event) => handleInPageNavigation(event, scrollHintHref)}
-          className="absolute bottom-5 left-1/2 z-20 flex -translate-x-1/2 items-center justify-center text-white/85 transition hover:text-white focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-white"
+          className="absolute bottom-5 left-1/2 z-20 hidden -translate-x-1/2 items-center justify-center text-white/85 transition hover:text-white focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-white sm:flex"
         >
           <span className="animate-bounce">
             <ChevronDown className="h-5 w-5" aria-hidden="true" />

--- a/src/components/molecules/ImmersiveVideoHero/index.tsx
+++ b/src/components/molecules/ImmersiveVideoHero/index.tsx
@@ -166,7 +166,7 @@ export function ImmersiveVideoHero({
     <div
       data-testid="immersive-video-hero"
       className={cn(
-        'relative min-h-[max(31rem,82svh)] w-full overflow-hidden rounded-[38px] border border-white/80 bg-slate-950 shadow-[0_44px_130px_-62px_rgba(2,6,23,0.72)] sm:min-h-[88svh] lg:min-h-[92vh]',
+        'relative min-h-[max(28rem,74svh)] w-full overflow-hidden rounded-[38px] border border-white/80 bg-slate-950 shadow-[0_44px_130px_-62px_rgba(2,6,23,0.72)] sm:min-h-[88svh] lg:min-h-[92vh]',
         className,
       )}
     >
@@ -282,7 +282,7 @@ export function ImmersiveVideoHero({
 
       <div
         className={cn(
-          'relative z-10 flex min-h-[max(31rem,82svh)] flex-col items-center justify-start px-5 pt-18 pb-16 text-center sm:min-h-[88svh] sm:justify-center sm:px-10 sm:py-16 lg:min-h-[92vh]',
+          'relative z-10 flex min-h-[max(28rem,74svh)] flex-col items-center justify-start px-5 pt-16 pb-12 text-center sm:min-h-[88svh] sm:justify-center sm:px-10 sm:py-16 lg:min-h-[92vh]',
           contentClassName,
         )}
       >
@@ -298,7 +298,7 @@ export function ImmersiveVideoHero({
         {eyebrowText ? (
           <p
             className={cn(
-              'mt-4 text-[10px] font-semibold tracking-[0.22em] text-white/75 uppercase sm:mt-6 sm:text-xs',
+              'mt-3 text-[10px] font-semibold tracking-[0.2em] text-white/75 uppercase sm:mt-6 sm:text-xs sm:tracking-[0.22em]',
               eyebrowClassName,
             )}
           >
@@ -309,7 +309,7 @@ export function ImmersiveVideoHero({
         {subheadlineText ? (
           <p
             className={cn(
-              'mt-2 max-w-[17rem] text-[11px] leading-[1.35] text-white/84 sm:mt-4 sm:max-w-3xl sm:text-base sm:leading-6',
+              'mt-2 max-w-[16rem] text-[11px] leading-[1.32] text-white/84 sm:mt-4 sm:max-w-3xl sm:text-base sm:leading-6',
               subheadlineClassName,
             )}
           >
@@ -323,7 +323,7 @@ export function ImmersiveVideoHero({
             align="center"
             variant="default"
             className={cn(
-              'mt-3 max-w-[15rem] text-[clamp(2.35rem,14vw,3.95rem)] leading-[0.98] font-semibold text-white [text-shadow:0_8px_28px_rgba(2,6,23,0.58)] sm:mt-4 sm:max-w-5xl sm:text-6xl sm:leading-[1.02] lg:text-[6.2rem]',
+              'mt-3 max-w-[15rem] text-[clamp(2rem,11.5vw,3.35rem)] leading-[0.98] font-semibold break-normal [hyphens:manual] text-white [text-shadow:0_8px_28px_rgba(2,6,23,0.58)] sm:mt-4 sm:max-w-5xl sm:text-6xl sm:leading-[1.02] sm:[hyphens:none] lg:text-[6.2rem]',
               headlineClassName,
             )}
           >
@@ -334,7 +334,7 @@ export function ImmersiveVideoHero({
         {descriptionText ? (
           <p
             className={cn(
-              'mt-3 max-w-[16rem] text-[13px] leading-5 text-white/90 [text-shadow:0_4px_18px_rgba(2,6,23,0.5)] sm:mt-6 sm:max-w-2xl sm:text-lg sm:leading-7',
+              'mt-2 max-w-[15rem] text-[13px] leading-5 text-white/90 [text-shadow:0_4px_18px_rgba(2,6,23,0.5)] sm:mt-6 sm:max-w-2xl sm:text-lg sm:leading-7',
               descriptionClassName,
             )}
           >
@@ -348,7 +348,7 @@ export function ImmersiveVideoHero({
             type="button"
             variant="primary"
             hoverEffect="wave"
-            className="mt-5 w-full max-w-[12.5rem] rounded-full px-6 py-5 sm:mt-8 sm:w-auto sm:max-w-none sm:px-8 sm:py-6"
+            className="mt-4 w-full max-w-[12.5rem] rounded-full px-6 py-5 sm:mt-8 sm:w-auto sm:max-w-none sm:px-8 sm:py-6"
           >
             <a href={ctaHref} onClick={(event) => handleInPageNavigation(event, ctaHref)}>
               {ctaLabel}

--- a/src/components/molecules/LanguageSwitcher/index.tsx
+++ b/src/components/molecules/LanguageSwitcher/index.tsx
@@ -37,7 +37,7 @@ export function LanguageSwitcher({
             key={option.value}
             href={option.href}
             className={cn(
-              'inline-flex min-w-8 items-center justify-center rounded-full px-2.5 py-1.5 text-[11px] font-semibold tracking-[0.14em] uppercase transition-colors sm:min-w-10 sm:px-3 sm:text-xs',
+              'inline-flex h-9 min-w-7 items-center justify-center rounded-full px-2 text-[11px] font-semibold tracking-[0.12em] uppercase transition-colors sm:h-10 sm:min-w-10 sm:px-3 sm:text-xs sm:tracking-[0.14em]',
               isActive
                 ? 'bg-white text-slate-900'
                 : 'text-white/88 hover:bg-white/12 hover:text-white focus-visible:bg-white/16',

--- a/src/components/molecules/LanguageSwitcher/index.tsx
+++ b/src/components/molecules/LanguageSwitcher/index.tsx
@@ -25,7 +25,7 @@ export function LanguageSwitcher({
     <nav
       aria-label={ariaLabel}
       className={cn(
-        'inline-flex items-center gap-1 rounded-full border border-white/35 bg-slate-900/38 p-1 backdrop-blur-md',
+        'inline-flex items-center gap-0.5 rounded-full border border-white/35 bg-slate-900/38 p-0.5 backdrop-blur-md sm:gap-1 sm:p-1',
         className,
       )}
     >
@@ -37,7 +37,7 @@ export function LanguageSwitcher({
             key={option.value}
             href={option.href}
             className={cn(
-              'inline-flex min-w-10 items-center justify-center rounded-full px-3 py-1.5 text-xs font-semibold tracking-[0.14em] uppercase transition-colors',
+              'inline-flex min-w-8 items-center justify-center rounded-full px-2.5 py-1.5 text-[11px] font-semibold tracking-[0.14em] uppercase transition-colors sm:min-w-10 sm:px-3 sm:text-xs',
               isActive
                 ? 'bg-white text-slate-900'
                 : 'text-white/88 hover:bg-white/12 hover:text-white focus-visible:bg-white/16',

--- a/src/components/organisms/CookieConsent/CookieConsentBanner.client.tsx
+++ b/src/components/organisms/CookieConsent/CookieConsentBanner.client.tsx
@@ -13,11 +13,11 @@ type CookieConsentBannerProps = {
 
 export function CookieConsentBanner({ config, onAcceptAll, onRejectAll, onCustomize }: CookieConsentBannerProps) {
   return (
-    <div className="fixed inset-x-0 bottom-0 z-50 px-4 pb-4 sm:px-6 lg:px-8">
+    <div className="fixed inset-x-0 bottom-0 z-50 px-4 pt-4 [padding-bottom:calc(env(safe-area-inset-bottom)+1rem)] sm:px-6 lg:px-8">
       <div className="mx-auto w-full max-w-6xl">
-        <div className="overflow-hidden rounded-3xl border border-border/70 bg-background/95 shadow-[0_30px_80px_rgba(0,0,0,0.18)] backdrop-blur-xl">
+        <div className="max-h-[calc(100svh-1rem)] overflow-y-auto overscroll-contain rounded-3xl border border-border/70 bg-background/95 shadow-[0_30px_80px_rgba(0,0,0,0.18)] backdrop-blur-xl sm:max-h-none">
           <div className="bg-linear-to-r from-primary/10 via-background to-accent/10 p-1">
-            <div className="grid gap-6 rounded-[1.35rem] bg-background/95 p-5 sm:p-6 lg:grid-cols-[minmax(0,1.4fr)_auto] lg:items-center">
+            <div className="grid gap-5 rounded-[1.35rem] bg-background/95 p-4 sm:p-6 lg:grid-cols-[minmax(0,1.4fr)_auto] lg:items-center">
               <div className="space-y-3">
                 <Heading as="h2" align="left" size="h4" className="max-w-2xl">
                   {config.banner.title}
@@ -28,13 +28,28 @@ export function CookieConsentBanner({ config, onAcceptAll, onRejectAll, onCustom
               </div>
 
               <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap lg:justify-end">
-                <Button type="button" variant="primary" className="rounded-full px-6" onClick={onAcceptAll}>
+                <Button
+                  type="button"
+                  variant="primary"
+                  className="w-full rounded-full px-6 sm:w-auto"
+                  onClick={onAcceptAll}
+                >
                   {config.banner.acceptLabel}
                 </Button>
-                <Button type="button" variant="secondary" className="rounded-full px-6" onClick={onRejectAll}>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="w-full rounded-full px-6 sm:w-auto"
+                  onClick={onRejectAll}
+                >
                   {config.banner.rejectLabel}
                 </Button>
-                <Button type="button" variant="outline" className="rounded-full px-6" onClick={onCustomize}>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full rounded-full px-6 sm:w-auto"
+                  onClick={onCustomize}
+                >
                   {config.banner.customizeLabel}
                 </Button>
               </div>

--- a/src/components/organisms/CookieConsent/CookieConsentBanner.client.tsx
+++ b/src/components/organisms/CookieConsent/CookieConsentBanner.client.tsx
@@ -13,25 +13,30 @@ type CookieConsentBannerProps = {
 
 export function CookieConsentBanner({ config, onAcceptAll, onRejectAll, onCustomize }: CookieConsentBannerProps) {
   return (
-    <div className="fixed inset-x-0 bottom-0 z-50 px-4 pt-4 [padding-bottom:calc(env(safe-area-inset-bottom)+1rem)] sm:px-6 lg:px-8">
+    <div className="fixed inset-x-0 bottom-0 z-50 px-3 pt-3 [padding-bottom:calc(env(safe-area-inset-bottom)+0.75rem)] sm:px-6 sm:pt-4 sm:[padding-bottom:calc(env(safe-area-inset-bottom)+1rem)] lg:px-8">
       <div className="mx-auto w-full max-w-6xl">
-        <div className="max-h-[calc(100svh-1rem)] overflow-y-auto overscroll-contain rounded-3xl border border-border/70 bg-background/95 shadow-[0_30px_80px_rgba(0,0,0,0.18)] backdrop-blur-xl sm:max-h-none">
+        <div className="max-h-[calc(100svh-0.75rem)] overflow-y-auto overscroll-contain rounded-3xl border border-border/70 bg-background/95 shadow-[0_30px_80px_rgba(0,0,0,0.18)] backdrop-blur-xl sm:max-h-none">
           <div className="bg-linear-to-r from-primary/10 via-background to-accent/10 p-1">
-            <div className="grid gap-5 rounded-[1.35rem] bg-background/95 p-4 sm:p-6 lg:grid-cols-[minmax(0,1.4fr)_auto] lg:items-center">
-              <div className="space-y-3">
-                <Heading as="h2" align="left" size="h4" className="max-w-2xl">
+            <div className="grid gap-4 rounded-[1.35rem] bg-background/95 p-3 sm:gap-5 sm:p-6 lg:grid-cols-[minmax(0,1.4fr)_auto] lg:items-center">
+              <div className="space-y-2.5 sm:space-y-3">
+                <Heading
+                  as="h2"
+                  align="left"
+                  size="h4"
+                  className="max-w-2xl text-lg sm:text-xl md:text-2xl lg:text-3xl"
+                >
                   {config.banner.title}
                 </Heading>
-                <p className="max-w-3xl text-sm leading-6 text-muted-foreground sm:text-base">
+                <p className="max-w-3xl text-[13px] leading-5 text-muted-foreground sm:text-base sm:leading-6">
                   {config.banner.description}
                 </p>
               </div>
 
-              <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap lg:justify-end">
+              <div className="grid grid-cols-2 gap-2.5 sm:flex sm:flex-row sm:flex-wrap sm:gap-3 lg:justify-end">
                 <Button
                   type="button"
                   variant="primary"
-                  className="w-full rounded-full px-6 sm:w-auto"
+                  className="h-11 w-full rounded-full px-4 sm:h-10 sm:w-auto sm:px-6"
                   onClick={onAcceptAll}
                 >
                   {config.banner.acceptLabel}
@@ -39,7 +44,7 @@ export function CookieConsentBanner({ config, onAcceptAll, onRejectAll, onCustom
                 <Button
                   type="button"
                   variant="secondary"
-                  className="w-full rounded-full px-6 sm:w-auto"
+                  className="h-11 w-full rounded-full px-4 sm:h-10 sm:w-auto sm:px-6"
                   onClick={onRejectAll}
                 >
                   {config.banner.rejectLabel}
@@ -47,7 +52,7 @@ export function CookieConsentBanner({ config, onAcceptAll, onRejectAll, onCustom
                 <Button
                   type="button"
                   variant="outline"
-                  className="w-full rounded-full px-6 sm:w-auto"
+                  className="col-span-2 h-11 w-full rounded-full px-4 sm:col-auto sm:h-10 sm:w-auto sm:px-6"
                   onClick={onCustomize}
                 >
                   {config.banner.customizeLabel}

--- a/src/components/organisms/CookieConsent/CookieConsentDialog.client.tsx
+++ b/src/components/organisms/CookieConsent/CookieConsentDialog.client.tsx
@@ -39,7 +39,7 @@ export function CookieConsentDialog({
 }: CookieConsentDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-2xl">
+      <DialogContent className="max-h-[calc(100svh-2rem)] overflow-y-auto p-5 sm:max-w-2xl sm:p-6">
         <DialogHeader>
           <DialogTitle>{config.settings.title}</DialogTitle>
           <DialogDescription>{config.settings.description}</DialogDescription>
@@ -47,7 +47,7 @@ export function CookieConsentDialog({
 
         <div className="space-y-4">
           {config.privacyPolicyHref ? (
-            <div className="flex items-start justify-between gap-4 rounded-2xl border border-border/70 bg-muted/25 px-4 py-3">
+            <div className="flex flex-col items-start gap-4 rounded-2xl border border-border/70 bg-muted/25 px-4 py-3 sm:flex-row sm:justify-between">
               <div className="space-y-1">
                 <p className="text-xs tracking-wide text-muted-foreground uppercase">Privacy policy</p>
                 <p className="text-sm text-muted-foreground">
@@ -102,15 +102,15 @@ export function CookieConsentDialog({
           </div>
         </div>
 
-        <DialogFooter className={cn('gap-3 sm:justify-between')}>
-          <Button type="button" variant="ghost" onClick={onCancel}>
+        <DialogFooter className={cn('gap-3 border-t border-border/70 pt-1 sm:justify-between')}>
+          <Button type="button" variant="ghost" className="w-full sm:w-auto" onClick={onCancel}>
             {config.settings.cancelLabel}
           </Button>
           <div className="flex flex-col-reverse gap-3 sm:flex-row">
-            <Button type="button" variant="outline" onClick={onRejectAll}>
+            <Button type="button" variant="outline" className="w-full sm:w-auto" onClick={onRejectAll}>
               {config.banner.rejectLabel}
             </Button>
-            <Button type="button" variant="primary" onClick={onSave}>
+            <Button type="button" variant="primary" className="w-full sm:w-auto" onClick={onSave}>
               {config.settings.saveLabel}
             </Button>
           </div>

--- a/src/components/organisms/CookieConsent/CookieConsentLauncher.client.tsx
+++ b/src/components/organisms/CookieConsent/CookieConsentLauncher.client.tsx
@@ -11,13 +11,13 @@ type CookieConsentLauncherProps = {
 
 export function CookieConsentLauncher({ label, onOpenSettings }: CookieConsentLauncherProps) {
   return (
-    <div className="fixed right-4 bottom-4 z-50 sm:right-6 sm:bottom-6">
+    <div className="fixed right-4 [bottom:calc(env(safe-area-inset-bottom)+1rem)] z-50 sm:right-6 sm:[bottom:calc(env(safe-area-inset-bottom)+1.5rem)]">
       <Button
         type="button"
         variant="outline"
         size="clear"
         aria-label={label}
-        className="group inline-flex h-11 w-11 items-center justify-start overflow-hidden rounded-full border border-border/80 bg-background/95 px-3 text-sm font-medium shadow-lg backdrop-blur-md transition-[width,box-shadow,background-color] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:w-[9.75rem] focus-visible:w-[9.75rem] sm:hover:w-[10.25rem] sm:focus-visible:w-[10.25rem]"
+        className="group inline-flex h-12 w-12 items-center justify-start overflow-hidden rounded-full border border-border/80 bg-background/95 px-3 text-sm font-medium shadow-lg backdrop-blur-md transition-[width,box-shadow,background-color] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:w-[9.75rem] focus-visible:w-[9.75rem] sm:hover:w-[10.25rem] sm:focus-visible:w-[10.25rem]"
         onClick={onOpenSettings}
       >
         <Cookie className="size-4 shrink-0 text-primary" aria-hidden="true" />

--- a/src/components/templates/Footer/Component.tsx
+++ b/src/components/templates/Footer/Component.tsx
@@ -14,20 +14,20 @@ export type FooterProps = {
 }
 
 export const Footer: React.FC<FooterProps> = ({ footerGroups, logoSrc, showPreviewBadge = false }) => (
-  <footer className="mt-auto bg-background text-foreground">
-    <Container className="py-12">
-      <div className="flex flex-col gap-12">
-        <div className="flex flex-col items-start gap-8 md:flex-row md:items-center md:justify-between md:gap-40">
+  <footer className="mt-auto border-t border-border/60 bg-background text-foreground">
+    <Container className="py-10 sm:py-12">
+      <div className="flex flex-col gap-10 sm:gap-12">
+        <div className="flex flex-col items-start gap-8 md:flex-row md:items-start md:justify-between md:gap-16">
           <Logo loading="lazy" priority="low" src={logoSrc} showPreviewBadge={showPreviewBadge} />
 
           <nav aria-label="Footer primary" className="w-full md:flex-1">
-            <div className="flex flex-col gap-12 md:flex-row md:items-start md:justify-between md:gap-x-6">
+            <div className="flex flex-col gap-8 sm:gap-10 md:flex-row md:items-start md:justify-between md:gap-x-6">
               {footerGroups.map((group) => (
-                <div key={group.title} className="flex flex-col items-start gap-6 pt-6 pl-1.5 md:flex-1 md:basis-0">
+                <div key={group.title} className="flex flex-col items-start gap-4 pt-0 pl-1.5 md:flex-1 md:basis-0">
                   <Heading as="h4" size="h6" align="left" className="text-lg text-foreground">
                     {group.title}
                   </Heading>
-                  <ul className="space-y-6">
+                  <ul className="space-y-4 sm:space-y-5">
                     {group.items.map((link) => (
                       <li key={`${group.title}-${link.href}-${link.label ?? ''}`}>
                         <UiLink {...link} variant="footer" />
@@ -40,12 +40,12 @@ export const Footer: React.FC<FooterProps> = ({ footerGroups, logoSrc, showPrevi
           </nav>
         </div>
 
-        <div className="flex flex-col items-center gap-4 pt-6 text-center">
+        <div className="flex flex-col items-center gap-4 pt-2 text-center sm:pt-6">
           <p className="text-normal text-muted-foreground">
             © Copyright {new Date().getFullYear()}. findmydoc All Rights Reserved
           </p>
 
-          <div className="flex items-center gap-4">
+          <div className="flex flex-wrap items-center justify-center gap-4">
             <SocialLink href="https://meta.com" aria-label="Meta" platform="meta" variant="outline" />
             <SocialLink href="https://x.com" aria-label="X" platform="x" variant="outline" />
             <SocialLink href="https://instagram.com" aria-label="Instagram" platform="instagram" variant="outline" />

--- a/src/components/templates/Header/Component.tsx
+++ b/src/components/templates/Header/Component.tsx
@@ -13,10 +13,16 @@ interface HeaderProps {
 }
 
 export const Header: React.FC<HeaderProps> = ({ navItems, logoSrc, showPreviewBadge = false }) => (
-  <header className="relative bg-white">
-    <Container className="flex items-center justify-between py-4">
-      <Link href="/">
-        <Logo loading="eager" priority="high" className="h-14" src={logoSrc} showPreviewBadge={showPreviewBadge} />
+  <header className="relative z-40 bg-white [--site-header-height:4.5rem] sm:[--site-header-height:5rem]">
+    <Container className="flex items-center justify-between gap-3 py-3 sm:py-4">
+      <Link href="/" className="shrink-0">
+        <Logo
+          loading="eager"
+          priority="high"
+          className="h-11 sm:h-14"
+          src={logoSrc}
+          showPreviewBadge={showPreviewBadge}
+        />
       </Link>
       <HeaderNav navItems={navItems} />
     </Container>

--- a/src/components/templates/Header/Nav/index.tsx
+++ b/src/components/templates/Header/Nav/index.tsx
@@ -236,6 +236,8 @@ export const HeaderNav: React.FC<{ navItems: HeaderNavItem[] }> = ({ navItems })
   }, [mobileOpen])
 
   useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+
     const mediaQuery = window.matchMedia('(min-width: 768px)')
     const handleChange = (event: MediaQueryListEvent) => {
       if (event.matches) {

--- a/src/components/templates/Header/Nav/index.tsx
+++ b/src/components/templates/Header/Nav/index.tsx
@@ -10,6 +10,7 @@ import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/
 
 const getNavItemKey = (item: HeaderNavItem, index: number): string =>
   item.href ?? `group-${index}-${item.label ?? 'item'}`
+const mobileMenuId = 'header-mobile-navigation'
 
 /* ------------------------------------------------------------------ */
 /*  Desktop dropdown for a single nav item with subItems              */
@@ -104,21 +105,22 @@ const MobileMenu: React.FC<{
 
   return (
     <nav
-      className="absolute inset-x-0 top-full z-40 border-t border-border bg-zinc-50 shadow-md md:hidden"
+      id={mobileMenuId}
+      className="absolute inset-x-0 top-full z-40 max-h-[calc(100svh-var(--site-header-height))] overflow-y-auto overscroll-contain border-t border-border bg-zinc-50/98 shadow-lg backdrop-blur md:hidden"
       aria-label="Mobile navigation"
     >
-      <div className="flex flex-col px-4 py-2">
+      <div className="flex flex-col px-5 py-3">
         {navItems.map((item, index) => {
           const itemKey = getNavItemKey(item, index)
 
           if (item.subItems && item.subItems.length > 0) {
             return (
               <Accordion key={itemKey} type="single" collapsible>
-                <AccordionItem value={`mobile-${itemKey}`} className="border-b-0">
-                  <AccordionTrigger className="py-2 text-base font-semibold text-foreground hover:text-foreground hover:no-underline">
+                <AccordionItem value={`mobile-${itemKey}`} className="border-border/70">
+                  <AccordionTrigger className="min-h-11 py-3 text-base font-semibold text-foreground hover:text-foreground hover:no-underline">
                     {item.label}
                   </AccordionTrigger>
-                  <AccordionContent className="border-t-0 pt-0 pb-2">
+                  <AccordionContent className="border-t-0 pt-0 pb-3">
                     <div className="flex flex-col gap-1 pl-4">
                       {item.subItems.map((sub) => {
                         const newTabProps = sub.newTab
@@ -128,7 +130,7 @@ const MobileMenu: React.FC<{
                           <Link
                             key={sub.href}
                             href={sub.href}
-                            className="rounded-sm px-3 py-2 text-sm text-foreground transition-colors hover:bg-zinc-100 hover:text-foreground"
+                            className="min-h-11 rounded-sm px-3 py-3 text-sm text-foreground transition-colors hover:bg-zinc-100 hover:text-foreground"
                             onClick={onClose}
                             {...newTabProps}
                           >
@@ -145,7 +147,7 @@ const MobileMenu: React.FC<{
 
           if (!item.href) {
             return (
-              <span key={itemKey} className="block py-2 text-base font-semibold text-foreground">
+              <span key={itemKey} className="block min-h-11 py-3 text-base font-semibold text-foreground">
                 {item.label}
               </span>
             )
@@ -157,7 +159,7 @@ const MobileMenu: React.FC<{
               key={itemKey}
               href={item.href}
               onClick={onClose}
-              className="block py-2 text-base font-semibold text-foreground transition-colors hover:text-foreground"
+              className="block min-h-11 py-3 text-base font-semibold text-foreground transition-colors hover:text-foreground"
               {...newTabProps}
             >
               {item.label}
@@ -208,6 +210,42 @@ export const HeaderNav: React.FC<{ navItems: HeaderNavItem[] }> = ({ navItems })
   )
 
   useEffect(() => clearCloseDelay, [clearCloseDelay])
+
+  useEffect(() => {
+    if (!mobileOpen) return
+
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    return () => {
+      document.body.style.overflow = previousOverflow
+    }
+  }, [mobileOpen])
+
+  useEffect(() => {
+    if (!mobileOpen) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setMobileOpen(false)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [mobileOpen])
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(min-width: 768px)')
+    const handleChange = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        setMobileOpen(false)
+      }
+    }
+
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [])
 
   // Close desktop dropdown on outside click
   useEffect(() => {
@@ -267,8 +305,9 @@ export const HeaderNav: React.FC<{ navItems: HeaderNavItem[] }> = ({ navItems })
       {/* Mobile hamburger toggle */}
       <button
         type="button"
-        className="inline-flex items-center justify-center rounded-md p-2 text-foreground transition-colors hover:bg-zinc-100 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden md:hidden"
+        className="inline-flex size-11 items-center justify-center rounded-md text-foreground transition-colors hover:bg-zinc-100 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden md:hidden"
         aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
+        aria-controls={mobileMenuId}
         aria-expanded={mobileOpen}
         onClick={() => setMobileOpen((prev) => !prev)}
       >

--- a/src/components/templates/HoldingPageConcept/ContactForm.client.tsx
+++ b/src/components/templates/HoldingPageConcept/ContactForm.client.tsx
@@ -101,7 +101,7 @@ export function HoldingPageContactForm({ contactMode, contactFormSlug, labels, p
           }}
           placeholder={copy.namePlaceholder}
           autoComplete="name"
-          className="h-11 rounded-xl border-slate-200 bg-slate-50/90 text-slate-950 placeholder:text-slate-400"
+          className="h-12 rounded-xl border-slate-200 bg-slate-50/90 text-slate-950 placeholder:text-slate-400"
         />
       )}
 
@@ -116,7 +116,7 @@ export function HoldingPageContactForm({ contactMode, contactFormSlug, labels, p
         }}
         placeholder={copy.emailPlaceholder}
         autoComplete="email"
-        className="h-11 rounded-xl border-slate-200 bg-slate-50/90 text-slate-950 placeholder:text-slate-400"
+        className="h-12 rounded-xl border-slate-200 bg-slate-50/90 text-slate-950 placeholder:text-slate-400"
       />
 
       {isCompactContact ? null : (
@@ -129,11 +129,17 @@ export function HoldingPageContactForm({ contactMode, contactFormSlug, labels, p
             resetMessages()
           }}
           placeholder={copy.messagePlaceholder}
-          className="min-h-32 rounded-xl border-slate-200 bg-slate-50/90 text-slate-950 placeholder:text-slate-400"
+          className="min-h-28 rounded-xl border-slate-200 bg-slate-50/90 text-slate-950 placeholder:text-slate-400 sm:min-h-32"
         />
       )}
 
-      <Button type="submit" variant="primary" hoverEffect="wave" className="w-full rounded-xl" disabled={isSubmitting}>
+      <Button
+        type="submit"
+        variant="primary"
+        hoverEffect="wave"
+        className="min-h-12 w-full rounded-xl"
+        disabled={isSubmitting}
+      >
         {isSubmitting ? copy.submittingLabel : primaryCtaLabel}
       </Button>
 

--- a/src/components/templates/HoldingPageConcept/index.tsx
+++ b/src/components/templates/HoldingPageConcept/index.tsx
@@ -1307,9 +1307,9 @@ function renderVariantLayout(
           <div className="mx-auto max-w-[94rem]">
             <div className="relative">
               {statusLabel ? (
-                <div className="pointer-events-none absolute top-3 left-3 z-30 sm:top-6 sm:left-6">
-                  <div className="inline-flex items-center gap-1 rounded-full border border-white/35 bg-slate-900/38 p-1 backdrop-blur-md">
-                    <span className="inline-flex min-w-8 items-center justify-center rounded-full px-2.5 py-1.5 text-[11px] font-semibold tracking-[0.14em] text-white/88 uppercase sm:min-w-10 sm:px-3 sm:text-xs">
+                <div className="pointer-events-none absolute top-2 left-2 z-30 sm:top-6 sm:left-6">
+                  <div className="inline-flex items-center gap-1 rounded-full border border-white/35 bg-slate-900/38 p-0.5 backdrop-blur-md sm:p-1">
+                    <span className="inline-flex h-9 min-w-fit items-center justify-center rounded-full px-3 text-[11px] font-semibold tracking-[0.1em] text-white/88 uppercase sm:h-10 sm:px-4 sm:text-xs sm:tracking-[0.14em]">
                       {statusLabel}
                     </span>
                   </div>
@@ -1317,7 +1317,7 @@ function renderVariantLayout(
               ) : null}
 
               {heroOverlay ? (
-                <div className="absolute top-3 right-3 z-30 sm:top-6 sm:right-6">{heroOverlay}</div>
+                <div className="absolute top-2 right-2 z-30 sm:top-6 sm:right-6">{heroOverlay}</div>
               ) : null}
 
               <ImmersiveVideoHero

--- a/src/components/templates/HoldingPageConcept/index.tsx
+++ b/src/components/templates/HoldingPageConcept/index.tsx
@@ -380,7 +380,7 @@ function ContactPanel({
       id="contact"
       className={cn(
         baseSurfaceClassName,
-        layout === 'strip' ? 'rounded-[32px] p-5 lg:p-6' : 'rounded-[32px] p-6 lg:p-7',
+        layout === 'strip' ? 'rounded-[32px] p-5 lg:p-6' : 'rounded-[32px] p-5 sm:p-6 lg:p-7',
         className,
       )}
     >
@@ -395,7 +395,7 @@ function ContactPanel({
             align="left"
             variant="default"
             size="h4"
-            className="mt-4 text-3xl font-semibold text-slate-950"
+            className="mt-4 text-2xl font-semibold text-slate-950 sm:text-3xl"
           >
             {contactTitle}
           </Heading>
@@ -403,7 +403,7 @@ function ContactPanel({
           <p className="mt-3 text-sm leading-6 text-slate-700">{contactDescription}</p>
         </div>
 
-        <div className={cn('mt-6', layout === 'strip' && 'lg:mt-0 lg:min-w-[320px] lg:flex-1')}>
+        <div className={cn('mt-5 sm:mt-6', layout === 'strip' && 'lg:mt-0 lg:min-w-[320px] lg:flex-1')}>
           <HoldingPageContactForm
             contactMode={contactMode}
             contactFormSlug={contactFormSlug}
@@ -437,7 +437,7 @@ function FooterBlock({
   const hasAudienceCopy = Boolean(bestFor.trim() || supportingNote.trim())
 
   return (
-    <div className={cn('mt-10 border-t border-slate-200/90 pt-6', className)}>
+    <div className={cn('mt-8 border-t border-slate-200/90 pt-6 sm:mt-10', className)}>
       <div
         className={cn(
           'flex flex-col gap-6',
@@ -462,7 +462,12 @@ function FooterBlock({
           </div>
         ) : null}
 
-        <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+        <div
+          className={cn(
+            'flex flex-wrap items-center gap-x-5 gap-y-2 text-sm',
+            hasAudienceCopy ? 'justify-start' : 'justify-center lg:justify-end',
+          )}
+        >
           {footerLinks.map((link) => (
             <UiLink
               key={`${link.href}-${link.label ?? 'link'}`}
@@ -1302,9 +1307,9 @@ function renderVariantLayout(
           <div className="mx-auto max-w-[94rem]">
             <div className="relative">
               {statusLabel ? (
-                <div className="pointer-events-none absolute top-4 left-4 z-30 sm:top-6 sm:left-6">
+                <div className="pointer-events-none absolute top-3 left-3 z-30 sm:top-6 sm:left-6">
                   <div className="inline-flex items-center gap-1 rounded-full border border-white/35 bg-slate-900/38 p-1 backdrop-blur-md">
-                    <span className="inline-flex min-w-10 items-center justify-center rounded-full px-3 py-1.5 text-xs font-semibold tracking-[0.14em] text-white/88 uppercase">
+                    <span className="inline-flex min-w-8 items-center justify-center rounded-full px-2.5 py-1.5 text-[11px] font-semibold tracking-[0.14em] text-white/88 uppercase sm:min-w-10 sm:px-3 sm:text-xs">
                       {statusLabel}
                     </span>
                   </div>
@@ -1312,7 +1317,7 @@ function renderVariantLayout(
               ) : null}
 
               {heroOverlay ? (
-                <div className="absolute top-4 right-4 z-30 sm:top-6 sm:right-6">{heroOverlay}</div>
+                <div className="absolute top-3 right-3 z-30 sm:top-6 sm:right-6">{heroOverlay}</div>
               ) : null}
 
               <ImmersiveVideoHero
@@ -1337,12 +1342,18 @@ function renderVariantLayout(
               />
             </div>
 
-            <div id="landing-content-start" className="mt-6 grid gap-4 xl:grid-cols-[1.08fr_0.92fr]">
-              <div className={cn(baseSurfaceClassName, 'flex h-full flex-col rounded-[28px] p-6 lg:p-7')}>
+            <div id="landing-content-start" className="mt-4 grid gap-4 sm:mt-6 xl:grid-cols-[1.08fr_0.92fr]">
+              <div className={cn(baseSurfaceClassName, 'flex h-full flex-col rounded-[28px] p-5 sm:p-6 lg:p-7')}>
                 <p className="text-xs font-semibold tracking-[0.28em] text-slate-500 uppercase">
                   {whySectionEyebrow ?? 'Why findmydoc'}
                 </p>
-                <Heading as="h2" align="left" variant="default" size="h4" className="mt-3 text-3xl text-slate-950">
+                <Heading
+                  as="h2"
+                  align="left"
+                  variant="default"
+                  size="h4"
+                  className="mt-3 text-2xl text-slate-950 sm:text-3xl"
+                >
                   {whySectionHeading ?? 'Compare clinics abroad with verified quality signals and trusted guidance.'}
                 </Heading>
                 <div className="mt-3 max-w-2xl space-y-3 text-base leading-7 text-slate-700">
@@ -1388,7 +1399,10 @@ function renderVariantLayout(
                   const Icon = signal.icon
 
                   return (
-                    <div key={signal.title} className="rounded-[18px] border border-slate-200 bg-white/92 px-4 py-3">
+                    <div
+                      key={signal.title}
+                      className="rounded-[18px] border border-slate-200 bg-white/92 px-4 py-3 sm:px-5 sm:py-4"
+                    >
                       <div className="flex items-start gap-3">
                         <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-slate-50">
                           <Icon className="h-4 w-4 text-[#0f8f85]" aria-hidden="true" />

--- a/src/features/temporaryLandingMode/content.ts
+++ b/src/features/temporaryLandingMode/content.ts
@@ -137,7 +137,7 @@ const copyByLocale: Record<TemporaryLandingLocale, TemporaryLandingCopy> = {
     statusLabel: 'Bald verfügbar',
     subheadlineText:
       'Strukturierte Klinikprofile und transparente Qualitäts-Signale - damit du die passende Klinik mit mehr Vertrauen findest.',
-    title: 'Eine Vergleichsplattform für Schönheitskliniken.',
+    title: 'Eine Vergleichs­plattform für Schönheits­kliniken.',
     whatYouGetEyebrow: 'DAS ERWARTET DICH',
     whySectionEyebrow: 'Founders vision',
     whySectionHeading: 'Patient:innen DACH',

--- a/src/stories/organisms/CookieConsent/CookieConsentManager.stories.tsx
+++ b/src/stories/organisms/CookieConsent/CookieConsentManager.stories.tsx
@@ -7,6 +7,23 @@ import { CookieConsentLauncher } from '@/components/organisms/CookieConsent/Cook
 import { CookieConsentManager } from '@/components/organisms/CookieConsent/CookieConsentManager.client'
 import { DEFAULT_COOKIE_CONSENT_CONFIG } from '@/features/cookieConsent'
 
+const denseCookieConsentConfig = {
+  ...DEFAULT_COOKIE_CONSENT_CONFIG,
+  banner: {
+    ...DEFAULT_COOKIE_CONSENT_CONFIG.banner,
+    description:
+      'We use essential cookies to keep the website working and optional cookies to understand journeys, improve comparison flows, and support embedded services across the public findmydoc experience.',
+    customizeLabel: 'Review cookie settings',
+  },
+  categories: DEFAULT_COOKIE_CONSENT_CONFIG.categories.map((category, index) => ({
+    ...category,
+    description:
+      index === 0
+        ? `${category.description} This includes analytics signals that help us understand how visitors move from the holding page to public patient flows.`
+        : category.description,
+  })),
+}
+
 const meta = {
   title: 'Domain/Shared/Organisms/CookieConsent',
   component: CookieConsentManager,
@@ -90,4 +107,19 @@ export const Manager: Story = {
     config: DEFAULT_COOKIE_CONSENT_CONFIG,
     initialConsent: null,
   },
+}
+
+export const BannerLongCopy: Story = {
+  args: {
+    config: denseCookieConsentConfig,
+    initialConsent: null,
+  },
+  render: () => (
+    <CookieConsentBanner
+      config={denseCookieConsentConfig}
+      onAcceptAll={() => {}}
+      onCustomize={() => {}}
+      onRejectAll={() => {}}
+    />
+  ),
 }

--- a/src/stories/templates/Footer.stories.tsx
+++ b/src/stories/templates/Footer.stories.tsx
@@ -4,6 +4,15 @@ import { footerData } from './fixtures'
 import { withMockRouter } from '../utils/routerDecorator'
 import { normalizeFooterNavGroups } from '@/utilities/normalizeNavItems'
 
+const normalizedFooterGroups = normalizeFooterNavGroups(footerData)
+const denseFooterGroups = normalizedFooterGroups.map((group, index) => ({
+  ...group,
+  items: group.items.map((item, itemIndex) => ({
+    ...item,
+    label: index === 0 && itemIndex === 0 ? `${item.label} and patient guidance` : item.label,
+  })),
+}))
+
 const meta = {
   title: 'Shared/Templates/Footer',
   component: Footer,
@@ -13,7 +22,7 @@ const meta = {
   },
   tags: ['autodocs', 'domain:shared', 'layer:template', 'status:stable', 'used-in:route:/'],
   args: {
-    footerGroups: normalizeFooterNavGroups(footerData),
+    footerGroups: normalizedFooterGroups,
   },
 } satisfies Meta<typeof Footer>
 
@@ -42,5 +51,11 @@ export const WithoutNavLinks: Story = {
       serviceLinks: [],
       informationLinks: [],
     }),
+  },
+}
+
+export const DenseContent: Story = {
+  args: {
+    footerGroups: denseFooterGroups,
   },
 }

--- a/src/stories/templates/Header.stories.tsx
+++ b/src/stories/templates/Header.stories.tsx
@@ -6,6 +6,14 @@ import { normalizeHeaderNavItems } from '@/utilities/normalizeNavItems'
 
 const navItems = normalizeHeaderNavItems(headerData)
 const navItemsWithSubs = normalizeHeaderNavItems(headerDataWithSubmenus)
+const denseNavItems = navItemsWithSubs.map((item, index) => ({
+  ...item,
+  label: index === 0 ? 'Compare international clinics' : item.label,
+  subItems: item.subItems?.map((sub, subIndex) => ({
+    ...sub,
+    label: subIndex === 0 ? `${sub.label} and treatment guidance` : sub.label,
+  })),
+}))
 
 const meta = {
   title: 'Shared/Templates/Header',
@@ -44,5 +52,12 @@ export const CompactNav: Story = {
 export const WithSubmenus: Story = {
   args: {
     navItems: navItemsWithSubs,
+  },
+}
+
+/** Header stress case with longer mobile labels and nested links. */
+export const DenseNavigation: Story = {
+  args: {
+    navItems: denseNavItems,
   },
 }

--- a/src/stories/templates/HeaderNav.stories.tsx
+++ b/src/stories/templates/HeaderNav.stories.tsx
@@ -164,7 +164,7 @@ export const MobileCompactSubmenu: Story = {
     const clinicsTrigger = mobileCanvas.getByRole('button', { name: 'Clinics' })
 
     expect(clinicsTrigger.className).toContain('text-base')
-    expect(clinicsTrigger.className).toContain('py-2')
+    expect(clinicsTrigger.className).toContain('py-3')
 
     await userEvent.click(clinicsTrigger)
     expect(mobileCanvas.getByRole('link', { name: 'All Clinics' })).toBeInTheDocument()

--- a/src/stories/templates/HoldingPageConcept.stories.tsx
+++ b/src/stories/templates/HoldingPageConcept.stories.tsx
@@ -48,6 +48,16 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+const mobileStressArgs = {
+  ...holdingPageConcept,
+  contactDescription:
+    'Use this contact form to send us a direct request. Include a short title, your message, and your email so we can reply with launch timing and first-access details.',
+  footerLinks: holdingPageConcept.footerLinks.map((link, index) =>
+    index === 0 ? { ...link, label: 'Contact and launch updates' } : link,
+  ),
+  primaryCtaLabel: 'Request early access',
+} satisfies typeof holdingPageConcept
+
 const assertConceptFrame: Story['play'] = async ({ args, canvasElement }) => {
   const canvas = within(canvasElement)
 
@@ -110,5 +120,10 @@ const assertConceptFrame: Story['play'] = async ({ args, canvasElement }) => {
 
 export const HoldingPage: Story = {
   args: holdingPageConcept,
+  play: assertConceptFrame,
+}
+
+export const MobileStress: Story = {
+  args: mobileStressArgs,
   play: assertConceptFrame,
 }

--- a/tests/unit/features/temporaryLandingMode/content.test.ts
+++ b/tests/unit/features/temporaryLandingMode/content.test.ts
@@ -36,7 +36,7 @@ const expectedLocalizedCopyByLocale = {
     eyebrow: 'Wer schön sein will muss vergleichen.',
     subheadlineText:
       'Strukturierte Klinikprofile und transparente Qualitäts-Signale - damit du die passende Klinik mit mehr Vertrauen findest.',
-    title: 'Eine Vergleichsplattform für Schönheitskliniken.',
+    title: 'Eine Vergleichs\u00adplattform für Schönheits\u00adkliniken.',
     description:
       'findmydoc bündelt Erfahrungsberichte und Qualitätsindikatoren an einem Ort - transparent, vergleichbar, verständlich.',
     whatYouGetEyebrow: 'DAS ERWARTET DICH',
@@ -122,7 +122,9 @@ describe('temporaryLandingMode content', () => {
 
   it('maps the planned locale-specific headline anchors', () => {
     expect(getTemporaryLandingPageContent('en').title).toBe('Better matches for treatments abroad.')
-    expect(getTemporaryLandingPageContent('de').title).toBe('Eine Vergleichsplattform für Schönheitskliniken.')
+    expect(getTemporaryLandingPageContent('de').title).toBe(
+      'Eine Vergleichs\u00adplattform für Schönheits\u00adkliniken.',
+    )
     expect(getTemporaryLandingPageContent('tr').title).toBe('Avrupa’dan daha nitelikli başvurular.')
   })
 


### PR DESCRIPTION
Improves the public shell and holding page on mobile without changing the established desktop visual language.

## What changed
- harden the public shell for mobile by tightening the viewport structure, constraining the mobile navigation to the available height, locking body scroll while the menu is open, and reducing footer and cookie-consent density
- refine the holding page pilot across the multilingual hero, top pills, CTA spacing, and contact reachability so the narrowest mobile viewports remain readable and usable
- keep the visual language stable while fixing mobile wrapping, spacing, and hierarchy problems instead of redesigning the UI

## Validation
- `pnpm format`
- `pnpm check`
- `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build`
- Playwright runtime screenshots on the public shell routes and the holding page across `320/375/640/768/1024`
- holding-page browser review on `?lang=en` and `?lang=de` after the hero spacing and wrapping refinements

Screenshots:
- `output/playwright/manual/phase1-shell/home-shell-320.png`
- `output/playwright/manual/phase1-shell/home-mobile-menu-open-375.png`
- `output/playwright/manual/phase1-shell/home-cookie-dialog-375.png`
- `output/playwright/manual/phase1-shell/posts-shell-1024.png`
- `output/playwright/manual/phase2-holding-after/holding-320.png`
- `output/playwright/manual/phase2-holding-after/holding-375.png`
- `output/playwright/manual/phase2-holding-after/holding-375-contact.png`

## Development
- #356
- #958
- #959
