### PR TITLE
feat(frontend): add landing scroll reveal transitions

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -10,6 +10,7 @@ import { LandingProcess } from '@/components/organisms/Landing/LandingProcess'
 import { LandingContact } from '@/components/organisms/Landing/LandingContact'
 import { BlogCardCollection } from '@/components/organisms/Blog/BlogCardCollection'
 import { FAQSection } from '@/components/organisms/FAQ'
+import { ScrollReveal } from '@/components/molecules/ScrollReveal'
 import { landingProcessHomepageStepImages } from '@/utilities/placeholders/landingProcess'
 import { normalizePost } from '@/utilities/blog/normalizePost'
 import { getLandingMedicalSpecialtyCategories } from '@/utilities/landing/medicalSpecialtyCategories'
@@ -105,72 +106,78 @@ export default async function Home({
         }}
       />
 
-      <LandingTestimonials
-        testimonials={[
-          {
-            quote:
-              'The platform makes treatment research easier by structuring clinic details around what patients need before deciding.',
-            author: 'Maya Bennett',
-            role: 'Digital Health Research Advisor',
-            image: ph80x80,
-          },
-          {
-            quote:
-              'I appreciate how trust signals are integrated into the comparison flow instead of being hidden in long profile text.',
-            author: 'Daniel Ortega',
-            role: 'Healthcare UX Reviewer',
-            image: ph80x80,
-          },
-          {
-            quote:
-              'For users planning treatment abroad, the direct contact step is clear, practical, and aligned with real decision journeys.',
-            author: 'Sophie Klein',
-            role: 'International Care Pathway Consultant',
-            image: ph80x80,
-          },
-        ]}
-        title="Expert feedback"
-        description="Perspectives from healthcare and product experts who reviewed the patient decision flow."
-        className="md:pt-28"
-      />
+      <ScrollReveal>
+        <LandingTestimonials
+          testimonials={[
+            {
+              quote:
+                'The platform makes treatment research easier by structuring clinic details around what patients need before deciding.',
+              author: 'Maya Bennett',
+              role: 'Digital Health Research Advisor',
+              image: ph80x80,
+            },
+            {
+              quote:
+                'I appreciate how trust signals are integrated into the comparison flow instead of being hidden in long profile text.',
+              author: 'Daniel Ortega',
+              role: 'Healthcare UX Reviewer',
+              image: ph80x80,
+            },
+            {
+              quote:
+                'For users planning treatment abroad, the direct contact step is clear, practical, and aligned with real decision journeys.',
+              author: 'Sophie Klein',
+              role: 'International Care Pathway Consultant',
+              image: ph80x80,
+            },
+          ]}
+          title="Expert feedback"
+          description="Perspectives from healthcare and product experts who reviewed the patient decision flow."
+          className="md:pt-28"
+        />
+      </ScrollReveal>
 
-      <LandingCategories
-        title="Categories"
-        description="Explore verified clinics by specialty and compare the best options for your needs."
-        categories={landingSpecialtyCategories.categories}
-        items={landingSpecialtyCategories.items}
-        featuredIds={landingSpecialtyCategories.featuredIds}
-      />
+      <ScrollReveal>
+        <LandingCategories
+          title="Categories"
+          description="Explore verified clinics by specialty and compare the best options for your needs."
+          categories={landingSpecialtyCategories.categories}
+          items={landingSpecialtyCategories.items}
+          featuredIds={landingSpecialtyCategories.featuredIds}
+        />
+      </ScrollReveal>
 
