### PR TITLE
fix: preserve full query in media URL normalization

### DIFF
--- a/src/utilities/media/resolveMediaImage.ts
+++ b/src/utilities/media/resolveMediaImage.ts
@@ -24,7 +24,9 @@ const DEFAULT_SIZE_ORDER = ['xlarge', 'large', 'medium', 'small', 'thumbnail']
 const normalizePayloadApiFileUrl = (src: string): string => {
   if (!src.includes('/api/') || !src.includes('/file/')) return src
 
-  const [pathPart = '', queryPart] = src.split('?')
+  const queryStartIndex = src.indexOf('?')
+  const pathPart = queryStartIndex === -1 ? src : src.slice(0, queryStartIndex)
+  const queryPart = queryStartIndex === -1 ? undefined : src.slice(queryStartIndex + 1)
   const marker = '/file/'
   const markerIndex = pathPart.indexOf(marker)
 

--- a/tests/unit/utilities/resolveMediaImage.test.ts
+++ b/tests/unit/utilities/resolveMediaImage.test.ts
@@ -26,4 +26,23 @@ describe('resolveMediaImage', () => {
       height: 480,
     })
   })
+
+  it('preserves full query content when file URLs contain additional question marks', () => {
+    const image = resolveMediaImage(
+      {
+        alt: 'Example',
+        url: '/api/clinicMedia/file/folder%2Fimg.jpg?note=first?second&lang=de',
+        width: 1200,
+        height: 800,
+      },
+      'Fallback alt',
+    )
+
+    expect(image).toEqual({
+      src: '/api/clinicMedia/file/folder/img.jpg?note=first?second&lang=de',
+      alt: 'Example',
+      width: 1200,
+      height: 800,
+    })
+  })
 })


### PR DESCRIPTION
media image URLs now keep full query content during normalization.

## What changed

- replace split-based query parsing in `resolveMediaImage` URL normalization with first-delimiter slicing
- preserve complete query payload even when query values contain additional `?`
- add regression test for a media URL containing `?note=first?second&lang=de`

## Validation

- `pnpm check`
- `pnpm format`
- `pnpm vitest run tests/unit/utilities/resolveMediaImage.test.ts` (environment-blocked: permission-matrix global setup exit 255)

## Development

- Closes #1068
