### PR TITLE
fix: include seed media assets in preview bundle

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,8 @@ const NEXT_PUBLIC_SERVER_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
   ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
   : undefined || process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:3000'
 
+const SEED_ASSET_TRACING_INCLUDE = './src/endpoints/seed/assets/**/*'
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
@@ -27,6 +29,9 @@ const nextConfig = {
         hostname: 'placehold.co',
       },
     ],
+  },
+  outputFileTracingIncludes: {
+    '/api/**/*': [SEED_ASSET_TRACING_INCLUDE],
   },
   reactStrictMode: true,
   redirects,

--- a/src/endpoints/seed/utils/import-globals.ts
+++ b/src/endpoints/seed/utils/import-globals.ts
@@ -56,7 +56,7 @@ export async function importGlobals(payload: Payload): Promise<{
         slug,
         data,
         overrideAccess: true,
-        context: slug === 'landingPages' ? {} : { disableRevalidate: true },
+        context: { disableRevalidate: true },
       })
       updated += 1
     } catch (error) {

--- a/src/endpoints/seed/utils/upsert.ts
+++ b/src/endpoints/seed/utils/upsert.ts
@@ -1,4 +1,6 @@
-import { randomUUID } from 'crypto'
+import { createHash, randomUUID } from 'crypto'
+import fs from 'fs'
+import path from 'path'
 import type { CollectionSlug, Payload, PayloadRequest } from 'payload'
 
 export type UpsertResult = { created: boolean; updated: boolean }
@@ -31,6 +33,12 @@ type S3LikeError = {
 type ValidationErrorLike = {
   path?: unknown
   message?: unknown
+}
+
+const UPLOAD_IMAGE_SIZE_NAMES = ['thumbnail', 'square', 'small', 'medium', 'large', 'xlarge', 'og'] as const
+
+function shortHash(input: string): string {
+  return createHash('sha1').update(input).digest('hex').slice(0, 10)
 }
 
 function parseMissingResourceFromMessage(message: string): string | null {
@@ -237,6 +245,72 @@ async function clearTrashedUploadFilenames(options: {
   }
 }
 
+function derivePlatformSeedStoragePath(filePath: string): string | null {
+  let size: number | null = null
+
+  try {
+    size = fs.statSync(filePath).size
+  } catch {
+    return null
+  }
+
+  const baseFilename = path.basename(filePath).replace(/[\\/]/g, '_')
+  if (!baseFilename) return null
+
+  const hashInput = `platform:${baseFilename}${size ? `:${size}` : ''}`
+  return `platform/${shortHash(hashInput)}-${baseFilename}`
+}
+
+function deriveSeedBaseFilename(filePath: string): string | null {
+  const baseFilename = path.basename(filePath).replace(/[\\/]/g, '_')
+  return baseFilename || null
+}
+
+function shouldClearPlatformSeedUploadTargetsBeforeUpdate(options: {
+  collection: CollectionSlug
+  current: Record<string, unknown>
+  filePath?: string
+}): boolean {
+  const { collection, current, filePath } = options
+  if (collection !== 'platformContentMedia' || !filePath) return false
+
+  const currentStoragePath = typeof current.storagePath === 'string' ? current.storagePath : null
+  if (!currentStoragePath) return false
+
+  const expectedStoragePath = derivePlatformSeedStoragePath(filePath)
+  if (expectedStoragePath === currentStoragePath) return true
+
+  const baseFilename = deriveSeedBaseFilename(filePath)
+  return Boolean(baseFilename && currentStoragePath.endsWith(`-${baseFilename}`))
+}
+
+async function clearUploadDeletionTargetsBeforeUpdate(options: {
+  payload: Payload
+  collection: CollectionSlug
+  id: string | number
+  context: Record<string, unknown>
+  req: Partial<PayloadRequest>
+}) {
+  const sizeData = Object.fromEntries(
+    UPLOAD_IMAGE_SIZE_NAMES.map((sizeName) => [sizeName, { filename: null }]),
+  ) as Record<(typeof UPLOAD_IMAGE_SIZE_NAMES)[number], { filename: null }>
+
+  await options.payload.update({
+    collection: options.collection,
+    id: options.id,
+    overrideAccess: true,
+    context: {
+      ...options.context,
+      skipCloudStorage: true,
+    },
+    data: {
+      filename: null,
+      sizes: sizeData,
+    },
+    req: options.req,
+  })
+}
+
 async function updateWithNoSuchKeyRecovery(
   payload: Payload,
   params: {
@@ -413,6 +487,22 @@ export async function upsertByStableId<T extends Record<string, unknown>>(
   // If found doc is trashed, restore it by clearing deletedAt.
   if (current.deletedAt) {
     nextData.deletedAt = null
+  }
+
+  if (
+    shouldClearPlatformSeedUploadTargetsBeforeUpdate({
+      collection,
+      current: current as Record<string, unknown>,
+      filePath: options?.filePath,
+    })
+  ) {
+    await clearUploadDeletionTargetsBeforeUpdate({
+      payload,
+      collection,
+      id: current.id,
+      context: operationContext,
+      req: operationReq,
+    })
   }
 
   await updateWithNoSuchKeyRecovery(payload, {

--- a/tests/unit/config/next-config.test.ts
+++ b/tests/unit/config/next-config.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import nextConfig from '../../../next.config.js'
+
+describe('nextConfig', () => {
+  it('includes seed assets in API output tracing', () => {
+    expect(nextConfig.outputFileTracingIncludes?.['/api/**/*']).toContain('./src/endpoints/seed/assets/**/*')
+  })
+})

--- a/tests/unit/endpoints/seed/globals-seed.test.ts
+++ b/tests/unit/endpoints/seed/globals-seed.test.ts
@@ -43,6 +43,7 @@ describe('seedGlobalsBaseline', () => {
     expect(updateGlobal).toHaveBeenCalledWith(
       expect.objectContaining({
         slug: 'landingPages',
+        context: { disableRevalidate: true },
         data: expect.objectContaining({
           home: expect.objectContaining({
             hero: expect.objectContaining({

--- a/tests/unit/endpoints/seed/seed-media-assets.test.ts
+++ b/tests/unit/endpoints/seed/seed-media-assets.test.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const mediaSeedFiles = [
+  'src/endpoints/seed/data/baseline/platformContentMedia.json',
+  'src/endpoints/seed/data/demo/clinicMedia.json',
+  'src/endpoints/seed/data/demo/platformContentMedia.json',
+  'src/endpoints/seed/data/demo/userProfileMedia.json',
+] as const
+
+type SeedMediaRecord = {
+  filePath?: string
+  stableId?: string
+}
+
+describe('seed media assets', () => {
+  it('keeps media file paths aligned with existing seed assets', () => {
+    const missingFiles = mediaSeedFiles.flatMap((seedFile) => {
+      const records = JSON.parse(fs.readFileSync(seedFile, 'utf8')) as SeedMediaRecord[]
+
+      return records.flatMap((record) => {
+        if (!record.filePath) return []
+
+        const resolvedPath = path.resolve(process.cwd(), record.filePath)
+
+        return fs.existsSync(resolvedPath) ? [] : [`${seedFile}:${record.stableId ?? 'unknown'} -> ${record.filePath}`]
+      })
+    })
+
+    expect(missingFiles).toEqual([])
+  })
+})

--- a/tests/unit/endpoints/seed/upsert-s3-recovery.test.ts
+++ b/tests/unit/endpoints/seed/upsert-s3-recovery.test.ts
@@ -1,6 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createHash } from 'crypto'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
 import type { Payload } from 'payload'
 import { upsertByStableId } from '@/endpoints/seed/utils/upsert'
+
+function platformSeedStoragePathFor(filePath: string): string {
+  const baseFilename = path.basename(filePath).replace(/[\\/]/g, '_')
+  const size = fs.statSync(filePath).size
+  const hashInput = `platform:${baseFilename}${size ? `:${size}` : ''}`
+  const hash = createHash('sha1').update(hashInput).digest('hex').slice(0, 10)
+
+  return `platform/${hash}-${baseFilename}`
+}
 
 describe('upsertByStableId S3 NoSuchKey recovery', () => {
   const find = vi.fn()
@@ -20,6 +33,11 @@ describe('upsertByStableId S3 NoSuchKey recovery', () => {
   } as unknown as Payload
 
   beforeEach(() => {
+    find.mockReset()
+    create.mockReset()
+    update.mockReset()
+    updateOne.mockReset().mockResolvedValue(undefined)
+    warn.mockReset()
     vi.stubEnv('S3_BUCKET', 'portalfiles')
   })
 
@@ -113,6 +131,70 @@ describe('upsertByStableId S3 NoSuchKey recovery', () => {
 
     expect(result).toEqual({ created: false, updated: true })
     expect(updateCalls).toBe(2)
+  })
+
+  it('clears same-target platform upload filenames before updating seed media', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'seed-media-'))
+    const filePath = path.join(tempDir, 'landing-image.webp')
+    fs.writeFileSync(filePath, 'seed-image')
+
+    try {
+      find.mockResolvedValue({
+        totalDocs: 1,
+        docs: [
+          {
+            id: 'media-3',
+            filename: 'stale-landing-image.webp',
+            sizes: {
+              thumbnail: { filename: 'stale-landing-image-300x200.webp' },
+            },
+            storagePath: platformSeedStoragePathFor(filePath),
+          },
+        ],
+      })
+      update.mockResolvedValue({ id: 'media-3' })
+
+      const result = await upsertByStableId(
+        payload,
+        'platformContentMedia',
+        {
+          stableId: '8c419e7c-8475-49c4-b07f-e8a8f3b92d56',
+          alt: 'Landing image',
+        },
+        { filePath },
+      )
+
+      expect(result).toEqual({ created: false, updated: true })
+      expect(update).toHaveBeenCalledTimes(2)
+      expect(update).toHaveBeenNthCalledWith(1, {
+        collection: 'platformContentMedia',
+        id: 'media-3',
+        overrideAccess: true,
+        context: {
+          disableRevalidate: true,
+          disableSearchSync: true,
+          seedMediaExpectedNoSuchKeyRecovery: true,
+          skipCloudStorage: true,
+        },
+        req: {
+          context: {
+            disableRevalidate: true,
+            disableSearchSync: true,
+            seedMediaExpectedNoSuchKeyRecovery: true,
+          },
+        },
+        data: {
+          filename: null,
+          sizes: expect.objectContaining({
+            medium: { filename: null },
+            thumbnail: { filename: null },
+          }),
+        },
+      })
+      expect(create).not.toHaveBeenCalled()
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
   })
 
   it('retries create after clearing trashed upload filenames when filename is blocked by unique index', async () => {


### PR DESCRIPTION
Preview baseline seeding can now read bundled seed media assets before uploading platform content media.

## What changed
- Include src/endpoints/seed/assets in Next output tracing for API routes so Vercel Preview bundles the seed files.
- Add regression coverage for the tracing rule and for seed media JSON paths pointing to existing files.
- Harden baseline media re-upload recovery for existing platform content media and disable global revalidation during seed globals.

## Validation
- pnpm format
- PAYLOAD_SECRET=dev-secret NODE_ENV=test pnpm exec vitest run --project=unit tests/unit/config/next-config.test.ts tests/unit/endpoints/seed/seed-media-assets.test.ts tests/unit/endpoints/seed/upsert-s3-recovery.test.ts tests/unit/endpoints/seed/globals-seed.test.ts tests/unit/endpoints/seed/seedEndpoint-success.test.ts tests/unit/endpoints/seed/baselineFailFast.test.ts
- PAYLOAD_SECRET=dev-secret pnpm check
- PAYLOAD_SECRET=dev-secret pnpm build
- build trace check confirmed /api/[...slug] includes 62 seed assets, including dental-root.webp
- PAYLOAD_SECRET=dev-secret pnpm seed:run -- --type baseline

## Development
Closes #1028
