### PR TITLE
fix(components): match legal links exactly

### DIFF
--- a/src/components/templates/Footer/Component.tsx
+++ b/src/components/templates/Footer/Component.tsx
@@ -6,6 +6,7 @@ import { Container } from '@/components/molecules/Container'
 import { UiLink } from '@/components/molecules/Link'
 import { Logo } from '@/components/molecules/Logo/Logo'
 import { SocialLink } from '@/components/molecules/SocialLink'
+import { LEGACY_LEGAL_REDIRECTS, REQUIRED_LEGAL_FOOTER_LINKS } from '@/utilities/legalPages'
 import type { FooterNavGroup } from '@/utilities/normalizeNavItems'
 
 export type FooterProps = {
@@ -14,8 +15,17 @@ export type FooterProps = {
   showPreviewBadge?: boolean
 }
 
+const legalFooterHrefs = new Set([
+  ...REQUIRED_LEGAL_FOOTER_LINKS.map(({ href }) => href),
+  ...LEGACY_LEGAL_REDIRECTS.map(({ from }) => from),
+])
+
+function normalizeFooterHref(href: string): string {
+  return href === '/' ? href : href.replace(/\/+$/, '')
+}
+
 export const Footer: React.FC<FooterProps> = ({ footerGroups, logoSrc, showPreviewBadge = false }) => {
-  const isLegalLink = (href: string) => href.includes('/privacy') || href.includes('/imprint')
+  const isLegalLink = (href: string) => legalFooterHrefs.has(normalizeFooterHref(href))
   const legalQuickLinks = footerGroups
     .flatMap((group) => group.items)
     .filter((link) => isLegalLink(link.href))

--- a/tests/unit/components/templates/footer.test.tsx
+++ b/tests/unit/components/templates/footer.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from 'react'
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { Footer } from '@/components/templates/Footer/Component'
@@ -31,6 +31,18 @@ describe('Footer template', () => {
     },
   ]
 
+  const footerGroupsWithLegalLink: FooterNavGroup[] = [
+    footerGroups[0]!,
+    footerGroups[1]!,
+    {
+      title: 'Information',
+      items: [
+        { href: '/privacy-settings', label: 'Privacy settings', appearance: 'inline', newTab: false },
+        { href: '/privacy-policy', label: 'Privacy Policy', appearance: 'inline', newTab: false },
+      ],
+    },
+  ]
+
   it('renders nav and social links', () => {
     render(<Footer footerGroups={footerGroups} />)
 
@@ -47,5 +59,14 @@ describe('Footer template', () => {
     logos.forEach((logo) => {
       expect(logo).toHaveAttribute('src', '/preview-logo.png')
     })
+  })
+
+  it('only promotes canonical legal footer links into the quick links group', () => {
+    render(<Footer footerGroups={footerGroupsWithLegalLink} />)
+
+    const legalQuickLinks = screen.getByRole('navigation', { name: 'Footer legal quick links' })
+
+    expect(within(legalQuickLinks).getByRole('link', { name: 'Privacy Policy' })).toBeInTheDocument()
+    expect(within(legalQuickLinks).queryByRole('link', { name: 'Privacy settings' })).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
This prevents unrelated footer links from being promoted into the legal quick-links area.

## What changed
- Replaced the footer substring check with exact canonical legal href matching from `src/utilities/legalPages.ts`.
- Added a unit test that keeps `/privacy-settings` out of the legal quick-links group.

## Development
- Closes #999
