### PR TITLE
fix: correct embla carousel alignment

### DIFF
--- a/src/components/organisms/Landing/LandingTestimonialsCarousel.tsx
+++ b/src/components/organisms/Landing/LandingTestimonialsCarousel.tsx
@@ -42,10 +42,10 @@ const MIN_RENDERED_SLIDES = 9
 const EMBLA_DURATION = 12
 const DESKTOP_STAGE_MIN_WIDTH = 1024
 
-const getSlideAlignment = (viewSize: number, snapSize: number) => {
+const getSlideAlignment = (viewSize: number, _snapSize: number) => {
   if (viewSize < DESKTOP_STAGE_MIN_WIDTH) return 0
 
-  return Math.max(0, (viewSize - snapSize) / 2)
+  return 0.5
 }
 
 const getRepeatCount = (length: number) => {


### PR DESCRIPTION
This fixes the testimonials carousel centering on desktop.

## What changed
- Corrected the Embla `align` callback in `src/components/organisms/Landing/LandingTestimonialsCarousel.tsx` to return the expected fractional value for desktop alignment.

## Validation
- `pnpm format`
- `pnpm check`

## Development
- Closes [#1065](https://github.com/findmydoc-platform/website/issues/1065)
