### PR TITLE
fix: block protocol-relative paths in preview route

### DIFF
--- a/src/app/(frontend)/next/preview/route.ts
+++ b/src/app/(frontend)/next/preview/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest): Promise<Response> {
     return new Response('Insufficient search params', { status: 404 })
   }
 
-  if (!path.startsWith('/')) {
+  if (!path.startsWith('/') || path.startsWith('//')) {
     return new Response('This endpoint can only be used for relative previews', { status: 500 })
   }
 

--- a/tests/unit/app/frontend/next/preview/route.test.ts
+++ b/tests/unit/app/frontend/next/preview/route.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 
-const authMock = vi.fn()
+const { authMock, redirectMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  redirectMock: vi.fn(),
+}))
 
 vi.mock('payload', () => ({
   getPayload: vi.fn().mockResolvedValue({
@@ -10,7 +13,9 @@ vi.mock('payload', () => ({
   }),
 }))
 
-const redirectMock = vi.fn()
+vi.mock('@payload-config', () => ({
+  default: {},
+}))
 
 vi.mock('next/navigation', () => ({
   redirect: redirectMock,

--- a/tests/unit/app/frontend/next/preview/route.test.ts
+++ b/tests/unit/app/frontend/next/preview/route.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const authMock = vi.fn()
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn().mockResolvedValue({
+    auth: authMock,
+    logger: { error: vi.fn() },
+  }),
+}))
+
+const redirectMock = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}))
+
+vi.mock('next/headers', () => ({
+  draftMode: vi.fn().mockResolvedValue({
+    disable: vi.fn(),
+    enable: vi.fn(),
+  }),
+}))
+
+import { GET } from '@/app/(frontend)/next/preview/route'
+
+describe('GET /next/preview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.PREVIEW_SECRET = 'test-secret'
+  })
+
+  it('rejects protocol-relative paths before auth or redirects', async () => {
+    const request = new NextRequest(
+      'http://localhost/next/preview?path=//evil.example&collection=posts&slug=hello-world&previewSecret=test-secret',
+    )
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(500)
+    await expect(response.text()).resolves.toBe('This endpoint can only be used for relative previews')
+    expect(authMock).not.toHaveBeenCalled()
+    expect(redirectMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Previews now reject protocol-relative redirect paths so draft-mode redirects stay on-origin.

## What changed
- reject `path` values starting with `//` in `/next/preview`
- keep existing relative-path requirement for internal previews
- add unit regression test for `//evil.example` to ensure auth/redirect are not reached

## Validation
- `pnpm check` ✅
- `pnpm format` ✅
- `pnpm vitest run tests/unit/app/frontend/next/preview/route.test.ts` ⚠️ blocked in this environment (permission-matrix global setup exit=255)
- `pnpm build` ⚠️ blocked in this environment (Postgres connect `EPERM 127.0.0.1:5432`)

## Development
- Closes #1015
