### PR TITLE
fix: handle localized demo post seed content

### DIFF
--- a/src/endpoints/seed/baseline/run-baseline.ts
+++ b/src/endpoints/seed/baseline/run-baseline.ts
@@ -94,6 +94,7 @@ export async function runBaselineSeeds(
         collection: step.collection,
         fileName: step.fileName,
         mapping: step.mapping,
+        localizedFields: step.localizedFields,
         defaults,
         resolvers,
         context: step.context,

--- a/src/endpoints/seed/demo/run-demo.ts
+++ b/src/endpoints/seed/demo/run-demo.ts
@@ -117,6 +117,7 @@ export async function runDemoSeeds(payload: Payload, options: { reset?: boolean 
         collection: step.collection,
         fileName: step.fileName,
         mapping: step.mapping,
+        localizedFields: step.localizedFields,
         context: 'context' in step ? step.context : undefined,
         resolvers,
         req,

--- a/src/endpoints/seed/tasks/seedChunkTask.ts
+++ b/src/endpoints/seed/tasks/seedChunkTask.ts
@@ -336,6 +336,7 @@ export const seedChunkTask = {
         context: input.context,
         req: seedReq,
         stableIds: input.stableIds,
+        localizedFields: input.localizedFields,
       })
 
       const warnings = [...result.warnings]

--- a/src/endpoints/seed/utils/import-collection.ts
+++ b/src/endpoints/seed/utils/import-collection.ts
@@ -1,6 +1,7 @@
 import type { CollectionSlug, Payload } from 'payload'
 import fs from 'fs'
 import path from 'path'
+import { CONTENT_LOCALES, DEFAULT_CONTENT_LOCALE, type ContentLocale } from '@/utilities/contentLocalization'
 import type { SeedKind, SeedRecord } from './load-json'
 import type { StableIdResolvers } from './resolvers'
 import { loadSeedFile } from './load-json'
@@ -23,6 +24,8 @@ export type CollectionImportResult = {
   failures: string[]
 }
 
+type LocalizedSeedUpdates = Partial<Record<ContentLocale, Record<string, unknown>>>
+
 function setValueAtPath(target: Record<string, unknown>, path: string, value: unknown) {
   const parts = path.split('.')
   let current: Record<string, unknown> = target
@@ -43,6 +46,91 @@ function setValueAtPath(target: Record<string, unknown>, path: string, value: un
       }
       current = current[key] as Record<string, unknown>
     }
+  }
+}
+
+function getValueAtPath(target: Record<string, unknown>, path: string): unknown {
+  const parts = path.split('.')
+  let current: unknown = target
+
+  for (const key of parts) {
+    if (!key) continue
+    if (!current || typeof current !== 'object') {
+      return undefined
+    }
+    current = (current as Record<string, unknown>)[key]
+  }
+
+  return current
+}
+
+function isLocalizedSeedValue(value: unknown): value is Partial<Record<ContentLocale, unknown>> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+
+  return CONTENT_LOCALES.some((locale) => Object.prototype.hasOwnProperty.call(value, locale))
+}
+
+function extractLocalizedFieldUpdates(draft: Record<string, unknown>, localizedFields: string[]): LocalizedSeedUpdates {
+  const updates: LocalizedSeedUpdates = {}
+
+  for (const fieldPath of localizedFields) {
+    const localizedValue = getValueAtPath(draft, fieldPath)
+    if (!isLocalizedSeedValue(localizedValue)) {
+      continue
+    }
+
+    const defaultValue = localizedValue[DEFAULT_CONTENT_LOCALE]
+    if (typeof defaultValue !== 'undefined') {
+      setValueAtPath(draft, fieldPath, defaultValue)
+    }
+
+    for (const locale of CONTENT_LOCALES) {
+      if (locale === DEFAULT_CONTENT_LOCALE) continue
+
+      const localeValue = localizedValue[locale]
+      if (typeof localeValue === 'undefined') continue
+
+      const localeUpdate = updates[locale] ?? {}
+      setValueAtPath(localeUpdate, fieldPath, localeValue)
+      updates[locale] = localeUpdate
+    }
+  }
+
+  return updates
+}
+
+async function applyLocalizedFieldUpdates(options: {
+  payload: Payload
+  collection: CollectionSlug
+  docId: string | number
+  updates: LocalizedSeedUpdates
+  context?: Record<string, unknown>
+  req?: Partial<import('payload').PayloadRequest>
+}) {
+  const { payload, collection, docId, updates, context, req } = options
+
+  for (const locale of CONTENT_LOCALES) {
+    if (locale === DEFAULT_CONTENT_LOCALE) continue
+
+    const data = updates[locale]
+    if (!data || Object.keys(data).length === 0) continue
+
+    await payload.update({
+      collection,
+      id: docId,
+      locale,
+      data,
+      trash: true,
+      overrideAccess: true,
+      context: {
+        disableRevalidate: true,
+        disableSearchSync: true,
+        ...(context ?? {}),
+      },
+      req,
+    })
   }
 }
 