-      <LandingFeatures
-        variant="green"
-        backgroundImage={featureBackground}
-        backgroundParallax={{ rangePx: 64 }}
-        features={[
-          {
-            title: 'Qualified Leads',
-            subtitle: '',
-            description:
-              'Compare aesthetic clinics based on treatments, specializations and qualifications. All information is presented clearly to support informed decision making.',
-            icon: CheckCircle,
-          },
-          {
-            title: 'Reputation Boost',
-            subtitle: '',
-            description:
-              'Clinics create and manage their own profiles and provide relevant qualifications according to their aesthetic services. This ensures reliable and comparable information.',
-            icon: TrendingUp,
-          },
-          {
-            title: 'Visibility Increase',
-            subtitle: '',
-            description: 'Patients contact clinics directly without intermediaries, obligations or hidden fees.',
-            icon: Eye,
-          },
-        ]}
-        title="Benefits for Patients"
-        description="Compare verified clinics for dental care, hair transplants, and aesthetic treatments with clear trust signals and transparent profile data."
-      />
+      <ScrollReveal>
+        <LandingFeatures
+          variant="green"
+          backgroundImage={featureBackground}
+          backgroundParallax={{ rangePx: 64 }}
+          features={[
+            {
+              title: 'Qualified Leads',
+              subtitle: '',
+              description:
+                'Compare aesthetic clinics based on treatments, specializations and qualifications. All information is presented clearly to support informed decision making.',
+              icon: CheckCircle,
+            },
+            {
+              title: 'Reputation Boost',
+              subtitle: '',
+              description:
+                'Clinics create and manage their own profiles and provide relevant qualifications according to their aesthetic services. This ensures reliable and comparable information.',
+              icon: TrendingUp,
+            },
+            {
+              title: 'Visibility Increase',
+              subtitle: '',
+              description: 'Patients contact clinics directly without intermediaries, obligations or hidden fees.',
+              icon: Eye,
+            },
+          ]}
+          title="Benefits for Patients"
+          description="Compare verified clinics for dental care, hair transplants, and aesthetic treatments with clear trust signals and transparent profile data."
+        />
+      </ScrollReveal>
 
       <LandingProcess
         title="Our Process"
@@ -206,25 +213,31 @@ export default async function Home({
         stepActivationOffsetPx={[0, 28, 48, 0]}
       />
 
-      <FAQSection
-        title={homepageFaqSection.title}
-        description="This section answers the most common questions clinics and medical networks have about gaining international patients through our comparison platform. It provides clarity on regions, qualifications, visibility and how clinics connect with international patients across the DACH region and Europe."
-        items={homepageFaqSection.items}
-        defaultOpenItemId={homepageFaqSection.defaultOpenItemId}
-      />
-
-      {normalizedPosts.length > 0 && (
-        <BlogCardCollection
-          title="From our blog"
-          intro="Explore practical insights, expert perspectives, and the latest topics across health and medicine."
-          posts={normalizedPosts}
+      <ScrollReveal>
+        <FAQSection
+          title={homepageFaqSection.title}
+          description="This section answers the most common questions clinics and medical networks have about gaining international patients through our comparison platform. It provides clarity on regions, qualifications, visibility and how clinics connect with international patients across the DACH region and Europe."
+          items={homepageFaqSection.items}
+          defaultOpenItemId={homepageFaqSection.defaultOpenItemId}
         />
-      )}
+      </ScrollReveal>
 
-      <LandingContact
-        title="Contact"
-        description="Planning treatment abroad? Share your goals and we will help you find relevant clinics and next steps with confidence."
-      />
+      {normalizedPosts.length > 0 ? (
+        <ScrollReveal>
+          <BlogCardCollection
+            title="From our blog"
+            intro="Explore practical insights, expert perspectives, and the latest topics across health and medicine."
+            posts={normalizedPosts}
+          />
+        </ScrollReveal>
+      ) : null}
+
+      <ScrollReveal>
+        <LandingContact
+          title="Contact"
+          description="Planning treatment abroad? Share your goals and we will help you find relevant clinics and next steps with confidence."
+        />
+      </ScrollReveal>
     </main>
   )
 }

