### PR TITLE
docs(telemetry): align posthog host example with eu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,7 @@ S3_ENDPOINT=YOUR_S3_ENDPOINT # S3 storage endpoint URL
 
 # PostHog configuration for analytics
 NEXT_PUBLIC_POSTHOG_KEY=KEY_XXXXXXXX
-NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 
 # To display test-time console logs (the test runner is quiet by default),
 # do NOT commit TEST_SHOW_LOGS to your .env files. Instead, run locally like:


### PR DESCRIPTION
keeps the default PostHog setup example aligned with the EU project host.

## What changed
- switch `NEXT_PUBLIC_POSTHOG_HOST` in `.env.example` from the US host to the EU host
- keep the repository example configuration consistent with existing PostHog docs and test configuration

## Development
- Closes #956

## Validation
- `pnpm format`
- `pnpm docs:check`
