### PR TITLE
fix(ci): drive payload type feedback from generated diffs

### DIFF
--- a/.codex/skills/gh-release-publish/scripts/lib.mjs
+++ b/.codex/skills/gh-release-publish/scripts/lib.mjs
@@ -1790,6 +1790,7 @@ export async function buildStakeholderAnnouncementSourceWithReferences({
  *   googleChatSecretName?: string
  *   chatWorkflowFile?: string
  *   chatWorkflowRef?: string
+ *   releaseTargetCommitish?: string
  *   workflowFile?: string
  *   workflowRef?: string
  * }} options

--- a/.github/scripts/ci/check-payload-types.sh
+++ b/.github/scripts/ci/check-payload-types.sh
@@ -5,6 +5,8 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/../../.." && pwd)"
 base_ref="${GITHUB_BASE_REF:-}"
 summary_file="${GITHUB_STEP_SUMMARY:-}"
+snippet_max_hunks=3
+snippet_max_lines=120
 
 if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" || -z "${base_ref}" ]]; then
   echo "Payload type diff reporting only runs on pull_request events; skipping."
@@ -14,6 +16,68 @@ fi
 base_commit="origin/${base_ref}"
 git -C "${repo_root}" fetch --no-tags origin "${base_ref}" >/dev/null 2>&1
 git -C "${repo_root}" rev-parse --verify "${base_commit}" >/dev/null
+
+write_multiline_output() {
+  local key="$1"
+  local value="$2"
+  local delimiter="PAYLOAD_TYPES_${key}_EOF"
+
+  {
+    echo "${key}<<${delimiter}"
+    printf '%s\n' "${value}"
+    echo "${delimiter}"
+  } >> "${GITHUB_OUTPUT}"
+}
+
+emit_outputs() {
+  if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
+    return
+  fi
+
+  {
+    echo "schema_config_changed=${schema_config_changed}"
+    echo "schema_anchor_path=${schema_anchor_path}"
+    echo "payload_dependency_changed=${payload_dependency_changed}"
+    echo "payload_dependency_anchor_path=${payload_dependency_anchor_path}"
+    echo "dependency_manifest_changed=${dependency_manifest_changed}"
+    echo "committed_payload_types_changed=${committed_payload_types_changed}"
+    echo "generated_diff_detected=${generated_diff_detected}"
+    echo "unknown_other_cause=${unknown_other_cause}"
+    echo "review_comment_mode=${review_comment_mode}"
+    echo "review_anchor_path=${review_anchor_path}"
+  } >> "${GITHUB_OUTPUT}"
+
+  write_multiline_output "diff_snippet" "${diff_snippet}"
+}
+
+build_diff_snippet() {
+  local diff_file="$1"
+
+  awk -v max_hunks="${snippet_max_hunks}" -v max_lines="${snippet_max_lines}" '
+    BEGIN {
+      hunk_count = 0
+      line_count = 0
+    }
+    NR <= 2 {
+      print
+      line_count += 1
+      next
+    }
+    /^@@/ {
+      hunk_count += 1
+      if (hunk_count > max_hunks) {
+        exit
+      }
+    }
+    {
+      if (line_count >= max_lines) {
+        exit
+      }
+      print
+      line_count += 1
+    }
+  ' "${diff_file}"
+}
 
 schema_config_changed='false'
 schema_anchor_path=''
@@ -30,6 +94,19 @@ schema_changed_files="$(
 if [[ -n "${schema_changed_files}" ]]; then
   schema_config_changed='true'
   schema_anchor_path="$(printf '%s\n' "${schema_changed_files}" | head -n 1)"
+fi
+
+dependency_manifest_changed='false'
+dependency_manifest_anchor_path=''
+
+if ! git -C "${repo_root}" diff --quiet "${base_commit}...HEAD" -- package.json; then
+  dependency_manifest_changed='true'
+  dependency_manifest_anchor_path='package.json'
+fi
+
+if ! git -C "${repo_root}" diff --quiet "${base_commit}...HEAD" -- pnpm-lock.yaml; then
+  dependency_manifest_changed='true'
+  dependency_manifest_anchor_path="${dependency_manifest_anchor_path:-pnpm-lock.yaml}"
 fi
 
 payload_dependency_changed='false'