--- a/src/app/(frontend)/partners/clinics/page.tsx
+++ b/src/app/(frontend)/partners/clinics/page.tsx
@@ -26,6 +26,7 @@ import {
 import { LandingHero } from '@/components/organisms/Heroes/LandingHero'
 import { CallToAction } from '@/components/organisms/CallToAction'
 import { FAQSection } from '@/components/organisms/FAQ'
+import { ScrollReveal } from '@/components/molecules/ScrollReveal'
 import {
   landingProcessPartnerStepImages,
   landingProcessPlaceholderSubtitle,
@@ -59,11 +60,13 @@ export default async function ClinicLandingPage() {
   return (
     <main className="flex min-h-screen flex-col">
       <LandingHero title={clinicHeroData.title} description={clinicHeroData.description} image={clinicHeroData.image} />
-      <LandingFeatures
-        features={clinicFeaturesData}
-        title="Features"
-        description="Increase your clinic’s visibility, attract qualified patients, and grow internationally through transparent, verified profiles."
-      />
+      <ScrollReveal>
+        <LandingFeatures
+          features={clinicFeaturesData}
+          title="Features"
+          description="Increase your clinic’s visibility, attract qualified patients, and grow internationally through transparent, verified profiles."
+        />
+      </ScrollReveal>
       <LandingProcess
         title={landingProcessPlaceholderTitle}
         subtitle={landingProcessPlaceholderSubtitle}
@@ -72,65 +75,81 @@ export default async function ClinicLandingPage() {
         stepPercentages={[0, 33.33, 66.67, 100]}
         stepActivationOffsetPx={[0, 28, 48, 0]}
       />
-      <LandingCategories
-        title="Our Categories"
-        description="Showcase your clinic under the categories patients search most."
-        categories={landingSpecialtyCategories.categories}
-        items={landingSpecialtyCategories.items}
-        featuredIds={landingSpecialtyCategories.featuredIds}
-      />
-      <section className="py-20">
-        <CallToAction
-          variant="spotlight"
-          richText={
-            <Heading as="h2" align="left" className="text-4xl font-bold text-foreground md:text-5xl">
-              {clinicCTAData.title}
-            </Heading>
-          }
-          links={[
-            {
-              href: clinicCTAData.buttonLink,
-              label: clinicCTAData.buttonText,
-              appearance: 'default',
-              size: 'lg',
-              className: 'bg-secondary text-white hover:bg-secondary/90',
-            },
-          ]}
+      <ScrollReveal>
+        <LandingCategories
+          title="Our Categories"
+          description="Showcase your clinic under the categories patients search most."
+          categories={landingSpecialtyCategories.categories}
+          items={landingSpecialtyCategories.items}
+          featuredIds={landingSpecialtyCategories.featuredIds}
         />
-      </section>
-      <LandingTeam
-        team={clinicTeamData}
-        title="Our Team"
-        description="We are a multidisciplinary team with backgrounds in healthcare, international patient management, medical marketing, and platform technology. Our focus is simple: helping clinics gain international patients in a sustainable, ethical, and measurable way."
-      />
-      <LandingTestimonials
-        testimonials={clinicTestimonialsData}
-        title="Testimonials"
-        description="Feedback from healthcare and clinic growth experts who reviewed the partner onboarding and visibility model."
-      />
-      <LandingPricing
-        plans={clinicPricingData}
-        title="Pricing"
-        description="Choose the monthly tier that matches your growth stage. Performance-based commission and optional add-ons sit alongside the subscription model."
-        modelItems={clinicPricingModelItems}
-      />
-      <FAQSection
-        title={clinicPartnersFaqSection.title}
-        description={clinicPartnersFaqSection.description}
-        items={clinicPartnersFaqSection.items}
-        defaultOpenItemId={clinicPartnersFaqSection.defaultOpenItemId}
-      />
-      {normalizedPosts.length > 0 && (
-        <BlogCardCollection
-          title="From our blog"
-          intro="Explore practical insights, expert perspectives, and the latest topics across health and medicine."
-          posts={normalizedPosts}
+      </ScrollReveal>
+      <ScrollReveal>
+        <section className="py-20">
+          <CallToAction
+            variant="spotlight"
+            richText={
+              <Heading as="h2" align="left" className="text-4xl font-bold text-foreground md:text-5xl">
+                {clinicCTAData.title}
+              </Heading>
+            }
+            links={[
+              {
+                href: clinicCTAData.buttonLink,
+                label: clinicCTAData.buttonText,
+                appearance: 'default',
+                size: 'lg',
+                className: 'bg-secondary text-white hover:bg-secondary/90',
+              },
+            ]}
+          />
+        </section>
+      </ScrollReveal>
+      <ScrollReveal>
+        <LandingTeam
+          team={clinicTeamData}
+          title="Our Team"
+          description="We are a multidisciplinary team with backgrounds in healthcare, international patient management, medical marketing, and platform technology. Our focus is simple: helping clinics gain international patients in a sustainable, ethical, and measurable way."
         />
-      )}
-      <LandingContact
-        title="Kontakt"
-        description="Interested in gaining international patients and increasing your clinic’s global reach? Contact us to explore how your clinic can benefit from our international comparison platform."
-      />
+      </ScrollReveal>
+      <ScrollReveal>
+        <LandingTestimonials
+          testimonials={clinicTestimonialsData}
+          title="Testimonials"
+          description="Feedback from healthcare and clinic growth experts who reviewed the partner onboarding and visibility model."
+        />
+      </ScrollReveal>
+      <ScrollReveal>
+        <LandingPricing
+          plans={clinicPricingData}
+          title="Pricing"
+          description="Choose the monthly tier that matches your growth stage. Performance-based commission and optional add-ons sit alongside the subscription model."
+          modelItems={clinicPricingModelItems}
+        />
+      </ScrollReveal>
+      <ScrollReveal>
+        <FAQSection
+          title={clinicPartnersFaqSection.title}
+          description={clinicPartnersFaqSection.description}
+          items={clinicPartnersFaqSection.items}
+          defaultOpenItemId={clinicPartnersFaqSection.defaultOpenItemId}
+        />
+      </ScrollReveal>
+      {normalizedPosts.length > 0 ? (
+        <ScrollReveal>
+          <BlogCardCollection
+            title="From our blog"
+            intro="Explore practical insights, expert perspectives, and the latest topics across health and medicine."
+            posts={normalizedPosts}
+          />
+        </ScrollReveal>
+      ) : null}
+      <ScrollReveal>
+        <LandingContact
+          title="Kontakt"
+          description="Interested in gaining international patients and increasing your clinic’s global reach? Contact us to explore how your clinic can benefit from our international comparison platform."
+        />
+      </ScrollReveal>
     </main>
   )
 }

--- a/src/components/molecules/ScrollReveal/index.tsx
+++ b/src/components/molecules/ScrollReveal/index.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import React, { useLayoutEffect, useRef } from 'react'
+import gsap from 'gsap'
+import { ScrollTrigger } from 'gsap/ScrollTrigger'
+
+import { usePrefersReducedMotion } from '@/utilities/use-prefers-reduced-motion'
+import { cn } from '@/utilities/ui'
+
+gsap.registerPlugin(ScrollTrigger)
+
+const REVEAL_PRESETS = {
+  section: {
+    duration: 0.7,
+    distancePx: 24,
+    stagger: 0.12,
+  },
+  surface: {
+    duration: 0.64,
+    distancePx: 18,
+    stagger: 0.1,
+  },
+} as const
+
+export type ScrollRevealProps = {
+  children: React.ReactNode
+  className?: string
+  preset?: keyof typeof REVEAL_PRESETS
+  start?: string
+  staggerSelector?: string
+}
+
+const DEFAULT_START = 'top 82%'
+
+const resolveViewportThreshold = (start: string): number => {
+  const match = /^top\s+(\d+(?:\.\d+)?)%$/i.exec(start.trim())
+  if (!match) return 0.82
+
+  const value = Number.parseFloat(match[1] ?? '82')
+  if (!Number.isFinite(value)) return 0.82
+
+  return Math.min(1, Math.max(0, value / 100))
+}
+
+export const ScrollReveal: React.FC<ScrollRevealProps> = ({
+  children,
+  className,
+  preset = 'section',
+  start = DEFAULT_START,
+  staggerSelector,
+}) => {
+  const rootRef = useRef<HTMLDivElement | null>(null)
+  const playRevealRef = useRef<(() => void) | null>(null)
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  useLayoutEffect(() => {
+    const root = rootRef.current
+    if (!root) return
+
+    root.dataset.scrollRevealPreset = preset
+
+    if (prefersReducedMotion) {
+      root.dataset.scrollRevealMode = 'reduced'
+      root.dataset.scrollRevealState = 'visible'
+      playRevealRef.current = null
+      return
+    }
+
+    const presetConfig = REVEAL_PRESETS[preset]
+    const staggerTargets = staggerSelector
+      ? Array.from(root.querySelectorAll<HTMLElement>(staggerSelector)).filter((node) => node.isConnected)
+      : []
+    const animationTargets = staggerTargets.length > 0 ? staggerTargets : [root]
+
+    let hasPlayed = false
+    const context = gsap.context(() => {
+      root.dataset.scrollRevealMode = staggerTargets.length > 0 ? 'stagger' : 'single'
+      root.dataset.scrollRevealState = 'hidden'
+
+      gsap.set(animationTargets, {
+        opacity: 0,
+        y: presetConfig.distancePx,
+        willChange: 'opacity, transform',
+      })
+
+      const tween = gsap.to(animationTargets, {
+        duration: presetConfig.duration,
+        ease: 'power2.out',
+        opacity: 1,
+        paused: true,
+        stagger: animationTargets.length > 1 ? presetConfig.stagger : 0,
+        y: 0,
+        onStart: () => {
+          root.dataset.scrollRevealState = 'animating'
+        },
+        onComplete: () => {
+          root.dataset.scrollRevealState = 'visible'
+          gsap.set(animationTargets, {
+            clearProps: 'opacity,transform,willChange',
+          })
+        },
+      })
+
+      let trigger: ScrollTrigger | null = null
+      const playReveal = () => {
+        if (hasPlayed) return
+        hasPlayed = true
+        trigger?.kill()
+        tween.play(0)
+      }
+
+      playRevealRef.current = playReveal
+      trigger = ScrollTrigger.create({
+        trigger: root,
+        start,
+        once: true,
+        onEnter: playReveal,
+      })
+
+      // Reveal immediately when the section already starts inside the trigger range.
+      if (root.getBoundingClientRect().top <= window.innerHeight * resolveViewportThreshold(start)) {
+        playReveal()
+      }
+    }, root)
+
+    return () => {
+      playRevealRef.current = null
+      context.revert()
+    }
+  }, [prefersReducedMotion, preset, staggerSelector, start])
+
+  const handleFocusCapture = () => {
+    playRevealRef.current?.()
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      className={cn(className)}
+      data-scroll-reveal-root=""
+      data-scroll-reveal-state="visible"
+      onFocusCapture={handleFocusCapture}
+    >
+      {children}
+    </div>
+  )
+}
+
+export default ScrollReveal

--- a/src/components/templates/HoldingPageConcept/index.tsx
+++ b/src/components/templates/HoldingPageConcept/index.tsx
@@ -7,6 +7,7 @@ import { Heading } from '@/components/atoms/Heading'
 import { ImmersiveVideoHero } from '@/components/molecules/ImmersiveVideoHero'
 import { Container } from '@/components/molecules/Container'
 import { UiLink, type UiLinkProps } from '@/components/molecules/Link'
+import { ScrollReveal } from '@/components/molecules/ScrollReveal'
 import { HoldingPageContactForm } from './ContactForm.client'
 import type { HoldingPageContactFormLabels } from './contactForm.shared'
 import { cn } from '@/utilities/ui'
@@ -1342,89 +1343,95 @@ function renderVariantLayout(
               />
             </div>
 
-            <div id="landing-content-start" className="mt-4 grid gap-4 sm:mt-6 xl:grid-cols-[1.08fr_0.92fr]">
-              <div className={cn(baseSurfaceClassName, 'flex h-full flex-col rounded-[28px] p-5 sm:p-6 lg:p-7')}>
-                <p className="text-xs font-semibold tracking-[0.28em] text-slate-500 uppercase">
-                  {whySectionEyebrow ?? 'Why findmydoc'}
-                </p>
-                <Heading
-                  as="h2"
-                  align="left"
-                  variant="default"
-                  size="h4"
-                  className="mt-3 text-2xl text-slate-950 sm:text-3xl"
-                >
-                  {whySectionHeading ?? 'Compare clinics abroad with verified quality signals and trusted guidance.'}
-                </Heading>
-                <div className="mt-3 max-w-2xl space-y-3 text-base leading-7 text-slate-700">
-                  {narrative
-                    .split('\n\n')
-                    .filter((paragraph) => paragraph.trim().length > 0)
-                    .map((paragraph) => (
-                      <p key={paragraph}>{paragraph}</p>
+            <ScrollReveal preset="surface">
+              <div id="landing-content-start" className="mt-4 grid gap-4 sm:mt-6 xl:grid-cols-[1.08fr_0.92fr]">
+                <div className={cn(baseSurfaceClassName, 'flex h-full flex-col rounded-[28px] p-5 sm:p-6 lg:p-7')}>
+                  <p className="text-xs font-semibold tracking-[0.28em] text-slate-500 uppercase">
+                    {whySectionEyebrow ?? 'Why findmydoc'}
+                  </p>
+                  <Heading
+                    as="h2"
+                    align="left"
+                    variant="default"
+                    size="h4"
+                    className="mt-3 text-2xl text-slate-950 sm:text-3xl"
+                  >
+                    {whySectionHeading ?? 'Compare clinics abroad with verified quality signals and trusted guidance.'}
+                  </Heading>
+                  <div className="mt-3 max-w-2xl space-y-3 text-base leading-7 text-slate-700">
+                    {narrative
+                      .split('\n\n')
+                      .filter((paragraph) => paragraph.trim().length > 0)
+                      .map((paragraph) => (
+                        <p key={paragraph}>{paragraph}</p>
+                      ))}
+                  </div>
+                  <div className="mt-5 flex flex-wrap gap-2 xl:mt-auto">
+                    {searchSnapshot.internalLinks.map((link) => (
+                      <span
+                        key={`${link.href}-${link.label ?? 'internal-link'}`}
+                        className="inline-flex rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700"
+                      >
+                        {link.label ?? link.href}
+                      </span>
                     ))}
+                  </div>
                 </div>
-                <div className="mt-5 flex flex-wrap gap-2 xl:mt-auto">
-                  {searchSnapshot.internalLinks.map((link) => (
-                    <span
-                      key={`${link.href}-${link.label ?? 'internal-link'}`}
-                      className="inline-flex rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700"
-                    >
-                      {link.label ?? link.href}
-                    </span>
-                  ))}
-                </div>
+
+                <ContactPanel
+                  contactConsentCompact={contactConsentCompact}
+                  contactConsentFull={contactConsentFull}
+                  contactEyebrow={contactEyebrow}
+                  contactFormLabels={contactFormLabels}
+                  contactFormSlug={contactFormSlug}
+                  contactDescription={contactDescription}
+                  contactMode={contactMode}
+                  contactTitle={contactTitle}
+                  primaryCtaLabel={primaryCtaLabel}
+                  className="rounded-[28px]"
+                />
               </div>
+            </ScrollReveal>
 
-              <ContactPanel
-                contactConsentCompact={contactConsentCompact}
-                contactConsentFull={contactConsentFull}
-                contactEyebrow={contactEyebrow}
-                contactFormLabels={contactFormLabels}
-                contactFormSlug={contactFormSlug}
-                contactDescription={contactDescription}
-                contactMode={contactMode}
-                contactTitle={contactTitle}
-                primaryCtaLabel={primaryCtaLabel}
-                className="rounded-[28px]"
-              />
-            </div>
+            <ScrollReveal preset="surface">
+              <div className={cn(baseSurfaceClassName, 'mt-6 rounded-[24px] p-4 sm:p-5')}>
+                <p className="text-[11px] font-semibold tracking-[0.22em] text-slate-500 uppercase">
+                  {whatYouGetEyebrow ?? 'What you get'}
+                </p>
+                <div className="mt-3 grid gap-3 lg:grid-cols-3">
+                  {signals.map((signal) => {
+                    const Icon = signal.icon
 
-            <div className={cn(baseSurfaceClassName, 'mt-6 rounded-[24px] p-4 sm:p-5')}>
-              <p className="text-[11px] font-semibold tracking-[0.22em] text-slate-500 uppercase">
-                {whatYouGetEyebrow ?? 'What you get'}
-              </p>
-              <div className="mt-3 grid gap-3 lg:grid-cols-3">
-                {signals.map((signal) => {
-                  const Icon = signal.icon
-
-                  return (
-                    <div
-                      key={signal.title}
-                      className="rounded-[18px] border border-slate-200 bg-white/92 px-4 py-3 sm:px-5 sm:py-4"
-                    >
-                      <div className="flex items-start gap-3">
-                        <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-slate-50">
-                          <Icon className="h-4 w-4 text-[#0f8f85]" aria-hidden="true" />
-                        </span>
-                        <div>
-                          <p className="text-base font-semibold text-slate-950">{signal.title}</p>
-                          <p className="mt-2 text-sm leading-6 text-slate-700">{signal.body}</p>
+                    return (
+                      <div
+                        key={signal.title}
+                        className="rounded-[18px] border border-slate-200 bg-white/92 px-4 py-3 sm:px-5 sm:py-4"
+                      >
+                        <div className="flex items-start gap-3">
+                          <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-slate-50">
+                            <Icon className="h-4 w-4 text-[#0f8f85]" aria-hidden="true" />
+                          </span>
+                          <div>
+                            <p className="text-base font-semibold text-slate-950">{signal.title}</p>
+                            <p className="mt-2 text-sm leading-6 text-slate-700">{signal.body}</p>
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  )
-                })}
+                    )
+                  })}
+                </div>
               </div>
-            </div>
+            </ScrollReveal>
           </div>
 
-          <FooterBlock
-            bestFor={bestFor}
-            footerLinks={footerLinks}
-            supportingNote={supportingNote}
-            className="mx-auto max-w-[94rem]"
-          />
+          <ScrollReveal>
+            <FooterBlock
+              bestFor={bestFor}
+              footerLinks={footerLinks}
+              supportingNote={supportingNote}
+              className="mx-auto max-w-[94rem]"
+            />
+          </ScrollReveal>
         </>
       )
 

--- a/src/stories/molecules/ScrollReveal.stories.tsx
+++ b/src/stories/molecules/ScrollReveal.stories.tsx
@@ -1,0 +1,154 @@
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, waitFor, within } from '@storybook/test'
+
+import { Heading } from '@/components/atoms/Heading'
+import { Container } from '@/components/molecules/Container'
+import { ScrollReveal } from '@/components/molecules/ScrollReveal'
+import { withViewportStory } from '../utils/viewportMatrix'
+
+const createMatchMedia = (prefersReducedMotion: boolean): typeof window.matchMedia => {
+  return ((query: string) => ({
+    addEventListener: () => undefined,
+    addListener: () => undefined,
+    dispatchEvent: () => false,
+    matches: query.includes('prefers-reduced-motion') ? prefersReducedMotion : false,
+    media: query,
+    onchange: null,
+    removeEventListener: () => undefined,
+    removeListener: () => undefined,
+  })) as typeof window.matchMedia
+}
+
+const meta = {
+  title: 'Shared/Molecules/ScrollReveal',
+  component: ScrollReveal,
+  parameters: {
+    demoFrame: { maxWidth: 'full', padded: false },
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Client-side section reveal wrapper for below-the-fold landing content. Reveals once on first entry and disables motion when reduced motion is preferred.',
+      },
+    },
+  },
+  tags: ['autodocs', 'domain:shared', 'layer:molecule', 'status:stable', 'used-in:shared'],
+  args: {
+    children: null,
+  },
+} satisfies Meta<typeof ScrollReveal>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const RevealStoryPage = () => {
+  return (
+    <div className="bg-slate-50 text-slate-950">
+      <Container className="py-24">
+        <Heading as="h2" align="left" className="text-4xl font-semibold text-foreground">
+          Scroll down
+        </Heading>
+        <p className="mt-4 max-w-2xl text-lg text-slate-600">
+          This spacer keeps the reveal target below the fold so the story can verify the one-time entrance animation.
+        </p>
+      </Container>
+
+      <div className="h-[82vh]" aria-hidden="true" />
+
+      <ScrollReveal preset="section">
+        <section className="bg-white py-20 shadow-[0_24px_80px_-60px_rgba(15,23,42,0.35)]">
+          <Container>
+            <Heading as="h2" align="left" className="text-4xl font-semibold text-foreground">
+              Reveal target
+            </Heading>
+            <p className="mt-4 max-w-2xl text-lg text-slate-600">
+              This section fades and lifts into place the first time it crosses the scroll trigger.
+            </p>
+          </Container>
+        </section>
+      </ScrollReveal>
+
+      <div className="h-[70vh]" aria-hidden="true" />
+    </div>
+  )
+}
+
+const ReducedMotionPreview = () => {
+  const [isReady, setIsReady] = React.useState(false)
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const originalMatchMedia = window.matchMedia
+    window.matchMedia = createMatchMedia(true)
+    setIsReady(true)
+
+    return () => {
+      window.matchMedia = originalMatchMedia
+    }
+  }, [])
+
+  if (!isReady) return null
+
+  return (
+    <ScrollReveal preset="surface">
+      <section className="bg-white py-20 shadow-[0_24px_80px_-60px_rgba(15,23,42,0.35)]">
+        <Container>
+          <Heading as="h2" align="left" className="text-4xl font-semibold text-foreground">
+            Reduced motion target
+          </Heading>
+          <p className="mt-4 max-w-2xl text-lg text-slate-600">
+            When reduced motion is preferred, the content stays immediately visible and no scroll trigger is registered.
+          </p>
+        </Container>
+      </section>
+    </ScrollReveal>
+  )
+}
+
+export const Default: Story = {
+  render: () => <RevealStoryPage />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const heading = await canvas.findByRole('heading', { name: /reveal target/i })
+    const root = heading.closest<HTMLElement>('[data-scroll-reveal-root]')
+
+    expect(root).not.toBeNull()
+    if (!root) return
+
+    await waitFor(() => {
+      expect(root.dataset.scrollRevealState).toBe('hidden')
+    })
+
+    root.scrollIntoView({ behavior: 'auto', block: 'center' })
+
+    await waitFor(() => {
+      expect(root.dataset.scrollRevealState).toBe('visible')
+    })
+  },
+}
+
+export const ReducedMotionFallback: Story = {
+  render: () => <ReducedMotionPreview />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const heading = await canvas.findByRole('heading', { name: /reduced motion target/i })
+    const root = heading.closest<HTMLElement>('[data-scroll-reveal-root]')
+
+    expect(root).not.toBeNull()
+    if (!root) return
+
+    await waitFor(() => {
+      expect(root.dataset.scrollRevealMode).toBe('reduced')
+      expect(root.dataset.scrollRevealState).toBe('visible')
+    })
+  },
+}
+
+export const Default320: Story = withViewportStory(Default, 'public320', 'Default / 320')
+export const Default375: Story = withViewportStory(Default, 'public375', 'Default / 375')
+export const Default640: Story = withViewportStory(Default, 'public640', 'Default / 640')
+export const Default768: Story = withViewportStory(Default, 'public768', 'Default / 768')
+export const Default1024: Story = withViewportStory(Default, 'public1024', 'Default / 1024')


