### PR TITLE
fix: base release skill on origin/main

### DIFF
--- a/.codex/skills/gh-release-publish/SKILL.md
+++ b/.codex/skills/gh-release-publish/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: gh-release-publish
-description: Publish a GitHub release for the website repository by calculating the next semantic version from Conventional Commit history, generating native GitHub release notes, dispatching the production deploy workflow, and sending a stakeholder-focused Google Chat webhook announcement. Use when Codex needs to create the next release tag, verify release preconditions on `main`, trigger the existing production deployment, or announce a shipped release in German for non-technical colleagues.
+description: Publish a GitHub release for the website repository by calculating the next semantic version from Conventional Commit history on `origin/main`, generating native GitHub release notes, dispatching the production deploy workflow, and sending a stakeholder-focused Google Chat webhook announcement. Use when Codex needs to create the next release tag, verify release preconditions on `origin/main`, trigger the existing production deployment, or announce a shipped release in German for non-technical colleagues.
 ---
 
 # GitHub Release Publish
 
 ## Overview
 
-Use this skill to ship a repository release end to end: validate the repo state, determine the next `vX.Y.Z` tag from commit history, publish the GitHub release with generated notes, wait for the production deploy workflow to finish, gather deterministic `commit -> PR -> linked issue` context for announcement drafting, and then send an explicitly drafted Google Chat announcement.
+Use this skill to ship a repository release end to end: fetch the latest `origin/main` state, determine the next `vX.Y.Z` tag from that remote commit history, publish the GitHub release with generated notes, wait for the production deploy workflow to finish, gather deterministic `commit -> PR -> linked issue` context for announcement drafting, and then send an explicitly drafted Google Chat announcement.
 
 ## Workflow
 
-1. Confirm the repository is on `main`, clean, and aligned with `origin/main`.
-2. Compute the next semantic version from commits since the latest merged `v*.*.*` tag.
+1. Fetch `origin/main` and tags, then treat that remote ref as the only release source of truth.
+2. Compute the next semantic version from commits since the latest merged `v*.*.*` tag on `origin/main`.
 3. Collect the PR/Issue source context from current commit history before the release is created.
 4. Resolve PRs from the commits in the release range through GitHub metadata, not primarily from commit-subject guessing.
 5. Resolve Issues only from the PR development-link / closing-issue metadata.
@@ -23,13 +23,11 @@ Use this skill to ship a repository release end to end: validate the repo state,
 
 ## Required Repository Assumptions
 
-- Only release from `main`.
-- Require a clean worktree.
-- Require `HEAD` to match `origin/main`.
 - Require GitHub CLI authentication with `repo` and `workflow` scopes.
-- Require an existing `v*.*.*` tag reachable from `main`.
+- Require an existing `v*.*.*` tag reachable from `origin/main`.
 - Abort if the next tag or release already exists.
 - Require the repository secret `GOOGLE_CHAT_WEBHOOK_URL` only for the final send step.
+- Local branch, local worktree cleanliness, and local `HEAD` do not affect the release calculation as long as `origin/main` and GitHub are reachable.
 
 ## Commands
 

--- a/.codex/skills/gh-release-publish/SKILL.md
+++ b/.codex/skills/gh-release-publish/SKILL.md
@@ -7,7 +7,7 @@ description: Publish a GitHub release for the website repository by calculating 
 
 ## Overview
 
-Use this skill to ship a repository release end to end: fetch the latest `origin/main` state, determine the next `vX.Y.Z` tag from that remote commit history, publish the GitHub release with generated notes, wait for the production deploy workflow to finish, gather deterministic `commit -> PR -> linked issue` context for announcement drafting, and then send an explicitly drafted Google Chat announcement.
+Use this skill to ship a repository release end to end: fetch the latest `origin/main` state, determine the next `vX.Y.Z` tag from that remote commit history, publish the GitHub release pinned to that fetched commit, dispatch the production deploy workflow from the created release tag, wait for it to finish, gather deterministic `commit -> PR -> linked issue` context for announcement drafting, and then send an explicitly drafted Google Chat announcement.
 
 ## Workflow
 
