### PR TITLE
fix: skip protocol-relative links in specialty query

### DIFF
--- a/src/components/organisms/Landing/LandingCategories.shared.ts
+++ b/src/components/organisms/Landing/LandingCategories.shared.ts
@@ -104,7 +104,7 @@ export function buildCategoryTabs(categories: LandingCategory[]): LandingCategor
 }
 
 export function withSpecialtyQuery(href: string, specialtyId: string | null) {
-  if (!href.startsWith('/')) return href
+  if (!href.startsWith('/') || href.startsWith('//')) return href
 
   const hashIndex = href.indexOf('#')
   const pathAndQuery = hashIndex >= 0 ? href.slice(0, hashIndex) : href

--- a/tests/unit/components/landingCategoriesShared.test.ts
+++ b/tests/unit/components/landingCategoriesShared.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, it } from 'vitest'
 import { withSpecialtyQuery } from '@/components/organisms/Landing/LandingCategories.shared'
 
 describe('withSpecialtyQuery', () => {
+  it('does not rewrite protocol-relative external links', () => {
+    const href = withSpecialtyQuery('//findmydoc.eu/listing-comparison#overview', 'nose')
+
+    expect(href).toBe('//findmydoc.eu/listing-comparison#overview')
+  })
+
   it('keeps full hash fragments when a specialty is added', () => {
     const href = withSpecialtyQuery('/listing-comparison#overview#details', 'nose')
 


### PR DESCRIPTION
Landing category specialty links no longer rewrite protocol-relative external URLs.

## What changed
- updated `withSpecialtyQuery` to skip protocol-relative URLs (`//...`) and only rewrite true internal paths
- added a regression unit test to assert that protocol-relative links are returned unchanged

## Validation
- `pnpm vitest run tests/unit/components/landingCategoriesShared.test.ts`
- `pnpm check`
- `pnpm format`

## Development
- closes #979