### PR DESCRIPTION
Adds subtle below-the-fold scroll reveals across the main landing surfaces.

## What changed
- add a reusable GSAP-based `ScrollReveal` molecule with reduced-motion fallback and no-JS-safe initialization
- wrap below-the-fold sections on the home and partner landing pages without touching the hero or `LandingProcess`
- apply section-level reveals to the temporary holding page's active `videoImmersiveHero` composition
- add Storybook coverage for default and reduced-motion behavior

## Validation
- `rtk pnpm format`
- `rtk pnpm check`
- `rtk pnpm build` *(fails in the existing local DB state: `column posts.title does not exist` during `/posts` prerender; the same environment also reports missing `pages.title` in runtime)*
- Storybook mobile QA via Playwright fallback for the reveal and holding-page states: `320`, `375-short`
- confirmed reveal visibility after first scroll, reduced-motion visibility, no horizontal overflow, and contact-field visibility in the successful runs
- route-level Playwright QA for `/`, `/partners/clinics`, and the temporary landing root remains blocked by the existing Payload/Postgres schema mismatch above

## Screenshots
- `output/playwright/storybook-scroll-reveals-rerun/scroll-reveal-default-320/final.png`
- `output/playwright/storybook-scroll-reveals-rerun/holding-mobile-375-short/final.png`

## Development
- Closes #1004
