### PR TITLE
fix: harden discovery routes for mobile

### DIFF
--- a/src/components/molecules/CheckboxWithLabel/index.tsx
+++ b/src/components/molecules/CheckboxWithLabel/index.tsx
@@ -29,14 +29,16 @@ export function CheckboxWithLabel({
   }
 
   return (
-    <label className={cn('flex items-center gap-3', disabled && 'cursor-not-allowed', className)}>
+    <label className={cn('flex items-start gap-3', disabled && 'cursor-not-allowed', className)}>
       <Checkbox
         checked={checked}
         disabled={disabled}
         className={checkboxClassName}
         onCheckedChange={handleCheckedChange}
       />
-      <span className={cn('text-sm font-normal', labelClassName)}>{label}</span>
+      <span className={cn('min-w-0 flex-1 pt-0.5 text-sm leading-5 font-normal break-words', labelClassName)}>
+        {label}
+      </span>
     </label>
   )
 }

--- a/src/components/molecules/ClinicDetail/HeroQualitySummary.tsx
+++ b/src/components/molecules/ClinicDetail/HeroQualitySummary.tsx
@@ -19,7 +19,7 @@ export function HeroQualitySummary({ trust }: HeroQualitySummaryProps) {
   const languagesPreview = trust.languages.slice(0, 4)
 
   return (
-    <Card className="max-w-[492px] rounded-[24px] border-0 shadow-brand-soft">
+    <Card className="w-full max-w-[492px] rounded-[24px] border-0 shadow-brand-soft">
       <CardContent className="space-y-4 p-5">
         <Heading as="h2" align="left" size="h5" className="text-secondary">
           Quality Snapshot

--- a/src/components/molecules/ClinicSearchBar/index.tsx
+++ b/src/components/molecules/ClinicSearchBar/index.tsx
@@ -39,17 +39,17 @@ export const ClinicSearchBar: React.FC<ClinicSearchBarProps> = ({
     onSearch?.(values)
   }
 
-  const Divider = () => <div className="h-16 w-px bg-border" aria-hidden="true" />
+  const Divider = () => <div className="h-px w-full bg-border md:h-16 md:w-px" aria-hidden="true" />
 
   return (
     <div
       className={cn(
-        'flex w-full max-w-5xl items-stretch rounded-2xl bg-card p-2 shadow-lg',
-        'md:items-center',
+        'flex w-full max-w-5xl flex-col items-stretch rounded-2xl bg-card p-2 shadow-lg',
+        'md:flex-row md:items-center',
         className,
       )}
     >
-      <div className="flex flex-1 items-center px-4 md:px-6">
+      <div className="flex flex-1 items-center px-4 py-2 md:px-6 md:py-0">
         <div className="w-full">
           <div className="text-sm text-foreground">Service</div>
           <Combobox
@@ -68,7 +68,7 @@ export const ClinicSearchBar: React.FC<ClinicSearchBarProps> = ({
 
       <Divider />
 
-      <div className="flex flex-1 items-center px-4 md:px-6">
+      <div className="flex flex-1 items-center px-4 py-2 md:px-6 md:py-0">
         <div className="w-full">
           <div className="text-sm text-foreground">Location</div>
           <Combobox
@@ -87,7 +87,7 @@ export const ClinicSearchBar: React.FC<ClinicSearchBarProps> = ({
 
       <Divider />
 
-      <div className="flex flex-1 items-center px-4 md:px-6">
+      <div className="flex flex-1 items-center px-4 py-2 md:px-6 md:py-0">
         <div className="w-full">
           <label className="text-sm text-foreground" htmlFor="clinic-search-budget">
             Budget (USD)
@@ -110,12 +110,12 @@ export const ClinicSearchBar: React.FC<ClinicSearchBarProps> = ({
         </div>
       </div>
 
-      <div className="flex items-center pr-2 pl-2 md:pl-4">
+      <div className="flex items-center px-2 pt-2 md:pt-0 md:pr-2 md:pl-4">
         <Button
           type="button"
           variant="primary"
           hoverEffect="wave"
-          className="h-10 rounded-full px-6"
+          className="h-10 w-full rounded-full px-6 md:w-auto"
           onClick={handleSearch}
         >
           Find my Doctor!

--- a/src/components/organisms/ClinicDetail/ClinicAppointmentSection.tsx
+++ b/src/components/organisms/ClinicDetail/ClinicAppointmentSection.tsx
@@ -54,11 +54,16 @@ export function ClinicAppointmentSection({
   onClearSelections,
 }: ClinicAppointmentSectionProps) {
   return (
-    <section id={sectionId} ref={sectionRef} className="grid gap-12 lg:grid-cols-12 lg:items-start">
-      <div className="space-y-8 lg:col-span-6">
+    <section id={sectionId} ref={sectionRef} className="grid gap-8 lg:grid-cols-12 lg:items-start">
+      <div className="space-y-6 lg:col-span-6 lg:space-y-8">
         <div className="space-y-1">
-          <p className="text-size-40 leading-[1.2] font-semibold text-primary">BOOK AN</p>
-          <Heading as="h2" align="left" size="h2" className="text-size-72 leading-[1.1389] text-secondary">
+          <p className="text-2xl leading-[1.15] font-semibold text-primary sm:text-size-40">BOOK AN</p>
+          <Heading
+            as="h2"
+            align="left"
+            size="h2"
+            className="text-5xl leading-tight text-secondary sm:text-size-72 sm:leading-[1.1389]"
+          >
             Appointment
           </Heading>
         </div>
@@ -176,14 +181,14 @@ export function ClinicAppointmentSection({
             />
           </label>
 
-          <div className="flex flex-wrap gap-3">
-            <Button type="submit" className="rounded-full px-8">
+          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+            <Button type="submit" className="w-full rounded-full px-8 sm:w-auto">
               Submit Contact Request
             </Button>
-            <Button type="button" variant="secondary" className="rounded-full" onClick={onResetFields}>
+            <Button type="button" variant="secondary" className="w-full rounded-full sm:w-auto" onClick={onResetFields}>
               Reset Form Fields
             </Button>
-            <Button type="button" variant="ghost" className="rounded-full" onClick={onClearSelections}>
+            <Button type="button" variant="ghost" className="w-full rounded-full sm:w-auto" onClick={onClearSelections}>
               Clear Doctor & Treatment
             </Button>
           </div>
@@ -211,10 +216,16 @@ export function ClinicAppointmentSection({
       </div>
 
       <div className="relative lg:col-span-6 lg:pt-24">
-        <div className="absolute inset-x-0 top-10 h-[360px] rounded-[180px] bg-accent/20" aria-hidden="true" />
-        <div className="absolute -right-6 bottom-[-48px] size-[260px] rounded-full bg-primary/20" aria-hidden="true" />
+        <div
+          className="absolute inset-x-0 top-6 h-[220px] rounded-[140px] bg-accent/20 sm:top-10 sm:h-[360px] sm:rounded-[180px]"
+          aria-hidden="true"
+        />
+        <div
+          className="absolute right-0 bottom-[-32px] size-[180px] rounded-full bg-primary/20 sm:-right-6 sm:bottom-[-48px] sm:size-[260px]"
+          aria-hidden="true"
+        />
 
-        <div className="relative mx-auto aspect-[599/745] w-full max-w-[599px] overflow-hidden rounded-[30px]">
+        <div className="relative mx-auto aspect-[16/11] w-full max-w-[599px] overflow-hidden rounded-[30px] sm:aspect-[599/745]">
           <Media
             htmlElement={null}
             src={appointmentImage.src}

--- a/src/components/organisms/ClinicDetail/HeroOverviewSection.tsx
+++ b/src/components/organisms/ClinicDetail/HeroOverviewSection.tsx
@@ -34,21 +34,26 @@ export function HeroOverviewSection({
   const specialistLabel = doctors.length === 1 ? 'listed specialist' : 'listed specialists'
 
   return (
-    <section className="grid gap-12 lg:grid-cols-12 lg:items-start">
-      <div className="space-y-8 lg:col-span-5 lg:pt-14">
+    <section className="grid gap-8 lg:grid-cols-12 lg:items-start">
+      <div className="min-w-0 space-y-6 lg:col-span-5 lg:space-y-8 lg:pt-14">
         <div className="space-y-2">
-          <p className="text-size-40 leading-[1.2] font-semibold text-primary">CLINIC OVERVIEW</p>
-          <Heading as="h1" align="left" size="h1" className="max-w-[9ch] text-size-72 leading-[1.1389] text-secondary">
+          <p className="text-2xl leading-[1.15] font-semibold text-primary sm:text-size-40">CLINIC OVERVIEW</p>
+          <Heading
+            as="h1"
+            align="left"
+            size="h1"
+            className="max-w-none text-5xl leading-tight [overflow-wrap:anywhere] break-words text-secondary sm:max-w-[10ch] sm:text-size-72 sm:leading-[1.1389]"
+          >
             {clinicName}
           </Heading>
         </div>
 
-        <p className="max-w-[492px] text-base leading-[26px] text-secondary/70">{description}</p>
+        <p className="max-w-[492px] text-base leading-7 text-secondary/70">{description}</p>
 
         <HeroQualitySummary trust={trust} />
       </div>
 
-      <div className="relative lg:col-span-7 lg:pl-8">
+      <div className="relative min-w-0 lg:col-span-7 lg:pl-8">
         <div className="relative ml-auto aspect-[667/649] w-full max-w-[667px] overflow-hidden rounded-[30px]">
           <Media
             htmlElement={null}
@@ -62,7 +67,7 @@ export function HeroOverviewSection({
 
         <Card
           className={cn(
-            'relative mt-10 ml-5 w-full max-w-[530px] rounded-[25px] border-0 shadow-brand-soft lg:absolute lg:left-0 lg:mt-0',
+            'relative mt-6 w-full max-w-[530px] rounded-[25px] border-0 shadow-brand-soft sm:mt-8 lg:absolute lg:left-0 lg:mt-0',
             isSparseDoctorsList ? 'lg:bottom-[-72px]' : 'lg:bottom-[-220px]',
           )}
         >

--- a/src/components/organisms/Doctors/RelatedDoctorSection.client.tsx
+++ b/src/components/organisms/Doctors/RelatedDoctorSection.client.tsx
@@ -76,10 +76,10 @@ export function RelatedDoctorCarousel({
 
   return (
     <div className={cn('w-full', className)}>
-      <div className="relative grid grid-cols-12 items-start gap-8 overflow-visible lg:gap-16 xl:gap-20">
+      <div className="relative grid grid-cols-1 items-start gap-6 overflow-visible lg:grid-cols-12 lg:gap-16 xl:gap-20">
         {title ? (
           <div className="relative z-20 col-span-12 lg:col-span-8 lg:col-start-5 lg:row-start-1">
-            <Heading as="h2" align="center" className="text-size-72 text-secondary">
+            <Heading as="h2" align="center" className="text-5xl text-secondary md:text-6xl lg:text-size-72">
               {title}
             </Heading>
           </div>

--- a/src/components/organisms/Doctors/RelatedDoctorSection.tsx
+++ b/src/components/organisms/Doctors/RelatedDoctorSection.tsx
@@ -8,8 +8,8 @@ export type RelatedDoctorSectionProps = RelatedDoctorCarouselProps
 
 export function RelatedDoctorSection({ title = 'Related Doctor', className, ...props }: RelatedDoctorSectionProps) {
   return (
-    <section className={cn('w-full', className)}>
-      <div className="container-content px-4 sm:px-6 lg:px-0">
+    <section className={cn('w-full overflow-x-clip', className)}>
+      <div className="container-content box-border">
         <RelatedDoctorCarousel title={title} {...props} />
       </div>
     </section>

--- a/src/components/organisms/Heroes/LandingHero/index.tsx
+++ b/src/components/organisms/Heroes/LandingHero/index.tsx
@@ -31,8 +31,8 @@ export const LandingHero: React.FC<LandingHeroProps> = ({
   return (
     <section
       className={cn(
-        'relative flex items-center justify-center bg-white py-20',
-        isClinicLanding ? 'min-h-[48rem] overflow-hidden' : 'min-h-[39rem]',
+        'relative flex items-center justify-center bg-white py-16 sm:py-20',
+        isClinicLanding ? 'min-h-[34rem] overflow-hidden sm:min-h-[48rem]' : 'min-h-[32rem] sm:min-h-[39rem]',
       )}
     >
       {image ? (
@@ -44,7 +44,7 @@ export const LandingHero: React.FC<LandingHeroProps> = ({
 
       <Container className="relative z-10 flex flex-col items-center text-center">
         <SectionHeading
-          className="mb-12"
+          className="mb-10 sm:mb-12"
           title={title}
           description={description}
           size="hero"
@@ -64,7 +64,7 @@ export const LandingHero: React.FC<LandingHeroProps> = ({
         )}
 
         {isClinicLanding && (
-          <div className="mt-16 animate-bounce">
+          <div className="mt-10 animate-bounce sm:mt-16">
             <svg
               width="24"
               height="24"

--- a/src/components/organisms/Landing/LandingCategoriesShell.tsx
+++ b/src/components/organisms/Landing/LandingCategoriesShell.tsx
@@ -148,7 +148,11 @@ export function LandingCategoriesShell({
 
   return (
     <React.Fragment>
-      <nav role="tablist" aria-label="Category filters" className="mb-12 flex flex-wrap justify-center gap-x-8 gap-y-3">
+      <nav
+        role="tablist"
+        aria-label="Category filters"
+        className="mb-10 flex flex-wrap justify-center gap-x-4 gap-y-3 sm:mb-12 sm:gap-x-8"
+      >
         {categoryTabs.map((category) => {
           const isActive = resolvedFilter === category.value
           const tabId = `landing-categories-tab-${category.value}`
@@ -165,8 +169,10 @@ export function LandingCategoriesShell({
               aria-controls={panelId}
               tabIndex={isActive ? 0 : -1}
               className={cn(
-                'relative cursor-pointer text-base font-medium transition-colors md:text-lg',
-                isActive ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
+                'relative inline-flex min-h-11 items-center rounded-full px-4 py-2 text-base font-medium transition-colors md:text-lg',
+                isActive
+                  ? 'bg-foreground/5 text-foreground'
+                  : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
               )}
             >
               {category.label}
@@ -181,7 +187,23 @@ export function LandingCategoriesShell({
         })}
       </nav>
 
-      <div id={panelId} role="tabpanel" aria-labelledby={activeTabId} className="relative mb-12 h-140 w-full">
+      <div className="mb-10 grid gap-4 lg:hidden">
+        {visibleItems.map((item) => (
+          <div
+            key={`mobile-${item.id}`}
+            className="relative aspect-[16/11] overflow-hidden rounded-2xl border border-border/60 bg-muted/40 shadow-sm"
+          >
+            {item.card}
+          </div>
+        ))}
+      </div>
+
+      <div
+        id={panelId}
+        role="tabpanel"
+        aria-labelledby={activeTabId}
+        className="relative mb-12 hidden h-140 w-full overflow-hidden lg:block"
+      >
         {scopedItems.map((item) => {
           const slotIndex = slotMap.get(item.id)
           const hasSlot = slotIndex !== undefined && slotIndex >= 0 && slotIndex < slots.length

--- a/src/components/organisms/Landing/LandingFeatures.tsx
+++ b/src/components/organisms/Landing/LandingFeatures.tsx
@@ -43,7 +43,7 @@ export const LandingFeatures: React.FC<LandingFeaturesProps> = ({
   return (
     <SectionBackground
       as="section"
-      className={cn('py-20', isGreen ? 'bg-accent' : 'bg-white')}
+      className={cn('py-16 sm:py-20', isGreen ? 'bg-accent' : 'bg-white')}
       media={
         backgroundImage
           ? {
@@ -86,7 +86,10 @@ export const LandingFeatures: React.FC<LandingFeaturesProps> = ({
                     as="h3"
                     size="h2"
                     align="left"
-                    className={cn('text-5xl', isGreen ? 'text-accent-foreground' : 'text-foreground')}
+                    className={cn(
+                      'text-3xl sm:text-4xl lg:text-5xl',
+                      isGreen ? 'text-accent-foreground' : 'text-foreground',
+                    )}
                   >
                     {feature.title}
                   </Heading>
@@ -101,7 +104,10 @@ export const LandingFeatures: React.FC<LandingFeaturesProps> = ({
                     </Heading>
                   ) : null}
                   <p
-                    className={cn('text-left text-lg', isGreen ? 'text-accent-foreground/80' : 'text-muted-foreground')}
+                    className={cn(
+                      'text-left text-base sm:text-lg',
+                      isGreen ? 'text-accent-foreground/80' : 'text-muted-foreground',
+                    )}
                   >
                     {feature.description}
                   </p>

--- a/src/components/organisms/Landing/LandingProcess.tsx
+++ b/src/components/organisms/Landing/LandingProcess.tsx
@@ -521,11 +521,43 @@ export const LandingProcess: React.FC<LandingProcessProps> = ({
   if (steps.length === 0) return null
 
   return (
-    <section className="bg-white py-20">
+    <section className="bg-white py-16 sm:py-20">
       <Container>
         <SectionHeading className="mb-16" title={title} description={subtitle} size="section" align="center" />
 
-        <div className="relative" ref={rootRef}>
+        <div className="space-y-10 lg:hidden">
+          {resolvedStepImages[0] ? (
+            <div className="relative aspect-[16/11] w-full overflow-hidden rounded-3xl bg-background">
+              <Image
+                src={resolvedStepImages[0].src}
+                alt={resolvedStepImages[0].alt}
+                fill
+                sizes="100vw"
+                className="object-cover"
+              />
+            </div>
+          ) : null}
+
+          <ol className="space-y-5">
+            {steps.map((step) => (
+              <li key={`mobile-${step.step}`} className="rounded-3xl border border-border/70 bg-white p-5 shadow-sm">
+                <div className="flex items-start gap-4">
+                  <span className="w-10 shrink-0 text-3xl leading-none font-bold text-foreground tabular-nums">
+                    {step.step}.
+                  </span>
+                  <div className="min-w-0">
+                    <Heading as="h3" size="h6" align="left" className="mb-2 text-xl leading-snug text-foreground">
+                      {step.title}
+                    </Heading>
+                    <p className="text-sm leading-7 text-muted-foreground">{step.description}</p>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+
+        <div className="relative hidden lg:block" ref={rootRef}>
           <div className="sticky top-24">
             <div className="grid gap-12 lg:grid-cols-2">
               <div className="relative z-10">

--- a/src/components/organisms/Listing/ListingCard.tsx
+++ b/src/components/organisms/Listing/ListingCard.tsx
@@ -53,13 +53,13 @@ export function ListingCard({ data, className }: { data: ListingCardData; classN
   return (
     <article
       className={cn(
-        'w-full rounded-2xl border border-border bg-card p-4 shadow-xs md:flex md:items-stretch md:gap-6 md:p-6',
+        'w-full overflow-hidden rounded-2xl border border-border bg-card p-4 shadow-xs md:flex md:items-stretch md:gap-6 md:p-6',
         className,
       )}
     >
       <div className="flex flex-1 flex-col gap-4 md:flex-row md:gap-6">
-        <div className="max-w-32 flex-[1_0_0] self-stretch">
-          <div className="relative aspect-square w-full overflow-hidden">
+        <div className="w-full self-stretch md:max-w-32 md:flex-[1_0_0]">
+          <div className="relative aspect-[16/10] w-full overflow-hidden rounded-xl md:aspect-square md:rounded-none">
             <Media
               htmlElement={null}
               src={data.media.src}
@@ -81,7 +81,7 @@ export function ListingCard({ data, className }: { data: ListingCardData; classN
                 as="h3"
                 align="left"
                 size="h5"
-                className="truncate text-2xl leading-tight font-semibold text-foreground"
+                className="text-2xl leading-tight font-semibold text-foreground md:truncate"
               >
                 {data.name}
               </Heading>
@@ -102,12 +102,12 @@ export function ListingCard({ data, className }: { data: ListingCardData; classN
           <TagList tags={data.tags} />
         </div>
 
-        <div className="flex shrink-0 flex-col gap-3 md:items-end md:pt-1">
-          <Button asChild className="h-12 w-36 text-sm font-semibold">
+        <div className="grid shrink-0 grid-cols-2 gap-3 md:flex md:w-36 md:flex-col md:items-end md:pt-1">
+          <Button asChild className="h-12 w-full text-sm font-semibold">
             <a href={data.actions.details.href}>{data.actions.details.label}</a>
           </Button>
           {data.actions.compare ? (
-            <Button asChild variant="secondary" className="h-12 w-36 text-sm font-semibold text-foreground">
+            <Button asChild variant="secondary" className="h-12 w-full text-sm font-semibold text-foreground">
               <a href={data.actions.compare.href}>{data.actions.compare.label}</a>
             </Button>
           ) : null}

--- a/src/components/organisms/Listing/ListingFilters.tsx
+++ b/src/components/organisms/Listing/ListingFilters.tsx
@@ -163,7 +163,7 @@ const Root = ({
         setSelectedRating,
       }}
     >
-      <aside className={cn('space-y-8 rounded-2xl bg-background p-6 shadow-sm', className)}>
+      <aside className={cn('min-w-0 space-y-8 rounded-2xl bg-background p-5 shadow-sm sm:p-6', className)}>
         <Heading as="h2" align="left" size="h5" className="font-semibold">
           Filter
         </Heading>

--- a/src/components/templates/ClinicDetailConcepts/ClinicDetail.tsx
+++ b/src/components/templates/ClinicDetailConcepts/ClinicDetail.tsx
@@ -137,7 +137,7 @@ export function ClinicDetail({
 
   return (
     <main className={cn('bg-muted text-foreground', className)}>
-      <Container className="pt-16 pb-28 lg:pt-20 lg:pb-64">
+      <Container className="pt-10 pb-14 lg:pt-20 lg:pb-64">
         {/* Figma parity requires fixed card/image dimensions for the hero composition and overlap behavior. */}
         <HeroOverviewSection
           clinicName={data.clinicName}
@@ -189,7 +189,7 @@ export function ClinicDetail({
 
       {relatedDoctors.length ? (
         <section ref={interaction.ourDoctorsRef}>
-          <Container className="py-10 lg:py-14">
+          <Container className="py-8 lg:py-14">
             <RelatedDoctorSection
               title="Our Doctors"
               doctors={relatedDoctors}
@@ -202,7 +202,7 @@ export function ClinicDetail({
         </section>
       ) : null}
 
-      <Container className="pt-4 pb-12 lg:pt-8 lg:pb-16">
+      <Container className="pt-2 pb-10 lg:pt-8 lg:pb-16">
         <ClinicAppointmentSection
           sectionId={CONTACT_FORM_ID}
           sectionRef={interaction.contactFormRef}

--- a/src/components/templates/ClinicDetailConcepts/ClinicDetail.tsx
+++ b/src/components/templates/ClinicDetailConcepts/ClinicDetail.tsx
@@ -136,7 +136,7 @@ export function ClinicDetail({
   }, [data.doctors, handleContactDoctor])
 
   return (
-    <main className={cn('bg-muted text-foreground', className)}>
+    <main className={cn('overflow-x-clip bg-muted text-foreground', className)}>
       <Container className="pt-10 pb-14 lg:pt-20 lg:pb-64">
         {/* Figma parity requires fixed card/image dimensions for the hero composition and overlap behavior. */}
         <HeroOverviewSection

--- a/src/components/templates/ListingComparison/Component.tsx
+++ b/src/components/templates/ListingComparison/Component.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { ArrowUpDown } from 'lucide-react'
 
+import { Button } from '@/components/atoms/button'
 import { Container } from '@/components/molecules/Container'
 import { ListingCard, type ListingCardData } from '@/components/organisms/Listing'
 import { FeatureHero, type FeatureHeroProps } from '@/components/organisms/Heroes/FeatureHero'
@@ -61,13 +62,18 @@ export function ListingComparison({
       <main>
         <section className="bg-muted/30 py-12" aria-label="Clinic filters and results">
           <Container>
-            <div className="grid gap-8 lg:grid-cols-[320px_1fr] lg:items-start">
-              <div id={filtersContainerId} aria-label="Filters">
+            <div className="grid gap-8 lg:grid-cols-[minmax(0,320px)_minmax(0,1fr)] lg:items-start">
+              <div id={filtersContainerId} className="order-2 min-w-0 lg:order-1" aria-label="Filters">
                 {filters}
               </div>
 
-              <section id="clinic-results" className="space-y-4" aria-label="Clinic results">
+              <section id="clinic-results" className="order-1 min-w-0 space-y-4 lg:order-2" aria-label="Clinic results">
                 {resultsContext}
+                <div className="flex justify-end lg:hidden">
+                  <Button asChild variant="secondary" className="min-h-11 rounded-full px-5">
+                    <a href={`#${filtersContainerId}`}>Jump to filters</a>
+                  </Button>
+                </div>
                 {defaultHeader}
                 {results.length > 0
                   ? results.map((data) => <ListingCard key={data.id} data={data} />)

--- a/src/stories/organisms/ClinicDetail/ClinicAppointmentSection.stories.tsx
+++ b/src/stories/organisms/ClinicDetail/ClinicAppointmentSection.stories.tsx
@@ -6,6 +6,7 @@ import { ClinicAppointmentSection } from '@/components/organisms/ClinicDetail'
 import type { ContactFormFields } from '@/components/organisms/ClinicDetail'
 import type { ClinicDetailDoctor, ClinicDetailTreatment } from '@/components/templates/ClinicDetailConcepts/types'
 import { clinicDetailFixture } from '@/stories/fixtures/clinicDetail'
+import { withViewportStory } from '../../utils/viewportMatrix'
 
 const doctors: ClinicDetailDoctor[] = clinicDetailFixture.doctors.slice(0, 3)
 const treatments: ClinicDetailTreatment[] = clinicDetailFixture.treatments.slice(0, 4)
@@ -129,3 +130,18 @@ export const InteractiveSubmit: Story = {
     await expect(canvas.getByRole('status')).toHaveTextContent('Contact request prepared for storybook preview.')
   },
 }
+
+export const InteractiveSubmit320: Story = withViewportStory(InteractiveSubmit, 'public320', 'Interactive submit / 320')
+export const InteractiveSubmit375: Story = withViewportStory(InteractiveSubmit, 'public375', 'Interactive submit / 375')
+export const InteractiveSubmit640: Story = withViewportStory(InteractiveSubmit, 'public640', 'Interactive submit / 640')
+export const InteractiveSubmit768: Story = withViewportStory(InteractiveSubmit, 'public768', 'Interactive submit / 768')
+export const InteractiveSubmit1024: Story = withViewportStory(
+  InteractiveSubmit,
+  'public1024',
+  'Interactive submit / 1024',
+)
+export const InteractiveSubmit1280: Story = withViewportStory(
+  InteractiveSubmit,
+  'public1280',
+  'Interactive submit / 1280',
+)

--- a/src/stories/organisms/ClinicDetail/HeroOverviewSection.stories.tsx
+++ b/src/stories/organisms/ClinicDetail/HeroOverviewSection.stories.tsx
@@ -4,6 +4,7 @@ import { expect, fn, userEvent, within } from '@storybook/test'
 
 import { HeroOverviewSection } from '@/components/organisms/ClinicDetail'
 import { clinicDetailFixture } from '@/stories/fixtures/clinicDetail'
+import { withViewportStory } from '../../utils/viewportMatrix'
 
 const heroDoctors = clinicDetailFixture.doctors.slice(0, 6)
 const singleDoctor = clinicDetailFixture.doctors.slice(0, 1)
@@ -109,3 +110,34 @@ export const EmptyDoctorsState: Story = {
     await expect(canvas.getByText(/No doctors are currently listed for this clinic/i)).toBeInTheDocument()
   },
 }
+
+export const InteractiveDoctorSelection320: Story = withViewportStory(
+  InteractiveDoctorSelection,
+  'public320',
+  'Interactive doctor selection / 320',
+)
+export const InteractiveDoctorSelection375: Story = withViewportStory(
+  InteractiveDoctorSelection,
+  'public375',
+  'Interactive doctor selection / 375',
+)
+export const InteractiveDoctorSelection640: Story = withViewportStory(
+  InteractiveDoctorSelection,
+  'public640',
+  'Interactive doctor selection / 640',
+)
+export const InteractiveDoctorSelection768: Story = withViewportStory(
+  InteractiveDoctorSelection,
+  'public768',
+  'Interactive doctor selection / 768',
+)
+export const InteractiveDoctorSelection1024: Story = withViewportStory(
+  InteractiveDoctorSelection,
+  'public1024',
+  'Interactive doctor selection / 1024',
+)
+export const InteractiveDoctorSelection1280: Story = withViewportStory(
+  InteractiveDoctorSelection,
+  'public1280',
+  'Interactive doctor selection / 1280',
+)

--- a/src/stories/organisms/Landing/LandingCategories.stories.tsx
+++ b/src/stories/organisms/Landing/LandingCategories.stories.tsx
@@ -3,6 +3,7 @@ import { expect, userEvent, within } from '@storybook/test'
 
 import { LandingCategories } from '@/components/organisms/Landing'
 import { clinicCategoriesData, clinicCategoryFeaturedIds, clinicCategoryItems } from '@/stories/fixtures/listings'
+import { withViewportStory } from '../../utils/viewportMatrix'
 
 const meta = {
   title: 'Domain/Landing/Organisms/LandingCategories',
@@ -54,3 +55,34 @@ export const CategorySwitchScramble: Story = {
     ).toHaveAttribute('aria-selected', 'true')
   },
 }
+
+export const CategorySwitchScramble320: Story = withViewportStory(
+  CategorySwitchScramble,
+  'public320',
+  'Category switch scramble / 320',
+)
+export const CategorySwitchScramble375: Story = withViewportStory(
+  CategorySwitchScramble,
+  'public375',
+  'Category switch scramble / 375',
+)
+export const CategorySwitchScramble640: Story = withViewportStory(
+  CategorySwitchScramble,
+  'public640',
+  'Category switch scramble / 640',
+)
+export const CategorySwitchScramble768: Story = withViewportStory(
+  CategorySwitchScramble,
+  'public768',
+  'Category switch scramble / 768',
+)
+export const CategorySwitchScramble1024: Story = withViewportStory(
+  CategorySwitchScramble,
+  'public1024',
+  'Category switch scramble / 1024',
+)
+export const CategorySwitchScramble1280: Story = withViewportStory(
+  CategorySwitchScramble,
+  'public1280',
+  'Category switch scramble / 1280',
+)

--- a/src/stories/organisms/Landing/LandingContact.stories.tsx
+++ b/src/stories/organisms/Landing/LandingContact.stories.tsx
@@ -1,11 +1,17 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect, within } from '@storybook/test'
+import { expect, userEvent, waitFor, within } from '@storybook/test'
 
 import { LandingContact } from '@/components/organisms/Landing'
+import { createMockFetchDecorator } from '../../utils/fetchDecorator'
+import { createDelayedJsonResponse } from '../../utils/mockHelpers'
+import { withViewportStory } from '../../utils/viewportMatrix'
+
+const mockFetch: typeof fetch = async () => createDelayedJsonResponse({ success: true })
 
 const meta = {
   title: 'Domain/Landing/Organisms/LandingContact',
   component: LandingContact,
+  decorators: [createMockFetchDecorator(mockFetch)],
   parameters: {
     layout: 'fullscreen',
   },
@@ -30,3 +36,76 @@ export const Default: Story = {
     await expect(canvas.getByRole('button', { name: 'Send message' })).toBeInTheDocument()
   },
 }
+
+export const Default320: Story = withViewportStory(Default, 'public320', 'Default / 320')
+export const Default375: Story = withViewportStory(Default, 'public375', 'Default / 375')
+export const Default640: Story = withViewportStory(Default, 'public640', 'Default / 640')
+export const Default768: Story = withViewportStory(Default, 'public768', 'Default / 768')
+export const Default1024: Story = withViewportStory(Default, 'public1024', 'Default / 1024')
+export const Default1280: Story = withViewportStory(Default, 'public1280', 'Default / 1280')
+
+const validationAndSubmitBase: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Send message' }))
+
+    await waitFor(() => {
+      expect(canvas.getByText('Email is required.')).toBeInTheDocument()
+    })
+
+    await userEvent.type(canvas.getByLabelText('Name'), 'Alex Morgan')
+    await userEvent.type(canvas.getByLabelText('Email'), 'alex@findmydoc.com')
+    await userEvent.type(
+      canvas.getByLabelText('Message'),
+      'I would like to discuss partnership options for our clinic.',
+    )
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Send message' }))
+
+    await waitFor(() => {
+      expect(canvas.getByText('Your request has been sent successfully.')).toBeInTheDocument()
+    })
+  },
+}
+
+export const ValidationAndSubmit320: Story = withViewportStory(
+  validationAndSubmitBase,
+  'public320',
+  'Validation and submit / 320',
+)
+export const ValidationAndSubmit375: Story = withViewportStory(
+  validationAndSubmitBase,
+  'public375',
+  'Validation and submit / 375',
+)
+export const ValidationAndSubmit640: Story = withViewportStory(
+  validationAndSubmitBase,
+  'public640',
+  'Validation and submit / 640',
+)
+export const ValidationAndSubmit768: Story = withViewportStory(
+  validationAndSubmitBase,
+  'public768',
+  'Validation and submit / 768',
+)
+export const ValidationAndSubmit1024: Story = withViewportStory(
+  validationAndSubmitBase,
+  'public1024',
+  'Validation and submit / 1024',
+)
+export const ValidationAndSubmit1280: Story = withViewportStory(
+  validationAndSubmitBase,
+  'public1280',
+  'Validation and submit / 1280',
+)
+export const ValidationAndSubmit320Short: Story = withViewportStory(
+  validationAndSubmitBase,
+  'public320Short',
+  'Validation and submit / 320 short',
+)
+export const ValidationAndSubmit375Short: Story = withViewportStory(
+  validationAndSubmitBase,
+  'public375Short',
+  'Validation and submit / 375 short',
+)

--- a/src/stories/organisms/Landing/LandingFeatures.stories.tsx
+++ b/src/stories/organisms/Landing/LandingFeatures.stories.tsx
@@ -3,6 +3,7 @@ import { expect, within } from '@storybook/test'
 
 import { LandingFeatures } from '@/components/organisms/Landing'
 import { clinicFeaturesData } from '@/stories/fixtures/listings'
+import { withViewportStory } from '../../utils/viewportMatrix'
 import ph1440x900 from '../../assets/placeholder-1440-900.svg'
 
 const meta = {
@@ -45,4 +46,18 @@ export const GreenVariant: Story = {
     variant: 'green',
     backgroundImage: ph1440x900,
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByRole('heading', { name: 'Why partner with us' })).toBeInTheDocument()
+    await expect(canvas.getByText('Qualified Leads')).toBeInTheDocument()
+    await expect(canvas.getByText('Reputation Boost')).toBeInTheDocument()
+  },
 }
+
+export const GreenVariant320: Story = withViewportStory(GreenVariant, 'public320', 'Green variant / 320')
+export const GreenVariant375: Story = withViewportStory(GreenVariant, 'public375', 'Green variant / 375')
+export const GreenVariant640: Story = withViewportStory(GreenVariant, 'public640', 'Green variant / 640')
+export const GreenVariant768: Story = withViewportStory(GreenVariant, 'public768', 'Green variant / 768')
+export const GreenVariant1024: Story = withViewportStory(GreenVariant, 'public1024', 'Green variant / 1024')
+export const GreenVariant1280: Story = withViewportStory(GreenVariant, 'public1280', 'Green variant / 1280')

--- a/src/stories/organisms/Landing/LandingPricing.stories.tsx
+++ b/src/stories/organisms/Landing/LandingPricing.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, within } from '@storybook/test'
 
 import { LandingPricing } from '@/components/organisms/Landing'
 import { clinicPricingData, clinicPricingModelItems } from '@/stories/fixtures/listings'
+import { withViewportStory } from '../../utils/viewportMatrix'
 
 const meta = {
   title: 'Domain/Landing/Organisms/LandingPricing',
@@ -23,4 +25,20 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByText('Pricing')).toBeInTheDocument()
+    await expect(canvas.getByText('Premium')).toBeInTheDocument()
+    await expect(canvas.getByText('EUR 199')).toBeInTheDocument()
+    await expect(canvas.getByText('EUR 349')).toBeInTheDocument()
+  },
+}
+
+export const Default320: Story = withViewportStory(Default, 'public320', 'Default / 320')
+export const Default375: Story = withViewportStory(Default, 'public375', 'Default / 375')
+export const Default640: Story = withViewportStory(Default, 'public640', 'Default / 640')
+export const Default768: Story = withViewportStory(Default, 'public768', 'Default / 768')
+export const Default1024: Story = withViewportStory(Default, 'public1024', 'Default / 1024')
+export const Default1280: Story = withViewportStory(Default, 'public1280', 'Default / 1280')

--- a/src/stories/organisms/Landing/LandingProcess.stories.tsx
+++ b/src/stories/organisms/Landing/LandingProcess.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, within } from '@storybook/test'
 
 import { LandingProcess } from '@/components/organisms/Landing'
 import { clinicProcessData } from '@/stories/fixtures/listings'
+import { withViewportStory } from '../../utils/viewportMatrix'
 import {
   landingProcessPlaceholderStepImages,
   landingProcessPlaceholderSubtitle,
@@ -60,7 +62,17 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByRole('heading', { name: landingProcessPlaceholderTitle })).toBeInTheDocument()
+    await expect(canvas.getAllByText('Reach Out').length).toBeGreaterThan(0)
+    await expect(canvas.getAllByText('Finalize Profile').length).toBeGreaterThan(0)
+    await expect(canvas.getAllByText('Verification & Quality Check').length).toBeGreaterThan(0)
+    await expect(canvas.getAllByText('Connect with Patients').length).toBeGreaterThan(0)
+  },
+}
 
 export const PercentControlledSteps: Story = {
   args: {
@@ -74,3 +86,10 @@ export const ActivationOffset: Story = {
     stepActivationOffsetPx: [0, 28, 48, 0],
   },
 }
+
+export const Default320: Story = withViewportStory(Default, 'public320', 'Default / 320')
+export const Default375: Story = withViewportStory(Default, 'public375', 'Default / 375')
+export const Default640: Story = withViewportStory(Default, 'public640', 'Default / 640')
+export const Default768: Story = withViewportStory(Default, 'public768', 'Default / 768')
+export const Default1024: Story = withViewportStory(Default, 'public1024', 'Default / 1024')
+export const Default1280: Story = withViewportStory(Default, 'public1280', 'Default / 1280')

--- a/src/stories/organisms/Landing/LandingTeam.stories.tsx
+++ b/src/stories/organisms/Landing/LandingTeam.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, userEvent, waitFor, within } from '@storybook/test'
 
 import { LandingTeam } from '@/components/organisms/Landing'
 import { clinicTeamData } from '@/stories/fixtures/listings'
+import { withViewportStory } from '../../utils/viewportMatrix'
 
 const getTeamMemberByName = (name: string) => {
   const member = clinicTeamData.find((teamMember) => teamMember.name === name)
@@ -36,7 +38,15 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByText('Our Team')).toBeInTheDocument()
+    await expect(canvas.getByText('Volkan Kablan')).toBeInTheDocument()
+    await expect(canvas.getByText('Anil Gökduman')).toBeInTheDocument()
+  },
+}
 
 export const MixedPhotoDisplayModes: Story = {
   args: {
@@ -49,3 +59,98 @@ export const MixedPhotoDisplayModes: Story = {
     description: 'Shows original and grayscale photo rendering, while placeholder images remain unchanged.',
   },
 }
+
+const carouselNavigationBase: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const slides = canvas.getAllByRole('group')
+    const firstSlide = slides[0]!
+
+    const nextButton = canvas.getByRole('button', { name: 'Next slide' })
+    const prevButton = canvas.getByRole('button', { name: 'Previous slide' })
+    const initialLeft = firstSlide.getBoundingClientRect().left
+
+    await expect(nextButton).toBeEnabled()
+    await expect(prevButton).toBeEnabled()
+
+    await userEvent.click(nextButton)
+    await waitFor(() => {
+      expect(firstSlide.getBoundingClientRect().left).toBeLessThan(initialLeft)
+    })
+
+    const afterNextLeft = firstSlide.getBoundingClientRect().left
+    await userEvent.click(prevButton)
+    await waitFor(() => {
+      expect(firstSlide.getBoundingClientRect().left).toBeGreaterThan(afterNextLeft)
+    })
+  },
+}
+
+export const Default320: Story = withViewportStory(Default, 'public320', 'Default / 320')
+export const Default375: Story = withViewportStory(Default, 'public375', 'Default / 375')
+export const Default640: Story = withViewportStory(Default, 'public640', 'Default / 640')
+export const Default768: Story = withViewportStory(Default, 'public768', 'Default / 768')
+export const Default1024: Story = withViewportStory(Default, 'public1024', 'Default / 1024')
+export const Default1280: Story = withViewportStory(Default, 'public1280', 'Default / 1280')
+
+export const MixedPhotoDisplayModes320: Story = withViewportStory(
+  MixedPhotoDisplayModes,
+  'public320',
+  'Photo display modes / 320',
+)
+export const MixedPhotoDisplayModes375: Story = withViewportStory(
+  MixedPhotoDisplayModes,
+  'public375',
+  'Photo display modes / 375',
+)
+export const MixedPhotoDisplayModes640: Story = withViewportStory(
+  MixedPhotoDisplayModes,
+  'public640',
+  'Photo display modes / 640',
+)
+export const MixedPhotoDisplayModes768: Story = withViewportStory(
+  MixedPhotoDisplayModes,
+  'public768',
+  'Photo display modes / 768',
+)
+export const MixedPhotoDisplayModes1024: Story = withViewportStory(
+  MixedPhotoDisplayModes,
+  'public1024',
+  'Photo display modes / 1024',
+)
+export const MixedPhotoDisplayModes1280: Story = withViewportStory(
+  MixedPhotoDisplayModes,
+  'public1280',
+  'Photo display modes / 1280',
+)
+
+export const CarouselNavigation320: Story = withViewportStory(
+  carouselNavigationBase,
+  'public320',
+  'Carousel navigation / 320',
+)
+export const CarouselNavigation375: Story = withViewportStory(
+  carouselNavigationBase,
+  'public375',
+  'Carousel navigation / 375',
+)
+export const CarouselNavigation640: Story = withViewportStory(
+  carouselNavigationBase,
+  'public640',
+  'Carousel navigation / 640',
+)
+export const CarouselNavigation768: Story = withViewportStory(
+  carouselNavigationBase,
+  'public768',
+  'Carousel navigation / 768',
+)
+export const CarouselNavigation1024: Story = withViewportStory(
+  carouselNavigationBase,
+  'public1024',
+  'Carousel navigation / 1024',
+)
+export const CarouselNavigation1280: Story = withViewportStory(
+  carouselNavigationBase,
+  'public1280',
+  'Carousel navigation / 1280',
+)

--- a/src/stories/organisms/Landing/LandingTestimonials.stories.tsx
+++ b/src/stories/organisms/Landing/LandingTestimonials.stories.tsx
@@ -3,6 +3,7 @@ import { expect, userEvent, waitFor, within } from '@storybook/test'
 
 import { LandingTestimonials } from '@/components/organisms/Landing'
 import { clinicTestimonialsData } from '@/stories/fixtures/listings'
+import { withViewportStory } from '../../utils/viewportMatrix'
 
 const meta = {
   title: 'Domain/Landing/Organisms/LandingTestimonials',
@@ -51,3 +52,34 @@ export const CarouselNavigation: Story = {
     await waitFor(() => expect(secondDot).not.toHaveAttribute('aria-current', 'true'))
   },
 }
+
+export const CarouselNavigation320: Story = withViewportStory(
+  CarouselNavigation,
+  'public320',
+  'Carousel navigation / 320',
+)
+export const CarouselNavigation375: Story = withViewportStory(
+  CarouselNavigation,
+  'public375',
+  'Carousel navigation / 375',
+)
+export const CarouselNavigation640: Story = withViewportStory(
+  CarouselNavigation,
+  'public640',
+  'Carousel navigation / 640',
+)
+export const CarouselNavigation768: Story = withViewportStory(
+  CarouselNavigation,
+  'public768',
+  'Carousel navigation / 768',
+)
+export const CarouselNavigation1024: Story = withViewportStory(
+  CarouselNavigation,
+  'public1024',
+  'Carousel navigation / 1024',
+)
+export const CarouselNavigation1280: Story = withViewportStory(
+  CarouselNavigation,
+  'public1280',
+  'Carousel navigation / 1280',
+)

--- a/src/stories/organisms/LandingHero.stories.tsx
+++ b/src/stories/organisms/LandingHero.stories.tsx
@@ -3,6 +3,7 @@ import { expect, within } from '@storybook/test'
 import { SiInstagram, SiMeta, SiX } from 'react-icons/si'
 
 import { LandingHero } from '@/components/organisms/Heroes/LandingHero'
+import { withViewportStory } from '../utils/viewportMatrix'
 import ph1440x900 from '../assets/placeholder-1440-900.svg'
 
 const meta = {
@@ -81,3 +82,10 @@ export const NoImage: Story = {
   },
   play: assertHeroContent,
 }
+
+export const WithSearchBar320: Story = withViewportStory(WithSearchBar, 'public320', 'With search bar / 320')
+export const WithSearchBar375: Story = withViewportStory(WithSearchBar, 'public375', 'With search bar / 375')
+export const WithSearchBar640: Story = withViewportStory(WithSearchBar, 'public640', 'With search bar / 640')
+export const WithSearchBar768: Story = withViewportStory(WithSearchBar, 'public768', 'With search bar / 768')
+export const WithSearchBar1024: Story = withViewportStory(WithSearchBar, 'public1024', 'With search bar / 1024')
+export const WithSearchBar1280: Story = withViewportStory(WithSearchBar, 'public1280', 'With search bar / 1280')

--- a/src/stories/organisms/ListingCard.stories.tsx
+++ b/src/stories/organisms/ListingCard.stories.tsx
@@ -3,6 +3,7 @@ import { expect, within } from '@storybook/test'
 
 import { ListingCard } from '@/components/organisms/Listing'
 import { clinicMedia, makeClinic } from '@/stories/fixtures/listings'
+import { withViewportStory } from '../utils/viewportMatrix'
 
 const meta: Meta<typeof ListingCard> = {
   title: 'Domain/Listing/Organisms/ListingCard',
@@ -125,4 +126,18 @@ export const LayoutStressTest: Story = {
       />
     </div>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByText(/Istanbul Universitesi Tip Fakultesi/i)).toBeInTheDocument()
+    await expect(canvas.getByRole('link', { name: 'Details' })).toHaveAttribute('href')
+    await expect(canvas.getByRole('link', { name: 'Compare' })).toHaveAttribute('href')
+  },
 }
+
+export const LayoutStress320: Story = withViewportStory(LayoutStressTest, 'public320', 'Layout stress / 320')
+export const LayoutStress375: Story = withViewportStory(LayoutStressTest, 'public375', 'Layout stress / 375')
+export const LayoutStress640: Story = withViewportStory(LayoutStressTest, 'public640', 'Layout stress / 640')
+export const LayoutStress768: Story = withViewportStory(LayoutStressTest, 'public768', 'Layout stress / 768')
+export const LayoutStress1024: Story = withViewportStory(LayoutStressTest, 'public1024', 'Layout stress / 1024')
+export const LayoutStress1280: Story = withViewportStory(LayoutStressTest, 'public1280', 'Layout stress / 1280')

--- a/src/stories/organisms/ListingFilters.stories.tsx
+++ b/src/stories/organisms/ListingFilters.stories.tsx
@@ -4,6 +4,7 @@ import { expect, userEvent, within } from '@storybook/test'
 
 import { ListingFilters } from '@/components/organisms/Listing'
 import { clinicFilterOptions } from '@/stories/fixtures'
+import { withViewportStory } from '../utils/viewportMatrix'
 
 const defaultCities = clinicFilterOptions.cities
 const defaultWaitTimes = clinicFilterOptions.waitTimes.map((option) => option.label)
@@ -80,3 +81,10 @@ export const Default: Story = {
     expect(getTreatments()).toEqual(['Knee replacement'])
   },
 }
+
+export const Default320: Story = withViewportStory(Default, 'public320', 'Default / 320')
+export const Default375: Story = withViewportStory(Default, 'public375', 'Default / 375')
+export const Default640: Story = withViewportStory(Default, 'public640', 'Default / 640')
+export const Default768: Story = withViewportStory(Default, 'public768', 'Default / 768')
+export const Default1024: Story = withViewportStory(Default, 'public1024', 'Default / 1024')
+export const Default1280: Story = withViewportStory(Default, 'public1280', 'Default / 1280')

--- a/src/stories/organisms/RelatedDoctorSection.stories.tsx
+++ b/src/stories/organisms/RelatedDoctorSection.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, userEvent, within } from '@storybook/test'
 
 import { RelatedDoctorSection, type RelatedDoctorItem } from '@/components/organisms/Doctors'
+import { withViewportStory } from '../utils/viewportMatrix'
 
 import clinicConsultation from '../assets/clinic-consultation.jpg'
 import clinicInterior from '../assets/content-clinic-interior.jpg'
@@ -117,3 +118,10 @@ export const Default: Story = {
     await expect(canvas.getByRole('heading', { name: 'Dr. Emily Wells, MD' })).toBeInTheDocument()
   },
 }
+
+export const Default320: Story = withViewportStory(Default, 'public320', 'Default / 320')
+export const Default375: Story = withViewportStory(Default, 'public375', 'Default / 375')
+export const Default640: Story = withViewportStory(Default, 'public640', 'Default / 640')
+export const Default768: Story = withViewportStory(Default, 'public768', 'Default / 768')
+export const Default1024: Story = withViewportStory(Default, 'public1024', 'Default / 1024')
+export const Default1280: Story = withViewportStory(Default, 'public1280', 'Default / 1280')

--- a/src/stories/templates/ClinicDetailConcepts.stories.tsx
+++ b/src/stories/templates/ClinicDetailConcepts.stories.tsx
@@ -3,6 +3,7 @@ import { expect, within } from '@storybook/test'
 
 import { ClinicDetail } from '@/components/templates/ClinicDetailConcepts'
 import { clinicDetailFixture, clinicDetailNoReviewsFixture } from '@/stories/fixtures/clinicDetail'
+import { withViewportStory } from '../utils/viewportMatrix'
 
 const meta = {
   title: 'Domain/Clinic/Templates/ClinicDetail',
@@ -58,3 +59,10 @@ export const Edge_NoReviews_FallbackText: Story = {
     await expect(canvas.getAllByText('No reviews yet').length).toBeGreaterThan(0)
   },
 }
+
+export const MainDefault320: Story = withViewportStory(Main_Default, 'public320', 'Main default / 320')
+export const MainDefault375: Story = withViewportStory(Main_Default, 'public375', 'Main default / 375')
+export const MainDefault640: Story = withViewportStory(Main_Default, 'public640', 'Main default / 640')
+export const MainDefault768: Story = withViewportStory(Main_Default, 'public768', 'Main default / 768')
+export const MainDefault1024: Story = withViewportStory(Main_Default, 'public1024', 'Main default / 1024')
+export const MainDefault1280: Story = withViewportStory(Main_Default, 'public1280', 'Main default / 1280')

--- a/src/stories/templates/Landing.stories.tsx
+++ b/src/stories/templates/Landing.stories.tsx
@@ -33,6 +33,7 @@ import {
   landingProcessPlaceholderSubtitle,
   landingProcessPlaceholderTitle,
 } from '@/utilities/placeholders/landingProcess'
+import { withViewportStory } from '../utils/viewportMatrix'
 
 const meta: Meta = {
   title: 'Domain/Landing/Templates/Landing',
@@ -282,3 +283,65 @@ export const Contact: StoryObj<typeof LandingContact> = {
     />
   ),
 }
+
+export const Team320: StoryObj<typeof LandingTeam> = withViewportStory(Team, 'public320', 'Team / 320')
+export const Team375: StoryObj<typeof LandingTeam> = withViewportStory(Team, 'public375', 'Team / 375')
+export const Team640: StoryObj<typeof LandingTeam> = withViewportStory(Team, 'public640', 'Team / 640')
+export const Team768: StoryObj<typeof LandingTeam> = withViewportStory(Team, 'public768', 'Team / 768')
+export const Team1024: StoryObj<typeof LandingTeam> = withViewportStory(Team, 'public1024', 'Team / 1024')
+export const Team1280: StoryObj<typeof LandingTeam> = withViewportStory(Team, 'public1280', 'Team / 1280')
+
+export const Testimonials320: StoryObj<typeof LandingTestimonials> = withViewportStory(
+  Testimonials,
+  'public320',
+  'Testimonials / 320',
+)
+export const Testimonials375: StoryObj<typeof LandingTestimonials> = withViewportStory(
+  Testimonials,
+  'public375',
+  'Testimonials / 375',
+)
+export const Testimonials640: StoryObj<typeof LandingTestimonials> = withViewportStory(
+  Testimonials,
+  'public640',
+  'Testimonials / 640',
+)
+export const Testimonials768: StoryObj<typeof LandingTestimonials> = withViewportStory(
+  Testimonials,
+  'public768',
+  'Testimonials / 768',
+)
+export const Testimonials1024: StoryObj<typeof LandingTestimonials> = withViewportStory(
+  Testimonials,
+  'public1024',
+  'Testimonials / 1024',
+)
+export const Testimonials1280: StoryObj<typeof LandingTestimonials> = withViewportStory(
+  Testimonials,
+  'public1280',
+  'Testimonials / 1280',
+)
+
+export const Pricing320: StoryObj<typeof LandingPricing> = withViewportStory(Pricing, 'public320', 'Pricing / 320')
+export const Pricing375: StoryObj<typeof LandingPricing> = withViewportStory(Pricing, 'public375', 'Pricing / 375')
+export const Pricing640: StoryObj<typeof LandingPricing> = withViewportStory(Pricing, 'public640', 'Pricing / 640')
+export const Pricing768: StoryObj<typeof LandingPricing> = withViewportStory(Pricing, 'public768', 'Pricing / 768')
+export const Pricing1024: StoryObj<typeof LandingPricing> = withViewportStory(Pricing, 'public1024', 'Pricing / 1024')
+export const Pricing1280: StoryObj<typeof LandingPricing> = withViewportStory(Pricing, 'public1280', 'Pricing / 1280')
+
+export const Contact320: StoryObj<typeof LandingContact> = withViewportStory(Contact, 'public320', 'Contact / 320')
+export const Contact375: StoryObj<typeof LandingContact> = withViewportStory(Contact, 'public375', 'Contact / 375')
+export const Contact640: StoryObj<typeof LandingContact> = withViewportStory(Contact, 'public640', 'Contact / 640')
+export const Contact768: StoryObj<typeof LandingContact> = withViewportStory(Contact, 'public768', 'Contact / 768')
+export const Contact1024: StoryObj<typeof LandingContact> = withViewportStory(Contact, 'public1024', 'Contact / 1024')
+export const Contact1280: StoryObj<typeof LandingContact> = withViewportStory(Contact, 'public1280', 'Contact / 1280')
+export const Contact320Short: StoryObj<typeof LandingContact> = withViewportStory(
+  Contact,
+  'public320Short',
+  'Contact / 320 short',
+)
+export const Contact375Short: StoryObj<typeof LandingContact> = withViewportStory(
+  Contact,
+  'public375Short',
+  'Contact / 375 short',
+)

--- a/src/stories/templates/ListingComparison.stories.tsx
+++ b/src/stories/templates/ListingComparison.stories.tsx
@@ -7,6 +7,7 @@ import { ListingComparison } from '@/components/templates/ListingComparison/Comp
 import { ListingComparisonFilters } from '@/app/(frontend)/listing-comparison/ListingComparisonFilters.client'
 import { sortListingComparison, SORT_OPTIONS, type SortOption } from '@/utilities/listingComparison/sort'
 import { SortControl } from '@/components/molecules/SortControl'
+import { withViewportStory } from '../utils/viewportMatrix'
 import {
   applyListingComparisonLocalFilters,
   type ListingComparisonFilterState,
@@ -441,3 +442,10 @@ export const SortByRating: Story = {
     })
   },
 }
+
+export const Default320: Story = withViewportStory(Default, 'public320', 'Default / 320')
+export const Default375: Story = withViewportStory(Default, 'public375', 'Default / 375')
+export const Default640: Story = withViewportStory(Default, 'public640', 'Default / 640')
+export const Default768: Story = withViewportStory(Default, 'public768', 'Default / 768')
+export const Default1024: Story = withViewportStory(Default, 'public1024', 'Default / 1024')
+export const Default1280: Story = withViewportStory(Default, 'public1280', 'Default / 1280')

--- a/tests/unit/components/landingCategories.test.tsx
+++ b/tests/unit/components/landingCategories.test.tsx
@@ -117,7 +117,7 @@ describe('LandingCategories', () => {
 
     expect(noseTab).toHaveAttribute('aria-selected', 'true')
     expect(screen.getByRole('tab', { name: 'All' })).toHaveAttribute('aria-selected', 'false')
-    expect(screen.getByText('Nose Item')).toBeInTheDocument()
+    expect(screen.getAllByText('Nose Item').length).toBeGreaterThanOrEqual(1)
     const ctaLink = screen.getByRole('link', { name: 'More clinics in Nose' })
     expect(ctaLink).toBeInTheDocument()
     expect(ctaLink).toHaveAttribute('href', '/listing-comparison?specialty=nose')


### PR DESCRIPTION
Mobile discovery routes now behave coherently on small screens without regressing the established desktop presentation.

## What changed
- moved `/listing-comparison` results ahead of filters on mobile, added a touch-sized `Jump to filters` action, and fixed filter/card shrink behavior that caused overflow
- hardened `/clinics/[slug]` for mobile with safer hero wrapping, smaller mobile media treatment, stacked form actions, and clipped related-doctor overflow
- added dedicated mobile fallbacks for `/partners/clinics` process and category sections while preserving the existing desktop scrollytelling and collage layouts

## Validation
- `pnpm format`
- `pnpm check`
- `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build`
- Playwright QA:
  - `run4`: matrix `320/375/640/768/1024/1280` for `/listing-comparison`, `/clinics/[slug]`, `/partners/clinics`
  - `run5`: mobile results-first listing flow, jump-to-filters interaction, and clinic map dialog at `375x700`
  - `run6`: touch-target metrics for the listing jump CTA and partner category tabs
- `mobile_ui_reviewer` passes:
  - pass 1: found one `6/10` listing mobile hierarchy issue, fixed in this branch
  - pass 2: no phase-relevant findings above `5/10`
  - pass 3: no phase-relevant findings above `5/10`

Screenshots:
- listing comparison mobile matrix and filtered state
- clinic detail mobile matrix and expanded map dialog at `375x700`
- partner clinics mobile process/category fallback states

## Development
- closes #962
- parent #356