@@ -96,8 +184,21 @@ export async function importCollection(options: {
   context?: Record<string, unknown>
   req?: Partial<import('payload').PayloadRequest>
   stableIds?: string[]
+  localizedFields?: string[]
 }): Promise<CollectionImportResult> {
-  const { payload, kind, collection, fileName, mapping = [], defaults, resolvers, context, req, stableIds } = options
+  const {
+    payload,
+    kind,
+    collection,
+    fileName,
+    mapping = [],
+    defaults,
+    resolvers,
+    context,
+    req,
+    stableIds,
+    localizedFields = [],
+  } = options
 
   const allRecords = await loadSeedFile(kind, fileName)
   const records =
@@ -230,6 +331,8 @@ export async function importCollection(options: {
         continue
       }
 
+      const localizedUpdates = extractLocalizedFieldUpdates(draft, localizedFields)
+
       const result = await upsertByStableId(payload, collection, draft, {
         filePath,
         context,
@@ -237,6 +340,23 @@ export async function importCollection(options: {
       })
       if (result.created) created += 1
       if (result.updated) updated += 1
+
+      if (Object.keys(localizedUpdates).length > 0) {
+        const docId = await resolvers.resolveIdByStableId(collection, record.stableId)
+        if (!docId) {
+          warnings.push(`Missing ${collection} stableId for localized update: ${record.stableId}`)
+          continue
+        }
+
+        await applyLocalizedFieldUpdates({
+          payload,
+          collection,
+          docId,
+          updates: localizedUpdates,
+          context,
+          req,
+        })
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       failures.push(`Failed ${formatRecordIdentifier(collection, record)}: ${message}`)

--- a/src/endpoints/seed/utils/job-types.ts
+++ b/src/endpoints/seed/utils/job-types.ts
@@ -16,6 +16,7 @@ export type SeedQueueJobInput = {
   fileName?: string
   mapping?: RelationMapping[]
   context?: Record<string, unknown>
+  localizedFields?: string[]
   reqUserStableId?: string
   requiresPlatformUser?: boolean
   stableIds?: string[]

--- a/src/endpoints/seed/utils/plan.ts
+++ b/src/endpoints/seed/utils/plan.ts
@@ -8,6 +8,7 @@ type CollectionPlanStep = {
   fileName: string
   mapping?: RelationMapping[]
   context?: Record<string, unknown>
+  localizedFields?: string[]
   reqUserStableId?: string
   requiresPlatformUser?: boolean
 }
@@ -157,6 +158,7 @@ export const demoPlan: SeedPlanStep[] = [
     name: 'posts',
     collection: 'posts',
     fileName: 'posts',
+    localizedFields: ['title', 'content', 'excerpt', 'meta.title', 'meta.description'],
     mapping: [
       {
         sourceField: 'heroImageStableId',

--- a/src/endpoints/seed/utils/planner.ts
+++ b/src/endpoints/seed/utils/planner.ts
@@ -144,6 +144,7 @@ const createJobInput = (args: {
     fileName: args.step.fileName,
     mapping: args.step.mapping as RelationMapping[] | undefined,
     context: args.step.context,
+    localizedFields: args.step.localizedFields,
     reqUserStableId: args.step.reqUserStableId,
     requiresPlatformUser: args.step.requiresPlatformUser,
     stableIds: args.stableIds,

--- a/tests/integration/posts.lifecycle.test.ts
+++ b/tests/integration/posts.lifecycle.test.ts
@@ -10,6 +10,7 @@ import { testSlug } from '../fixtures/testSlug'
 import { slugify } from '@/utilities/slugify'
 import { findPostBySlug, findPublishedPostsPage } from '@/utilities/content/serverData'
 import type { Post, Tag, Category, BasicUser } from '@/payload-types'
+import demoPosts from '@/endpoints/seed/data/demo/posts.json'
 
 type CreatedUser = {
   basicUserId: number
@@ -327,6 +328,59 @@ describe('Posts integration - lifecycle and access', () => {
     expect(localizedPost?.excerpt).toBe('Kurzer deutscher Auszug.')
     expect(localizedPost?.meta?.title).toBe(`${title} SEO titel`)
     expect(localizedPost?.meta?.description).toBe('SEO description for integration tests.')
+  })
+
+  it('stores demo seed rich text blocks per locale', async () => {
+    const seedPost = demoPosts[0]
+    if (!seedPost) {
+      throw new Error('Expected at least one demo post seed record')
+    }
+
+    const title = `${slugPrefix} demo seed rich text`
+    const slug = slugify(title)
+
+    const created = await payload.create({
+      collection: 'posts',
+      data: {
+        stableId: `${slug}-stable`,
+        title,
+        slug,
+        content: seedPost.content.en as PostCreateData['content'],
+        excerpt: seedPost.excerpt.en,
+        _status: 'published',
+        meta: {
+          title: seedPost.meta.title.en,
+          description: seedPost.meta.description.en,
+        },
+      },
+      overrideAccess: true,
+      context: { disableRevalidate: true, disableSearchSync: true },
+    })
+
+    await payload.update({
+      collection: 'posts',
+      id: created.id,
+      locale: 'de',
+      data: {
+        title: `${title} de`,
+        content: seedPost.content.de as PostCreateData['content'],
+        excerpt: seedPost.excerpt.de,
+        meta: {
+          title: seedPost.meta.title.de,
+          description: seedPost.meta.description.de,
+        },
+      },
+      overrideAccess: true,
+      context: { disableRevalidate: true, disableSearchSync: true },
+    })
+
+    const localizedPost = await findPostBySlug(payload, slug, false, {
+      locale: 'de',
+      fallbackLocale: 'en',
+    })
+
+    expect(localizedPost?.content).toEqual(seedPost.content.de)
+    expect(JSON.stringify(localizedPost?.content)).toContain('"blockType":"banner"')
   })
 
   it('returns german localized values from published post list queries', async () => {

--- a/tests/unit/endpoints/seed/demoPartial.test.ts
+++ b/tests/unit/endpoints/seed/demoPartial.test.ts
@@ -55,6 +55,13 @@ describe('demo seed chunking', () => {
 
     expect(chunkedInputs.length).toBeGreaterThan(0)
     expect(chunkedInputs.some((input) => input?.stepName === 'platform-content-media')).toBe(true)
+    expect(queuedInputs.find((input) => input?.stepName === 'posts')?.localizedFields).toEqual([
+      'title',
+      'content',
+      'excerpt',
+      'meta.title',
+      'meta.description',
+    ])
 
     const runId = postBody.runId
     const getRes = makeRes()

--- a/tests/unit/endpoints/seed/import-collection.test.ts
+++ b/tests/unit/endpoints/seed/import-collection.test.ts
@@ -363,4 +363,82 @@ describe('importCollection', () => {
       description: { en: 'English description', de: 'Deutsche Beschreibung' },
     })
   })
+
+  it('splits configured localized fields into default upsert and locale updates', async () => {
+    const englishContent = {
+      root: {
+        type: 'root',
+        children: [],
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        version: 1,
+      },
+    }
+    const germanContent = {
+      root: {
+        type: 'root',
+        children: [],
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        version: 1,
+      },
+    }
+    const update = vi.fn(async () => ({ id: 'post-1-id' }))
+
+    mockLoadSeedFile.mockResolvedValueOnce([
+      {
+        stableId: 'post-1',
+        slug: 'localized-post',
+        title: { en: 'English title', de: 'Deutscher Titel' },
+        excerpt: { en: 'English excerpt', de: 'Deutscher Auszug' },
+        content: { en: englishContent, de: germanContent },
+        meta: {
+          title: { en: 'English SEO', de: 'Deutscher SEO' },
+          description: { en: 'English description', de: 'Deutsche Beschreibung' },
+        },
+      },
+    ])
+
+    await importCollection({
+      payload: makePayload({ update: update as unknown as Payload['update'] }),
+      kind: 'demo',
+      collection: 'posts',
+      fileName: 'posts',
+      localizedFields: ['title', 'content', 'excerpt', 'meta.title', 'meta.description'],
+      resolvers: makeResolvers(),
+    })
+
+    const payloadData = mockUpsertByStableId.mock.calls[0]?.[2] as Record<string, unknown> | undefined
+    expect(payloadData?.title).toBe('English title')
+    expect(payloadData?.excerpt).toBe('English excerpt')
+    expect(payloadData?.content).toEqual(englishContent)
+    expect(payloadData?.meta).toEqual({
+      title: 'English SEO',
+      description: 'English description',
+    })
+
+    expect(update).toHaveBeenCalledWith({
+      collection: 'posts',
+      id: 'post-1-id',
+      locale: 'de',
+      data: {
+        title: 'Deutscher Titel',
+        excerpt: 'Deutscher Auszug',
+        content: germanContent,
+        meta: {
+          title: 'Deutscher SEO',
+          description: 'Deutsche Beschreibung',
+        },
+      },
+      trash: true,
+      overrideAccess: true,
+      context: {
+        disableRevalidate: true,
+        disableSearchSync: true,
+      },
+      req: undefined,
+    })
+  })
 })

--- a/tests/unit/endpoints/seed/seedChunkTask.test.ts
+++ b/tests/unit/endpoints/seed/seedChunkTask.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Payload, PayloadRequest } from 'payload'
+import type { CollectionImportResult } from '@/endpoints/seed/utils/import-collection'
+import type { SeedQueueJobInput } from '@/endpoints/seed/utils/job-types'
+import { createMockPayload, createMockReq } from '../../helpers/testHelpers'
+import { mockUsers } from '../../helpers/mockUsers'
+
+const importCollection = vi.hoisted(() => vi.fn<() => Promise<CollectionImportResult>>())
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}))
+
+vi.mock('@/endpoints/seed/utils/import-collection', () => ({ importCollection }))
+
+import { seedChunkTask } from '@/endpoints/seed/tasks/seedChunkTask'
+import { createSeedRunRecord, registerSeedRunJob, saveSeedRunRecord } from '@/endpoints/seed/utils/state'
+
+describe('seedChunkTask', () => {
+  beforeEach(() => {
+    importCollection.mockReset()
+    importCollection.mockResolvedValue({
+      name: 'posts',
+      created: 0,
+      updated: 1,
+      warnings: [],
+      failures: [],
+    })
+  })
+
+  it('passes localized field metadata to collection imports', async () => {
+    const payload = createMockPayload()
+    const runId = 'seed-run-localized-posts'
+    const queue = `seed:${runId}`
+    const localizedFields = ['title', 'content', 'excerpt', 'meta.title', 'meta.description']
+    const input: SeedQueueJobInput = {
+      runId,
+      type: 'demo',
+      reset: false,
+      queue,
+      title: 'Posts',
+      stepName: 'posts',
+      kind: 'collection',
+      collection: 'posts',
+      fileName: 'posts',
+      stableIds: ['11111111-1111-1111-1111-111111111111'],
+      localizedFields,
+    }
+
+    const record = createSeedRunRecord({
+      runId,
+      type: 'demo',
+      reset: false,
+      queue,
+      totalJobs: 1,
+    })
+    await saveSeedRunRecord(payload as unknown as Payload, record)
+    await registerSeedRunJob(payload as unknown as Payload, runId, {
+      id: 'job-1',
+      order: 1,
+      status: 'queued',
+      input,
+      queue,
+      title: 'Posts',
+      stepName: 'posts',
+      kind: 'collection',
+      collection: 'posts',
+      fileName: 'posts',
+      createdAt: '2026-05-04T12:00:00.000Z',
+      created: 0,
+      updated: 0,
+      warnings: [],
+      failures: [],
+    })
+
+    await seedChunkTask.handler({
+      input,
+      job: { id: 'job-1' },
+      req: createMockReq(mockUsers.platform(), payload) as PayloadRequest,
+    })
+
+    expect(importCollection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'posts',
+        fileName: 'posts',
+        localizedFields,
+      }),
+    )
+  })
+})


### PR DESCRIPTION
Fixes demo seed runs where the Posts chunk failed because localized rich text values were sent to Payload as raw locale objects.

## What changed

- Split configured localized seed fields into default-locale upserts and follow-up locale updates.
- Mark demo Posts fields as localized seed fields and carry that metadata through direct runners and queued Dashboard jobs.
- Added unit coverage for import splitting, queue job metadata, and worker handoff.
- Added integration coverage for storing demo post rich text blocks per locale.

## Validation

- `rtk pnpm vitest --project unit --run tests/unit/endpoints/seed`
- `rtk pnpm vitest --project integration --run tests/integration/posts.lifecycle.test.ts -t "stores demo seed rich text blocks per locale" --hookTimeout 180000`
- `rtk pnpm format`
- `rtk pnpm check`
- `rtk bash -lc 'PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build'`
- `detect-secrets-hook --baseline .secrets.baseline` for changed files
- Security reviewer: no findings >= 5/10

## Development

Closes #1063