### PR TITLE
fix: prevent preview search indexing

### DIFF
--- a/next-sitemap.config.cjs
+++ b/next-sitemap.config.cjs
@@ -1,6 +1,22 @@
 const SITE_URL =
   process.env.NEXT_PUBLIC_SERVER_URL || process.env.VERCEL_PROJECT_PRODUCTION_URL || 'https://example.com'
 
+const normalizeEnvValue = (value) => {
+  if (!value) return null
+
+  const normalized = value.trim().toLowerCase()
+  return normalized.length > 0 ? normalized : null
+}
+
+const isPreviewRuntime =
+  (normalizeEnvValue(process.env.VERCEL_ENV) ??
+    normalizeEnvValue(process.env.DEPLOYMENT_ENV) ??
+    normalizeEnvValue(process.env.NODE_ENV)) === 'preview'
+const isTemporaryLandingModeEnabled = ['1', 'on', 'true', 'yes'].includes(
+  normalizeEnvValue(process.env.TEMPORARY_LANDING_MODE_ENABLED) ?? '',
+)
+const blockSearchIndexing = isPreviewRuntime || isTemporaryLandingModeEnabled
+
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
   siteUrl: SITE_URL,
@@ -8,11 +24,16 @@ module.exports = {
   exclude: ['/posts-sitemap.xml', '/pages-sitemap.xml', '/*', '/posts/*'],
   robotsTxtOptions: {
     policies: [
-      {
-        userAgent: '*',
-        disallow: '/admin/*',
-      },
+      blockSearchIndexing
+        ? {
+            userAgent: '*',
+            disallow: '/',
+          }
+        : {
+            userAgent: '*',
+            disallow: '/admin/*',
+          },
     ],
-    additionalSitemaps: [`${SITE_URL}/pages-sitemap.xml`, `${SITE_URL}/posts-sitemap.xml`],
+    additionalSitemaps: blockSearchIndexing ? [] : [`${SITE_URL}/pages-sitemap.xml`, `${SITE_URL}/posts-sitemap.xml`],
   },
 }

--- a/next.config.js
+++ b/next.config.js
@@ -7,8 +7,41 @@ const NEXT_PUBLIC_SERVER_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
   ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
   : undefined || process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:3000'
 
