### PR TITLE
fix(ci): surface payload type changes in pr reviews

### DIFF
--- a/.github/scripts/ci/check-payload-types.sh
+++ b/.github/scripts/ci/check-payload-types.sh
@@ -3,21 +3,150 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/../../.." && pwd)"
-source_file="${repo_root}/src/payload-types.ts"
+base_ref="${GITHUB_BASE_REF:-}"
+summary_file="${GITHUB_STEP_SUMMARY:-}"
 
-tmp_dir="$(mktemp -d)"
-trap 'rm -rf "${tmp_dir}"' EXIT
-
-generated_file="${tmp_dir}/payload-types.ts"
-
-echo "Generating Payload types into a temporary file..."
-PAYLOAD_TS_OUTPUT_PATH="${generated_file}" pnpm run payload generate:types
-
-if git -C "${repo_root}" diff --no-index --quiet -- "${source_file}" "${generated_file}"; then
-  echo "Payload types are up to date."
+if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" || -z "${base_ref}" ]]; then
+  echo "Payload type diff reporting only runs on pull_request events; skipping."
   exit 0
 fi
 
-echo "::error::src/payload-types.ts is out of date. Regenerate it with pnpm run payload generate:types and commit the result."
-git -C "${repo_root}" diff --no-index -- "${source_file}" "${generated_file}" || true
-exit 1
+base_commit="origin/${base_ref}"
+git -C "${repo_root}" fetch --no-tags origin "${base_ref}" >/dev/null 2>&1
+git -C "${repo_root}" rev-parse --verify "${base_commit}" >/dev/null
+
+schema_config_changed='false'
+schema_anchor_path=''
+schema_changed_files="$(
+  git -C "${repo_root}" diff --name-only "${base_commit}...HEAD" -- \
+    src/payload.config.ts \
+    src/collections \
+    src/globals \
+    src/blocks \
+    src/fields \
+    src/plugins
+)"
+
+if [[ -n "${schema_changed_files}" ]]; then
+  schema_config_changed='true'
+  schema_anchor_path="$(printf '%s\n' "${schema_changed_files}" | head -n 1)"
+fi
+
+payload_dependency_changed='false'
+payload_dependency_anchor_path=''
+payload_dependency_changed_files=''
+
+package_json_payload_dependency_changed='false'
+if ! git -C "${repo_root}" diff --quiet "${base_commit}...HEAD" -- package.json; then
+  if git -C "${repo_root}" diff --unified=0 "${base_commit}...HEAD" -- package.json | grep -Eq \
+    '^[+-][[:space:]]+"(payload|@payloadcms/[^"]+)":'; then
+    package_json_payload_dependency_changed='true'
+    payload_dependency_changed='true'
+    payload_dependency_anchor_path='package.json'
+    payload_dependency_changed_files='package.json'
+  fi
+fi
+
+pnpm_lock_payload_dependency_changed='false'
+if ! git -C "${repo_root}" diff --quiet "${base_commit}...HEAD" -- pnpm-lock.yaml; then
+  if git -C "${repo_root}" diff --unified=0 "${base_commit}...HEAD" -- pnpm-lock.yaml | grep -Eq \
+    '^[+-].*(@payloadcms/|(^|[^[:alnum:]_])payload@)'; then
+    pnpm_lock_payload_dependency_changed='true'
+    payload_dependency_changed='true'
+    payload_dependency_anchor_path="${payload_dependency_anchor_path:-pnpm-lock.yaml}"
+    if [[ -n "${payload_dependency_changed_files}" ]]; then
+      payload_dependency_changed_files="${payload_dependency_changed_files}"$'\n''pnpm-lock.yaml'
+    else
+      payload_dependency_changed_files='pnpm-lock.yaml'
+    fi
+  fi
+fi
+
+payload_types_changed='false'
+if ! git -C "${repo_root}" diff --quiet "${base_commit}...HEAD" -- src/payload-types.ts; then
+  payload_types_changed='true'
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "schema_config_changed=${schema_config_changed}"
+    echo "schema_anchor_path=${schema_anchor_path}"
+    echo "payload_dependency_changed=${payload_dependency_changed}"
+    echo "payload_dependency_anchor_path=${payload_dependency_anchor_path}"
+    echo "payload_types_changed=${payload_types_changed}"
+  } >> "${GITHUB_OUTPUT}"
+fi
+
+if [[ "${schema_config_changed}" == 'false' && "${payload_dependency_changed}" == 'false' && "${payload_types_changed}" == 'false' ]]; then
+  echo "No Payload-related changes detected."
+
+  if [[ -n "${summary_file}" ]]; then
+    {
+      echo "## Payload Types"
+      echo "- Base ref: \`${base_ref}\`"
+      echo "- Result: no Payload-related changes detected."
+    } >> "${summary_file}"
+  fi
+
+  exit 0
+fi
+
+if [[ "${schema_config_changed}" == 'true' ]]; then
+  echo "::notice::Payload schema/config inputs changed in this pull request."
+fi
+
+if [[ "${payload_dependency_changed}" == 'true' ]]; then
+  echo "::notice::Payload package versions changed in this pull request."
+fi
+
+if [[ "${payload_types_changed}" == 'true' ]]; then
+  echo "::notice::src/payload-types.ts changed in this pull request."
+fi
+
+if [[ "${payload_types_changed}" == 'false' && ( "${schema_config_changed}" == 'true' || "${payload_dependency_changed}" == 'true' ) ]]; then
+  echo "::warning::Payload inputs changed, but src/payload-types.ts did not."
+fi
+
+if [[ "${payload_types_changed}" == 'true' && "${schema_config_changed}" == 'false' && "${payload_dependency_changed}" == 'false' ]]; then
+  echo "::warning::src/payload-types.ts changed without a detected schema/config or Payload dependency change."
+fi
+
+if [[ -n "${summary_file}" ]]; then
+  {
+    echo "## Payload Types"
+    echo "- Base ref: \`${base_ref}\`"
+    echo "- Schema/config inputs changed: \`${schema_config_changed}\`"
+    echo "- Payload package versions changed: \`${payload_dependency_changed}\`"
+    echo "- Generated \`src/payload-types.ts\` changed: \`${payload_types_changed}\`"
+    echo ""
+  } >> "${summary_file}"
+
+  if [[ "${schema_config_changed}" == 'true' ]]; then
+    {
+      echo "<details><summary>schema/config input files</summary>"
+      echo ""
+      printf '%s\n' "${schema_changed_files}" | sed 's/^/- /'
+      echo "</details>"
+    } >> "${summary_file}"
+  fi
+
+  if [[ "${payload_dependency_changed}" == 'true' ]]; then
+    {
+      echo "<details><summary>payload dependency files</summary>"
+      echo ""
+      printf '%s\n' "${payload_dependency_changed_files}" | sed 's/^/- /'
+      echo "</details>"
+    } >> "${summary_file}"
+  fi
+
+  if [[ "${payload_types_changed}" == 'true' ]]; then
+    {
+      echo "<details><summary>payload-types diff</summary>"
+      echo ""
+      echo '```diff'
+      git -C "${repo_root}" diff --unified=3 "${base_commit}...HEAD" -- src/payload-types.ts | sed '1,4d'
+      echo '```'
+      echo "</details>"
+    } >> "${summary_file}"
+  fi
+fi