@@ -16,8 +16,8 @@ Use this skill to ship a repository release end to end: fetch the latest `origin
 3. Collect the PR/Issue source context from current commit history before the release is created.
 4. Resolve PRs from the commits in the release range through GitHub metadata, not primarily from commit-subject guessing.
 5. Resolve Issues only from the PR development-link / closing-issue metadata.
-6. Publish a non-draft GitHub release with native generated release notes.
-7. Dispatch `.github/workflows/deploy-production.yml` and wait for it to finish successfully.
+6. Publish a non-draft GitHub release with native generated release notes, pinned to the fetched `origin/main` commit SHA.
+7. Dispatch `.github/workflows/deploy-production.yml` from the created release tag and wait for it to finish successfully.
 8. Use the collected source context in Codex to draft the final German Google Chat message.
 9. Send the final approved message explicitly through the dedicated GitHub Actions workflow that reads the repository secret.
 

--- a/.codex/skills/gh-release-publish/scripts/compute-next-release.mjs
+++ b/.codex/skills/gh-release-publish/scripts/compute-next-release.mjs
@@ -2,14 +2,18 @@
 
 import {
   determineNextReleaseWithReferences,
+  fetchMainAndTags,
   formatReleasePlanSummary,
   getLatestReleaseTag,
   getRepoSlug,
 } from './lib.mjs'
 
+const RELEASE_REF = 'origin/main'
+
 try {
   const jsonMode = process.argv.includes('--json')
-  const lastTag = getLatestReleaseTag()
+  fetchMainAndTags()
+  const lastTag = getLatestReleaseTag(RELEASE_REF)
 
   if (!lastTag) {
     throw new Error('No merged semantic version tag matching v*.*.* was found.')
@@ -17,6 +21,7 @@ try {
 
   const result = await determineNextReleaseWithReferences({
     lastTag,
+    ref: RELEASE_REF,
     repoSlug: getRepoSlug(),
   })
 

--- a/.codex/skills/gh-release-publish/scripts/lib.mjs
+++ b/.codex/skills/gh-release-publish/scripts/lib.mjs
@@ -225,8 +225,8 @@ export function bumpVersion(tag, bump) {
   throw new Error(`Unsupported bump level: ${bump}`)
 }
 
-export function getLatestReleaseTag(cwd = process.cwd()) {
-  const { stdout } = run('git', ['tag', '--merged', 'HEAD', '--sort=-v:refname', '--list', 'v*.*.*'], { cwd })
+export function getLatestReleaseTag(ref = 'HEAD', cwd = process.cwd()) {
+  const { stdout } = run('git', ['tag', '--merged', ref, '--sort=-v:refname', '--list', 'v*.*.*'], { cwd })
   const tag = stdout
     .split('\n')
     .map((line) => line.trim())
@@ -234,8 +234,8 @@ export function getLatestReleaseTag(cwd = process.cwd()) {
   return tag ?? null
 }
 
-export function getCommitRange(lastTag) {
-  return `${lastTag}..HEAD`
+export function getCommitRange(lastTag, ref = 'HEAD') {
+  return `${lastTag}..${ref}`
 }
 
 export function parseCommitRecord(record) {
@@ -293,9 +293,9 @@ export function parseCommitRecord(record) {
   }
 }
 
-export function getCommitsSinceTag(lastTag, cwd = process.cwd()) {
+export function getCommitsSinceTag(lastTag, ref = 'HEAD', cwd = process.cwd()) {
   const format = '%H%x1f%s%x1f%B%x1e'
-  const { stdout } = run('git', ['log', getCommitRange(lastTag), `--format=${format}`], {
+  const { stdout } = run('git', ['log', getCommitRange(lastTag, ref), `--format=${format}`], {
     cwd,
   })
 
@@ -306,8 +306,8 @@ export function getCommitsSinceTag(lastTag, cwd = process.cwd()) {
     .map(parseCommitRecord)
 }
 
-export function determineNextRelease(lastTag, cwd = process.cwd()) {
-  const commits = getCommitsSinceTag(lastTag, cwd)
+export function determineNextRelease(lastTag, ref = 'HEAD', cwd = process.cwd()) {
+  const commits = getCommitsSinceTag(lastTag, ref, cwd)
   if (commits.length === 0) {
     throw new Error(`No commits found since ${lastTag}.`)
   }
@@ -453,11 +453,12 @@ export function assessContextualReleaseFromReferences(releasePlan, references = 
 
 export async function determineNextReleaseWithReferences({
   lastTag,
+  ref = 'HEAD',
   cwd = process.cwd(),
   repoSlug = null,
   runJsonImpl = runJson,
 }) {
-  const releasePlan = determineNextRelease(lastTag, cwd)
+  const releasePlan = determineNextRelease(lastTag, ref, cwd)
   const effectiveRepoSlug = repoSlug ?? getRepoSlug(cwd)
   const references = await fetchAssociatedPullRequestIssueReferencesFromCommits({
     repoSlug: effectiveRepoSlug,

--- a/.codex/skills/gh-release-publish/scripts/lib.mjs
+++ b/.codex/skills/gh-release-publish/scripts/lib.mjs
@@ -592,7 +592,7 @@ export async function waitForWorkflowRun({
   cwd = process.cwd(),
   repoSlug,
   workflowFile,
-  ref = 'main',
+  ref = null,
   headSha,
   dispatchedAt,
   timeoutSeconds = Number(process.env.GH_RELEASE_PUBLISH_RUN_TIMEOUT_SECONDS ?? 1800),
@@ -602,14 +602,10 @@ export async function waitForWorkflowRun({
   let runInfo = null
 
   while (Date.now() - startedAt < timeoutSeconds * 1000) {
-    const runs = runJson(
-      'gh',
-      [
-        'api',
-        `repos/${repoSlug}/actions/workflows/${workflowFile}/runs?event=workflow_dispatch&branch=${ref}&per_page=10`,
-      ],
-      { cwd },
-    )
+    const query = ref
+      ? `repos/${repoSlug}/actions/workflows/${workflowFile}/runs?event=workflow_dispatch&branch=${encodeURIComponent(ref)}&per_page=10`
+      : `repos/${repoSlug}/actions/workflows/${workflowFile}/runs?event=workflow_dispatch&per_page=10`
+    const runs = runJson('gh', ['api', query], { cwd })
 
     runInfo =
       runs.workflow_runs.find(
@@ -1807,8 +1803,9 @@ export async function buildDryRunPlan({
   googleChatSecretName = GOOGLE_CHAT_SECRET_NAME,
   chatWorkflowFile = GOOGLE_CHAT_WORKFLOW_FILE,
   chatWorkflowRef = 'main',
+  releaseTargetCommitish = 'main',
   workflowFile = PRODUCTION_DEPLOY_WORKFLOW_FILE,
-  workflowRef = 'main',
+  workflowRef = releasePlan.nextTag,
 }) {
   const releaseUrl = `https://github.com/${repoSlug}/releases/tag/${releasePlan.nextTag}`
   const resolvedReferences = references.length > 0 ? references : (releasePlan.references ?? [])
