### PR TITLE
fix: improve mobile-first public layouts

### DIFF
--- a/src/app/(frontend)/admin/login/page.tsx
+++ b/src/app/(frontend)/admin/login/page.tsx
@@ -104,7 +104,7 @@ export default async function LoginPage({
   }
 
   return (
-    <div className="flex flex-col items-center justify-center gap-6 p-6 md:p-10">
+    <div className="flex min-h-svh flex-col items-center justify-start gap-5 px-6 pt-6 pb-44 md:justify-center md:gap-6 md:p-10">
       {showPreviewLogo ? (
         <Logo loading="eager" priority="high" className="h-16" showPreviewBadge={showPreviewBadge} />
       ) : null}

--- a/src/app/(frontend)/listing-comparison/ListingComparisonFilters.client.tsx
+++ b/src/app/(frontend)/listing-comparison/ListingComparisonFilters.client.tsx
@@ -52,6 +52,9 @@ export type ListingComparisonFiltersProps = {
   priceBounds?: PriceBounds
   initialValues?: ListingComparisonFilterValues
   onChange?: (filters: ListingComparisonFilterValues) => void
+  defaultOpenSections?: Partial<
+    Record<'city' | 'waitTime' | 'medicalSpecialty' | 'subspecialty' | 'treatment', boolean>
+  >
 }
 
 type CollapsibleFilterSectionProps = {
@@ -206,6 +209,7 @@ export function ListingComparisonFilters({
   priceBounds,
   initialValues,
   onChange,
+  defaultOpenSections,
 }: ListingComparisonFiltersProps) {
   const normalizedPriceBounds = React.useMemo(() => normalizePriceBounds(priceBounds), [priceBounds])
   const activePriceBounds = React.useMemo(
@@ -221,11 +225,11 @@ export function ListingComparisonFilters({
   )
 
   const [openSections, setOpenSections] = React.useState({
-    city: true,
-    waitTime: true,
-    medicalSpecialty: true,
-    subspecialty: true,
-    treatment: true,
+    city: defaultOpenSections?.city ?? true,
+    waitTime: defaultOpenSections?.waitTime ?? false,
+    medicalSpecialty: defaultOpenSections?.medicalSpecialty ?? false,
+    subspecialty: defaultOpenSections?.subspecialty ?? false,
+    treatment: defaultOpenSections?.treatment ?? false,
   })
 
   const [cities, setCities] = React.useState<string[]>(initialValues?.cities ?? [])

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -56,12 +56,41 @@ export default async function Home({
   }
 
   const payload = await getPayload({ config: configPromise })
-  const [posts, landingSpecialtyCategories] = await Promise.all([
+  const [posts, landingSpecialtyCategories, cityResult] = await Promise.all([
     findLatestPosts(payload, 3),
     getLandingMedicalSpecialtyCategories(payload),
+    payload.find({
+      collection: 'cities',
+      depth: 0,
+      limit: 250,
+      overrideAccess: false,
+      pagination: false,
+      sort: 'name',
+      select: {
+        id: true,
+        name: true,
+      },
+    }),
   ])
 
   const normalizedPosts = posts.map(normalizePost)
+  const heroServiceOptions = landingSpecialtyCategories.items.map((item) => ({
+    label: item.title,
+    value: item.id,
+  }))
+  const heroLocationOptions = (cityResult.docs as Array<{ id: number; name?: string | null }>).flatMap((city) => {
+    const label = typeof city.name === 'string' ? city.name.trim() : ''
+    if (label.length === 0) {
+      return []
+    }
+
+    return [
+      {
+        label,
+        value: String(city.id),
+      },
+    ]
+  })
 
   return (
     <main>
@@ -70,6 +99,10 @@ export default async function Home({
         description="Compare selected aesthetic clinics in Turkey in a transparent and structured way. Our platform helps you understand treatment options, review clinic information and contact clinics directly with confidence."
         image="/images/landing/home-hero-telemedicine.jpg"
         variant="homepage"
+        searchOptions={{
+          service: heroServiceOptions,
+          location: heroLocationOptions,
+        }}
       />
 
       <LandingTestimonials
@@ -98,6 +131,7 @@ export default async function Home({
         ]}
         title="Expert feedback"
         description="Perspectives from healthcare and product experts who reviewed the patient decision flow."
+        className="md:pt-28"
       />
 
       <LandingCategories

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -48,6 +48,7 @@ import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc056
 import { default as default_ab46816a001b0b96177fe198da5e9467 } from '@/components/organisms/DeveloperDashboard'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
+/** @type import('payload').ImportMap */
 export const importMap = {
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,

--- a/src/components/atoms/checkbox.tsx
+++ b/src/components/atoms/checkbox.tsx
@@ -12,7 +12,7 @@ const Checkbox: React.FC<
 > = ({ className, ref, ...props }) => (
   <CheckboxPrimitive.Root
     className={cn(
-      'peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      'peer h-5 w-5 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
       className,
     )}
     ref={ref}

--- a/src/components/atoms/combobox.tsx
+++ b/src/components/atoms/combobox.tsx
@@ -23,6 +23,7 @@ export type ComboboxProps = {
   className?: string
   buttonClassName?: string
   contentClassName?: string
+  disabled?: boolean
 }
 
 export const Combobox: React.FC<ComboboxProps> = ({
@@ -35,6 +36,7 @@ export const Combobox: React.FC<ComboboxProps> = ({
   className,
   buttonClassName,
   contentClassName,
+  disabled = false,
 }) => {
   const [open, setOpen] = React.useState(false)
 
@@ -49,6 +51,7 @@ export const Combobox: React.FC<ComboboxProps> = ({
           aria-expanded={open}
           variant="outline"
           className={cn('w-full justify-between', buttonClassName)}
+          disabled={disabled}
         >
           <span className={cn(!selected && 'text-muted-foreground')}>{selected?.label ?? placeholder}</span>
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" aria-hidden="true" />

--- a/src/components/molecules/CheckboxWithLabel/index.tsx
+++ b/src/components/molecules/CheckboxWithLabel/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { ComponentProps } from 'react'
+import { useId, type ComponentProps } from 'react'
 import { Checkbox } from '@/components/atoms/checkbox'
 import { cn } from '@/utilities/ui'
 
@@ -23,22 +23,42 @@ export function CheckboxWithLabel({
   labelClassName,
   onCheckedChange,
 }: CheckboxWithLabelProps) {
+  const checkboxId = useId()
+
   const handleCheckedChange: ComponentProps<typeof Checkbox>['onCheckedChange'] = (next) => {
     if (typeof next !== 'boolean') return
     onCheckedChange?.(next)
   }
 
+  const toggleSelection = () => {
+    if (disabled) return
+    onCheckedChange?.(!checked)
+  }
+
   return (
-    <label className={cn('flex items-start gap-3', disabled && 'cursor-not-allowed', className)}>
+    <div
+      className={cn(
+        'flex min-h-11 cursor-pointer items-start gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-muted/40',
+        disabled && 'cursor-not-allowed opacity-60 hover:bg-transparent',
+        className,
+      )}
+      onClick={toggleSelection}
+      role="presentation"
+    >
       <Checkbox
+        aria-labelledby={`${checkboxId}-label`}
         checked={checked}
         disabled={disabled}
-        className={checkboxClassName}
+        className={cn('mt-0.5 h-5 w-5', checkboxClassName)}
         onCheckedChange={handleCheckedChange}
+        onClick={(event) => event.stopPropagation()}
       />
-      <span className={cn('min-w-0 flex-1 pt-0.5 text-sm leading-5 font-normal break-words', labelClassName)}>
+      <span
+        id={`${checkboxId}-label`}
+        className={cn('min-w-0 flex-1 pt-0.5 text-sm leading-5 font-normal break-words', labelClassName)}
+      >
         {label}
       </span>
-    </label>
+    </div>
   )
 }

--- a/src/components/molecules/ClinicSearchBar/index.tsx
+++ b/src/components/molecules/ClinicSearchBar/index.tsx
@@ -58,6 +58,8 @@ export const ClinicSearchBar: React.FC<ClinicSearchBarProps> = ({
             onValueChange={(service) => onValuesChange({ ...values, service })}
             placeholder="Select a service"
             searchPlaceholder="Search services…"
+            emptyLabel="No services available."
+            disabled={serviceOptions.length === 0}
             buttonClassName={cn(
               'h-auto w-full justify-between border-0 bg-transparent px-0 py-1 text-left text-base font-medium',
               'shadow-none hover:bg-transparent',
@@ -77,6 +79,8 @@ export const ClinicSearchBar: React.FC<ClinicSearchBarProps> = ({
             onValueChange={(location) => onValuesChange({ ...values, location })}
             placeholder="Select a location"
             searchPlaceholder="Search locations…"
+            emptyLabel="No locations available."
+            disabled={locationOptions.length === 0}
             buttonClassName={cn(
               'h-auto w-full justify-between border-0 bg-transparent px-0 py-1 text-left text-base font-medium',
               'shadow-none hover:bg-transparent',

--- a/src/components/molecules/Media/ImageMedia/index.tsx
+++ b/src/components/molecules/Media/ImageMedia/index.tsx
@@ -19,6 +19,7 @@ export const ImageMedia: React.FC<MediaProps> = (props) => {
     size: sizeFromProps,
     src: srcFromProps,
     loading: loadingFromProps,
+    onError,
     width,
     height,
   } = props
@@ -46,6 +47,7 @@ export const ImageMedia: React.FC<MediaProps> = (props) => {
       priority={priority}
       quality={DEFAULT_IMAGE_QUALITY}
       loading={loading}
+      onError={onError}
       sizes={sizes}
       src={src}
       width={!fill ? width : undefined}

--- a/src/components/molecules/Media/types.ts
+++ b/src/components/molecules/Media/types.ts
@@ -8,6 +8,7 @@ export interface Props {
   htmlElement?: ElementType | null
   imgClassName?: string
   onClick?: () => void
+  onError?: () => void
   onLoad?: () => void
   loading?: 'lazy' | 'eager' // for NextImage only
   priority?: boolean // for NextImage only

--- a/src/components/molecules/SectionHeading/index.tsx
+++ b/src/components/molecules/SectionHeading/index.tsx
@@ -28,8 +28,8 @@ const sectionHeadingVariants = cva('flex w-full flex-col gap-6', {
 const titleVariants = cva('font-bold tracking-tight', {
   variants: {
     size: {
-      section: 'text-4xl md:text-5xl',
-      hero: 'text-5xl leading-tight md:text-7xl',
+      section: 'text-3xl sm:text-4xl md:text-5xl',
+      hero: 'text-4xl leading-tight sm:text-5xl md:text-7xl',
     },
     tone: {
       default: 'text-foreground',
@@ -45,8 +45,8 @@ const titleVariants = cva('font-bold tracking-tight', {
 const descriptionVariants = cva('', {
   variants: {
     size: {
-      section: 'text-lg text-foreground/80 md:text-xl',
-      hero: 'text-xl text-foreground/80 md:text-2xl',
+      section: 'text-base text-foreground/80 sm:text-lg md:text-xl',
+      hero: 'text-base text-foreground/80 sm:text-lg md:text-2xl',
     },
     tone: {
       default: '',
@@ -88,7 +88,15 @@ export const SectionHeading: React.FC<SectionHeadingProps> = ({
       <HeadingTag id={titleId} className={cn(titleVariants({ size, tone }), titleClassName)}>
         {title}
       </HeadingTag>
-      <p className={cn(descriptionVariants({ size, tone }), descriptionClassName)}>{description}</p>
+      <p
+        className={cn(
+          descriptionVariants({ size, tone }),
+          align === 'center' ? 'mx-auto max-w-3xl text-balance' : 'max-w-3xl text-pretty',
+          descriptionClassName,
+        )}
+      >
+        {description}
+      </p>
     </header>
   )
 }

--- a/src/components/organisms/CookieConsent/CookieConsentLauncher.client.tsx
+++ b/src/components/organisms/CookieConsent/CookieConsentLauncher.client.tsx
@@ -11,17 +11,17 @@ type CookieConsentLauncherProps = {
 
 export function CookieConsentLauncher({ label, onOpenSettings }: CookieConsentLauncherProps) {
   return (
-    <div className="fixed right-4 [bottom:calc(env(safe-area-inset-bottom)+1rem)] z-50 sm:right-6 sm:[bottom:calc(env(safe-area-inset-bottom)+1.5rem)]">
+    <div className="fixed right-3 [bottom:calc(env(safe-area-inset-bottom)+0.875rem)] z-40 sm:right-6 sm:[bottom:calc(env(safe-area-inset-bottom)+1.5rem)]">
       <Button
         type="button"
         variant="outline"
         size="clear"
         aria-label={label}
-        className="group inline-flex h-12 w-12 items-center justify-start overflow-hidden rounded-full border border-border/80 bg-background/95 px-3 text-sm font-medium shadow-lg backdrop-blur-md transition-[width,box-shadow,background-color] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:w-[9.75rem] focus-visible:w-[9.75rem] sm:hover:w-[10.25rem] sm:focus-visible:w-[10.25rem]"
+        className="group inline-flex h-11 w-11 items-center justify-center overflow-hidden rounded-full border border-border/80 bg-background/95 px-0 text-sm font-medium shadow-lg backdrop-blur-md transition-[width,box-shadow,background-color] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] sm:h-12 sm:w-12 sm:justify-start sm:px-3 sm:hover:w-[10.25rem] sm:focus-visible:w-[10.25rem]"
         onClick={onOpenSettings}
       >
         <Cookie className="size-4 shrink-0 text-primary" aria-hidden="true" />
-        <span className="pointer-events-none max-w-0 translate-x-2 overflow-hidden pl-0 text-left leading-none whitespace-nowrap opacity-0 transition-[max-width,opacity,transform,padding-left] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:max-w-[9rem] group-hover:translate-x-0 group-hover:pl-2 group-hover:opacity-100 group-focus-visible:max-w-[9rem] group-focus-visible:translate-x-0 group-focus-visible:pl-2 group-focus-visible:opacity-100 motion-reduce:transition-none">
+        <span className="pointer-events-none hidden max-w-0 translate-x-2 overflow-hidden pl-0 text-left leading-none whitespace-nowrap opacity-0 transition-[max-width,opacity,transform,padding-left] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none sm:inline sm:group-hover:max-w-[9rem] sm:group-hover:translate-x-0 sm:group-hover:pl-2 sm:group-hover:opacity-100 sm:group-focus-visible:max-w-[9rem] sm:group-focus-visible:translate-x-0 sm:group-focus-visible:pl-2 sm:group-focus-visible:opacity-100">
           {label}
         </span>
       </Button>

--- a/src/components/organisms/CookieConsent/CookieConsentManager.client.tsx
+++ b/src/components/organisms/CookieConsent/CookieConsentManager.client.tsx
@@ -13,7 +13,7 @@ type CookieConsentManagerProps = {
   initialConsent: CookieConsentState | null
 }
 
-const compactBannerRoutes = new Set(['/login/patient', '/register/patient', '/register/clinic'])
+const compactBannerRoutes = new Set(['/login/patient', '/register/patient', '/register/clinic', '/admin/login'])
 
 export function CookieConsentManager({ config, initialConsent }: CookieConsentManagerProps) {
   const pathname = usePathname()

--- a/src/components/organisms/Heroes/LandingHero/LandingHeroSearchBar.client.tsx
+++ b/src/components/organisms/Heroes/LandingHero/LandingHeroSearchBar.client.tsx
@@ -3,9 +3,20 @@
 import * as React from 'react'
 import { useRouter } from 'next/navigation'
 
+import type { ComboboxOption } from '@/components/atoms/combobox'
 import { ClinicSearchBar, type ClinicSearchValues } from '@/components/molecules/ClinicSearchBar'
 
-export function LandingHeroSearchBarClient({ className }: { className?: string }) {
+type LandingHeroSearchBarClientProps = {
+  className?: string
+  serviceOptions?: ComboboxOption[]
+  locationOptions?: ComboboxOption[]
+}
+
+export function LandingHeroSearchBarClient({
+  className,
+  serviceOptions,
+  locationOptions,
+}: LandingHeroSearchBarClientProps) {
   const router = useRouter()
   const [values, setValues] = React.useState<ClinicSearchValues>({
     service: '',
@@ -18,6 +29,8 @@ export function LandingHeroSearchBarClient({ className }: { className?: string }
       className={className}
       values={values}
       onValuesChange={setValues}
+      serviceOptions={serviceOptions}
+      locationOptions={locationOptions}
       onSearch={(nextValues) => {
         const params = new URLSearchParams()
         if (nextValues.service.trim().length > 0) {

--- a/src/components/organisms/Heroes/LandingHero/index.tsx
+++ b/src/components/organisms/Heroes/LandingHero/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Image, { type StaticImageData } from 'next/image'
 
+import type { ComboboxOption } from '@/components/atoms/combobox'
 import { Container } from '@/components/molecules/Container'
 import { SectionHeading } from '@/components/molecules/SectionHeading'
 import { LandingHeroSearchBarClient } from './LandingHeroSearchBar.client'
@@ -16,6 +17,10 @@ export type LandingHeroProps = {
     label: string
     icon: React.ReactNode
   }[]
+  searchOptions?: {
+    service: ComboboxOption[]
+    location: ComboboxOption[]
+  }
 }
 
 export const LandingHero: React.FC<LandingHeroProps> = ({
@@ -24,6 +29,7 @@ export const LandingHero: React.FC<LandingHeroProps> = ({
   image,
   variant = 'clinic-landing',
   socialLinks,
+  searchOptions,
 }) => {
   const isHomepage = variant === 'homepage'
   const isClinicLanding = variant === 'clinic-landing'
@@ -31,8 +37,8 @@ export const LandingHero: React.FC<LandingHeroProps> = ({
   return (
     <section
       className={cn(
-        'relative flex items-center justify-center bg-white py-16 sm:py-20',
-        isClinicLanding ? 'min-h-[34rem] overflow-hidden sm:min-h-[48rem]' : 'min-h-[32rem] sm:min-h-[39rem]',
+        'relative flex items-center justify-center bg-white py-14 sm:py-20',
+        isClinicLanding ? 'min-h-[34rem] overflow-hidden sm:min-h-[48rem]' : 'min-h-[32rem] md:min-h-[39rem] md:pb-28',
       )}
     >
       {image ? (
@@ -42,15 +48,23 @@ export const LandingHero: React.FC<LandingHeroProps> = ({
         </div>
       ) : null}
 
-      <Container className="relative z-10 flex flex-col items-center text-center">
+      <Container className="relative z-10 flex flex-col items-center gap-8 text-center md:gap-10">
         <SectionHeading
-          className="mb-10 sm:mb-12"
+          className="w-full"
           title={title}
           description={description}
           size="hero"
           align="center"
           headingAs="h1"
         />
+
+        {isHomepage ? (
+          <LandingHeroSearchBarClient
+            className="mx-auto w-full md:hidden"
+            serviceOptions={searchOptions?.service}
+            locationOptions={searchOptions?.location}
+          />
+        ) : null}
 
         {isClinicLanding && Array.isArray(socialLinks) && socialLinks.length > 0 && (
           <div className="flex space-x-6">
@@ -87,8 +101,12 @@ export const LandingHero: React.FC<LandingHeroProps> = ({
       </Container>
 
       {isHomepage && (
-        <div className="absolute bottom-0 left-0 z-20 w-full translate-y-1/2 px-4">
-          <LandingHeroSearchBarClient className="mx-auto" />
+        <div className="absolute right-0 bottom-0 left-0 z-20 hidden w-full translate-y-1/2 px-4 md:block">
+          <LandingHeroSearchBarClient
+            className="mx-auto"
+            serviceOptions={searchOptions?.service}
+            locationOptions={searchOptions?.location}
+          />
         </div>
       )}
     </section>

--- a/src/components/organisms/Landing/LandingFeatures.tsx
+++ b/src/components/organisms/Landing/LandingFeatures.tsx
@@ -43,7 +43,7 @@ export const LandingFeatures: React.FC<LandingFeaturesProps> = ({
   return (
     <SectionBackground
       as="section"
-      className={cn('py-16 sm:py-20', isGreen ? 'bg-accent' : 'bg-white')}
+      className={cn('py-14 sm:py-16 md:py-20', isGreen ? 'bg-accent' : 'bg-white')}
       media={
         backgroundImage
           ? {
@@ -65,7 +65,7 @@ export const LandingFeatures: React.FC<LandingFeaturesProps> = ({
     >
       <Container>
         <SectionHeading
-          className="mb-16"
+          className="mb-10 sm:mb-12 md:mb-16"
           title={title}
           description={description}
           size="section"
@@ -73,21 +73,24 @@ export const LandingFeatures: React.FC<LandingFeaturesProps> = ({
           tone={isGreen ? 'accent' : 'default'}
         />
 
-        <div className="grid gap-12 md:grid-cols-3">
+        <div className="grid gap-8 sm:gap-10 md:grid-cols-3 md:gap-12">
           {features.map((feature, index) => {
             const Icon = feature.icon
             return (
-              <div key={index} className="flex flex-col items-start gap-4 md:flex-row md:items-start md:gap-6">
-                <div className="mb-2 flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-muted md:mb-0">
+              <div
+                key={index}
+                className="flex flex-col items-center gap-4 text-center md:flex-row md:items-start md:gap-6 md:text-left"
+              >
+                <div className="mb-1 flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-muted md:mb-0">
                   <Icon className="h-8 w-8 text-foreground" />
                 </div>
-                <div className="flex flex-col items-start gap-2">
+                <div className="flex flex-col items-center gap-2 md:items-start">
                   <Heading
                     as="h3"
                     size="h2"
-                    align="left"
+                    align="center"
                     className={cn(
-                      'text-3xl sm:text-4xl lg:text-5xl',
+                      'text-center text-2xl sm:text-3xl md:text-left lg:text-5xl',
                       isGreen ? 'text-accent-foreground' : 'text-foreground',
                     )}
                   >
@@ -96,16 +99,19 @@ export const LandingFeatures: React.FC<LandingFeaturesProps> = ({
                   {feature.subtitle ? (
                     <Heading
                       as="h4"
-                      align="left"
+                      align="center"
                       size="h6"
-                      className={cn('text-xl', isGreen ? 'text-accent-foreground' : 'text-foreground')}
+                      className={cn(
+                        'text-center text-lg md:text-left',
+                        isGreen ? 'text-accent-foreground' : 'text-foreground',
+                      )}
                     >
                       {feature.subtitle}
                     </Heading>
                   ) : null}
                   <p
                     className={cn(
-                      'text-left text-base sm:text-lg',
+                      'text-center text-sm sm:text-base md:text-left md:text-lg',
                       isGreen ? 'text-accent-foreground/80' : 'text-muted-foreground',
                     )}
                   >

--- a/src/components/organisms/Landing/LandingTestimonials.tsx
+++ b/src/components/organisms/Landing/LandingTestimonials.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { Container } from '@/components/molecules/Container'
 import { SectionHeading } from '@/components/molecules/SectionHeading'
+import { cn } from '@/utilities/ui'
 
 import { LandingTestimonialsCarouselClient } from './LandingTestimonialsCarousel'
 import type { LandingTestimonial } from './LandingTestimonials.types'
@@ -10,13 +11,19 @@ type LandingTestimonialsProps = {
   testimonials: LandingTestimonial[]
   title: string
   description: string
+  className?: string
 }
-export const LandingTestimonials: React.FC<LandingTestimonialsProps> = ({ testimonials, title, description }) => {
+export const LandingTestimonials: React.FC<LandingTestimonialsProps> = ({
+  testimonials,
+  title,
+  description,
+  className,
+}) => {
   return (
-    <section className="bg-white py-20">
+    <section className={cn('bg-white py-16 sm:py-20', className)}>
       <Container>
         <SectionHeading
-          className="mb-16"
+          className="mb-10 sm:mb-12 md:mb-16"
           title={title}
           titleId="landing-testimonials"
           description={description}

--- a/src/components/organisms/Landing/LandingTestimonialsCarousel.tsx
+++ b/src/components/organisms/Landing/LandingTestimonialsCarousel.tsx
@@ -399,6 +399,35 @@ const Track: React.FC<TrackProps> = ({ className }) => {
   )
 }
 
+const MobileSlide: React.FC = () => {
+  const { testimonials, activeIndex } = useCarouselContext()
+  const testimonial = testimonials[activeIndex]
+
+  if (!testimonial) return null
+
+  return (
+    <div className="px-1 md:hidden">
+      <article className="mx-auto flex w-full max-w-xl flex-col items-center justify-between rounded-3xl border border-border bg-white p-6 text-center shadow-sm">
+        <p className="mb-6 text-base leading-7 font-medium text-muted-foreground sm:text-lg sm:leading-relaxed">
+          &quot;{testimonial.quote}&quot;
+        </p>
+
+        <div className="flex flex-col items-center gap-3">
+          <div className="relative h-16 w-16 overflow-hidden rounded-full">
+            <Image src={testimonial.image} alt={testimonial.author} fill sizes="64px" className="object-cover" />
+          </div>
+          <div className="space-y-1">
+            <Heading as="h4" align="center" size="h6" className="text-lg font-bold text-foreground">
+              {testimonial.author}
+            </Heading>
+            <p className="text-sm font-medium text-muted-foreground">{testimonial.role}</p>
+          </div>
+        </div>
+      </article>
+    </div>
+  )
+}
+
 type DotsProps = {
   className?: string
 }
@@ -445,7 +474,8 @@ export const LandingTestimonialsCarouselClient: React.FC<LandingTestimonialsCaro
 }) => {
   return (
     <Root testimonials={testimonials} className={className} ariaLabel={ariaLabel} labelledById={labelledById}>
-      <Track />
+      <MobileSlide />
+      <Track className="hidden md:block" />
       <Dots />
     </Root>
   )

--- a/src/components/organisms/Listing/ListingCard.tsx
+++ b/src/components/organisms/Listing/ListingCard.tsx
@@ -76,12 +76,12 @@ export function ListingCard({ data, className }: { data: ListingCardData; classN
           {data.priceFrom ? <PriceSummary priceFrom={data.priceFrom} /> : null}
 
           <div className="flex flex-col">
-            <div className="flex items-center gap-3">
+            <div className="flex flex-col items-start gap-2 md:flex-row md:items-center md:gap-3">
               <Heading
                 as="h3"
                 align="left"
                 size="h5"
-                className="text-2xl leading-tight font-semibold text-foreground md:truncate"
+                className="text-xl leading-tight font-semibold text-foreground sm:text-2xl md:truncate"
               >
                 {data.name}
               </Heading>
@@ -102,7 +102,7 @@ export function ListingCard({ data, className }: { data: ListingCardData; classN
           <TagList tags={data.tags} />
         </div>
 
-        <div className="grid shrink-0 grid-cols-2 gap-3 md:flex md:w-36 md:flex-col md:items-end md:pt-1">
+        <div className="flex shrink-0 flex-col gap-3 md:w-36 md:items-end md:pt-1">
           <Button asChild className="h-12 w-full text-sm font-semibold">
             <a href={data.actions.details.href}>{data.actions.details.label}</a>
           </Button>

--- a/src/components/templates/Footer/Component.tsx
+++ b/src/components/templates/Footer/Component.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/atoms/accordion'
 import { Heading } from '@/components/atoms/Heading'
 import { Container } from '@/components/molecules/Container'
 import { UiLink } from '@/components/molecules/Link'
@@ -13,45 +14,113 @@ export type FooterProps = {
   showPreviewBadge?: boolean
 }
 
-export const Footer: React.FC<FooterProps> = ({ footerGroups, logoSrc, showPreviewBadge = false }) => (
-  <footer className="mt-auto border-t border-border/60 bg-background text-foreground">
-    <Container className="py-10 sm:py-12">
-      <div className="flex flex-col gap-10 sm:gap-12">
-        <div className="flex flex-col items-start gap-8 md:flex-row md:items-start md:justify-between md:gap-16">
-          <Logo loading="lazy" priority="low" src={logoSrc} showPreviewBadge={showPreviewBadge} />
+export const Footer: React.FC<FooterProps> = ({ footerGroups, logoSrc, showPreviewBadge = false }) => {
+  const isLegalLink = (href: string) => href.includes('/privacy') || href.includes('/imprint')
+  const legalQuickLinks = footerGroups
+    .flatMap((group) => group.items)
+    .filter((link) => isLegalLink(link.href))
+    .filter((link, index, links) => links.findIndex((candidate) => candidate.href === link.href) === index)
+  const mobileFooterGroups = footerGroups.map((group) => ({
+    ...group,
+    items: group.items.filter((link) => !isLegalLink(link.href)),
+  }))
 
-          <nav aria-label="Footer primary" className="w-full md:flex-1">
-            <div className="flex flex-col gap-8 sm:gap-10 md:flex-row md:items-start md:justify-between md:gap-x-6">
-              {footerGroups.map((group) => (
-                <div key={group.title} className="flex flex-col items-start gap-4 pt-0 pl-1.5 md:flex-1 md:basis-0">
-                  <Heading as="h4" size="h6" align="left" className="text-lg text-foreground">
+  return (
+    <footer className="mt-auto border-t border-border/60 bg-background text-foreground">
+      <Container className="py-8 sm:py-12">
+        <div className="flex flex-col gap-8 sm:gap-12">
+          <div className="flex flex-col gap-8 md:hidden">
+            <Logo loading="lazy" priority="low" src={logoSrc} showPreviewBadge={showPreviewBadge} />
+
+            <Accordion type="multiple" className="rounded-2xl border border-border/70 bg-card">
+              {mobileFooterGroups.map((group) => (
+                <AccordionItem key={group.title} value={group.title} className="border-border/70 px-4">
+                  <AccordionTrigger className="min-h-11 py-4 text-base font-semibold text-foreground hover:no-underline">
                     {group.title}
-                  </Heading>
-                  <ul className="space-y-4 sm:space-y-5">
-                    {group.items.map((link) => (
-                      <li key={`${group.title}-${link.href}-${link.label ?? ''}`}>
-                        <UiLink {...link} variant="footer" />
-                      </li>
-                    ))}
-                  </ul>
-                </div>
+                  </AccordionTrigger>
+                  <AccordionContent className="border-t-0 pt-0 pb-4">
+                    {group.items.length > 0 ? (
+                      <ul className="space-y-3">
+                        {group.items.map((link) => (
+                          <li key={`${group.title}-${link.href}-${link.label ?? ''}`}>
+                            <UiLink {...link} variant="footer" />
+                          </li>
+                        ))}
+                      </ul>
+                    ) : null}
+                  </AccordionContent>
+                </AccordionItem>
               ))}
+            </Accordion>
+
+            {legalQuickLinks.length > 0 ? (
+              <nav aria-label="Footer legal quick links" className="flex flex-wrap items-center gap-x-4 gap-y-2">
+                {legalQuickLinks.map((link) => (
+                  <UiLink key={`legal-${link.href}-${link.label ?? ''}`} {...link} variant="footer" />
+                ))}
+              </nav>
+            ) : null}
+
+            <div className="flex flex-col items-start gap-4 border-t border-border/60 pt-4">
+              <div className="flex flex-wrap items-center gap-4">
+                <SocialLink href="https://meta.com" aria-label="Meta" platform="meta" variant="outline" />
+                <SocialLink href="https://x.com" aria-label="X" platform="x" variant="outline" />
+                <SocialLink
+                  href="https://instagram.com"
+                  aria-label="Instagram"
+                  platform="instagram"
+                  variant="outline"
+                />
+              </div>
+              <p className="text-sm text-muted-foreground">
+                © Copyright {new Date().getFullYear()}. findmydoc All Rights Reserved
+              </p>
             </div>
-          </nav>
-        </div>
+          </div>
 
-        <div className="flex flex-col items-center gap-4 pt-2 text-center sm:pt-6">
-          <p className="text-normal text-muted-foreground">
-            © Copyright {new Date().getFullYear()}. findmydoc All Rights Reserved
-          </p>
+          <div className="hidden md:flex md:flex-col md:gap-12">
+            <div className="flex flex-col items-start gap-8 md:flex-row md:items-start md:justify-between md:gap-16">
+              <Logo loading="lazy" priority="low" src={logoSrc} showPreviewBadge={showPreviewBadge} />
 
-          <div className="flex flex-wrap items-center justify-center gap-4">
-            <SocialLink href="https://meta.com" aria-label="Meta" platform="meta" variant="outline" />
-            <SocialLink href="https://x.com" aria-label="X" platform="x" variant="outline" />
-            <SocialLink href="https://instagram.com" aria-label="Instagram" platform="instagram" variant="outline" />
+              <nav aria-label="Footer primary" className="w-full md:flex-1">
+                <div className="flex flex-col gap-8 sm:gap-10 md:flex-row md:items-start md:justify-between md:gap-x-6">
+                  {footerGroups.map((group) => (
+                    <div key={group.title} className="flex flex-col items-start gap-4 pt-0 pl-1.5 md:flex-1 md:basis-0">
+                      <Heading as="h4" size="h6" align="left" className="text-lg text-foreground">
+                        {group.title}
+                      </Heading>
+                      <ul className="space-y-4 sm:space-y-5">
+                        {group.items.map((link) => (
+                          <li key={`${group.title}-${link.href}-${link.label ?? ''}`}>
+                            <UiLink {...link} variant="footer" />
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              </nav>
+            </div>
+
+            <div className="flex flex-col items-center gap-4 pt-2 text-center sm:pt-6">
+              <p className="text-normal text-muted-foreground">
+                © Copyright {new Date().getFullYear()}. findmydoc All Rights Reserved
+              </p>
+
+              <div className="flex flex-wrap items-center justify-center gap-4">
+                <SocialLink href="https://meta.com" aria-label="Meta" platform="meta" variant="outline" />
+                <SocialLink href="https://x.com" aria-label="X" platform="x" variant="outline" />
+                <SocialLink
+                  href="https://instagram.com"
+                  aria-label="Instagram"
+                  platform="instagram"
+                  variant="outline"
+                />
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-    </Container>
-  </footer>
-)
+      </Container>
+    </footer>
+  )
+}

--- a/src/components/templates/Header/Nav/index.tsx
+++ b/src/components/templates/Header/Nav/index.tsx
@@ -106,10 +106,10 @@ const MobileMenu: React.FC<{
   return (
     <nav
       id={mobileMenuId}
-      className="absolute inset-x-0 top-full z-40 max-h-[calc(100svh-var(--site-header-height))] overflow-y-auto overscroll-contain border-t border-border bg-zinc-50/98 shadow-lg backdrop-blur lg:hidden"
+      className="fixed inset-x-0 top-[var(--site-header-height)] bottom-0 z-[60] border-t border-border bg-zinc-50/98 shadow-lg backdrop-blur lg:hidden"
       aria-label="Mobile navigation"
     >
-      <div className="flex flex-col px-5 py-3">
+      <div className="flex h-full flex-col overflow-y-auto overscroll-contain px-5 pt-3 pb-[calc(env(safe-area-inset-bottom)+1rem)]">
         {navItems.map((item, index) => {
           const itemKey = getNavItemKey(item, index)
 

--- a/src/components/templates/ListingComparison/Component.tsx
+++ b/src/components/templates/ListingComparison/Component.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { ArrowUpDown } from 'lucide-react'
 
-import { Button } from '@/components/atoms/button'
 import { Container } from '@/components/molecules/Container'
 import { ListingCard, type ListingCardData } from '@/components/organisms/Listing'
 import { FeatureHero, type FeatureHeroProps } from '@/components/organisms/Heroes/FeatureHero'
@@ -63,17 +62,12 @@ export function ListingComparison({
         <section className="bg-muted/30 py-12" aria-label="Clinic filters and results">
           <Container>
             <div className="grid gap-8 lg:grid-cols-[minmax(0,320px)_minmax(0,1fr)] lg:items-start">
-              <div id={filtersContainerId} className="order-2 min-w-0 lg:order-1" aria-label="Filters">
+              <div id={filtersContainerId} className="order-1 min-w-0 lg:order-1" aria-label="Filters">
                 {filters}
               </div>
 
-              <section id="clinic-results" className="order-1 min-w-0 space-y-4 lg:order-2" aria-label="Clinic results">
+              <section id="clinic-results" className="order-2 min-w-0 space-y-4 lg:order-2" aria-label="Clinic results">
                 {resultsContext}
-                <div className="flex justify-end lg:hidden">
-                  <Button asChild variant="secondary" className="min-h-11 rounded-full px-5">
-                    <a href={`#${filtersContainerId}`}>Jump to filters</a>
-                  </Button>
-                </div>
                 {defaultHeader}
                 {results.length > 0
                   ? results.map((data) => <ListingCard key={data.id} data={data} />)

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -4831,7 +4831,6 @@ export interface TaskCreateCollectionExport {
       | 'forms'
       | 'form-submissions'
       | 'search'
-      | 'payload-mcp-api-keys'
       | 'exports'
       | 'imports';
     drafts?: ('yes' | 'no') | null;

--- a/src/stories/organisms/Landing/LandingTestimonials.stories.tsx
+++ b/src/stories/organisms/Landing/LandingTestimonials.stories.tsx
@@ -61,7 +61,7 @@ export const CarouselNavigation: Story = {
   },
 }
 
-export const MobileSingleCardCycle: Story = {
+const mobileSingleCardCycleStory: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const getDots = () => canvas.getAllByRole('button', { name: /^Go to slide \d+ of \d+$/ })
@@ -77,6 +77,12 @@ export const MobileSingleCardCycle: Story = {
     })
   },
 }
+
+export const MobileSingleCardCycle: Story = withViewportStory(
+  mobileSingleCardCycleStory,
+  'public375',
+  'Mobile Single Card Cycle',
+)
 
 export const CarouselNavigation320: Story = withViewportStory(
   CarouselNavigation,
@@ -109,12 +115,12 @@ export const CarouselNavigation1280: Story = withViewportStory(
   'Carousel navigation / 1280',
 )
 export const MobileSingleCardCycle320: Story = withViewportStory(
-  MobileSingleCardCycle,
+  mobileSingleCardCycleStory,
   'public320',
   'Mobile single card cycle / 320',
 )
 export const MobileSingleCardCycle375: Story = withViewportStory(
-  MobileSingleCardCycle,
+  mobileSingleCardCycleStory,
   'public375',
   'Mobile single card cycle / 375',
 )

--- a/src/stories/organisms/Landing/LandingTestimonials.stories.tsx
+++ b/src/stories/organisms/Landing/LandingTestimonials.stories.tsx
@@ -61,6 +61,23 @@ export const CarouselNavigation: Story = {
   },
 }
 
+export const MobileSingleCardCycle: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const getDots = () => canvas.getAllByRole('button', { name: /^Go to slide \d+ of \d+$/ })
+
+    await expect(canvas.getByRole('heading', { name: 'Alex Morgan' })).toBeVisible()
+    await expect(canvas.queryByRole('heading', { name: 'Nina Feld' })).not.toBeInTheDocument()
+
+    await userEvent.click(getDots()[1]!)
+
+    await waitFor(() => {
+      expect(canvas.getByRole('heading', { name: 'Nina Feld' })).toBeVisible()
+      expect(canvas.queryByRole('heading', { name: 'Alex Morgan' })).not.toBeInTheDocument()
+    })
+  },
+}
+
 export const CarouselNavigation320: Story = withViewportStory(
   CarouselNavigation,
   'public320',
@@ -90,4 +107,14 @@ export const CarouselNavigation1280: Story = withViewportStory(
   CarouselNavigation,
   'public1280',
   'Carousel navigation / 1280',
+)
+export const MobileSingleCardCycle320: Story = withViewportStory(
+  MobileSingleCardCycle,
+  'public320',
+  'Mobile single card cycle / 320',
+)
+export const MobileSingleCardCycle375: Story = withViewportStory(
+  MobileSingleCardCycle,
+  'public375',
+  'Mobile single card cycle / 375',
 )

--- a/src/stories/templates/Footer.stories.tsx
+++ b/src/stories/templates/Footer.stories.tsx
@@ -69,12 +69,17 @@ export const DenseContent: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
+    const aboutTrigger = canvas.queryByRole('button', { name: 'About' })
+    if (aboutTrigger) {
+      await userEvent.click(aboutTrigger)
+    }
+
     await expect(canvas.getByRole('link', { name: /patient guidance/i })).toBeInTheDocument()
     await expect(canvas.getByRole('link', { name: /imprint/i })).toBeInTheDocument()
   },
 }
 
-export const MobileAccordionNavigation: Story = {
+const mobileAccordionNavigationStory: Story = {
   args: {
     footerGroups: denseFooterGroups,
   },
@@ -103,6 +108,12 @@ export const MobileAccordionNavigation: Story = {
     })
   },
 }
+
+export const MobileAccordionNavigation: Story = withViewportStory(
+  mobileAccordionNavigationStory,
+  'public375',
+  'Mobile accordion navigation',
+)
 
 export const FocusedLegalLinks320: Story = withViewportStory(
   FocusedLegalLinks,
@@ -142,12 +153,12 @@ export const DenseContent768: Story = withViewportStory(DenseContent, 'public768
 export const DenseContent1024: Story = withViewportStory(DenseContent, 'public1024', 'Dense content / 1024')
 export const DenseContent1280: Story = withViewportStory(DenseContent, 'public1280', 'Dense content / 1280')
 export const MobileAccordionNavigation320: Story = withViewportStory(
-  MobileAccordionNavigation,
+  mobileAccordionNavigationStory,
   'public320',
   'Mobile accordion navigation / 320',
 )
 export const MobileAccordionNavigation375: Story = withViewportStory(
-  MobileAccordionNavigation,
+  mobileAccordionNavigationStory,
   'public375',
   'Mobile accordion navigation / 375',
 )

--- a/src/stories/templates/Footer.stories.tsx
+++ b/src/stories/templates/Footer.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect, within } from '@storybook/test'
+import { expect, userEvent, waitFor, within } from '@storybook/test'
 import { Footer } from '@/components/templates/Footer/Component'
 import { footerData } from './fixtures'
 import { withMockRouter } from '../utils/routerDecorator'
@@ -46,7 +46,7 @@ export const FocusedLegalLinks: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    await expect(canvas.getByRole('link', { name: /imprint/i })).toBeInTheDocument()
+    await expect(canvas.getByRole('link', { name: /privacy policy/i })).toBeInTheDocument()
     await expect(canvas.queryByRole('link', { name: /patient guidance/i })).not.toBeInTheDocument()
   },
 }
@@ -71,6 +71,36 @@ export const DenseContent: Story = {
 
     await expect(canvas.getByRole('link', { name: /patient guidance/i })).toBeInTheDocument()
     await expect(canvas.getByRole('link', { name: /imprint/i })).toBeInTheDocument()
+  },
+}
+
+export const MobileAccordionNavigation: Story = {
+  args: {
+    footerGroups: denseFooterGroups,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await waitFor(() => {
+      expect(canvas.getAllByRole('link', { name: /privacy policy/i })).toHaveLength(1)
+      expect(canvas.getAllByRole('link', { name: /imprint/i })).toHaveLength(1)
+    })
+
+    const aboutTrigger = canvas.getByRole('button', { name: 'About' })
+    await userEvent.click(aboutTrigger)
+
+    await waitFor(() => {
+      expect(canvas.getByRole('link', { name: /partner landing/i })).toBeInTheDocument()
+    })
+
+    const informationTrigger = canvas.getByRole('button', { name: 'Information' })
+    await userEvent.click(informationTrigger)
+
+    await waitFor(() => {
+      expect(canvas.getByRole('link', { name: /terms of service/i })).toBeInTheDocument()
+      expect(canvas.getAllByRole('link', { name: /privacy policy/i })).toHaveLength(1)
+      expect(canvas.getAllByRole('link', { name: /imprint/i })).toHaveLength(1)
+    })
   },
 }
 
@@ -111,3 +141,13 @@ export const DenseContent640: Story = withViewportStory(DenseContent, 'public640
 export const DenseContent768: Story = withViewportStory(DenseContent, 'public768', 'Dense content / 768')
 export const DenseContent1024: Story = withViewportStory(DenseContent, 'public1024', 'Dense content / 1024')
 export const DenseContent1280: Story = withViewportStory(DenseContent, 'public1280', 'Dense content / 1280')
+export const MobileAccordionNavigation320: Story = withViewportStory(
+  MobileAccordionNavigation,
+  'public320',
+  'Mobile accordion navigation / 320',
+)
+export const MobileAccordionNavigation375: Story = withViewportStory(
+  MobileAccordionNavigation,
+  'public375',
+  'Mobile accordion navigation / 375',
+)

--- a/src/stories/templates/ListingComparison.stories.tsx
+++ b/src/stories/templates/ListingComparison.stories.tsx
@@ -335,6 +335,7 @@ export const FilterByShortWaitTime: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
+    await userEvent.click(canvas.getByRole('button', { name: /^Wait time/ }))
     await userEvent.click(canvas.getByRole('checkbox', { name: 'Up to 2 weeks' }))
 
     await waitFor(() => {
@@ -355,6 +356,7 @@ export const FilterByTreatmentHipReplacement: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
+    await userEvent.click(canvas.getByRole('button', { name: /^Treatment/ }))
     await userEvent.click(canvas.getByRole('checkbox', { name: 'Hip replacement' }))
 
     await waitFor(() => {

--- a/src/utilities/listingComparison/serverData/presentation.ts
+++ b/src/utilities/listingComparison/serverData/presentation.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
 import type { VerificationBadgeVariant } from '@/components/atoms/verification-badge'
 import type { ListingCardData } from '@/components/organisms/Listing'
 import type { Clinic } from '@/payload-types'
@@ -12,6 +15,8 @@ const PLACEHOLDER_MEDIA = {
   src: '/images/placeholder-576-968.svg',
   alt: 'Clinic placeholder image',
 }
+const CLINIC_MEDIA_API_PREFIX = '/api/clinicMedia/file/'
+const CLINIC_MEDIA_PUBLIC_DIR = path.join(process.cwd(), 'public', 'clinic-media')
 
 function normalizeVerification(value: unknown): VerificationBadgeVariant {
   if (value === 'bronze' || value === 'silver' || value === 'gold' || value === 'unverified') {
@@ -28,6 +33,20 @@ function mapLocationHref(coordinates: unknown): string | undefined {
   if (!Number.isFinite(lat) || !Number.isFinite(lng)) return undefined
 
   return `https://www.google.com/maps?q=${encodeURIComponent(`${lat},${lng}`)}`
+}
+
+function hasAvailableClinicMedia(url: string | null | undefined): boolean {
+  if (!url) return false
+  if (!url.startsWith(CLINIC_MEDIA_API_PREFIX)) return true
+
+  const rawFileName = url.slice(CLINIC_MEDIA_API_PREFIX.length).split('?')[0] ?? ''
+  const fileName = decodeURIComponent(rawFileName).replace(/^\/+/, '')
+
+  if (!fileName) {
+    return false
+  }
+
+  return fs.existsSync(path.join(CLINIC_MEDIA_PUBLIC_DIR, fileName))
 }
 
 export function buildClinicPresentationMeta(
@@ -95,7 +114,9 @@ export function mapListingCardResults(pageRows: ClinicRow[], reviewCounts: Map<n
     const ratingValue = typeof clinic.averageRating === 'number' ? clinic.averageRating : 0
     const ratingCount = reviewCounts.get(clinic.id) ?? 0
     const resolvedMedia = resolveMediaDescriptorFromLoadedRelation(clinic.thumbnail, 'clinicMedia')
-    const mediaSrc = resolvedMedia?.url ?? PLACEHOLDER_MEDIA.src
+    const mediaSrc = hasAvailableClinicMedia(resolvedMedia?.url)
+      ? (resolvedMedia?.url ?? PLACEHOLDER_MEDIA.src)
+      : PLACEHOLDER_MEDIA.src
     const mediaAlt =
       typeof resolvedMedia?.alt === 'string' && resolvedMedia.alt.trim().length > 0
         ? resolvedMedia.alt

--- a/src/utilities/normalizeNavItems.ts
+++ b/src/utilities/normalizeNavItems.ts
@@ -1,6 +1,6 @@
 import { isNotNull, isRecord, resolveHrefFromCMSLink } from '@/blocks/_shared/utils'
 import type { UiLinkProps } from '@/components/molecules/Link'
-import { REQUIRED_LEGAL_FOOTER_LINKS } from '@/utilities/legalPages'
+import { LEGACY_LEGAL_REDIRECTS, REQUIRED_LEGAL_FOOTER_LINKS } from '@/utilities/legalPages'
 
 type SupportedLinkType = 'custom' | 'reference' | 'group'
 
@@ -96,15 +96,42 @@ function appendRequiredLegalFooterLinks(items: UiLinkProps[]): UiLinkProps[] {
   const normalizeHrefForComparison = (href: string): string => {
     if (href === '/') return href
     const withoutTrailingSlash = href.replace(/\/+$/, '')
-    return withoutTrailingSlash.length > 0 ? withoutTrailingSlash : '/'
+    const normalizedHref = withoutTrailingSlash.length > 0 ? withoutTrailingSlash : '/'
+    return legalRedirectMap.get(normalizedHref) ?? normalizedHref
   }
 
-  const existingHrefs = new Set(items.map((item) => normalizeHrefForComparison(item.href)))
+  const legalRedirectMap = new Map<string, string>(LEGACY_LEGAL_REDIRECTS.map(({ from, to }) => [from, to]))
+  const canonicalizedItems = items.map((item) => {
+    const normalizedHref = hrefWithoutTrailingSlash(item.href)
+    const redirectedHref = legalRedirectMap.get(normalizedHref)
+
+    if (!redirectedHref) {
+      return item
+    }
+
+    return {
+      ...item,
+      href: redirectedHref,
+    }
+  })
+  const deduplicatedItems = canonicalizedItems.filter(
+    (item, index, collection) =>
+      collection.findIndex(
+        (candidate) => normalizeHrefForComparison(candidate.href) === normalizeHrefForComparison(item.href),
+      ) === index,
+  )
+  const existingHrefs = new Set(deduplicatedItems.map((item) => normalizeHrefForComparison(item.href)))
   const missingRequired = REQUIRED_LEGAL_FOOTER_LINKS.filter(
     (item) => !existingHrefs.has(normalizeHrefForComparison(item.href)),
   )
 
-  return [...items, ...missingRequired]
+  return [...deduplicatedItems, ...missingRequired]
+}
+
+function hrefWithoutTrailingSlash(href: string): string {
+  if (href === '/') return href
+  const withoutTrailingSlash = href.replace(/\/+$/, '')
+  return withoutTrailingSlash.length > 0 ? withoutTrailingSlash : '/'
 }
 
 export function normalizeFooterNavGroups(

--- a/tests/e2e/public/listing-comparison.public-smoke.spec.ts
+++ b/tests/e2e/public/listing-comparison.public-smoke.spec.ts
@@ -26,6 +26,9 @@ test('listing filters preserve the selected specialty when rating changes @smoke
 
   await page.goto('/listing-comparison', { waitUntil: 'domcontentloaded' })
   await expect(page.getByRole('heading', { name: 'Compare clinic prices' })).toBeVisible()
+  const medicalSpecialtyToggle = page.getByRole('button', { name: /^Medical Specialty/ })
+  await medicalSpecialtyToggle.click()
+  await expect(medicalSpecialtyToggle).toHaveAttribute('aria-expanded', 'true')
   await page.getByRole('checkbox', { name: 'Dental', exact: true }).click()
   await waitForSearchParam(page, 'specialty', '1')
 

--- a/tests/unit/app/frontend/home.page.test.ts
+++ b/tests/unit/app/frontend/home.page.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   headersMock: vi.fn(),
   getPayloadMock: vi.fn(),
   payloadFindMock: vi.fn(),
+  findLatestPostsMock: vi.fn(),
   getLandingMedicalSpecialtyCategoriesMock: vi.fn(),
   normalizePostMock: vi.fn((post: unknown) => post),
   temporaryLandingPageComponent: vi.fn(() => null),
@@ -35,6 +36,10 @@ vi.mock('@/utilities/blog/normalizePost', () => ({
   normalizePost: mocks.normalizePostMock,
 }))
 
+vi.mock('@/utilities/content/serverData', () => ({
+  findLatestPosts: mocks.findLatestPostsMock,
+}))
+
 vi.mock('@/components/templates/TemporaryLandingPage', () => ({
   TemporaryLandingPage: mocks.temporaryLandingPageComponent,
 }))
@@ -46,6 +51,7 @@ describe('frontend home page route', () => {
 
     mocks.headersMock.mockResolvedValue(new Headers())
     mocks.payloadFindMock.mockResolvedValue({ docs: [] })
+    mocks.findLatestPostsMock.mockResolvedValue([])
     mocks.getLandingMedicalSpecialtyCategoriesMock.mockResolvedValue({
       categories: [],
       items: [],
@@ -143,7 +149,26 @@ describe('frontend home page route', () => {
     await pageModule.default()
 
     expect(mocks.getPayloadMock).toHaveBeenCalledTimes(1)
+    expect(mocks.findLatestPostsMock).toHaveBeenCalledTimes(1)
+    expect(mocks.findLatestPostsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        find: mocks.payloadFindMock,
+      }),
+      3,
+    )
     expect(mocks.payloadFindMock).toHaveBeenCalledTimes(1)
+    expect(mocks.payloadFindMock).toHaveBeenCalledWith({
+      collection: 'cities',
+      depth: 0,
+      limit: 250,
+      overrideAccess: false,
+      pagination: false,
+      sort: 'name',
+      select: {
+        id: true,
+        name: true,
+      },
+    })
     expect(mocks.getLandingMedicalSpecialtyCategoriesMock).toHaveBeenCalledTimes(1)
   })
 

--- a/tests/unit/components/listingComparisonFilters.test.tsx
+++ b/tests/unit/components/listingComparisonFilters.test.tsx
@@ -25,6 +25,24 @@ const treatmentGroups = [
   },
 ]
 
+const defaultFilterValues = {
+  cities: [],
+  specialty: null,
+  waitTimes: [],
+  treatments: [],
+  priceRange: [0, 20000] as [number, number],
+  rating: null,
+}
+
+const openTreatmentSection = {
+  treatment: true,
+}
+
+const openMedicalSpecialtyAndTreatmentSections = {
+  medicalSpecialty: true,
+  treatment: true,
+}
+
 describe('ListingComparisonFilters', () => {
   beforeAll(() => {
     class ResizeObserverMock {
@@ -46,19 +64,13 @@ describe('ListingComparisonFilters', () => {
     vi.unstubAllGlobals()
   })
 
-  it('renders all treatment groups by default when no specialty is selected', () => {
+  it('renders all treatment groups when no specialty is selected and the treatment section is open', () => {
     render(
       <ListingComparisonFilters
         specialtyOptions={specialtyOptions}
         treatmentGroups={treatmentGroups}
-        initialValues={{
-          cities: [],
-          specialty: null,
-          waitTimes: [],
-          treatments: [],
-          priceRange: [0, 20000],
-          rating: null,
-        }}
+        initialValues={defaultFilterValues}
+        defaultOpenSections={openTreatmentSection}
       />,
     )
 
@@ -75,15 +87,9 @@ describe('ListingComparisonFilters', () => {
       <ListingComparisonFilters
         specialtyOptions={specialtyOptions}
         treatmentGroups={treatmentGroups}
-        initialValues={{
-          cities: [],
-          specialty: null,
-          waitTimes: [],
-          treatments: [],
-          priceRange: [0, 20000],
-          rating: null,
-        }}
+        initialValues={defaultFilterValues}
         onChange={onChange}
+        defaultOpenSections={openTreatmentSection}
       />,
     )
 
@@ -112,6 +118,7 @@ describe('ListingComparisonFilters', () => {
           rating: null,
         }}
         onChange={onChange}
+        defaultOpenSections={openMedicalSpecialtyAndTreatmentSections}
       />,
     )
 
@@ -133,14 +140,8 @@ describe('ListingComparisonFilters', () => {
       <ListingComparisonFilters
         specialtyOptions={specialtyOptions}
         treatmentGroups={treatmentGroups}
-        initialValues={{
-          cities: [],
-          specialty: null,
-          waitTimes: [],
-          treatments: [],
-          priceRange: [0, 20000],
-          rating: null,
-        }}
+        initialValues={defaultFilterValues}
+        defaultOpenSections={openTreatmentSection}
       />,
     )
 
@@ -159,15 +160,9 @@ describe('ListingComparisonFilters', () => {
       <ListingComparisonFilters
         specialtyOptions={specialtyOptions}
         treatmentGroups={treatmentGroups}
-        initialValues={{
-          cities: [],
-          specialty: null,
-          waitTimes: [],
-          treatments: [],
-          priceRange: [0, 20000],
-          rating: null,
-        }}
+        initialValues={defaultFilterValues}
         onChange={onChange}
+        defaultOpenSections={openTreatmentSection}
       />,
     )
 
@@ -198,6 +193,7 @@ describe('ListingComparisonFilters', () => {
           priceRange: [0, 20000],
           rating: null,
         }}
+        defaultOpenSections={openTreatmentSection}
       />,
     )
 

--- a/tests/unit/components/templates/footer.test.tsx
+++ b/tests/unit/components/templates/footer.test.tsx
@@ -34,15 +34,18 @@ describe('Footer template', () => {
   it('renders nav and social links', () => {
     render(<Footer footerGroups={footerGroups} />)
 
-    expect(screen.getByRole('link', { name: 'About us' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Meta' })).toBeInTheDocument()
+    expect(screen.getAllByRole('link', { name: 'About us' }).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('link', { name: 'Meta' }).length).toBeGreaterThan(0)
   })
 
   it('applies custom logo source', () => {
     render(<Footer footerGroups={footerGroups} logoSrc="/preview-logo.png" />)
 
-    const logo = screen.getByRole('img', { name: 'findmydoc' })
-    expect(logo).toBeInTheDocument()
-    expect(logo).toHaveAttribute('src', '/preview-logo.png')
+    const logos = screen.getAllByRole('img', { name: 'findmydoc' })
+
+    expect(logos.length).toBeGreaterThan(0)
+    logos.forEach((logo) => {
+      expect(logo).toHaveAttribute('src', '/preview-logo.png')
+    })
   })
 })

--- a/tests/unit/utilities/listingComparisonPresentation.test.ts
+++ b/tests/unit/utilities/listingComparisonPresentation.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { Clinic } from '@/payload-types'
 import { mapListingCardResults } from '@/utilities/listingComparison/serverData/presentation'
@@ -26,7 +27,13 @@ function buildRow(clinic: Clinic): ClinicRow {
 }
 
 describe('mapListingCardResults media resolution', () => {
-  it('uses relation URL when available', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses relation URL when the media file is available', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+
     const clinic = buildClinic({
       id: 1,
       name: 'Alpha Clinic',

--- a/tests/unit/utilities/listingComparisonPresentation.test.ts
+++ b/tests/unit/utilities/listingComparisonPresentation.test.ts
@@ -45,7 +45,7 @@ describe('mapListingCardResults media resolution', () => {
     expect(result[0]?.actions.details.href).toBe('/clinics/alpha-clinic-1')
   })
 
-  it('builds media URL from filename when relation URL is null', () => {
+  it('falls back to the placeholder when only a missing filename-derived upload is available', () => {
     const clinic = buildClinic({
       id: 2,
       name: 'Bravo Clinic',
@@ -59,7 +59,7 @@ describe('mapListingCardResults media resolution', () => {
 
     const result = mapListingCardResults([buildRow(clinic)], new Map())
 
-    expect(result[0]?.media.src).toBe('/api/clinicMedia/file/from-filename.jpg')
+    expect(result[0]?.media.src).toBe('/images/placeholder-576-968.svg')
     expect(result[0]?.media.alt).toBe('Bravo image')
   })
 

--- a/tests/unit/utilities/normalizeNavItems.test.ts
+++ b/tests/unit/utilities/normalizeNavItems.test.ts
@@ -730,4 +730,18 @@ describe('normalizeFooterNavGroups', () => {
       ],
     })
   })
+
+  it('should canonicalize legacy privacy links without duplicating the required legal item', () => {
+    const result = normalizeFooterNavGroups({
+      informationLinks: [{ link: { type: 'custom', url: '/privacy', label: 'Privacy Policy', newTab: false } }],
+    })
+
+    expect(result[2]).toEqual({
+      title: 'Information',
+      items: [
+        { href: '/privacy-policy', label: 'Privacy Policy', newTab: false, appearance: 'inline' },
+        { href: '/imprint', label: 'Imprint', newTab: false, appearance: 'inline' },
+      ],
+    })
+  })
 })


### PR DESCRIPTION
Mobile users can now complete the key public flows without the layout failures that were blocking search, comparison, and login on narrow viewports.

## What changed
- Moved the homepage search into a true mobile-first flow layout, reduced mobile hero typography, and split testimonials into a dedicated single-card mobile presentation.
- Reworked mobile feature sections and the footer so they read as centered, calmer mobile UX, with accordion navigation and deduplicated legal links.
- Flipped listing comparison to show filters before results, enlarged touch targets, stacked card CTAs, and added a server-side placeholder fallback when clinic media uploads are unavailable locally.
- Tightened cookie consent behavior on mobile, including a smaller launcher and a compact admin login banner with more short-height breathing room.
- Added and updated Storybook coverage plus the listing media presentation test for the new mobile states.

## Validation
- `pnpm format`
- `pnpm check`
- `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build`
- Playwright mobile QA on `/`, `/partners/clinics`, `/listing-comparison`, and `/admin/login` at `320x568`, `320x700`, and `375x812`

## Screenshots
- Homepage hero/search/testimonials on mobile (`320x700`)
- Partner features section on mobile (`375x812`)
- Listing comparison filters and cards on mobile (`320x700`)
- Admin login with compact cookie banner (`320x568`)

## Development
- Closes #990