--- a/.github/scripts/lib/review-comment-sync.cjs
+++ b/.github/scripts/lib/review-comment-sync.cjs
@@ -1,0 +1,241 @@
+const MAX_PAGES = 20
+const PAGE_SIZE = 100
+
+const normalizeAnchorPath = (anchor) => {
+  if (!anchor) {
+    return ''
+  }
+
+  if (typeof anchor === 'string') {
+    return anchor
+  }
+
+  return String(anchor.filename ?? '')
+}
+
+const createManagedMarker = ({ scopeName, categoryKey }) => `<!-- review-comment-sync:${scopeName}:${categoryKey} -->`
+
+async function listPullFiles({ github, owner, repo, pull_number }) {
+  const files = []
+
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const { data } = await github.rest.pulls.listFiles({
+      owner,
+      repo,
+      pull_number,
+      per_page: PAGE_SIZE,
+      page,
+    })
+
+    if (!data?.length) {
+      break
+    }
+
+    files.push(...data)
+
+    if (data.length < PAGE_SIZE) {
+      break
+    }
+  }
+
+  return files
+}
+
+async function listReviewComments({ github, owner, repo, pull_number }) {
+  const comments = []
+
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const { data } = await github.rest.pulls.listReviewComments({
+      owner,
+      repo,
+      pull_number,
+      per_page: PAGE_SIZE,
+      page,
+    })
+
+    if (!data?.length) {
+      break
+    }
+
+    comments.push(...data)
+
+    if (data.length < PAGE_SIZE) {
+      break
+    }
+  }
+
+  return comments
+}
+
+async function deleteReviewComment({ github, owner, repo, comment_id }) {
+  await github.rest.pulls.deleteReviewComment({
+    owner,
+    repo,
+    comment_id,
+  })
+}
+
+function isManagedBotComment({ comment, marker }) {
+  const body = String(comment.body ?? '')
+  const login = String(comment.user?.login ?? '')
+  const userType = String(comment.user?.type ?? '')
+
+  return body.includes(marker) && login === 'github-actions[bot]' && userType === 'Bot'
+}
+
+async function syncCategoryComment({
+  github,
+  owner,
+  repo,
+  pull_number,
+  commit_id,
+  existingComments,
+  active,
+  anchorPath,
+  body,
+}) {
+  if (!active) {
+    for (const comment of existingComments) {
+      await deleteReviewComment({ github, owner, repo, comment_id: comment.id })
+    }
+
+    return
+  }
+
+  if (!anchorPath) {
+    return
+  }
+
+  const reusableComment = existingComments.find((comment) => comment.path === anchorPath)
+  const staleComments = existingComments.filter((comment) => comment.id !== reusableComment?.id)
+
+  for (const comment of staleComments) {
+    await deleteReviewComment({ github, owner, repo, comment_id: comment.id })
+  }
+
+  if (reusableComment) {
+    if (reusableComment.body !== body) {
+      await github.rest.pulls.updateReviewComment({
+        owner,
+        repo,
+        comment_id: reusableComment.id,
+        body,
+      })
+    }
+
+    return
+  }
+
+  await github.rest.pulls.createReviewComment({
+    owner,
+    repo,
+    pull_number,
+    commit_id,
+    path: anchorPath,
+    subject_type: 'file',
+    body,
+  })
+}
+
+async function syncManagedFileReviewComments({ github, context, core, scopeName, categories }) {
+  const pullRequest = context.payload.pull_request
+
+  if (!pullRequest) {
+    core.info(`No pull_request payload available; skipping ${scopeName}.`)
+    return
+  }
+
+  const owner = context.repo.owner
+  const repo = context.repo.repo
+  const pull_number = pullRequest.number
+  const commit_id = pullRequest.head.sha
+
+  const files = await listPullFiles({ github, owner, repo, pull_number })
+  const reviewComments = await listReviewComments({ github, owner, repo, pull_number })
+
+  const categoryStates = {}
+
+  for (const category of categories) {
+    const marker = createManagedMarker({ scopeName, categoryKey: category.key })
+
+    categoryStates[category.key] = {
+      marker,
+      existingComments: reviewComments.filter((comment) => isManagedBotComment({ comment, marker })),
+      active: false,
+      anchorPath: '',
+      body: '',
+    }
+  }
+
+  for (const category of categories) {
+    categoryStates[category.key].active = Boolean(
+      await category.isActive({
+        files,
+        pullRequest,
+        context,
+        github,
+        core,
+        categoryStates,
+      }),
+    )
+  }
+
+  const activeCategoryCount = Object.values(categoryStates).filter((categoryState) => categoryState.active).length
+
+  if (activeCategoryCount === 0) {
+    core.info(`No active review comment categories for ${scopeName}.`)
+  }
+
+  for (const category of categories) {
+    const categoryState = categoryStates[category.key]
+
+    if (categoryState.active) {
+      categoryState.anchorPath = normalizeAnchorPath(
+        await category.getAnchorPath({
+          files,
+          pullRequest,
+          context,
+          github,
+          core,
+          categoryStates,
+        }),
+      )
+
+      if (!categoryState.anchorPath) {
+        core.warning(`No anchor path available for ${scopeName}:${category.key}.`)
+      } else {
+        const body = await category.buildBody({
+          files,
+          pullRequest,
+          context,
+          github,
+          core,
+          categoryStates,
+          marker: categoryState.marker,
+        })
+
+        categoryState.body = String(body).includes(categoryState.marker)
+          ? String(body)
+          : `${categoryState.marker}\n${String(body)}`
+      }
+    }
+
+    await syncCategoryComment({
+      github,
+      owner,
+      repo,
+      pull_number,
+      commit_id,
+      existingComments: categoryState.existingComments,
+      active: categoryState.active,
+      anchorPath: categoryState.anchorPath,
+      body: categoryState.body,
+    })
+  }
+}
+
+module.exports = {
+  createManagedMarker,
+  isManagedBotComment,
+  syncManagedFileReviewComments,
+}