@@ -1827,7 +1824,7 @@ export async function buildDryRunPlan({
       endpoint: `repos/${repoSlug}/releases`,
       payload: buildReleasePayload({
         tag: releasePlan.nextTag,
-        targetCommitish: 'main',
+        targetCommitish: releaseTargetCommitish,
       }),
       expectedUrl: releaseUrl,
     },

--- a/.codex/skills/gh-release-publish/scripts/publish-release.mjs
+++ b/.codex/skills/gh-release-publish/scripts/publish-release.mjs
@@ -105,6 +105,7 @@ async function main() {
       googleChatSecretConfigured,
       googleChatSecretName: GOOGLE_CHAT_SECRET_NAME,
       chatWorkflowFile: GOOGLE_CHAT_WORKFLOW_FILE,
+      releaseTargetCommitish: remoteHead,
     })
 
     if (dryRunJson) {
@@ -132,7 +133,7 @@ async function main() {
   const release = createRelease({
     repoSlug,
     tag: releasePlan.nextTag,
-    targetCommitish: 'main',
+    targetCommitish: remoteHead,
   })
   const releaseUrl = release.html_url ?? release.url
   console.log(`Release created: ${releaseUrl}`)
@@ -140,14 +141,14 @@ async function main() {
   const dispatch = dispatchWorkflow({
     repoSlug,
     workflowFile: PRODUCTION_DEPLOY_WORKFLOW_FILE,
-    ref: 'main',
+    ref: releasePlan.nextTag,
   })
   console.log('Production workflow dispatched.')
 
   const workflowRun = await waitForWorkflowRun({
     repoSlug,
     workflowFile: PRODUCTION_DEPLOY_WORKFLOW_FILE,
-    ref: 'main',
+    ref: null,
     headSha: remoteHead,
     dispatchedAt: dispatch.dispatchedAt,
   })

--- a/.codex/skills/gh-release-publish/scripts/publish-release.mjs
+++ b/.codex/skills/gh-release-publish/scripts/publish-release.mjs
@@ -11,8 +11,6 @@ import {
   ensureGhAuth,
   fetchMainAndTags,
   formatReleasePlanSummary,
-  getCurrentBranch,
-  getGitStatusPorcelain,
   getHeadSha,
   getLatestReleaseTag,
   getReleaseByTag,
@@ -27,6 +25,8 @@ import {
   tagExists,
   waitForWorkflowRun,
 } from './lib.mjs'
+
+const RELEASE_REF = 'origin/main'
 
 function ensureExactFlagSelection() {
   const dryRun = process.argv.includes('--dry-run')
@@ -78,30 +78,15 @@ async function main() {
     repoSlug,
     secretName: GOOGLE_CHAT_SECRET_NAME,
   })
-
-  const branch = getCurrentBranch()
-  if (branch !== 'main') {
-    throw new Error(`Releases must be created from main. Current branch: ${branch}`)
-  }
-
-  const status = getGitStatusPorcelain()
-  if (status) {
-    throw new Error('Working tree must be clean before publishing a release.')
-  }
-
-  const localHead = getHeadSha('HEAD')
-  const remoteHead = getHeadSha('origin/main')
-  if (localHead !== remoteHead) {
-    throw new Error('HEAD must match origin/main before publishing a release.')
-  }
-
-  const lastTag = getLatestReleaseTag()
+  const remoteHead = getHeadSha(RELEASE_REF)
+  const lastTag = getLatestReleaseTag(RELEASE_REF)
   if (!lastTag) {
     throw new Error('No merged semantic version tag matching v*.*.* was found.')
   }
 
   const releasePlan = await determineNextReleaseWithReferences({
     lastTag,
+    ref: RELEASE_REF,
     repoSlug,
   })
   if (tagExists(releasePlan.nextTag)) {
@@ -163,7 +148,7 @@ async function main() {
     repoSlug,
     workflowFile: PRODUCTION_DEPLOY_WORKFLOW_FILE,
     ref: 'main',
-    headSha: localHead,
+    headSha: remoteHead,
     dispatchedAt: dispatch.dispatchedAt,
   })
   console.log(`Production workflow succeeded: ${workflowRun.html_url}`)

--- a/tests/unit/scripts/gh-release-publish.test.ts
+++ b/tests/unit/scripts/gh-release-publish.test.ts
@@ -464,12 +464,14 @@ describe('gh-release-publish announcement source flow', () => {
       references: MANAGEMENT_REFERENCES,
       siteUrl: 'https://findmydoc.eu',
       googleChatSecretConfigured: true,
+      releaseTargetCommitish: 'abc123',
     })
 
     expect(dryRunPlan.release.endpoint).toBe('repos/findmydoc-platform/website/releases')
     expect(dryRunPlan.release.payload.tag_name).toBe('v0.30.0')
+    expect(dryRunPlan.release.payload.target_commitish).toBe('abc123')
     expect(dryRunPlan.deployment.workflowFile).toBe(PRODUCTION_DEPLOY_WORKFLOW_FILE)
-    expect(dryRunPlan.deployment.payload.ref).toBe('main')
+    expect(dryRunPlan.deployment.payload.ref).toBe('v0.30.0')
     expect(dryRunPlan.chat.repositorySecretConfigured).toBe(true)
     expect(dryRunPlan.chat.repositorySecretName).toBe(GOOGLE_CHAT_SECRET_NAME)
     expect(dryRunPlan.chat.workflowFile).toBe('send-release-google-chat.yml')


### PR DESCRIPTION
This change makes the release skill derive release scope from origin/main instead of the caller local Git state.

## What changed
- moved the shared release helpers to accept an explicit Git ref and use origin/main for tag lookup, commit range calculation, and SemVer planning in the release flow
- removed local branch, clean-worktree, and HEAD == origin/main guards from the publish script while keeping fetch origin main --tags as the sync step
- pinned GitHub release creation to the fetched origin/main SHA, dispatched production deploys from the created release tag, and updated the related unit test and skill docs to match that behavior

## Validation
- pnpm format
- pnpm vitest tests/unit/scripts/gh-release-publish.test.ts
- node .codex/skills/gh-release-publish/scripts/publish-release.mjs --dry-run
- pnpm check (fails due to existing src/payload-types.ts drift outside this change)
- pnpm ai:slop-check (fails due to existing AGENTS.md line-budget violation: 181 > 180)

## Development
- Closes #992
