### PR TITLE
fix: delay default scroll reveal trigger

### DIFF
--- a/src/components/molecules/ScrollReveal/index.tsx
+++ b/src/components/molecules/ScrollReveal/index.tsx
@@ -30,14 +30,14 @@ export type ScrollRevealProps = {
   staggerSelector?: string
 }
 
-const DEFAULT_START = 'top 82%'
+const DEFAULT_START = 'top 76%'
 
 const resolveViewportThreshold = (start: string): number => {
   const match = /^top\s+(\d+(?:\.\d+)?)%$/i.exec(start.trim())
-  if (!match) return 0.82
+  if (!match) return 0.76
 
-  const value = Number.parseFloat(match[1] ?? '82')
-  if (!Number.isFinite(value)) return 0.82
+  const value = Number.parseFloat(match[1] ?? '76')
+  if (!Number.isFinite(value)) return 0.76
 
   return Math.min(1, Math.max(0, value / 100))
 }


### PR DESCRIPTION
Landing sections now reveal slightly later, so below-the-fold content is more visible before the entrance animation starts.

## What changed
- moved the shared `ScrollReveal` default trigger from `top 82%` to `top 76%`
- aligned the fallback viewport-threshold parser with the same `76%` default so initial-load and scroll-trigger behavior stay consistent
- left the reveal animation strength, distance, and duration unchanged

## Validation
- `rtk pnpm format`
- `rtk pnpm check`
- `rtk pnpm build`
- Playwright runtime verification on `/` at `320x740`, `375x812`, `640x900`, `768x1024`, `1024x900`, and `375x600`
- Playwright runtime verification on `/partners/clinics` at `375x812` and `1024x900`
- Verified reveal state stays `hidden` around `79%` viewport entry and becomes `visible` after crossing the new trigger on the checked routes
- Verified no horizontal overflow on the checked viewports

## Screenshots
- `output/playwright/scroll-reveal-threshold/home-320-79-hidden.png`: first reveal block still hidden before the new trigger
- `output/playwright/scroll-reveal-threshold/home-320-75-visible.png`: first reveal block visible after crossing the new trigger
- `output/playwright/scroll-reveal-threshold/home-375-short-75-visible.png`: short-height mobile check after reveal
- `output/playwright/scroll-reveal-threshold/home-1024-75-visible.png`: desktop check after reveal
- `output/playwright/scroll-reveal-threshold/partners-clinics-375-75-visible.png`: secondary landing route check after reveal

## Development
- Closes #1008