--- a/.github/scripts/payload-type-review-comments.cjs
+++ b/.github/scripts/payload-type-review-comments.cjs
@@ -1,0 +1,119 @@
+const { syncManagedFileReviewComments } = require('./lib/review-comment-sync.cjs')
+
+const SCHEMA_CATEGORY = 'schema-config'
+const DEPENDENCY_CATEGORY = 'payload-dependencies'
+const TYPES_CATEGORY = 'generated-types'
+
+const isSchemaConfigPath = (filename) =>
+  filename === 'src/payload.config.ts' ||
+  filename.startsWith('src/collections/') ||
+  filename.startsWith('src/globals/') ||
+  filename.startsWith('src/blocks/') ||
+  filename.startsWith('src/fields/') ||
+  filename.startsWith('src/plugins/')
+
+const isDependencyPath = (filename) => filename === 'package.json' || filename === 'pnpm-lock.yaml'
+
+const hasPayloadDependencyDiff = (files) =>
+  files.some((file) => {
+    if (!isDependencyPath(file.filename)) {
+      return false
+    }
+
+    const patch = String(file.patch ?? '')
+
+    if (file.filename === 'package.json') {
+      return /^[+-][ \t]+"(payload|@payloadcms\/[^"]+)":/m.test(patch)
+    }
+
+    return /^[+-].*(@payloadcms\/|(^|[^A-Za-z0-9_])payload@)/m.test(patch)
+  })
+
+const formatChangedFiles = (files) =>
+  files
+    .slice(0, 5)
+    .map((file) => `- \`${file.filename}\``)
+    .join('\n')
+
+const getPayloadCategoryFlags = (categoryStates) => ({
+  schemaConfigChanged: Boolean(categoryStates[SCHEMA_CATEGORY]?.active),
+  payloadDependencyChanged: Boolean(categoryStates[DEPENDENCY_CATEGORY]?.active),
+  payloadTypesChanged: Boolean(categoryStates[TYPES_CATEGORY]?.active),
+})
+
+const payloadTypeReviewCategories = [
+  {
+    key: SCHEMA_CATEGORY,
+    isActive: ({ files }) => files.some((file) => isSchemaConfigPath(file.filename)),
+    getAnchorPath: ({ files }) => files.find((file) => isSchemaConfigPath(file.filename))?.filename ?? '',
+    buildBody: ({ files, categoryStates }) => {
+      const { payloadTypesChanged } = getPayloadCategoryFlags(categoryStates)
+      const lead = payloadTypesChanged
+        ? 'Payload schema/config inputs changed in this PR, and `src/payload-types.ts` also changed.'
+        : 'Payload schema/config inputs changed in this PR, but `src/payload-types.ts` did not.'
+
+      return [
+        lead,
+        '',
+        'Review whether the generated Payload types are expected for these schema/config changes, then resolve this conversation.',
+        '',
+        'Changed files:',
+        formatChangedFiles(files.filter((file) => isSchemaConfigPath(file.filename))),
+      ].join('\n')
+    },
+  },
+  {
+    key: DEPENDENCY_CATEGORY,
+    isActive: ({ files }) => hasPayloadDependencyDiff(files),
+    getAnchorPath: ({ files }) =>
+      files.find((file) => file.filename === 'package.json')?.filename ??
+      files.find((file) => file.filename === 'pnpm-lock.yaml')?.filename ??
+      '',
+    buildBody: ({ files, categoryStates }) => {
+      const { payloadTypesChanged } = getPayloadCategoryFlags(categoryStates)
+      const lead = payloadTypesChanged
+        ? 'Payload package versions changed in this PR, and `src/payload-types.ts` also changed.'
+        : 'Payload package versions changed in this PR, but `src/payload-types.ts` did not.'
+
+      return [
+        lead,
+        '',
+        'Upstream Payload releases can change generated type output. Review whether the resulting Payload types are expected for this dependency change, then resolve this conversation.',
+        '',
+        'Changed files:',
+        formatChangedFiles(files.filter((file) => isDependencyPath(file.filename))),
+      ].join('\n')
+    },
+  },
+  {
+    key: TYPES_CATEGORY,
+    isActive: ({ files }) => files.some((file) => file.filename === 'src/payload-types.ts'),
+    getAnchorPath: () => 'src/payload-types.ts',
+    buildBody: ({ categoryStates }) => {
+      const { schemaConfigChanged, payloadDependencyChanged } = getPayloadCategoryFlags(categoryStates)
+      const lead =
+        schemaConfigChanged || payloadDependencyChanged
+          ? '`src/payload-types.ts` changed in this PR.'
+          : '`src/payload-types.ts` changed without a detected schema/config or Payload dependency change in this PR.'
+
+      return [
+        lead,
+        '',
+        'Review whether this generated type diff is intentional, then resolve this conversation.',
+        '',
+        'Changed files:',
+        '- `src/payload-types.ts`',
+      ].join('\n')
+    },
+  },
+]
+
+module.exports = async function run({ github, context, core }) {
+  await syncManagedFileReviewComments({
+    github,
+    context,
+    core,
+    scopeName: 'payload-type-review',
+    categories: payloadTypeReviewCategories,
+  })
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Check migrations
         run: bash ./.github/scripts/ci/check-migrations-diff.sh "origin/main" "HEAD"
 
-      - name: Check payload types
+      - name: Report payload type changes
         run: pnpm run check:payload-types
 
       - name: Story governance check

--- a/.github/workflows/pr-gates.yml
+++ b/.github/workflows/pr-gates.yml
@@ -11,6 +11,24 @@ permissions:
   contents: read
 
 jobs:
+  payload-type-review-comments:
+    name: sync payload type review comments
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: sync payload type review comments
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const run = require('./.github/scripts/payload-type-review-comments.cjs');
+            await run({ github, context, core });
+
   pr-label:
     name: label pr
     runs-on: ubuntu-latest

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -4831,7 +4831,6 @@ export interface TaskCreateCollectionExport {
       | 'forms'
       | 'form-submissions'
       | 'search'
-      | 'payload-mcp-api-keys'
       | 'exports'
       | 'imports';
     drafts?: ('yes' | 'no') | null;

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -17,40 +17,6 @@ import { shouldUseCloudStorage } from './storageConfig'
 import { Page, Post } from '@/payload-types'
 import { getServerSideURL } from '@/utilities/getURL'
 
-const systemCollectionSlugOrder = ['exports', 'imports', 'payload-mcp-api-keys'] as const
-const systemCollectionSlugSet = new Set<string>(systemCollectionSlugOrder)
-
-const stabilizeSystemCollectionOrderPlugin: Plugin = (incomingConfig) => {
-  const collections = incomingConfig.collections ?? []
-  const firstSystemCollectionIndex = collections.findIndex((collection) => systemCollectionSlugSet.has(collection.slug))
-
-  if (firstSystemCollectionIndex === -1) {
-    return incomingConfig
-  }
-
-  const collectionsBySlug = new Map(collections.map((collection) => [collection.slug, collection]))
-  const orderedSystemCollections = systemCollectionSlugOrder
-    .map((slug) => collectionsBySlug.get(slug))
-    .filter((collection): collection is NonNullable<typeof collection> => Boolean(collection))
-
-  if (orderedSystemCollections.length < 2) {
-    return incomingConfig
-  }
-
-  const remainingCollections = collections
-    .slice(firstSystemCollectionIndex)
-    .filter((collection) => !systemCollectionSlugSet.has(collection.slug))
-
-  return {
-    ...incomingConfig,
-    collections: [
-      ...collections.slice(0, firstSystemCollectionIndex),
-      ...orderedSystemCollections,
-      ...remainingCollections,
-    ],
-  }
-}
-
 const generateTitle: GenerateTitle<Post | Page> = ({ doc }) => {
   return doc?.title ? `${doc.title} | findmydoc` : 'findmydoc'
 }
@@ -233,6 +199,5 @@ export const plugins: Plugin[] = [
       { slug: 'tags' },
     ],
   }),
-  stabilizeSystemCollectionOrderPlugin,
   s3StoragePlugin,
 ]


### PR DESCRIPTION
Payload type changes are now surfaced in PR summaries and resolvable review threads instead of failing CI on environment-order noise.

## What changed
- removed the runtime system-collection reordering workaround from the Payload plugin stack
- changed `.github/scripts/ci/check-payload-types.sh` to classify schema/config changes, Payload dependency changes, and generated type diffs in PR validation without failing the job
- added a generic file review comment sync helper in `.github/scripts/lib/review-comment-sync.cjs` plus a Payload-specific adapter used from `PR Gates` to keep resolvable review threads attached to relevant files
- hardened managed review comment reuse so only bot-authored marker comments are synchronized

## Validation
- `pnpm format`
- `pnpm check`
- `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build`
- `node --check .github/scripts/lib/review-comment-sync.cjs`
- `node --check .github/scripts/payload-type-review-comments.cjs`

## Development
- Closes #987