+const SEARCH_ROBOTS_HEADER_VALUE = 'noindex, nofollow, noarchive'
+
+const normalizeEnvValue = (value) => {
+  if (!value) return null
+
+  const normalized = value.trim().toLowerCase()
+  return normalized.length > 0 ? normalized : null
+}
+
+const isPreviewRuntime =
+  (normalizeEnvValue(process.env.VERCEL_ENV) ??
+    normalizeEnvValue(process.env.DEPLOYMENT_ENV) ??
+    normalizeEnvValue(process.env.NODE_ENV)) === 'preview'
+const isTemporaryLandingModeEnabled = ['1', 'on', 'true', 'yes'].includes(
+  normalizeEnvValue(process.env.TEMPORARY_LANDING_MODE_ENABLED) ?? '',
+)
+const blockSearchIndexing = isPreviewRuntime || isTemporaryLandingModeEnabled
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async headers() {
+    return blockSearchIndexing
+      ? [
+          {
+            headers: [
+              {
+                key: 'X-Robots-Tag',
+                value: SEARCH_ROBOTS_HEADER_VALUE,
+              },
+            ],
+            source: '/:path*',
+          },
+        ]
+      : []
+  },
   images: {
     localPatterns: IMAGE_LOCAL_PATTERNS,
     qualities: IMAGE_QUALITIES,

--- a/src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts
+++ b/src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts
@@ -3,6 +3,7 @@ import { getPayload } from 'payload'
 import config from '@payload-config'
 import { unstable_cache } from 'next/cache'
 import { findPageSitemapDocs } from '@/utilities/content/serverData'
+import { SEARCH_ROBOTS_HEADER, SEARCH_ROBOTS_HEADER_VALUE, shouldBlockSearchIndexing } from '@/features/searchIndexing'
 
 const getPagesSitemap = unstable_cache(
   async () => {
@@ -43,6 +44,12 @@ const getPagesSitemap = unstable_cache(
 )
 
 export async function GET() {
+  if (shouldBlockSearchIndexing(process.env)) {
+    return getServerSideSitemap([], {
+      [SEARCH_ROBOTS_HEADER]: SEARCH_ROBOTS_HEADER_VALUE,
+    })
+  }
+
   const sitemap = await getPagesSitemap()
 
   return getServerSideSitemap(sitemap)

--- a/src/app/(frontend)/(sitemaps)/posts-sitemap.xml/route.ts
+++ b/src/app/(frontend)/(sitemaps)/posts-sitemap.xml/route.ts
@@ -3,6 +3,7 @@ import { getPayload } from 'payload'
 import config from '@payload-config'
 import { unstable_cache } from 'next/cache'
 import { findPostSitemapDocs } from '@/utilities/content/serverData'
+import { SEARCH_ROBOTS_HEADER, SEARCH_ROBOTS_HEADER_VALUE, shouldBlockSearchIndexing } from '@/features/searchIndexing'
 
 const getPostsSitemap = unstable_cache(
   async () => {
@@ -30,6 +31,12 @@ const getPostsSitemap = unstable_cache(
 )
 
 export async function GET() {
+  if (shouldBlockSearchIndexing(process.env)) {
+    return getServerSideSitemap([], {
+      [SEARCH_ROBOTS_HEADER]: SEARCH_ROBOTS_HEADER_VALUE,
+    })
+  }
+
   const sitemap = await getPostsSitemap()
 
   return getServerSideSitemap(sitemap)

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -22,6 +22,7 @@ import { getCachedGlobal, getGlobal } from '@/utilities/getGlobals'
 import { normalizeFooterNavGroups, normalizeHeaderNavItems } from '@/utilities/normalizeNavItems'
 import { isNonProductionDeployment, PREVIEW_GUARD_LOCK_REQUEST_HEADER } from '@/features/previewGuard'
 import { COOKIE_CONSENT_COOKIE_NAME, resolveCookieConsentContext } from '@/features/cookieConsent'
+import { SEARCH_ROBOTS_HEADER_VALUE, shouldBlockSearchIndexing } from '@/features/searchIndexing'
 import type { Footer as FooterType, Header as HeaderType } from '@/payload-types'
 import type { CookieConsent as CookieConsentType } from '@/payload-types'
 
@@ -57,6 +58,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const requestHeaders = await headers()
   const showSiteChrome = requestHeaders.get(PREVIEW_GUARD_LOCK_REQUEST_HEADER) !== '1'
   const showPreviewBadge = isNonProductionDeployment(process.env)
+  const blockSearchIndexing = shouldBlockSearchIndexing(process.env)
   const configuredHeaderLogoSrc = process.env.NEXT_PUBLIC_HEADER_LOGO_SRC?.trim() || undefined
   const configuredFooterLogoSrc = process.env.NEXT_PUBLIC_FOOTER_LOGO_SRC?.trim() || undefined
   const headerLogoSrc = configuredHeaderLogoSrc
@@ -85,6 +87,12 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       <head>
         <link href="/favicon.ico" rel="icon" sizes="32x32" />
         <link href="/favicon.svg" rel="icon" type="image/svg+xml" />
+        {blockSearchIndexing ? (
+          <>
+            <meta content={SEARCH_ROBOTS_HEADER_VALUE} name="robots" />
+            <meta content={`${SEARCH_ROBOTS_HEADER_VALUE}, noimageindex`} name="googlebot" />
+          </>
+        ) : null}
       </head>
       <body className="min-h-screen bg-background text-foreground antialiased">
         <div className="flex min-h-screen min-h-svh flex-col">
@@ -122,6 +130,20 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 export const metadata: Metadata = {
   metadataBase: new URL(getServerSideURL()),
   openGraph: mergeOpenGraph(),
+  robots: shouldBlockSearchIndexing(process.env)
+    ? {
+        follow: false,
+        googleBot: {
+          follow: false,
+          index: false,
+          noarchive: true,
+          noimageindex: true,
+        },
+        index: false,
+        noarchive: true,
+        nocache: true,
+      }
+    : undefined,
   twitter: {
     card: 'summary_large_image',
     creator: '@payloadcms',

--- a/src/features/searchIndexing/index.ts
+++ b/src/features/searchIndexing/index.ts
@@ -1,0 +1,16 @@
+import { resolveRuntimeClass } from '@/features/runtimePolicy'
+import { isTemporaryLandingModeEnabled } from '@/features/temporaryLandingMode'
+
+type SearchIndexingEnvInput = {
+  DEPLOYMENT_ENV?: string
+  NODE_ENV?: string
+  TEMPORARY_LANDING_MODE_ENABLED?: string
+  VERCEL_ENV?: string
+}
+
+export const SEARCH_ROBOTS_HEADER = 'X-Robots-Tag'
+export const SEARCH_ROBOTS_HEADER_VALUE = 'noindex, nofollow, noarchive'
+
+export const shouldBlockSearchIndexing = (env: SearchIndexingEnvInput = process.env): boolean => {
+  return resolveRuntimeClass(env) === 'preview' || isTemporaryLandingModeEnabled(env)
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -14,6 +14,7 @@ import {
   isTemporaryLandingRootPath,
   TEMPORARY_LANDING_MODE_REQUEST_HEADER,
 } from '@/features/temporaryLandingMode'
+import { SEARCH_ROBOTS_HEADER, SEARCH_ROBOTS_HEADER_VALUE } from '@/features/searchIndexing'
 
 const PUBLIC_FILE = /\.[^/]+$/
 
@@ -58,6 +59,11 @@ const nextWithRequestHeaders = (request: NextRequest, headersToSet: Record<strin
   return NextResponse.next({ request: { headers: requestHeaders } })
 }
 
+const withSearchRobotsHeader = (response: NextResponse): NextResponse => {
+  response.headers.set(SEARCH_ROBOTS_HEADER, SEARCH_ROBOTS_HEADER_VALUE)
+  return response
+}
+
 const nextWithGuardLockHeader = (request: NextRequest): NextResponse =>
   nextWithRequestHeaders(request, { [PREVIEW_GUARD_LOCK_REQUEST_HEADER]: '1' })
 
@@ -86,30 +92,30 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
 
   if (temporaryLandingModeEnabled && !isPlatformUser) {
     if (isTemporaryLandingModeExemptPath(pathname)) {
-      return nextWithGuardLockHeader(request)
+      return withSearchRobotsHeader(nextWithGuardLockHeader(request))
     }
 
     if (isTemporaryLandingRootPath(pathname)) {
-      return nextWithTemporaryLandingHeaders(request)
+      return withSearchRobotsHeader(nextWithTemporaryLandingHeaders(request))
     }
 
-    return new NextResponse('Not Found', { status: 404 })
+    return withSearchRobotsHeader(new NextResponse('Not Found', { status: 404 }))
   }
 
   if (!previewGuardEnabled) {
-    return NextResponse.next()
+    return withSearchRobotsHeader(NextResponse.next())
   }
 
   if (isPlatformUser) {
-    return NextResponse.next()
+    return withSearchRobotsHeader(NextResponse.next())
   }
 
   if (isPreviewGuardExemptPath(pathname)) {
-    return nextWithGuardLockHeader(request)
+    return withSearchRobotsHeader(nextWithGuardLockHeader(request))
   }
 
   const redirectTarget = buildPreviewGuardLoginRedirect(request.nextUrl)
-  return NextResponse.redirect(new URL(redirectTarget, request.url))
+  return withSearchRobotsHeader(NextResponse.redirect(new URL(redirectTarget, request.url)))
 }
 
 export const config = {

--- a/tests/unit/app/frontend/previewLock.middleware.test.ts
+++ b/tests/unit/app/frontend/previewLock.middleware.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 
 import { PREVIEW_GUARD_LOCK_REQUEST_HEADER, PREVIEW_GUARD_LOGIN_REQUIRED_MESSAGE_KEY } from '@/features/previewGuard'
+import { SEARCH_ROBOTS_HEADER, SEARCH_ROBOTS_HEADER_VALUE } from '@/features/searchIndexing'
 import { TEMPORARY_LANDING_MODE_REQUEST_HEADER } from '@/features/temporaryLandingMode'
 
 const mocks = vi.hoisted(() => ({
@@ -60,6 +61,7 @@ describe('preview lock proxy', () => {
     expect(redirectUrl.pathname).toBe('/admin/login')
     expect(redirectUrl.searchParams.get('message')).toBe(PREVIEW_GUARD_LOGIN_REQUIRED_MESSAGE_KEY)
     expect(redirectUrl.searchParams.get('next')).toBe('/posts/example?foo=bar')
+    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
   })
 
   it('allows unauthenticated preview users on exempt routes and sets lock header', async () => {
@@ -70,6 +72,7 @@ describe('preview lock proxy', () => {
 
     expect(response.status).toBe(200)
     expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBe('1')
+    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
   })
 
   it('redirects authenticated clinic users in preview guard', async () => {
@@ -86,6 +89,7 @@ describe('preview lock proxy', () => {
     const redirectLocation = response.headers.get('location')
     const redirectUrl = new URL(redirectLocation as string)
     expect(redirectUrl.pathname).toBe('/admin/login')
+    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
   })
 
   it('allows authenticated platform users', async () => {
@@ -99,6 +103,7 @@ describe('preview lock proxy', () => {
     const response = await proxy(request)
 
     expect(response.status).toBe(200)
+    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
   })
 
   it('does not enforce preview lock outside preview environments', async () => {
@@ -106,6 +111,7 @@ describe('preview lock proxy', () => {
     const response = await proxy(request)
 
     expect(response.status).toBe(200)
+    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBeNull()
   })
 
   it('marks root requests for temporary landing mode', async () => {
@@ -117,6 +123,7 @@ describe('preview lock proxy', () => {
     expect(response.status).toBe(200)
     expect(response.headers.get(`x-middleware-request-${TEMPORARY_LANDING_MODE_REQUEST_HEADER}`)).toBe('1')
     expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBe('1')
+    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
   })
 
   it('returns 404 for non-root routes in temporary landing mode', async () => {
@@ -127,6 +134,7 @@ describe('preview lock proxy', () => {
 
     expect(response.status).toBe(404)
     expect(response.headers.get('location')).toBeNull()
+    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
   })
 
   it('keeps admin login reachable in temporary landing mode', async () => {
@@ -137,6 +145,7 @@ describe('preview lock proxy', () => {
 
     expect(response.status).toBe(200)
     expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBe('1')
+    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
   })
 
   it('keeps admin root reachable in temporary landing mode', async () => {
@@ -147,6 +156,7 @@ describe('preview lock proxy', () => {
 
     expect(response.status).toBe(200)
     expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBe('1')
+    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
   })
 
   it('keeps nested admin routes reachable in temporary landing mode', async () => {
@@ -157,6 +167,7 @@ describe('preview lock proxy', () => {
 
     expect(response.status).toBe(200)
     expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBe('1')
+    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
   })
 
   it('keeps auth recovery and registration routes reachable in temporary landing mode', async () => {
@@ -176,6 +187,7 @@ describe('preview lock proxy', () => {
       const response = await proxy(request)
       expect(response.status).toBe(200)
       expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBe('1')
+      expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
     }
   })
 
@@ -197,6 +209,10 @@ describe('preview lock proxy', () => {
     expect(privacyResponse.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBe('1')
     expect(imprintResponse.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBe('1')
     expect(contactResponse.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBe('1')
+
+    expect(privacyResponse.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
+    expect(imprintResponse.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
+    expect(contactResponse.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
   })
 
   it('allows platform users to bypass temporary landing mode', async () => {
@@ -210,6 +226,7 @@ describe('preview lock proxy', () => {
     const response = await proxy(request)
 
     expect(response.status).toBe(200)
+    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
   })
 
   it('prioritizes temporary landing mode over preview redirects', async () => {
@@ -221,6 +238,7 @@ describe('preview lock proxy', () => {
 
     expect(response.status).toBe(404)
     expect(response.headers.get('location')).toBeNull()
+    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
   })
 
   it('bypasses API routes', async () => {

--- a/tests/unit/features/searchIndexing/index.test.ts
+++ b/tests/unit/features/searchIndexing/index.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { SEARCH_ROBOTS_HEADER, SEARCH_ROBOTS_HEADER_VALUE, shouldBlockSearchIndexing } from '@/features/searchIndexing'
+
+describe('searchIndexing feature', () => {
+  it('uses a noindex robots response header value', () => {
+    expect(SEARCH_ROBOTS_HEADER).toBe('X-Robots-Tag')
+    expect(SEARCH_ROBOTS_HEADER_VALUE).toBe('noindex, nofollow, noarchive')
+  })
+
+  it('blocks indexing for preview runtime', () => {
+    expect(
+      shouldBlockSearchIndexing({
+        DEPLOYMENT_ENV: undefined,
+        NODE_ENV: 'production',
+        TEMPORARY_LANDING_MODE_ENABLED: undefined,
+        VERCEL_ENV: 'preview',
+      }),
+    ).toBe(true)
+  })
+
+  it('blocks indexing for temporary landing mode outside preview', () => {
+    expect(
+      shouldBlockSearchIndexing({
+        DEPLOYMENT_ENV: undefined,
+        NODE_ENV: 'production',
+        TEMPORARY_LANDING_MODE_ENABLED: 'true',
+        VERCEL_ENV: 'production',
+      }),
+    ).toBe(true)
+  })
+
+  it('does not block indexing for production without temporary landing mode', () => {
+    expect(
+      shouldBlockSearchIndexing({
+        DEPLOYMENT_ENV: undefined,
+        NODE_ENV: 'production',
+        TEMPORARY_LANDING_MODE_ENABLED: undefined,
+        VERCEL_ENV: 'production',
+      }),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
Preview and temporary landing deployments now keep crawler-visible surfaces limited to holding/login responses with explicit noindex signals.

## What changed

- Added a shared search-indexing policy for preview and temporary landing mode.
- Added `X-Robots-Tag: noindex, nofollow, noarchive` to preview/holding responses, including static paths via Next headers.
- Prevented dynamic page and post sitemaps from advertising URLs when search indexing is blocked.
- Updated generated robots policy to `Disallow: /` for preview or temporary landing mode.
- Covered the policy and proxy response behavior with unit tests.

## Validation

- `pnpm format`
- `pnpm check`
- `pnpm vitest tests/unit/app/frontend/previewLock.middleware.test.ts tests/unit/features/searchIndexing/index.test.ts tests/unit/features/temporaryLandingMode/index.test.ts tests/unit/features/previewGuard/index.test.ts`
- `PAYLOAD_SECRET=dev-secret pnpm build`
- Local preview/holding runtime checks:
  - `/` returned `200` with `X-Robots-Tag`
  - `/admin/login` returned `200` with `X-Robots-Tag`
  - `/posts/example` returned `404` with `X-Robots-Tag`
  - `/robots.txt` returned `Disallow: /` with `X-Robots-Tag`
  - `/pages-sitemap.xml` returned an empty URL set with `X-Robots-Tag`

## Development

Closes #1026
