### PR TITLE
fix: preserve landing query values when updating specialty

### DIFF
--- a/src/components/organisms/Landing/LandingCategories.shared.ts
+++ b/src/components/organisms/Landing/LandingCategories.shared.ts
@@ -109,7 +109,9 @@ export function withSpecialtyQuery(href: string, specialtyId: string | null) {
   const hashIndex = href.indexOf('#')
   const pathAndQuery = hashIndex >= 0 ? href.slice(0, hashIndex) : href
   const hash = hashIndex >= 0 ? href.slice(hashIndex + 1) : ''
-  const [pathnameValue = '/', query = ''] = (pathAndQuery ?? '/').split('?')
+  const queryIndex = pathAndQuery.indexOf('?')
+  const pathnameValue = queryIndex >= 0 ? pathAndQuery.slice(0, queryIndex) : pathAndQuery
+  const query = queryIndex >= 0 ? pathAndQuery.slice(queryIndex + 1) : ''
   const pathname = pathnameValue.length > 0 ? pathnameValue : '/'
   const params = new URLSearchParams(query)
 

--- a/tests/unit/components/landingCategoriesShared.test.ts
+++ b/tests/unit/components/landingCategoriesShared.test.ts
@@ -20,4 +20,10 @@ describe('withSpecialtyQuery', () => {
 
     expect(href).toBe('/listing-comparison#overview#details')
   })
+
+  it('preserves query content after the first ? when rewriting specialty', () => {
+    const href = withSpecialtyQuery('/listing-comparison?note=first?second', 'nose')
+
+    expect(href).toBe('/listing-comparison?note=first%3Fsecond&specialty=nose')
+  })
 })


### PR DESCRIPTION
Landing specialty links now keep complete existing query values while updating the `specialty` parameter.

## What changed
- replaced `split("?")` parsing in `withSpecialtyQuery` with first-index slicing
- preserved the full query tail after the first `?` before applying specialty mutation
- added a regression unit test for `/listing-comparison?note=first?second`

## Validation
- `pnpm check`
- `pnpm format`
- `pnpm vitest run tests/unit/components/landingCategoriesShared.test.ts` *(blocked locally: EPERM in unit global setup pipe listen)*

## Development
- closes #1061
