### PR TITLE
fix: backfill public shell mobile story coverage

### DIFF
--- a/src/components/templates/Header/Nav/index.tsx
+++ b/src/components/templates/Header/Nav/index.tsx
@@ -106,7 +106,7 @@ const MobileMenu: React.FC<{
   return (
     <nav
       id={mobileMenuId}
-      className="absolute inset-x-0 top-full z-40 max-h-[calc(100svh-var(--site-header-height))] overflow-y-auto overscroll-contain border-t border-border bg-zinc-50/98 shadow-lg backdrop-blur md:hidden"
+      className="absolute inset-x-0 top-full z-40 max-h-[calc(100svh-var(--site-header-height))] overflow-y-auto overscroll-contain border-t border-border bg-zinc-50/98 shadow-lg backdrop-blur lg:hidden"
       aria-label="Mobile navigation"
     >
       <div className="flex flex-col px-5 py-3">
@@ -238,7 +238,7 @@ export const HeaderNav: React.FC<{ navItems: HeaderNavItem[] }> = ({ navItems })
   useEffect(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
 
-    const mediaQuery = window.matchMedia('(min-width: 768px)')
+    const mediaQuery = window.matchMedia('(min-width: 1024px)')
     const handleChange = (event: MediaQueryListEvent) => {
       if (event.matches) {
         setMobileOpen(false)
@@ -266,7 +266,7 @@ export const HeaderNav: React.FC<{ navItems: HeaderNavItem[] }> = ({ navItems })
   return (
     <>
       {/* Desktop nav */}
-      <nav ref={desktopNavRef} className="hidden items-center gap-4 md:flex md:gap-6" aria-label="Main navigation">
+      <nav ref={desktopNavRef} className="hidden items-center gap-4 lg:flex lg:gap-6" aria-label="Main navigation">
         {items.map((item, i) => {
           const itemKey = getNavItemKey(item, i)
 
@@ -307,7 +307,7 @@ export const HeaderNav: React.FC<{ navItems: HeaderNavItem[] }> = ({ navItems })
       {/* Mobile hamburger toggle */}
       <button
         type="button"
-        className="inline-flex size-11 items-center justify-center rounded-md text-foreground transition-colors hover:bg-zinc-100 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden md:hidden"
+        className="inline-flex size-11 items-center justify-center rounded-md text-foreground transition-colors hover:bg-zinc-100 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden lg:hidden"
         aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
         aria-controls={mobileMenuId}
         aria-expanded={mobileOpen}

--- a/src/stories/molecules/ImmersiveVideoHero.stories.tsx
+++ b/src/stories/molecules/ImmersiveVideoHero.stories.tsx
@@ -3,6 +3,7 @@ import { expect, within } from '@storybook/test'
 
 import { ImmersiveVideoHero } from '@/components/molecules/ImmersiveVideoHero'
 import clinicHospitalExterior from '@/stories/assets/clinic-hospital-exterior.jpg'
+import { withViewportStory } from '../utils/viewportMatrix'
 
 const meta = {
   title: 'Shared/Molecules/ImmersiveVideoHero',
@@ -107,3 +108,27 @@ export const MissingVideo: Story = {
     await expect(canvas.getByTestId('hero-video-placeholder')).toBeInTheDocument()
   },
 }
+
+export const WithCrossfade320: Story = withViewportStory(WithCrossfade, 'public320', 'With crossfade / 320')
+export const WithCrossfade375: Story = withViewportStory(WithCrossfade, 'public375', 'With crossfade / 375')
+export const WithCrossfade640: Story = withViewportStory(WithCrossfade, 'public640', 'With crossfade / 640')
+export const WithCrossfade768: Story = withViewportStory(WithCrossfade, 'public768', 'With crossfade / 768')
+export const WithCrossfade1024: Story = withViewportStory(WithCrossfade, 'public1024', 'With crossfade / 1024')
+export const WithCrossfade1280: Story = withViewportStory(WithCrossfade, 'public1280', 'With crossfade / 1280')
+export const WithCrossfade320Short: Story = withViewportStory(
+  WithCrossfade,
+  'public320Short',
+  'With crossfade / 320 short',
+)
+export const WithCrossfade375Short: Story = withViewportStory(
+  WithCrossfade,
+  'public375Short',
+  'With crossfade / 375 short',
+)
+
+export const MissingVideo320: Story = withViewportStory(MissingVideo, 'public320', 'Missing video / 320')
+export const MissingVideo375: Story = withViewportStory(MissingVideo, 'public375', 'Missing video / 375')
+export const MissingVideo640: Story = withViewportStory(MissingVideo, 'public640', 'Missing video / 640')
+export const MissingVideo768: Story = withViewportStory(MissingVideo, 'public768', 'Missing video / 768')
+export const MissingVideo1024: Story = withViewportStory(MissingVideo, 'public1024', 'Missing video / 1024')
+export const MissingVideo1280: Story = withViewportStory(MissingVideo, 'public1280', 'Missing video / 1280')

--- a/src/stories/templates/Footer.stories.tsx
+++ b/src/stories/templates/Footer.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, within } from '@storybook/test'
 import { Footer } from '@/components/templates/Footer/Component'
 import { footerData } from './fixtures'
 import { withMockRouter } from '../utils/routerDecorator'
 import { normalizeFooterNavGroups } from '@/utilities/normalizeNavItems'
+import { withViewportStory } from '../utils/viewportMatrix'
 
 const normalizedFooterGroups = normalizeFooterNavGroups(footerData)
 const denseFooterGroups = normalizedFooterGroups.map((group, index) => ({
@@ -41,6 +43,12 @@ export const FocusedLegalLinks: Story = {
       informationLinks: footerData.informationLinks?.slice(0, 1) ?? null,
     }),
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByRole('link', { name: /imprint/i })).toBeInTheDocument()
+    await expect(canvas.queryByRole('link', { name: /patient guidance/i })).not.toBeInTheDocument()
+  },
 }
 
 export const WithoutNavLinks: Story = {
@@ -58,4 +66,48 @@ export const DenseContent: Story = {
   args: {
     footerGroups: denseFooterGroups,
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByRole('link', { name: /patient guidance/i })).toBeInTheDocument()
+    await expect(canvas.getByRole('link', { name: /imprint/i })).toBeInTheDocument()
+  },
 }
+
+export const FocusedLegalLinks320: Story = withViewportStory(
+  FocusedLegalLinks,
+  'public320',
+  'Focused legal links / 320',
+)
+export const FocusedLegalLinks375: Story = withViewportStory(
+  FocusedLegalLinks,
+  'public375',
+  'Focused legal links / 375',
+)
+export const FocusedLegalLinks640: Story = withViewportStory(
+  FocusedLegalLinks,
+  'public640',
+  'Focused legal links / 640',
+)
+export const FocusedLegalLinks768: Story = withViewportStory(
+  FocusedLegalLinks,
+  'public768',
+  'Focused legal links / 768',
+)
+export const FocusedLegalLinks1024: Story = withViewportStory(
+  FocusedLegalLinks,
+  'public1024',
+  'Focused legal links / 1024',
+)
+export const FocusedLegalLinks1280: Story = withViewportStory(
+  FocusedLegalLinks,
+  'public1280',
+  'Focused legal links / 1280',
+)
+
+export const DenseContent320: Story = withViewportStory(DenseContent, 'public320', 'Dense content / 320')
+export const DenseContent375: Story = withViewportStory(DenseContent, 'public375', 'Dense content / 375')
+export const DenseContent640: Story = withViewportStory(DenseContent, 'public640', 'Dense content / 640')
+export const DenseContent768: Story = withViewportStory(DenseContent, 'public768', 'Dense content / 768')
+export const DenseContent1024: Story = withViewportStory(DenseContent, 'public1024', 'Dense content / 1024')
+export const DenseContent1280: Story = withViewportStory(DenseContent, 'public1280', 'Dense content / 1280')

--- a/src/stories/templates/Header.stories.tsx
+++ b/src/stories/templates/Header.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, userEvent, waitFor, within } from '@storybook/test'
 import { Header } from '@/components/templates/Header/Component'
 import { headerData, headerDataWithSubmenus } from './fixtures'
 import { withMockRouter } from '../utils/routerDecorator'
 import { normalizeHeaderNavItems } from '@/utilities/normalizeNavItems'
+import { withViewportStory } from '../utils/viewportMatrix'
 
 const navItems = normalizeHeaderNavItems(headerData)
 const navItemsWithSubs = normalizeHeaderNavItems(headerDataWithSubmenus)
@@ -38,6 +40,24 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+const runMobileDenseNavigationFlow: NonNullable<Story['play']> = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+
+  await userEvent.click(canvas.getByRole('button', { name: /open menu/i }))
+
+  const mobileNav = canvas.getByLabelText('Mobile navigation')
+  const mobileCanvas = within(mobileNav)
+  const clinicsTrigger = mobileCanvas.getByRole('button', { name: 'Compare international clinics' })
+
+  await userEvent.click(clinicsTrigger)
+  await expect(mobileCanvas.getByRole('link', { name: /all clinics and treatment guidance/i })).toBeInTheDocument()
+
+  await userEvent.click(canvas.getByRole('button', { name: /close menu/i }))
+  await waitFor(() => {
+    expect(canvas.queryByLabelText('Mobile navigation')).not.toBeInTheDocument()
+  })
+}
+
 /** Header with flat navigation items (no submenus). */
 export const Default: Story = {}
 
@@ -61,3 +81,27 @@ export const DenseNavigation: Story = {
     navItems: denseNavItems,
   },
 }
+
+export const DenseNavigation320: Story = withViewportStory(DenseNavigation, 'public320', 'Dense navigation / 320')
+export const DenseNavigation375: Story = withViewportStory(DenseNavigation, 'public375', 'Dense navigation / 375')
+export const DenseNavigation640: Story = withViewportStory(DenseNavigation, 'public640', 'Dense navigation / 640')
+export const DenseNavigation768: Story = withViewportStory(DenseNavigation, 'public768', 'Dense navigation / 768')
+export const DenseNavigation1024: Story = withViewportStory(DenseNavigation, 'public1024', 'Dense navigation / 1024')
+export const DenseNavigation1280: Story = withViewportStory(DenseNavigation, 'public1280', 'Dense navigation / 1280')
+export const DenseNavigation320Short: Story = withViewportStory(
+  DenseNavigation,
+  'public320Short',
+  'Dense navigation / 320 short',
+)
+export const DenseNavigation375Short: Story = withViewportStory(
+  DenseNavigation,
+  'public375Short',
+  'Dense navigation / 375 short',
+)
+
+DenseNavigation320.play = runMobileDenseNavigationFlow
+DenseNavigation375.play = runMobileDenseNavigationFlow
+DenseNavigation640.play = runMobileDenseNavigationFlow
+DenseNavigation768.play = runMobileDenseNavigationFlow
+DenseNavigation320Short.play = runMobileDenseNavigationFlow
+DenseNavigation375Short.play = runMobileDenseNavigationFlow

--- a/src/stories/templates/HoldingPageConcept.stories.tsx
+++ b/src/stories/templates/HoldingPageConcept.stories.tsx
@@ -1,12 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect, within } from '@storybook/test'
+import { expect, userEvent, waitFor, within } from '@storybook/test'
 
 import { HoldingPageConcept } from '@/components/templates/HoldingPageConcept'
 import { holdingPageConcept } from '@/stories/fixtures/holdingPageConcepts'
+import { createMockFetchDecorator } from '../utils/fetchDecorator'
+import { createDelayedJsonResponse } from '../utils/mockHelpers'
+import { withViewportStory } from '../utils/viewportMatrix'
+
+const mockFetch: typeof fetch = async () => createDelayedJsonResponse({ success: true })
 
 const meta = {
   title: 'Internal/Landing/Templates/HoldingPageConcept',
   component: HoldingPageConcept,
+  decorators: [createMockFetchDecorator(mockFetch)],
   parameters: {
     layout: 'fullscreen',
     docs: {
@@ -127,3 +133,61 @@ export const MobileStress: Story = {
   args: mobileStressArgs,
   play: assertConceptFrame,
 }
+
+const mobileStressSubmitBase: Story = {
+  args: mobileStressArgs,
+  play: async ({ args, canvasElement }) => {
+    await assertConceptFrame({ args, canvasElement } as Parameters<NonNullable<Story['play']>>[0])
+
+    const canvas = within(canvasElement)
+    const heroCta = canvas.getByRole('link', { name: String(args.primaryCtaLabel) })
+
+    await userEvent.click(heroCta)
+    await waitFor(() => {
+      expect(window.location.hash).toBe('#contact')
+    })
+
+    if (window.innerWidth >= 640) {
+      await userEvent.click(canvas.getByRole('link', { name: 'Scroll down' }))
+      await waitFor(() => {
+        expect(window.location.hash).toBe('#landing-content-start')
+      })
+    }
+
+    await userEvent.click(canvas.getByRole('button', { name: String(args.primaryCtaLabel) }))
+
+    await waitFor(() => {
+      expect(canvas.getByText('Email is required.')).toBeInTheDocument()
+    })
+
+    await userEvent.type(canvas.getByLabelText('Name'), 'Taylor Brooks')
+    await userEvent.type(canvas.getByLabelText('Email'), 'taylor@findmydoc.com')
+    await userEvent.type(
+      canvas.getByLabelText('Message'),
+      'Please keep me updated about the launch timeline and early access options.',
+    )
+
+    await userEvent.click(canvas.getByRole('button', { name: String(args.primaryCtaLabel) }))
+
+    await waitFor(() => {
+      expect(canvas.getByText('Your request has been sent successfully.')).toBeInTheDocument()
+    })
+  },
+}
+
+export const MobileStress320: Story = withViewportStory(mobileStressSubmitBase, 'public320', 'Mobile stress / 320')
+export const MobileStress375: Story = withViewportStory(mobileStressSubmitBase, 'public375', 'Mobile stress / 375')
+export const MobileStress640: Story = withViewportStory(mobileStressSubmitBase, 'public640', 'Mobile stress / 640')
+export const MobileStress768: Story = withViewportStory(mobileStressSubmitBase, 'public768', 'Mobile stress / 768')
+export const MobileStress1024: Story = withViewportStory(mobileStressSubmitBase, 'public1024', 'Mobile stress / 1024')
+export const MobileStress1280: Story = withViewportStory(mobileStressSubmitBase, 'public1280', 'Mobile stress / 1280')
+export const MobileStress320Short: Story = withViewportStory(
+  mobileStressSubmitBase,
+  'public320Short',
+  'Mobile stress / 320 short',
+)
+export const MobileStress375Short: Story = withViewportStory(
+  mobileStressSubmitBase,
+  'public375Short',
+  'Mobile stress / 375 short',
+)

--- a/src/stories/utils/viewportMatrix.ts
+++ b/src/stories/utils/viewportMatrix.ts
@@ -1,0 +1,125 @@
+const VIEWPORT_HEIGHT = '900px'
+const SHORT_VIEWPORT_HEIGHT = '700px'
+
+export const PUBLIC_STORYBOOK_VIEWPORTS = {
+  public320: {
+    name: 'Public 320',
+    styles: { width: '320px', height: VIEWPORT_HEIGHT },
+    type: 'mobile',
+  },
+  public375: {
+    name: 'Public 375',
+    styles: { width: '375px', height: VIEWPORT_HEIGHT },
+    type: 'mobile',
+  },
+  public640: {
+    name: 'Public 640',
+    styles: { width: '640px', height: VIEWPORT_HEIGHT },
+    type: 'mobile',
+  },
+  public768: {
+    name: 'Public 768',
+    styles: { width: '768px', height: VIEWPORT_HEIGHT },
+    type: 'tablet',
+  },
+  public1024: {
+    name: 'Public 1024',
+    styles: { width: '1024px', height: VIEWPORT_HEIGHT },
+    type: 'desktop',
+  },
+  public1280: {
+    name: 'Public 1280',
+    styles: { width: '1280px', height: VIEWPORT_HEIGHT },
+    type: 'desktop',
+  },
+  public320Short: {
+    name: 'Public 320 short',
+    styles: { width: '320px', height: SHORT_VIEWPORT_HEIGHT },
+    type: 'mobile',
+  },
+  public375Short: {
+    name: 'Public 375 short',
+    styles: { width: '375px', height: SHORT_VIEWPORT_HEIGHT },
+    type: 'mobile',
+  },
+} as const
+
+export type PublicViewportKey = keyof typeof PUBLIC_STORYBOOK_VIEWPORTS
+
+const PUBLIC_STORYBOOK_VIEWPORT_WIDTHS: Record<PublicViewportKey, number> = {
+  public320: 320,
+  public375: 375,
+  public640: 640,
+  public768: 768,
+  public1024: 1024,
+  public1280: 1280,
+  public320Short: 320,
+  public375Short: 375,
+}
+
+export const FULL_VIEWPORT_MATRIX_PARAMETERS = {
+  chromatic: {
+    viewports: Object.values(PUBLIC_STORYBOOK_VIEWPORT_WIDTHS),
+  },
+}
+
+export const VIEWPORT_STORY_PARAMETERS: Record<
+  PublicViewportKey,
+  {
+    chromatic: { viewports: [number] }
+    viewport: { options: typeof PUBLIC_STORYBOOK_VIEWPORTS }
+  }
+> = Object.fromEntries(
+  Object.entries(PUBLIC_STORYBOOK_VIEWPORT_WIDTHS).map(([key, width]) => [
+    key,
+    {
+      chromatic: { viewports: [width] },
+      viewport: { options: PUBLIC_STORYBOOK_VIEWPORTS },
+    },
+  ]),
+) as Record<
+  PublicViewportKey,
+  {
+    chromatic: { viewports: [number] }
+    viewport: { options: typeof PUBLIC_STORYBOOK_VIEWPORTS }
+  }
+>
+
+type StoryLike = {
+  globals?: Record<string, unknown>
+  name?: string
+  parameters?: Record<string, unknown>
+}
+
+export function withViewportStory<T extends StoryLike>(story: T, viewport: PublicViewportKey, name: string): T {
+  const viewportParameters = VIEWPORT_STORY_PARAMETERS[viewport]
+  const currentParameters = story.parameters ?? {}
+  const currentChromatic = (currentParameters.chromatic as Record<string, unknown> | undefined) ?? {}
+  const currentViewport = (currentParameters.viewport as Record<string, unknown> | undefined) ?? {}
+  const currentGlobals = story.globals ?? {}
+  const currentViewportGlobals = (currentGlobals.viewport as Record<string, unknown> | undefined) ?? {}
+
+  return {
+    ...story,
+    globals: {
+      ...currentGlobals,
+      viewport: {
+        ...currentViewportGlobals,
+        value: viewport,
+        isRotated: false,
+      },
+    },
+    name,
+    parameters: {
+      ...currentParameters,
+      chromatic: {
+        ...currentChromatic,
+        ...viewportParameters.chromatic,
+      },
+      viewport: {
+        ...currentViewport,
+        ...viewportParameters.viewport,
+      },
+    },
+  }
+}


### PR DESCRIPTION
Public shell and holding-page mobile stories now cover the full viewport matrix, and the header stays in its mobile drawer state through 768px to avoid tablet overflow.

## What changed
- backfilled Storybook viewport coverage for `Header`, `Footer`, `HoldingPageConcept`, and `ImmersiveVideoHero` across `320/375/640/768/1024/1280`
- added short-height stories and interaction flows for the mobile header drawer and the holding-page hero-to-contact path
- introduced a shared Storybook viewport helper for the public mobile matrix on `main`
- tightened the public header breakpoint from `md` to `lg` so long navigation labels do not overflow at `768px`

## Validation
- `pnpm format`
- `pnpm check`
- `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build`
- `pnpm stories:governance:check`
- `pnpm vitest --project storybook --run`
- `mobile_ui_reviewer` x3

Screenshots:
- `output/playwright/review-pr955-pass3/header-dense-768-open.png`
- `output/playwright/review-pr955-pass3/header-dense-320x700-open.png`
- `output/playwright/review-pr955-pass3/holding-mobile-stress-320-contact.png`
- `output/playwright/review-pr955-pass3/holding-mobile-stress-320-errors.png`
- `output/playwright/review-pr955-pass3/footer-dense-320.png`
- `output/playwright/review-pr955-pass3/video-hero-320x700.png`

## Development
- closes #973
- parent #356