@@ -62,91 +139,141 @@ if ! git -C "${repo_root}" diff --quiet "${base_commit}...HEAD" -- pnpm-lock.yam
   fi
 fi
 
-payload_types_changed='false'
+committed_payload_types_changed='false'
 if ! git -C "${repo_root}" diff --quiet "${base_commit}...HEAD" -- src/payload-types.ts; then
-  payload_types_changed='true'
+  committed_payload_types_changed='true'
 fi
 
-if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-  {
-    echo "schema_config_changed=${schema_config_changed}"
-    echo "schema_anchor_path=${schema_anchor_path}"
-    echo "payload_dependency_changed=${payload_dependency_changed}"
-    echo "payload_dependency_anchor_path=${payload_dependency_anchor_path}"
-    echo "payload_types_changed=${payload_types_changed}"
-  } >> "${GITHUB_OUTPUT}"
-fi
+generated_diff_detected='false'
+unknown_other_cause='false'
+review_comment_mode='none'
+review_anchor_path=''
+diff_snippet=''
 
-if [[ "${schema_config_changed}" == 'false' && "${payload_dependency_changed}" == 'false' && "${payload_types_changed}" == 'false' ]]; then
-  echo "No Payload-related changes detected."
+if [[ "${schema_config_changed}" == 'false' && "${dependency_manifest_changed}" == 'false' && "${committed_payload_types_changed}" == 'false' ]]; then
+  emit_outputs
+  echo "No Payload-related source, dependency, or committed payload type changes detected."
 
   if [[ -n "${summary_file}" ]]; then
     {
       echo "## Payload Types"
       echo "- Base ref: \`${base_ref}\`"
-      echo "- Result: no Payload-related changes detected."
+      echo "- Result: no Payload type comparison triggered."
     } >> "${summary_file}"
   fi
 
   exit 0
 fi
 
-if [[ "${schema_config_changed}" == 'true' ]]; then
-  echo "::notice::Payload schema/config inputs changed in this pull request."
+tmp_dir="$(mktemp -d)"
+base_worktree="${tmp_dir}/base-worktree"
+base_types_file="${tmp_dir}/generated-base-payload-types.ts"
+head_types_file="${tmp_dir}/generated-head-payload-types.ts"
+full_diff_file="${tmp_dir}/generated-payload-types.diff"
+
+cleanup() {
+  git -C "${repo_root}" worktree remove --force "${base_worktree}" >/dev/null 2>&1 || true
+  rm -rf "${tmp_dir}"
+}
+
+trap cleanup EXIT
+
+git -C "${repo_root}" worktree add --detach "${base_worktree}" "${base_commit}" >/dev/null
+
+if [[ "${dependency_manifest_changed}" == 'true' ]]; then
+  echo "Installing base-commit dependencies for Payload type comparison..."
+  (
+    cd "${base_worktree}"
+    pnpm install --frozen-lockfile
+  )
+else
+  ln -s "${repo_root}/node_modules" "${base_worktree}/node_modules"
 fi
 
-if [[ "${payload_dependency_changed}" == 'true' ]]; then
-  echo "::notice::Payload package versions changed in this pull request."
+echo "Generating Payload types for PR head..."
+(
+  cd "${repo_root}"
+  PAYLOAD_TS_OUTPUT_PATH="${head_types_file}" pnpm run payload generate:types
+)
+
+echo "Generating Payload types for PR base..."
+(
+  cd "${base_worktree}"
+  PAYLOAD_TS_OUTPUT_PATH="${base_types_file}" pnpm run payload generate:types
+)
+
+if diff -u \
+  --label generated/base/payload-types.ts \
+  --label generated/head/payload-types.ts \
+  "${base_types_file}" \
+  "${head_types_file}" > "${full_diff_file}"; then
+  generated_diff_detected='false'
+else
+  diff_exit_code=$?
+
+  if [[ "${diff_exit_code}" -ne 1 ]]; then
+    exit "${diff_exit_code}"
+  fi
+
+  generated_diff_detected='true'
 fi
 
