### PR TITLE
fix: harden public auth routes for mobile

### DIFF
--- a/src/app/(frontend)/_components/PublicAuthRouteShell.tsx
+++ b/src/app/(frontend)/_components/PublicAuthRouteShell.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react'
+
+import { cn } from '@/utilities/ui'
+
+type PublicAuthRouteShellProps = {
+  children: ReactNode
+  className?: string
+}
+
+export const PUBLIC_AUTH_FORM_CONTAINER_CLASSNAME = 'px-0 py-4 sm:px-0 sm:py-6 md:py-8'
+
+export function PublicAuthRouteShell({ children, className }: PublicAuthRouteShellProps) {
+  return (
+    <section
+      className={cn(
+        'px-5 pt-4 pb-[calc(env(safe-area-inset-bottom)+4.5rem)] sm:px-6 sm:pt-5 sm:pb-[calc(env(safe-area-inset-bottom)+5rem)] md:px-8 md:pt-8 md:pb-16',
+        className,
+      )}
+    >
+      <div className="mx-auto flex w-full max-w-5xl justify-center">{children}</div>
+    </section>
+  )
+}

--- a/src/app/(frontend)/login/patient/page.tsx
+++ b/src/app/(frontend)/login/patient/page.tsx
@@ -1,3 +1,7 @@
+import {
+  PUBLIC_AUTH_FORM_CONTAINER_CLASSNAME,
+  PublicAuthRouteShell,
+} from '@/app/(frontend)/_components/PublicAuthRouteShell'
 import * as LoginForm from '@/components/organisms/Auth/LoginForm'
 import Link from 'next/link'
 
