### PR TITLE
test: scope clinic map smoke ignore to osm embeds

### DIFF
--- a/tests/e2e/helpers/browserIssues.ts
+++ b/tests/e2e/helpers/browserIssues.ts
@@ -27,7 +27,9 @@ export const createBrowserIssueCollector = (
     }
 
     const text = message.text()
-    if (options.ignoredConsoleErrors?.some((pattern) => consoleErrorMatches(text, pattern))) {
+    const locationUrl = message.location().url
+    const matchText = locationUrl ? `${text} ${locationUrl}` : text
+    if (options.ignoredConsoleErrors?.some((pattern) => consoleErrorMatches(matchText, pattern))) {
       return
     }
 

--- a/tests/e2e/public/clinic-detail.public-smoke.spec.ts
+++ b/tests/e2e/public/clinic-detail.public-smoke.spec.ts
@@ -43,7 +43,11 @@ test.describe('clinic detail map dialog', () => {
     page,
     context,
   }) => {
-    const issues = createBrowserIssueCollector(page)
+    const issues = createBrowserIssueCollector(page, {
+      ignoredConsoleErrors: [
+        /Failed to load resource: the server responded with a status of 404 .*openstreetmap\.org\//,
+      ],
+    })
 
     await context.clearCookies()
     await setCookieConsent(context, { functional: true })

--- a/tests/unit/helpers/adminUI.test.ts
+++ b/tests/unit/helpers/adminUI.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { createBrowserIssueCollector } from '../../e2e/helpers/adminUI'
 import type { Page } from '@playwright/test'
 
-type ConsoleListener = (message: { type: () => string; text: () => string }) => void
+type ConsoleListener = (message: { type: () => string; text: () => string; location: () => { url: string } }) => void
 type PageErrorListener = (error: Error) => void
 
 const createMockPage = () => {
@@ -23,8 +23,8 @@ const createMockPage = () => {
 
   return {
     page,
-    emitConsoleError(text: string) {
-      const message = { type: () => 'error', text: () => text }
+    emitConsoleError(text: string, url = '') {
+      const message = { type: () => 'error', text: () => text, location: () => ({ url }) }
       for (const listener of consoleListeners) {
         listener(message)
       }
@@ -51,5 +51,22 @@ describe('createBrowserIssueCollector', () => {
 
     expect(issues.consoleErrors).toEqual([])
     expect(issues.pageErrors).toEqual(['unexpected page error'])
+  })
+
+  it('can ignore a console error only when the source URL matches', () => {
+    const mockPage = createMockPage()
+    const issues = createBrowserIssueCollector(mockPage.page, {
+      ignoredConsoleErrors: [
+        /Failed to load resource: the server responded with a status of 404 .*openstreetmap\.org\//,
+      ],
+    })
+
+    mockPage.emitConsoleError(
+      'Failed to load resource: the server responded with a status of 404 ()',
+      'https://www.openstreetmap.org/export/embed.html?bbox=1%2C2%2C3%2C4',
+    )
+    mockPage.emitConsoleError('Failed to load resource: the server responded with a status of 404 ()', '/api/internal')
+
+    expect(issues.consoleErrors).toEqual(['Failed to load resource: the server responded with a status of 404 ()'])
   })
 })


### PR DESCRIPTION
This change stabilizes the clinic detail public smoke test against a known intermittent OpenStreetMap embed 404 in CI without weakening the browser issue checks globally.

## What changed
- updated the browser issue collector to match ignored console errors against the combined console text and source URL
- scoped the clinic detail map smoke ignore to the OpenStreetMap embed 404 instead of ignoring all 404 console errors
- added unit coverage for the URL-scoped ignore behavior in the browser issue collector helper

## Validation
- pnpm format
- pnpm vitest tests/unit/helpers/adminUI.test.ts
- pnpm tests:e2e:smoke:public --grep "clinic detail map dialog"

## Development
- Closes #995