-if [[ "${payload_types_changed}" == 'true' ]]; then
-  echo "::notice::src/payload-types.ts changed in this pull request."
+if [[ "${generated_diff_detected}" == 'false' ]]; then
+  emit_outputs
+  echo "Compared CI-generated Payload types for base and head. No diff detected."
+
+  if [[ -n "${summary_file}" ]]; then
+    {
+      echo "## Payload Types"
+      echo "- Base ref: \`${base_ref}\`"
+      echo "- Result: no CI-generated Payload type diff detected."
+    } >> "${summary_file}"
+  fi
+
+  exit 0
 fi
 
-if [[ "${payload_types_changed}" == 'false' && ( "${schema_config_changed}" == 'true' || "${payload_dependency_changed}" == 'true' ) ]]; then
-  echo "::warning::Payload inputs changed, but src/payload-types.ts did not."
+if [[ "${schema_config_changed}" == 'false' && "${payload_dependency_changed}" == 'false' ]]; then
+  unknown_other_cause='true'
 fi
 
-if [[ "${payload_types_changed}" == 'true' && "${schema_config_changed}" == 'false' && "${payload_dependency_changed}" == 'false' ]]; then
-  echo "::warning::src/payload-types.ts changed without a detected schema/config or Payload dependency change."
+if [[ -n "${schema_anchor_path}" ]]; then
+  review_comment_mode='review'
+  review_anchor_path="${schema_anchor_path}"
+elif [[ -n "${payload_dependency_anchor_path}" ]]; then
+  review_comment_mode='review'
+  review_anchor_path="${payload_dependency_anchor_path}"
+elif [[ -n "${dependency_manifest_anchor_path}" ]]; then
+  review_comment_mode='review'
+  review_anchor_path="${dependency_manifest_anchor_path}"
+elif [[ "${committed_payload_types_changed}" == 'true' ]]; then
+  review_comment_mode='review'
+  review_anchor_path='src/payload-types.ts'
+else
+  review_comment_mode='sticky'
 fi
+
+diff_snippet="$(build_diff_snippet "${full_diff_file}")"
+
+emit_outputs
+
+echo "::notice::CI-generated Payload types differ between the PR base and head commits."
 
 if [[ -n "${summary_file}" ]]; then
   {
     echo "## Payload Types"
     echo "- Base ref: \`${base_ref}\`"
-    echo "- Schema/config inputs changed: \`${schema_config_changed}\`"
-    echo "- Payload package versions changed: \`${payload_dependency_changed}\`"
-    echo "- Generated \`src/payload-types.ts\` changed: \`${payload_types_changed}\`"
+    echo "- CI-generated diff detected: \`true\`"
+    echo "- Review comment mode: \`${review_comment_mode}\`"
+    echo "- Schema/config change: \`${schema_config_changed}\`"
+    echo "- Payload dependency change: \`${payload_dependency_changed}\`"
+    echo "- Unknown/other: \`${unknown_other_cause}\`"
     echo ""
+    echo "<details><summary>CI-generated payload type diff</summary>"
+    echo ""
+    echo '```diff'
+    cat "${full_diff_file}"
+    echo '```'
+    echo "</details>"
   } >> "${summary_file}"
-
-  if [[ "${schema_config_changed}" == 'true' ]]; then
-    {
-      echo "<details><summary>schema/config input files</summary>"
-      echo ""
-      printf '%s\n' "${schema_changed_files}" | sed 's/^/- /'
-      echo "</details>"
-    } >> "${summary_file}"
-  fi
-
-  if [[ "${payload_dependency_changed}" == 'true' ]]; then
-    {
-      echo "<details><summary>payload dependency files</summary>"
-      echo ""
-      printf '%s\n' "${payload_dependency_changed_files}" | sed 's/^/- /'
-      echo "</details>"
-    } >> "${summary_file}"
-  fi
-
-  if [[ "${payload_types_changed}" == 'true' ]]; then
-    {
-      echo "<details><summary>payload-types diff</summary>"
-      echo ""
-      echo '```diff'
-      git -C "${repo_root}" diff --unified=3 "${base_commit}...HEAD" -- src/payload-types.ts | sed '1,4d'
-      echo '```'
-      echo "</details>"
-    } >> "${summary_file}"
-  fi
 fi