@@ -18,8 +22,12 @@ export default async function LoginPage({
   const statusMessage = messageKey ? patientLoginMessages[messageKey] : undefined
 
   return (
-    <div className="my-12 flex flex-col items-center justify-center gap-6 p-6 md:p-10">
-      <LoginForm.Root userTypes="patient" redirectPath="/" className="w-full max-w-md">
+    <PublicAuthRouteShell>
+      <LoginForm.Root
+        userTypes="patient"
+        redirectPath="/"
+        className={`w-full max-w-md ${PUBLIC_AUTH_FORM_CONTAINER_CLASSNAME}`}
+      >
         <LoginForm.Header
           title="Patient Login"
           description="Sign in to your patient account to access your medical information"
@@ -44,6 +52,6 @@ export default async function LoginPage({
           </p>
         </LoginForm.Footer>
       </LoginForm.Root>
-    </div>
+    </PublicAuthRouteShell>
   )
 }

--- a/src/app/(frontend)/register/clinic/page.tsx
+++ b/src/app/(frontend)/register/clinic/page.tsx
@@ -1,9 +1,13 @@
+import {
+  PUBLIC_AUTH_FORM_CONTAINER_CLASSNAME,
+  PublicAuthRouteShell,
+} from '@/app/(frontend)/_components/PublicAuthRouteShell'
 import { ClinicRegistrationForm } from '@/components/organisms/Auth/ClinicRegistrationForm'
 
 export default function ClinicRegistrationPage() {
   return (
-    <div className="flex flex-col items-center justify-center gap-6 p-6 pb-48 md:p-10 md:pb-56">
-      <ClinicRegistrationForm />
-    </div>
+    <PublicAuthRouteShell>
+      <ClinicRegistrationForm containerClassName={PUBLIC_AUTH_FORM_CONTAINER_CLASSNAME} />
+    </PublicAuthRouteShell>
   )
 }

--- a/src/app/(frontend)/register/patient/page.tsx
+++ b/src/app/(frontend)/register/patient/page.tsx
@@ -1,9 +1,13 @@
+import {
+  PUBLIC_AUTH_FORM_CONTAINER_CLASSNAME,
+  PublicAuthRouteShell,
+} from '@/app/(frontend)/_components/PublicAuthRouteShell'
 import { PatientRegistrationForm } from '@/components/organisms/Auth/PatientRegistrationForm'
 
 export default async function PatientRegistrationPage() {
   return (
-    <div className="my-12 flex flex-col items-center justify-center gap-6 p-6 pb-48 md:p-10 md:pb-56">
-      <PatientRegistrationForm />
-    </div>
+    <PublicAuthRouteShell>
+      <PatientRegistrationForm containerClassName={PUBLIC_AUTH_FORM_CONTAINER_CLASSNAME} />
+    </PublicAuthRouteShell>
   )
 }

--- a/src/components/organisms/Auth/ClinicRegistrationForm.tsx
+++ b/src/components/organisms/Auth/ClinicRegistrationForm.tsx
@@ -3,13 +3,18 @@
 import { RegistrationForm } from '@/components/organisms/Auth/RegistrationForm'
 import { submitClinicRegistration } from '@/auth/utilities/registrationSubmissions'
 
-export function ClinicRegistrationForm() {
+type ClinicRegistrationFormProps = {
+  containerClassName?: string
+}
+
+export function ClinicRegistrationForm({ containerClassName }: ClinicRegistrationFormProps) {
   return (
     <RegistrationForm
       title="Register Clinic"
       description="Register your clinic"
       successMessage="Thanks, your clinic registration has been submitted. We will review it and get back to you soon."
       submitButtonText="Submit Registration"
+      containerClassName={containerClassName}
       fields={[
         { name: 'clinicName', label: 'Clinic Name', type: 'text', autoComplete: 'organization', required: true },
         {

--- a/src/components/organisms/Auth/PatientRegistrationForm.tsx
+++ b/src/components/organisms/Auth/PatientRegistrationForm.tsx
@@ -5,7 +5,11 @@ import { useRouter } from 'next/navigation'
 import { RegistrationForm } from '@/components/organisms/Auth/RegistrationForm'
 import { submitPatientRegistration } from '@/auth/utilities/registrationSubmissions'
 
-export function PatientRegistrationForm() {
+type PatientRegistrationFormProps = {
+  containerClassName?: string
+}
+
+export function PatientRegistrationForm({ containerClassName }: PatientRegistrationFormProps) {
   const router = useRouter()
 
   return (
@@ -61,6 +65,7 @@ export function PatientRegistrationForm() {
         login: { href: '/login/patient', text: 'Sign in here' },
         home: { href: '/', text: '← Back to home' },
       }}
+      containerClassName={containerClassName}
       onSubmit={submitPatientRegistration}
       onSuccess={() => {
         startTransition(() => {

--- a/src/components/organisms/Auth/RegistrationForm.tsx
+++ b/src/components/organisms/Auth/RegistrationForm.tsx
@@ -9,6 +9,7 @@ import { Alert } from '@/components/atoms/alert'
 import { Card, CardContent, CardDescription, CardHeader } from '@/components/atoms/card'
 import { Heading } from '@/components/atoms/Heading'
 import Link from 'next/link'
+import { cn } from '@/utilities/ui'
 
 interface FormField {
   name: string
@@ -27,6 +28,7 @@ interface RegistrationFormProps {
   successMessage?: string
   fields: FormField[]
   submitButtonText: string
+  containerClassName?: string
   links?: {
     login?: { href: string; text: string }
     home?: { href: string; text: string }
@@ -43,6 +45,7 @@ export function RegistrationForm({
   successMessage = 'Your registration was submitted successfully.',
   fields,
   submitButtonText,
+  containerClassName,
   links,
   onSubmit,
   onSuccess,
@@ -118,7 +121,7 @@ export function RegistrationForm({
   }, [])
 
   return (
-    <div className="flex items-start justify-center px-0 py-8 sm:px-4 sm:py-12">
+    <div className={cn('flex items-start justify-center px-0 py-8 sm:px-4 sm:py-12', containerClassName)}>
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-2 p-5 pb-4 sm:p-6 sm:pb-5">
           <Heading as="h1" align="center" size="h4" className="text-[1.65rem] leading-tight text-balance sm:text-2xl">

--- a/src/components/organisms/CookieConsent/CookieConsentBanner.client.tsx
+++ b/src/components/organisms/CookieConsent/CookieConsentBanner.client.tsx
@@ -5,60 +5,110 @@ import { Heading } from '@/components/atoms/Heading'
 import type { CookieConsentConfig } from '@/features/cookieConsent'
 
 type CookieConsentBannerProps = {
+  compact?: boolean
   config: CookieConsentConfig
   onAcceptAll: () => void
   onRejectAll: () => void
   onCustomize: () => void
 }
 
-export function CookieConsentBanner({ config, onAcceptAll, onRejectAll, onCustomize }: CookieConsentBannerProps) {
+export function CookieConsentBanner({
+  compact = false,
+  config,
+  onAcceptAll,
+  onRejectAll,
+  onCustomize,
+}: CookieConsentBannerProps) {
   return (
-    <div className="fixed inset-x-0 bottom-0 z-50 px-3 pt-3 [padding-bottom:calc(env(safe-area-inset-bottom)+0.75rem)] sm:px-6 sm:pt-4 sm:[padding-bottom:calc(env(safe-area-inset-bottom)+1rem)] lg:px-8">
+    <div
+      className={`fixed inset-x-0 bottom-0 z-50 px-2.5 sm:px-6 sm:pt-4 sm:[padding-bottom:calc(env(safe-area-inset-bottom)+1rem)] lg:px-8 ${
+        compact
+          ? 'pt-1.5 [padding-bottom:calc(env(safe-area-inset-bottom)+0.25rem)]'
+          : 'pt-2 [padding-bottom:calc(env(safe-area-inset-bottom)+0.625rem)]'
+      }`}
+    >
       <div className="mx-auto w-full max-w-6xl">
         <div className="max-h-[calc(100svh-0.75rem)] overflow-y-auto overscroll-contain rounded-3xl border border-border/70 bg-background/95 shadow-[0_30px_80px_rgba(0,0,0,0.18)] backdrop-blur-xl sm:max-h-none">
           <div className="bg-linear-to-r from-primary/10 via-background to-accent/10 p-1">
-            <div className="grid gap-4 rounded-[1.35rem] bg-background/95 p-3 sm:gap-5 sm:p-6 lg:grid-cols-[minmax(0,1.4fr)_auto] lg:items-center">
-              <div className="space-y-2.5 sm:space-y-3">
-                <Heading
-                  as="h2"
-                  align="left"
-                  size="h4"
-                  className="max-w-2xl text-lg sm:text-xl md:text-2xl lg:text-3xl"
-                >
-                  {config.banner.title}
-                </Heading>
-                <p className="max-w-3xl text-[13px] leading-5 text-muted-foreground sm:text-base sm:leading-6">
-                  {config.banner.description}
-                </p>
+            {compact ? (
+              <div className="rounded-[1.35rem] bg-background/95 p-2.5">
+                <div className="space-y-2">
+                  <Heading as="h2" align="left" size="h4" className="text-sm leading-tight sm:text-base">
+                    {config.banner.title}
+                  </Heading>
+                  <p className="sr-only">{config.banner.description}</p>
+                  <div className="grid grid-cols-3 gap-2">
+                    <Button
+                      type="button"
+                      variant="primary"
+                      className="h-9 w-full rounded-full px-2 text-[11px] whitespace-nowrap sm:text-sm"
+                      onClick={onAcceptAll}
+                    >
+                      {config.banner.acceptLabel}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className="h-9 w-full rounded-full px-2 text-[11px] whitespace-nowrap sm:text-sm"
+                      onClick={onRejectAll}
+                    >
+                      {config.banner.rejectLabel}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      className="h-9 w-full rounded-full px-2 text-[11px] whitespace-nowrap sm:text-sm"
+                      onClick={onCustomize}
+                    >
+                      {config.banner.customizeLabel}
+                    </Button>
+                  </div>
+                </div>
               </div>
+            ) : (
+              <div className="grid gap-3 rounded-[1.35rem] bg-background/95 p-2.5 sm:gap-5 sm:p-6 lg:grid-cols-[minmax(0,1.4fr)_auto] lg:items-center">
+                <div className="space-y-2 sm:space-y-3">
+                  <Heading
+                    as="h2"
+                    align="left"
+                    size="h4"
+                    className="max-w-2xl text-base leading-tight sm:text-xl md:text-2xl lg:text-3xl"
+                  >
+                    {config.banner.title}
+                  </Heading>
+                  <p className="line-clamp-3 max-w-3xl text-xs leading-[1.35rem] text-muted-foreground sm:line-clamp-none sm:text-base sm:leading-6">
+                    {config.banner.description}
+                  </p>
+                </div>
 
-              <div className="grid grid-cols-2 gap-2.5 sm:flex sm:flex-row sm:flex-wrap sm:gap-3 lg:justify-end">
-                <Button
-                  type="button"
-                  variant="primary"
-                  className="h-11 w-full rounded-full px-4 sm:h-10 sm:w-auto sm:px-6"
-                  onClick={onAcceptAll}
-                >
-                  {config.banner.acceptLabel}
-                </Button>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  className="h-11 w-full rounded-full px-4 sm:h-10 sm:w-auto sm:px-6"
-                  onClick={onRejectAll}
-                >
-                  {config.banner.rejectLabel}
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="col-span-2 h-11 w-full rounded-full px-4 sm:col-auto sm:h-10 sm:w-auto sm:px-6"
-                  onClick={onCustomize}
-                >
-                  {config.banner.customizeLabel}
-                </Button>
+                <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-row sm:flex-wrap sm:gap-3 lg:justify-end">
+                  <Button
+                    type="button"
+                    variant="primary"
+                    className="h-10 w-full rounded-full px-4 text-sm sm:h-10 sm:w-auto sm:px-6"
+                    onClick={onAcceptAll}
+                  >
+                    {config.banner.acceptLabel}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    className="h-10 w-full rounded-full px-4 text-sm sm:h-10 sm:w-auto sm:px-6"
+                    onClick={onRejectAll}
+                  >
+                    {config.banner.rejectLabel}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="col-span-2 h-9 w-full rounded-full px-4 text-sm sm:col-auto sm:h-10 sm:w-auto sm:px-6"
+                    onClick={onCustomize}
+                  >
+                    {config.banner.customizeLabel}
+                  </Button>
+                </div>
               </div>
-            </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/organisms/CookieConsent/CookieConsentManager.client.tsx
+++ b/src/components/organisms/CookieConsent/CookieConsentManager.client.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { usePathname } from 'next/navigation'
+
 import type { CookieConsentConfig, CookieConsentState } from '@/features/cookieConsent'
 import { CookieConsentBanner } from './CookieConsentBanner.client'
 import { CookieConsentDialog } from './CookieConsentDialog.client'
@@ -11,11 +13,15 @@ type CookieConsentManagerProps = {
   initialConsent: CookieConsentState | null
 }
 
+const compactBannerRoutes = new Set(['/login/patient', '/register/patient', '/register/clinic'])
+
 export function CookieConsentManager({ config, initialConsent }: CookieConsentManagerProps) {
+  const pathname = usePathname()
   const controller = useCookieConsentController({
     config,
     initialConsent,
   })
+  const useCompactBanner = pathname ? compactBannerRoutes.has(pathname) : false
 
   if (!config?.enabled) {
     return null
@@ -25,6 +31,7 @@ export function CookieConsentManager({ config, initialConsent }: CookieConsentMa
     <>
       {controller.isBannerVisible ? (
         <CookieConsentBanner
+          compact={useCompactBanner}
           config={config}
           onAcceptAll={() => controller.persistConsent('accepted', controller.acceptAllCategories)}
           onCustomize={controller.openSettings}

--- a/src/stories/organisms/CookieConsent/CookieConsentManager.stories.tsx
+++ b/src/stories/organisms/CookieConsent/CookieConsentManager.stories.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, userEvent, within } from '@storybook/test'
 
 import { CookieConsentBanner } from '@/components/organisms/CookieConsent/CookieConsentBanner.client'
 import { CookieConsentDialog } from '@/components/organisms/CookieConsent/CookieConsentDialog.client'
 import { CookieConsentLauncher } from '@/components/organisms/CookieConsent/CookieConsentLauncher.client'
 import { CookieConsentManager } from '@/components/organisms/CookieConsent/CookieConsentManager.client'
 import { DEFAULT_COOKIE_CONSENT_CONFIG } from '@/features/cookieConsent'
+import { withViewportStory } from '../../utils/viewportMatrix'
 
 const denseCookieConsentConfig = {
   ...DEFAULT_COOKIE_CONSENT_CONFIG,
@@ -21,6 +23,30 @@ const denseCookieConsentConfig = {
       index === 0
         ? `${category.description} This includes analytics signals that help us understand how visitors move from the holding page to public patient flows.`
         : category.description,
+  })),
+}
+
+const authRouteCookieConsentConfig = {
+  ...denseCookieConsentConfig,
+  banner: {
+    ...denseCookieConsentConfig.banner,
+    title: 'Allow optional cookies before continuing with your secure patient or clinic sign-in flow.',
+    description:
+      'We keep essential cookies enabled for secure sign-in and optional cookies available for journey analytics, embedded support, and comparison improvements while you move between public auth routes.',
+    customizeLabel: 'Choose settings',
+  },
+  settings: {
+    ...denseCookieConsentConfig.settings,
+    description:
+      'Review the optional cookies that support sign-in help, comparison analytics, and embedded trust content before continuing through the public patient and clinic account flows.',
+    saveLabel: 'Save auth settings',
+  },
+  categories: denseCookieConsentConfig.categories.map((category, index) => ({
+    ...category,
+    description:
+      index === 0
+        ? `${category.description} This can include sign-in assistance, handoff analytics, and support signals across patient and clinic registration routes.`
+        : `${category.description} This may appear while moving between login, patient registration, and clinic registration pages.`,
   })),
 }
 
@@ -122,4 +148,128 @@ export const BannerLongCopy: Story = {
       onRejectAll={() => {}}
     />
   ),
+}
+
+const authCompactBannerBase: Story = {
+  args: {
+    config: authRouteCookieConsentConfig,
+    initialConsent: null,
+  },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: '/login/patient',
+      },
+    },
+  },
+  render: () => {
+    return (
+      <div className="min-h-screen bg-background pb-28">
+        <CookieConsentManager config={authRouteCookieConsentConfig} initialConsent={null} />
+      </div>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const documentBody = within(canvasElement.ownerDocument.body)
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByRole('button', { name: /choose settings/i })).toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('button', { name: /choose settings/i }))
+    await expect(documentBody.getByRole('dialog', { name: /cookie settings/i })).toBeInTheDocument()
+    await userEvent.click(documentBody.getByRole('button', { name: /cancel/i }))
+    await expect(documentBody.queryByRole('dialog', { name: /cookie settings/i })).not.toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: /choose settings/i })).toBeInTheDocument()
+  },
+}
+
+const authDialogBase: Story = {
+  args: {
+    config: authRouteCookieConsentConfig,
+    initialConsent: null,
+  },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: '/register/patient',
+      },
+    },
+  },
+  render: () => {
+    return (
+      <div className="min-h-screen bg-background">
+        <CookieConsentManager config={authRouteCookieConsentConfig} initialConsent={null} />
+      </div>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const documentBody = within(canvasElement.ownerDocument.body)
+
+    await userEvent.click(within(canvasElement).getByRole('button', { name: /choose settings/i }))
+    await expect(documentBody.getByRole('dialog', { name: /cookie settings/i })).toBeInTheDocument()
+    await userEvent.click(documentBody.getByRole('checkbox', { name: /analytics cookies/i }))
+    await expect(documentBody.getByRole('checkbox', { name: /analytics cookies/i })).toBeChecked()
+    await expect(documentBody.getByRole('button', { name: /save auth settings/i })).toBeInTheDocument()
+  },
+}
+
+export const AuthCompactBanner320: Story = withViewportStory(
+  authCompactBannerBase,
+  'public320',
+  'Auth compact banner / 320',
+)
+export const AuthCompactBanner375: Story = withViewportStory(
+  authCompactBannerBase,
+  'public375',
+  'Auth compact banner / 375',
+)
+export const AuthCompactBanner640: Story = withViewportStory(
+  authCompactBannerBase,
+  'public640',
+  'Auth compact banner / 640',
+)
+export const AuthCompactBanner768: Story = withViewportStory(
+  authCompactBannerBase,
+  'public768',
+  'Auth compact banner / 768',
+)
+export const AuthCompactBanner1024: Story = withViewportStory(
+  authCompactBannerBase,
+  'public1024',
+  'Auth compact banner / 1024',
+)
+export const AuthCompactBanner1280: Story = withViewportStory(
+  authCompactBannerBase,
+  'public1280',
+  'Auth compact banner / 1280',
+)
+export const AuthCompactBanner375Short: Story = withViewportStory(
+  authCompactBannerBase,
+  'public375Short',
+  'Auth compact banner / 375 short',
+)
+
+export const AuthDialog320: Story = withViewportStory(authDialogBase, 'public320', 'Auth dialog / 320')
+export const AuthDialog375: Story = withViewportStory(authDialogBase, 'public375', 'Auth dialog / 375')
+export const AuthDialog640: Story = withViewportStory(authDialogBase, 'public640', 'Auth dialog / 640')
+export const AuthDialog768: Story = withViewportStory(authDialogBase, 'public768', 'Auth dialog / 768')
+export const AuthDialog1024: Story = withViewportStory(authDialogBase, 'public1024', 'Auth dialog / 1024')
+export const AuthDialog1280: Story = withViewportStory(authDialogBase, 'public1280', 'Auth dialog / 1280')
+export const AuthDialog375Short: Story = {
+  ...withViewportStory(authDialogBase, 'public375Short', 'Auth dialog / 375 short'),
+  play: async ({ canvasElement }) => {
+    const documentBody = within(canvasElement.ownerDocument.body)
+
+    await userEvent.click(within(canvasElement).getByRole('button', { name: /choose settings/i }))
+    await expect(documentBody.getByRole('dialog', { name: /cookie settings/i })).toBeInTheDocument()
+    await userEvent.click(documentBody.getByRole('checkbox', { name: /analytics cookies/i }))
+
+    const saveButton = documentBody.getByRole('button', { name: /save auth settings/i })
+    const cancelButton = documentBody.getByRole('button', { name: /cancel/i })
+
+    saveButton.scrollIntoView({ block: 'nearest' })
+    await expect(saveButton).toBeVisible()
+
+    cancelButton.scrollIntoView({ block: 'nearest' })
+    await expect(cancelButton).toBeVisible()
+  },
 }

--- a/tests/unit/components/cookieConsentManager.test.tsx
+++ b/tests/unit/components/cookieConsentManager.test.tsx
@@ -22,6 +22,10 @@ vi.mock('@/posthog/analytics', () => ({
   setAnalyticsConsent: posthogClientMocks.setAnalyticsConsent,
 }))
 
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}))
+
 const config: CookieConsentConfig = DEFAULT_COOKIE_CONSENT_CONFIG
 
 function clearConsentCookie() {


### PR DESCRIPTION
Improves the public auth routes on mobile so login and registration stay readable and actionable from first visit through submit states.

## What changed
- add a shared public-auth route shell and route-level container overrides so the three public auth pages use tighter mobile spacing without broad desktop regressions
- keep the patient login, patient registration, and clinic registration routes aligned on the same mobile-first wrapper while preserving the Shared Auth building blocks from Phase 3
- add a compact cookie-consent banner mode only on the public auth routes so first-visit mobile users do not lose the primary CTA behind the consent banner
- cover the route-aware consent behavior in the cookie consent manager unit test setup

## Validation
- `pnpm format`
- `pnpm check`
- `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build`
- Playwright runtime QA for `/login/patient`, `/register/patient`, and `/register/clinic` at `320/375/640/768/1024`
- First-visit consent-banner geometry rechecks at `320x812` and `375x700` in `output/playwright/manual/phase4-auth-routes/run6`
- 3 `mobile_ui_reviewer` passes for `#961`; no open phase-relevant findings `>5/10` after pass 3

Screenshots:
- `output/playwright/manual/phase4-auth-routes/run1/login-patient-320.png`
- `output/playwright/manual/phase4-auth-routes/run1/register-patient-320.png`
- `output/playwright/manual/phase4-auth-routes/run1/register-clinic-320.png`
- `output/playwright/manual/phase4-auth-routes/run3/register-patient-success-375-final.png`
- `output/playwright/manual/phase4-auth-routes/run3/register-clinic-success-375-final.png`
- `output/playwright/manual/phase4-auth-routes/run6/login-patient-320-first-visit.png`
- `output/playwright/manual/phase4-auth-routes/run6/register-patient-320-first-visit.png`
- `output/playwright/manual/phase4-auth-routes/run6/register-clinic-375x700-first-visit.png`

## Development
- #961
- #356
