### PR TITLE
chore: clarify collection copy

### DIFF
--- a/src/collections/ClinicApplications.ts
+++ b/src/collections/ClinicApplications.ts
@@ -151,7 +151,7 @@ export const ClinicApplications: CollectionConfig = {
     {
       name: 'linkedRecords',
       type: 'group',
-      label: 'Created clinic records',
+      label: 'Created records',
       admin: {
         description: 'Records created from this application',
         condition: (data) => data?.status !== 'submitted',

--- a/src/collections/Reviews.ts
+++ b/src/collections/Reviews.ts
@@ -138,7 +138,7 @@ export const Reviews: CollectionConfig = {
     },
     {
       type: 'collapsible',
-      label: 'Edit History',
+      label: 'Recent edits',
       admin: {
         initCollapsed: true,
         description: 'Last edits to this review',


### PR DESCRIPTION
This makes a few clinic-admin field labels clearer for first-time users.

## What changed
- Renamed the clinic application group label from "Created clinic records" to "Created records".
- Renamed the review section label from "Edit History" to "Recent edits".

## Validation
- `pnpm format`
- `pnpm check`

## Screenshots
- Admin collection labels in `ClinicApplications` and `Reviews`.

## Development
- Fixes [Issue #1001](https://github.com/findmydoc-platform/website/issues/1001)