--- a/.github/scripts/lib/review-comment-sync.cjs
+++ b/.github/scripts/lib/review-comment-sync.cjs
@@ -13,13 +13,21 @@ const normalizeAnchorPath = (anchor) => {
   return String(anchor.filename ?? '')
 }
 
-const createManagedMarker = ({ scopeName, categoryKey }) => `<!-- review-comment-sync:${scopeName}:${categoryKey} -->`
+const createManagedMarker = ({ scopeName, key }) => `<!-- review-comment-sync:${scopeName}:${key} -->`
 
-async function listPullFiles({ github, owner, repo, pull_number }) {
-  const files = []
+function isManagedBotComment({ comment, marker }) {
+  const body = String(comment.body ?? '')
+  const login = String(comment.user?.login ?? '')
+  const userType = String(comment.user?.type ?? '')
+
+  return body.includes(marker) && login === 'github-actions[bot]' && userType === 'Bot'
+}
+
+async function listPullReviewComments({ github, owner, repo, pull_number }) {
+  const comments = []
 
   for (let page = 1; page <= MAX_PAGES; page += 1) {
-    const { data } = await github.rest.pulls.listFiles({
+    const { data } = await github.rest.pulls.listReviewComments({
       owner,
       repo,
       pull_number,
@@ -31,24 +39,24 @@ async function listPullFiles({ github, owner, repo, pull_number }) {
       break
     }
 
-    files.push(...data)
+    comments.push(...data)
 
     if (data.length < PAGE_SIZE) {
       break
     }
   }
 
-  return files
+  return comments
 }
 
-async function listReviewComments({ github, owner, repo, pull_number }) {
+async function listPullIssueComments({ github, owner, repo, issue_number }) {
   const comments = []
 
   for (let page = 1; page <= MAX_PAGES; page += 1) {
-    const { data } = await github.rest.pulls.listReviewComments({
+    const { data } = await github.rest.issues.listComments({
       owner,
       repo,
-      pull_number,
+      issue_number,
       per_page: PAGE_SIZE,
       page,
     })
@@ -75,33 +83,15 @@ async function deleteReviewComment({ github, owner, repo, comment_id }) {
   })
 }
 
-function isManagedBotComment({ comment, marker }) {
-  const body = String(comment.body ?? '')
-  const login = String(comment.user?.login ?? '')
-  const userType = String(comment.user?.type ?? '')
-
-  return body.includes(marker) && login === 'github-actions[bot]' && userType === 'Bot'
+async function deleteIssueComment({ github, owner, repo, comment_id }) {
+  await github.rest.issues.deleteComment({
+    owner,
+    repo,
+    comment_id,
+  })
 }
 
-async function syncCategoryComment({
-  github,
-  owner,
-  repo,
-  pull_number,
-  commit_id,
-  existingComments,
-  active,
-  anchorPath,
-  body,
-}) {
-  if (!active) {
-    for (const comment of existingComments) {
-      await deleteReviewComment({ github, owner, repo, comment_id: comment.id })
-    }
-
-    return
-  }
-
+async function syncReviewComment({ github, owner, repo, pull_number, commit_id, existingComments, anchorPath, body }) {
   if (!anchorPath) {
     return
   }
@@ -137,105 +127,118 @@ async function syncCategoryComment({
   })
 }
 
-async function syncManagedFileReviewComments({ github, context, core, scopeName, categories }) {
+async function syncStickyIssueComment({ github, owner, repo, issue_number, existingComments, body }) {
+  const reusableComment = existingComments[0]
+  const staleComments = existingComments.slice(1)
+
+  for (const comment of staleComments) {
+    await deleteIssueComment({ github, owner, repo, comment_id: comment.id })
+  }
+
+  if (reusableComment) {
+    if (reusableComment.body !== body) {
+      await github.rest.issues.updateComment({
+        owner,
+        repo,
+        comment_id: reusableComment.id,
+        body,
+      })
+    }
+
+    return
+  }
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number,
+    body,
+  })
+}
+
+async function syncManagedPullRequestFeedback({ github, context, core, scopeName, key, mode, body, anchorPath = '' }) {
   const pullRequest = context.payload.pull_request
 
   if (!pullRequest) {
-    core.info(`No pull_request payload available; skipping ${scopeName}.`)
+    core.info(`No pull_request payload available; skipping ${scopeName}:${key}.`)
     return
   }
 
   const owner = context.repo.owner
   const repo = context.repo.repo
   const pull_number = pullRequest.number
+  const issue_number = pullRequest.number
   const commit_id = pullRequest.head.sha
+  const marker = createManagedMarker({ scopeName, key })
+  const managedBody = String(body).includes(marker) ? String(body) : `${marker}\n${String(body)}`
 
-  const files = await listPullFiles({ github, owner, repo, pull_number })
-  const reviewComments = await listReviewComments({ github, owner, repo, pull_number })
+  const reviewComments = (await listPullReviewComments({ github, owner, repo, pull_number })).filter((comment) =>
+    isManagedBotComment({ comment, marker }),
+  )
+  const issueComments = (await listPullIssueComments({ github, owner, repo, issue_number })).filter((comment) =>
+    isManagedBotComment({ comment, marker }),
+  )
 
-  const categoryStates = {}
-
-  for (const category of categories) {
-    const marker = createManagedMarker({ scopeName, categoryKey: category.key })
-
-    categoryStates[category.key] = {
-      marker,
-      existingComments: reviewComments.filter((comment) => isManagedBotComment({ comment, marker })),
-      active: false,
-      anchorPath: '',
-      body: '',
-    }
-  }
-
-  for (const category of categories) {
-    categoryStates[category.key].active = Boolean(
-      await category.isActive({
-        files,
-        pullRequest,
-        context,
-        github,
-        core,
-        categoryStates,
-      }),
-    )
-  }
-
-  const activeCategoryCount = Object.values(categoryStates).filter((categoryState) => categoryState.active).length
-
-  if (activeCategoryCount === 0) {
-    core.info(`No active review comment categories for ${scopeName}.`)
-  }
-
-  for (const category of categories) {
-    const categoryState = categoryStates[category.key]
-
-    if (categoryState.active) {
-      categoryState.anchorPath = normalizeAnchorPath(
-        await category.getAnchorPath({
-          files,
-          pullRequest,
-          context,
-          github,
-          core,
-          categoryStates,
-        }),
-      )
-
-      if (!categoryState.anchorPath) {
-        core.warning(`No anchor path available for ${scopeName}:${category.key}.`)
-      } else {
-        const body = await category.buildBody({
-          files,
-          pullRequest,
-          context,
-          github,
-          core,
-          categoryStates,
-          marker: categoryState.marker,
-        })
-
-        categoryState.body = String(body).includes(categoryState.marker)
-          ? String(body)
-          : `${categoryState.marker}\n${String(body)}`
-      }
+  if (mode === 'none') {
+    for (const comment of reviewComments) {
+      await deleteReviewComment({ github, owner, repo, comment_id: comment.id })
     }
 
-    await syncCategoryComment({
+    for (const comment of issueComments) {
+      await deleteIssueComment({ github, owner, repo, comment_id: comment.id })
+    }
+
+    return
+  }
+
+  if (mode === 'review') {
+    for (const comment of issueComments) {
+      await deleteIssueComment({ github, owner, repo, comment_id: comment.id })
+    }
+
+    const normalizedAnchorPath = normalizeAnchorPath(anchorPath)
+
+    if (!normalizedAnchorPath) {
+      core.warning(`No anchor path available for ${scopeName}:${key}; falling back is the caller's responsibility.`)
+      return
+    }
+
+    await syncReviewComment({
       github,
       owner,
       repo,
       pull_number,
       commit_id,
-      existingComments: categoryState.existingComments,
-      active: categoryState.active,
-      anchorPath: categoryState.anchorPath,
-      body: categoryState.body,
+      existingComments: reviewComments,
+      anchorPath: normalizedAnchorPath,
+      body: managedBody,
     })
+
+    return
   }
+
+  if (mode === 'sticky') {
+    for (const comment of reviewComments) {
+      await deleteReviewComment({ github, owner, repo, comment_id: comment.id })
+    }
+
+    await syncStickyIssueComment({
+      github,
+      owner,
+      repo,
+      issue_number,
+      existingComments: issueComments,
+      body: managedBody,
+    })
+
+    return
+  }
+
+  throw new Error(`Unsupported managed PR feedback mode: ${mode}`)
 }
 
 module.exports = {
   createManagedMarker,
   isManagedBotComment,
-  syncManagedFileReviewComments,
+  syncManagedPullRequestFeedback,
 }

--- a/.github/scripts/payload-type-review-comments.cjs
+++ b/.github/scripts/payload-type-review-comments.cjs
@@ -1,119 +1,68 @@
-const { syncManagedFileReviewComments } = require('./lib/review-comment-sync.cjs')
+const { syncManagedPullRequestFeedback } = require('./lib/review-comment-sync.cjs')
 
-const SCHEMA_CATEGORY = 'schema-config'
-const DEPENDENCY_CATEGORY = 'payload-dependencies'
-const TYPES_CATEGORY = 'generated-types'
+function readBoolean(value) {
+  return (
+    String(value ?? '')
+      .trim()
+      .toLowerCase() === 'true'
+  )
+}
 
-const isSchemaConfigPath = (filename) =>
-  filename === 'src/payload.config.ts' ||
-  filename.startsWith('src/collections/') ||
-  filename.startsWith('src/globals/') ||
-  filename.startsWith('src/blocks/') ||
-  filename.startsWith('src/fields/') ||
-  filename.startsWith('src/plugins/')
+function buildPayloadTypeReviewBody({
+  schemaConfigChanged,
+  payloadDependencyChanged,
+  unknownOtherCause,
+  diffSnippet,
+  mode,
+}) {
+  const lines = [
+    'CI generated Payload types differ between the PR base and head commits on the same runner.',
+    '',
+    'Likely cause flags (inferred, not proven):',
+    `- schema/config change: \`${schemaConfigChanged}\``,
+    `- payload dependency change: \`${payloadDependencyChanged}\``,
+    `- unknown/other: \`${unknownOtherCause}\``,
+    '',
+    'The snippet below shows the first 3 hunks / 120 lines of the CI-generated diff. Review whether this generator output is expected, then resolve this conversation.',
+  ]
 
-const isDependencyPath = (filename) => filename === 'package.json' || filename === 'pnpm-lock.yaml'
-
-const hasPayloadDependencyDiff = (files) =>
-  files.some((file) => {
-    if (!isDependencyPath(file.filename)) {
-      return false
-    }
-
-    const patch = String(file.patch ?? '')
-
-    if (file.filename === 'package.json') {
-      return /^[+-][ \t]+"(payload|@payloadcms\/[^"]+)":/m.test(patch)
-    }
-
-    return /^[+-].*(@payloadcms\/|(^|[^A-Za-z0-9_])payload@)/m.test(patch)
-  })
-
-const formatChangedFiles = (files) =>
-  files
-    .slice(0, 5)
-    .map((file) => `- \`${file.filename}\``)
-    .join('\n')
-
-const getPayloadCategoryFlags = (categoryStates) => ({
-  schemaConfigChanged: Boolean(categoryStates[SCHEMA_CATEGORY]?.active),
-  payloadDependencyChanged: Boolean(categoryStates[DEPENDENCY_CATEGORY]?.active),
-  payloadTypesChanged: Boolean(categoryStates[TYPES_CATEGORY]?.active),
-})
-
-const payloadTypeReviewCategories = [
-  {
-    key: SCHEMA_CATEGORY,
-    isActive: ({ files }) => files.some((file) => isSchemaConfigPath(file.filename)),
-    getAnchorPath: ({ files }) => files.find((file) => isSchemaConfigPath(file.filename))?.filename ?? '',
-    buildBody: ({ files, categoryStates }) => {
-      const { payloadTypesChanged } = getPayloadCategoryFlags(categoryStates)
-      const lead = payloadTypesChanged
-        ? 'Payload schema/config inputs changed in this PR, and `src/payload-types.ts` also changed.'
-        : 'Payload schema/config inputs changed in this PR, but `src/payload-types.ts` did not.'
-
-      return [
-        lead,
-        '',
-        'Review whether the generated Payload types are expected for these schema/config changes, then resolve this conversation.',
-        '',
-        'Changed files:',
-        formatChangedFiles(files.filter((file) => isSchemaConfigPath(file.filename))),
-      ].join('\n')
-    },
-  },
-  {
-    key: DEPENDENCY_CATEGORY,
-    isActive: ({ files }) => hasPayloadDependencyDiff(files),
-    getAnchorPath: ({ files }) =>
-      files.find((file) => file.filename === 'package.json')?.filename ??
-      files.find((file) => file.filename === 'pnpm-lock.yaml')?.filename ??
+  if (mode === 'sticky') {
+    lines.push(
       '',
-    buildBody: ({ files, categoryStates }) => {
-      const { payloadTypesChanged } = getPayloadCategoryFlags(categoryStates)
-      const lead = payloadTypesChanged
-        ? 'Payload package versions changed in this PR, and `src/payload-types.ts` also changed.'
-        : 'Payload package versions changed in this PR, but `src/payload-types.ts` did not.'
+      'No suitable changed PR file was available for a file review thread, so this was posted as a PR comment.',
+    )
+  }
 
-      return [
-        lead,
-        '',
-        'Upstream Payload releases can change generated type output. Review whether the resulting Payload types are expected for this dependency change, then resolve this conversation.',
-        '',
-        'Changed files:',
-        formatChangedFiles(files.filter((file) => isDependencyPath(file.filename))),
-      ].join('\n')
-    },
-  },
-  {
-    key: TYPES_CATEGORY,
-    isActive: ({ files }) => files.some((file) => file.filename === 'src/payload-types.ts'),
-    getAnchorPath: () => 'src/payload-types.ts',
-    buildBody: ({ categoryStates }) => {
-      const { schemaConfigChanged, payloadDependencyChanged } = getPayloadCategoryFlags(categoryStates)
-      const lead =
-        schemaConfigChanged || payloadDependencyChanged
-          ? '`src/payload-types.ts` changed in this PR.'
-          : '`src/payload-types.ts` changed without a detected schema/config or Payload dependency change in this PR.'
+  lines.push(
+    '',
+    '<details><summary>CI-generated payload type diff snippet</summary>',
+    '',
+    '```diff',
+    diffSnippet.trimEnd(),
+    '```',
+    '</details>',
+  )
 
-      return [
-        lead,
-        '',
-        'Review whether this generated type diff is intentional, then resolve this conversation.',
-        '',
-        'Changed files:',
-        '- `src/payload-types.ts`',
-      ].join('\n')
-    },
-  },
-]
+  return lines.join('\n')
+}
 
-module.exports = async function run({ github, context, core }) {
-  await syncManagedFileReviewComments({
+module.exports = async function run({ github, context, core, env = process.env }) {
+  const mode = String(env.PAYLOAD_TYPE_REVIEW_MODE ?? 'none')
+
+  await syncManagedPullRequestFeedback({
     github,
     context,
     core,
     scopeName: 'payload-type-review',
-    categories: payloadTypeReviewCategories,
+    key: 'generated-diff',
+    mode,
+    anchorPath: env.PAYLOAD_TYPE_REVIEW_ANCHOR_PATH ?? '',
+    body: buildPayloadTypeReviewBody({
+      schemaConfigChanged: readBoolean(env.PAYLOAD_TYPE_SCHEMA_CONFIG_CHANGED),
+      payloadDependencyChanged: readBoolean(env.PAYLOAD_TYPE_PAYLOAD_DEPENDENCY_CHANGED),
+      unknownOtherCause: readBoolean(env.PAYLOAD_TYPE_UNKNOWN_OTHER_CAUSE),
+      diffSnippet: String(env.PAYLOAD_TYPE_DIFF_SNIPPET ?? '').trim(),
+      mode,
+    }),
   })
 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,6 +99,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -128,8 +129,26 @@ jobs:
       - name: Check migrations
         run: bash ./.github/scripts/ci/check-migrations-diff.sh "origin/main" "HEAD"
 
-      - name: Report payload type changes
+      - name: Compare generated payload types
+        id: payload_types
         run: pnpm run check:payload-types
+
+      - name: Sync payload type review comment
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PAYLOAD_TYPE_REVIEW_MODE: ${{ steps.payload_types.outputs.review_comment_mode }}
+          PAYLOAD_TYPE_REVIEW_ANCHOR_PATH: ${{ steps.payload_types.outputs.review_anchor_path }}
+          PAYLOAD_TYPE_SCHEMA_CONFIG_CHANGED: ${{ steps.payload_types.outputs.schema_config_changed }}
+          PAYLOAD_TYPE_PAYLOAD_DEPENDENCY_CHANGED: ${{ steps.payload_types.outputs.payload_dependency_changed }}
+          PAYLOAD_TYPE_UNKNOWN_OTHER_CAUSE: ${{ steps.payload_types.outputs.unknown_other_cause }}
+          PAYLOAD_TYPE_DIFF_SNIPPET: ${{ steps.payload_types.outputs.diff_snippet }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const run = require('./.github/scripts/payload-type-review-comments.cjs');
+            await run({ github, context, core, env: process.env });
 
       - name: Story governance check
         run: pnpm stories:governance:check

--- a/.github/workflows/pr-gates.yml
+++ b/.github/workflows/pr-gates.yml
@@ -11,24 +11,6 @@ permissions:
   contents: read
 
 jobs:
-  payload-type-review-comments:
-    name: sync payload type review comments
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: sync payload type review comments
-        continue-on-error: true
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const run = require('./.github/scripts/payload-type-review-comments.cjs');
-            await run({ github, context, core });
-
   pr-label:
     name: label pr
     runs-on: ubuntu-latest

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -160,14 +160,14 @@
         "filename": ".github/workflows/deploy.yml",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 298
+        "line_number": 317
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/deploy.yml",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 306
+        "line_number": 325
       }
     ],
     "docker-compose.test.yml": [
@@ -11517,5 +11517,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-14T07:47:31Z"
+  "generated_at": "2026-04-28T14:06:54Z"
 }


### PR DESCRIPTION
Reviewers now only get Payload type feedback when CI produces a real generated base-vs-head diff.

## What changed
- compare generated Payload types for the PR base and head commits on the same runner inside `PR Validation`
- move Payload review feedback to the actual CI diff result instead of flagging payload-related source-file changes alone
- post a managed file review thread with a short `diff` snippet when a changed PR file can anchor the feedback, or fall back to a sticky PR comment when no anchor exists
- keep the full generated diff in the step summary and infer high-level cause flags for schema/config, Payload dependency, and unknown/other
- generalize the managed PR feedback helper so CI flows can reuse the same review-thread / sticky-comment sync path
- add the missing `releaseTargetCommitish` JSDoc option in the release skill so `pnpm check` stays green

## Validation
- `pnpm format`
- `pnpm check`
- `bash -n .github/scripts/ci/check-payload-types.sh`
- `node --check .github/scripts/lib/review-comment-sync.cjs`
- `node --check .github/scripts/payload-type-review-comments.cjs`

## Development
- closes #997
