### PR TITLE
fix(forms): avoid double-slash form API URL

### DIFF
--- a/src/utilities/getForm.ts
+++ b/src/utilities/getForm.ts
@@ -16,9 +16,12 @@ export async function getForm(slug: string): Promise<Form | null> {
     return null
   }
 
-  const response = await fetch(
-    `${baseUrl}/api/forms?where[slug][equals]=${encodeURIComponent(trimmedSlug)}&limit=1&depth=0`,
-  )
+  const requestURL = new URL('/api/forms', baseUrl)
+  requestURL.searchParams.set('where[slug][equals]', trimmedSlug)
+  requestURL.searchParams.set('limit', '1')
+  requestURL.searchParams.set('depth', '0')
+
+  const response = await fetch(requestURL.toString())
 
   if (!response.ok) {
     throw new Error('Could not load form')

--- a/tests/unit/utilities/getForm.test.ts
+++ b/tests/unit/utilities/getForm.test.ts
@@ -33,7 +33,7 @@ describe('getForm', () => {
     const result = await getForm('holding-contact')
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://example.com/api/forms?where[slug][equals]=holding-contact&limit=1&depth=0',
+      'https://example.com/api/forms?where%5Bslug%5D%5Bequals%5D=holding-contact&limit=1&depth=0',
     )
     expect(result).toEqual(form)
   })
@@ -50,7 +50,7 @@ describe('getForm', () => {
     await getForm('holding-contact')
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://localhost:3000/api/forms?where[slug][equals]=holding-contact&limit=1&depth=0',
+      'http://localhost:3000/api/forms?where%5Bslug%5D%5Bequals%5D=holding-contact&limit=1&depth=0',
     )
   })
 
@@ -67,7 +67,23 @@ describe('getForm', () => {
     await getForm('holding-contact')
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://portal.vercel.app/api/forms?where[slug][equals]=holding-contact&limit=1&depth=0',
+      'https://portal.vercel.app/api/forms?where%5Bslug%5D%5Bequals%5D=holding-contact&limit=1&depth=0',
+    )
+  })
+
+  it('handles base URL with trailing slash without producing double slashes', async () => {
+    process.env.NEXT_PUBLIC_SERVER_URL = 'https://example.com/'
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ docs: [{ id: 1, title: 'Holding Contact', slug: 'holding-contact' }] }),
+    })
+
+    await getForm('holding-contact')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.com/api/forms?where%5Bslug%5D%5Bequals%5D=holding-contact&limit=1&depth=0',
     )
   })
 
@@ -83,7 +99,7 @@ describe('getForm', () => {
     await getForm('holding contact')
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://localhost:3000/api/forms?where[slug][equals]=holding%20contact&limit=1&depth=0',
+      'http://localhost:3000/api/forms?where%5Bslug%5D%5Bequals%5D=holding+contact&limit=1&depth=0',
     )
   })
 


### PR DESCRIPTION
prevents malformed form API URLs when server base URL has a trailing slash.

## What changed
- replaced string concatenation in `getForm` URL construction with `new URL('/api/forms', baseUrl)`.
- moved query assembly to `URLSearchParams` via `searchParams.set`.
- added a regression test for trailing-slash base URLs.
- updated URL expectations in existing tests to match standards-compliant query encoding.

## Validation
- `pnpm vitest run tests/unit/utilities/getForm.test.ts`
- `pnpm check`
- `pnpm format`

## Development
- Closes #1006
