### PR TITLE
feat: add patient clinic favorites UI

### DIFF
--- a/src/app/(frontend)/clinics/[slug]/page.tsx
+++ b/src/app/(frontend)/clinics/[slug]/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from 'next'
-import { cookies, draftMode } from 'next/headers'
+import { cookies, draftMode, headers } from 'next/headers'
 import { notFound } from 'next/navigation'
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 
 import { ClinicDetail } from '@/components/templates/ClinicDetailConcepts'
 import { COOKIE_CONSENT_COOKIE_NAME, resolveCookieConsentContext } from '@/features/cookieConsent'
+import { buildPatientLoginHref } from '@/features/favorites/redirects'
+import { findFavoriteClinicStateRecord, resolveFavoriteClinicAuthContext } from '@/features/favorites/server'
 import { getClinicDetailServerData } from '@/utilities/clinicDetail/serverData'
 import { getGlobal } from '@/utilities/getGlobals'
 import type { CookieConsent as CookieConsentType } from '@/payload-types'
@@ -22,6 +24,7 @@ export default async function ClinicDetailPage({ params: paramsPromise }: Clinic
   const { slug } = await paramsPromise
   const { isEnabled: draft } = await draftMode()
   const payload = await getPayload({ config: configPromise })
+  const requestHeaders = await headers()
   const requestCookies = await cookies()
 
   const clinicDetailData = await getClinicDetailServerData(payload, slug, {
@@ -36,9 +39,27 @@ export default async function ClinicDetailPage({ params: paramsPromise }: Clinic
     notFound()
   }
 
+  const favoriteAuthContext = await resolveFavoriteClinicAuthContext({
+    payload,
+    headers: requestHeaders,
+  })
+  const favoriteStateByClinicId = favoriteAuthContext.patient
+    ? await findFavoriteClinicStateRecord({
+        payload,
+        patientId: favoriteAuthContext.patient.id,
+        clinicIds: [clinicDetailData.clinicId],
+      })
+    : {}
+  const clinicPath = `/clinics/${encodeURIComponent(slug)}`
+
   return (
     <ClinicDetail
       data={clinicDetailData}
+      favorite={{
+        isPatient: favoriteAuthContext.isPatient,
+        favoriteId: favoriteStateByClinicId[String(clinicDetailData.clinicId)] ?? null,
+        loginHref: buildPatientLoginHref(clinicPath),
+      }}
       cookieConsentConfig={cookieConsentContext.config}
       cookieConsentInitialConsent={cookieConsentContext.initialConsent}
     />

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -28,7 +28,7 @@ import type { CookieConsent as CookieConsentType } from '@/payload-types'
 
 const LIVE_PATIENT_ACCOUNT_MENU_LINKS: Partial<PublicAccountMenuLinks> = {
   dashboard: null,
-  favorites: null,
+  favorites: '/patient/favorites',
   profile: null,
   signOut: '/logout',
 }

--- a/src/app/(frontend)/listing-comparison/ListingComparisonPage.client.tsx
+++ b/src/app/(frontend)/listing-comparison/ListingComparisonPage.client.tsx
@@ -1,10 +1,13 @@
 'use client'
 
 import * as React from 'react'
+import { usePathname, useSearchParams } from 'next/navigation'
 import { Award, BadgeCheck, Shield, Users } from 'lucide-react'
 
 import type { ListingCardData } from '@/components/organisms/Listing'
 import { ListingComparison } from '@/components/templates/ListingComparison/Component'
+import { FavoriteClinicButton } from '@/features/favorites/FavoriteClinicButton'
+import { buildPatientLoginHref } from '@/features/favorites/redirects'
 import { SortControl } from '@/components/molecules/SortControl'
 import { Pagination } from '@/components/molecules/Pagination'
 import { Breadcrumb } from '@/components/molecules/Breadcrumb'
@@ -81,6 +84,10 @@ export type ListingComparisonPageClientProps = {
     badges: string[]
   }
   results: ListingCardData[]
+  favorites: {
+    isPatient: boolean
+    favoriteStateByClinicId: Record<string, number>
+  }
   filterOptions: {
     cities: ListingFilterOption[]
     waitTimes: Array<{ label: string; minWeeks: number; maxWeeks?: number }>
@@ -104,12 +111,20 @@ export function ListingComparisonPageClient({
   hero,
   trust,
   results,
+  favorites,
   filterOptions,
   priceBounds,
   queryState,
   pagination,
   specialtyContext,
 }: ListingComparisonPageClientProps) {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const currentPath = React.useMemo(() => {
+    const query = searchParams.toString()
+    return `${pathname}${query ? `?${query}` : ''}`
+  }, [pathname, searchParams])
+  const loginHref = React.useMemo(() => buildPatientLoginHref(currentPath), [currentPath])
   const normalizedPriceBounds = React.useMemo(
     () =>
       normalizePriceBounds(priceBounds, {
@@ -167,6 +182,20 @@ export function ListingComparisonPageClient({
       }
       totalResultsCount={pagination.totalResults}
       results={results}
+      renderResultCornerAction={(data) => {
+        const clinicId = Number(data.id)
+        if (!Number.isFinite(clinicId)) return null
+
+        return (
+          <FavoriteClinicButton
+            clinicId={clinicId}
+            initialFavoriteId={favorites.favoriteStateByClinicId[String(clinicId)] ?? null}
+            isPatient={favorites.isPatient}
+            loginHref={loginHref}
+            variant="icon"
+          />
+        )
+      }}
       resultsContext={
         specialtyContext.breadcrumbs.length > 0 ? <Breadcrumb items={specialtyContext.breadcrumbs} /> : null
       }

--- a/src/app/(frontend)/listing-comparison/page.tsx
+++ b/src/app/(frontend)/listing-comparison/page.tsx
@@ -1,6 +1,8 @@
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
+import { headers } from 'next/headers'
 
+import { findFavoriteClinicStateRecord, resolveFavoriteClinicAuthContext } from '@/features/favorites/server'
 import { getListingComparisonServerData } from '@/utilities/listingComparison/serverData'
 
 import { ListingComparisonPageClient } from './ListingComparisonPage.client'
@@ -13,8 +15,21 @@ export const dynamic = 'force-dynamic'
 
 export default async function ListingComparisonPage({ searchParams: searchParamsPromise }: ListingComparisonPageArgs) {
   const searchParams = (await searchParamsPromise) ?? {}
+  const requestHeaders = await headers()
   const payload = await getPayload({ config: configPromise })
   const listingData = await getListingComparisonServerData(payload, searchParams)
+  const favoriteAuthContext = await resolveFavoriteClinicAuthContext({
+    payload,
+    headers: requestHeaders,
+  })
+  const favoriteClinicIds = listingData.results.map((result) => Number(result.id)).filter((id) => Number.isFinite(id))
+  const favoriteStateByClinicId = favoriteAuthContext.patient
+    ? await findFavoriteClinicStateRecord({
+        payload,
+        patientId: favoriteAuthContext.patient.id,
+        clinicIds: favoriteClinicIds,
+      })
+    : {}
 
   const primarySpecialty = listingData.specialtyContext.selected[0]
   const specialtySuffix = primarySpecialty
@@ -41,6 +56,10 @@ export default async function ListingComparisonPage({ searchParams: searchParams
       pagination={listingData.pagination}
       specialtyContext={listingData.specialtyContext}
       results={listingData.results}
+      favorites={{
+        isPatient: favoriteAuthContext.isPatient,
+        favoriteStateByClinicId,
+      }}
       trust={{
         title: 'Trust proven quality',
         subtitle: 'We only work with certified clinics and guarantee transparent, up-to-date\npricing information',

--- a/src/app/(frontend)/login/patient/page.tsx
+++ b/src/app/(frontend)/login/patient/page.tsx
@@ -3,6 +3,8 @@ import {
   PublicAuthRouteShell,
 } from '@/app/(frontend)/_components/PublicAuthRouteShell'
 import * as LoginForm from '@/components/organisms/Auth/LoginForm'
+import { PATIENT_LOGIN_PATH } from '@/features/favorites/redirects'
+import { sanitizeInternalRedirectPath } from '@/utilities/routing/sanitizeInternalRedirectPath'
 import Link from 'next/link'
 
 const patientLoginMessages: Record<string, { text: string; variant?: 'success' | 'info' | 'warning' }> = {
@@ -15,17 +17,22 @@ const patientLoginMessages: Record<string, { text: string; variant?: 'success' |
 export default async function LoginPage({
   searchParams: searchParamsPromise,
 }: {
-  searchParams?: Promise<{ message?: string }>
+  searchParams?: Promise<{ message?: string; next?: string }>
 }) {
   const resolvedSearchParams = await searchParamsPromise
   const messageKey = resolvedSearchParams?.message
   const statusMessage = messageKey ? patientLoginMessages[messageKey] : undefined
+  const postLoginRedirectPath = sanitizeInternalRedirectPath({
+    nextPath: resolvedSearchParams?.next,
+    fallbackPath: '/',
+    blockedPaths: [PATIENT_LOGIN_PATH],
+  })
 
   return (
     <PublicAuthRouteShell>
       <LoginForm.Root
         userTypes="patient"
-        redirectPath="/"
+        redirectPath={postLoginRedirectPath}
         className={`w-full max-w-md ${PUBLIC_AUTH_FORM_CONTAINER_CLASSNAME}`}
       >
         <LoginForm.Header

--- a/src/app/(frontend)/patient/favorites/page.tsx
+++ b/src/app/(frontend)/patient/favorites/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+import configPromise from '@payload-config'
+import { getPayload } from 'payload'
+
+import { Button } from '@/components/atoms/button'
+import { Heading } from '@/components/atoms/Heading'
+import { Container } from '@/components/molecules/Container'
+import { FavoriteClinicsList } from '@/features/favorites/FavoriteClinicsList.client'
+import { buildPatientLoginHref } from '@/features/favorites/redirects'
+import { findPatientFavoriteClinicListItems, resolveFavoriteClinicAuthContext } from '@/features/favorites/server'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: 'Saved clinics | findmydoc',
+  description: 'Review and manage clinics saved to your patient account.',
+}
+
+export default async function PatientFavoritesPage() {
+  const requestHeaders = await headers()
+  const payload = await getPayload({ config: configPromise })
+  const authContext = await resolveFavoriteClinicAuthContext({
+    payload,
+    headers: requestHeaders,
+  })
+
+  if (!authContext.patient) {
+    redirect(buildPatientLoginHref('/patient/favorites'))
+  }
+
+  const items = await findPatientFavoriteClinicListItems({
+    payload,
+    patientId: authContext.patient.id,
+  })
+  const savedClinicLabel = items.length === 1 ? 'saved clinic' : 'saved clinics'
+
+  return (
+    <main className="bg-muted/30 py-10 sm:py-14">
+      <Container className="space-y-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div className="min-w-0 space-y-2">
+            <Heading as="h1" align="left" size="h2" className="text-secondary">
+              Saved clinics
+            </Heading>
+            <p className="text-sm leading-6 text-muted-foreground">
+              {items.length} {savedClinicLabel} in your patient account.
+            </p>
+          </div>
+          <Button asChild variant="secondary" className="w-full sm:w-auto">
+            <Link href="/listing-comparison">Browse clinics</Link>
+          </Button>
+        </div>
+
+        <FavoriteClinicsList initialItems={items} />
+      </Container>
+    </main>
+  )
+}

--- a/src/components/organisms/ClinicDetail/HeroOverviewSection.tsx
+++ b/src/components/organisms/ClinicDetail/HeroOverviewSection.tsx
@@ -18,6 +18,7 @@ type HeroOverviewSectionProps = {
   doctors: ClinicDetailDoctor[]
   activeDoctorId: string
   onDoctorSelect: (doctorId: string) => void
+  favoriteAction?: React.ReactNode
 }
 
 export function HeroOverviewSection({
@@ -28,6 +29,7 @@ export function HeroOverviewSection({
   doctors,
   activeDoctorId,
   onDoctorSelect,
+  favoriteAction,
 }: HeroOverviewSectionProps) {
   const hasDoctors = doctors.length > 0
   const isSparseDoctorsList = doctors.length <= 1
@@ -49,6 +51,8 @@ export function HeroOverviewSection({
         </div>
 
         <p className="max-w-[492px] text-base leading-7 text-secondary/70">{description}</p>
+
+        {favoriteAction ? <div className="max-w-[492px]">{favoriteAction}</div> : null}
 
         <HeroQualitySummary trust={trust} />
       </div>

--- a/src/components/organisms/Listing/ListingCard.tsx
+++ b/src/components/organisms/Listing/ListingCard.tsx
@@ -49,14 +49,24 @@ export type ListingCardData = {
   }
 }
 
-export function ListingCard({ data, className }: { data: ListingCardData; className?: string }) {
+export function ListingCard({
+  data,
+  className,
+  cornerAction,
+}: {
+  data: ListingCardData
+  className?: string
+  cornerAction?: React.ReactNode
+}) {
   return (
     <article
       className={cn(
-        'w-full overflow-hidden rounded-2xl border border-border bg-card p-4 shadow-xs md:flex md:items-stretch md:gap-6 md:p-6',
+        'relative w-full overflow-hidden rounded-2xl border border-border bg-card p-4 shadow-xs md:flex md:items-stretch md:gap-6 md:p-6',
         className,
       )}
     >
+      {cornerAction ? <div className="absolute top-4 right-4 z-10 md:top-5 md:right-5">{cornerAction}</div> : null}
+
       <div className="flex flex-1 flex-col gap-4 md:flex-row md:gap-6">
         <div className="w-full self-stretch md:max-w-32 md:flex-[1_0_0]">
           <div className="relative aspect-[16/10] w-full overflow-hidden rounded-xl md:aspect-square md:rounded-none">
@@ -102,7 +112,7 @@ export function ListingCard({ data, className }: { data: ListingCardData; classN
           <TagList tags={data.tags} />
         </div>
 
-        <div className="flex shrink-0 flex-col gap-3 md:w-36 md:items-end md:pt-1">
+        <div className={cn('flex shrink-0 flex-col gap-3 md:w-36 md:items-end', cornerAction ? 'md:pt-14' : 'md:pt-1')}>
           <Button asChild className="h-12 w-full text-sm font-semibold">
             <a href={data.actions.details.href}>{data.actions.details.label}</a>
           </Button>

--- a/src/components/templates/ClinicDetailConcepts/ClinicDetail.tsx
+++ b/src/components/templates/ClinicDetailConcepts/ClinicDetail.tsx
@@ -15,6 +15,7 @@ import {
 import { RelatedDoctorSection, type RelatedDoctorItem } from '@/components/organisms/Doctors'
 import { TreatmentsStrip, type TreatmentsStripItem } from '@/components/organisms/TreatmentsStrip'
 import { useCookieConsentToolAllowed } from '@/features/cookieConsent/useCookieConsentToolAllowed'
+import { FavoriteClinicButton } from '@/features/favorites/FavoriteClinicButton'
 import { cn } from '@/utilities/ui'
 
 import { useClinicDetailInteractionState } from './hooks/useClinicDetailInteractionState'
@@ -50,6 +51,7 @@ function buildTreatmentDescription({ category, priceFromUsd }: { category?: stri
 export function ClinicDetail({
   data,
   className,
+  favorite,
   cookieConsentConfig = null,
   cookieConsentInitialConsent = null,
 }: ClinicDetailConceptProps) {
@@ -147,6 +149,18 @@ export function ClinicDetail({
           doctors={heroDoctors}
           activeDoctorId={interaction.activeHeroDoctorId}
           onDoctorSelect={interaction.toggleDoctorSelection}
+          favoriteAction={
+            favorite ? (
+              <FavoriteClinicButton
+                clinicId={data.clinicId}
+                initialFavoriteId={favorite.favoriteId ?? null}
+                isPatient={favorite.isPatient}
+                loginHref={favorite.loginHref}
+                variant="hero"
+                unsavedLabel="Save clinic"
+              />
+            ) : undefined
+          }
         />
       </Container>
 

--- a/src/components/templates/ClinicDetailConcepts/types.ts
+++ b/src/components/templates/ClinicDetailConcepts/types.ts
@@ -61,6 +61,7 @@ export type ClinicDetailContact = {
 }
 
 export type ClinicDetailData = {
+  clinicId: number
   clinicSlug: string
   clinicName: string
   heroImage: { src: string; alt: string }
@@ -77,6 +78,11 @@ export type ClinicDetailData = {
 export type ClinicDetailConceptProps = {
   data: ClinicDetailData
   className?: string
+  favorite?: {
+    isPatient: boolean
+    favoriteId?: number | null
+    loginHref: string
+  }
   cookieConsentConfig?: CookieConsentConfig | null
   cookieConsentInitialConsent?: CookieConsentState | null
 }

--- a/src/components/templates/ListingComparison/Component.tsx
+++ b/src/components/templates/ListingComparison/Component.tsx
@@ -17,6 +17,7 @@ export type ListingComparisonProps = {
   sortControl?: React.ReactNode
   resultsContext?: React.ReactNode
   resultsFooter?: React.ReactNode
+  renderResultCornerAction?: (data: ListingCardData) => React.ReactNode
 }
 
 export function ListingComparison({
@@ -29,6 +30,7 @@ export function ListingComparison({
   sortControl,
   resultsContext,
   resultsFooter,
+  renderResultCornerAction,
 }: ListingComparisonProps) {
   const filtersContainerId = 'listing-comparison-filters'
   const visibleCount = results.length
@@ -70,7 +72,9 @@ export function ListingComparison({
                 {resultsContext}
                 {defaultHeader}
                 {results.length > 0
-                  ? results.map((data) => <ListingCard key={data.id} data={data} />)
+                  ? results.map((data) => (
+                      <ListingCard key={data.id} data={data} cornerAction={renderResultCornerAction?.(data)} />
+                    ))
                   : (emptyState ?? null)}
                 {resultsFooter}
               </section>

--- a/src/features/favorites/FavoriteClinicButton.tsx
+++ b/src/features/favorites/FavoriteClinicButton.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+import * as React from 'react'
+import Link from 'next/link'
+import { Heart } from 'lucide-react'
+
+import { Button } from '@/components/atoms/button'
+import { cn } from '@/utilities/ui'
+
+type FavoriteClinicButtonVariant = 'compact' | 'hero' | 'icon' | 'list'
+
+export type FavoriteClinicButtonChange = {
+  isFavorite: boolean
+  favoriteId: number | null
+}
+
+export type FavoriteClinicButtonProps = {
+  clinicId: number
+  initialFavoriteId?: number | null
+  isPatient: boolean
+  loginHref: string
+  variant?: FavoriteClinicButtonVariant
+  savedLabel?: string
+  unsavedLabel?: string
+  pendingLabel?: string
+  className?: string
+  onFavoriteChange?: (change: FavoriteClinicButtonChange) => void
+}
+
+type FavoriteClinicApiDoc = {
+  id?: unknown
+  doc?: {
+    id?: unknown
+  }
+}
+
+type FavoriteClinicApiListResponse = {
+  docs?: FavoriteClinicApiDoc[]
+}
+
+const VARIANT_CLASSNAMES: Record<FavoriteClinicButtonVariant, string> = {
+  compact: 'h-12 w-full gap-2 px-4 text-sm font-semibold md:h-10',
+  hero: 'h-12 w-full gap-2 px-5 text-sm font-semibold sm:w-auto',
+  icon: 'size-11 rounded-full p-0 shadow-xs backdrop-blur',
+  list: 'h-10 w-full gap-2 px-4 text-sm font-semibold sm:w-auto',
+}
+
+function toFavoriteId(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+
+  return null
+}
+
+function toFavoriteIdFromDoc(value: FavoriteClinicApiDoc | null | undefined): number | null {
+  return toFavoriteId(value?.id) ?? toFavoriteId(value?.doc?.id)
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  const body = (await response.json().catch(() => null)) as {
+    message?: unknown
+    errors?: unknown
+    error?: unknown
+  } | null
+  const fallback = 'We could not update your saved clinics. Please try again.'
+
+  if (typeof body?.message === 'string' && body.message.trim().length > 0) return body.message
+  if (typeof body?.error === 'string' && body.error.trim().length > 0) return body.error
+
+  return fallback
+}
+
+async function findExistingFavoriteId(clinicId: number): Promise<number | null> {
+  const params = new URLSearchParams({
+    depth: '0',
+    limit: '1',
+  })
+  params.set('where[clinic][equals]', String(clinicId))
+
+  const response = await fetch(`/api/favoriteclinics?${params.toString()}`, {
+    credentials: 'same-origin',
+    cache: 'no-store',
+  })
+
+  if (!response.ok) return null
+
+  const body = (await response.json().catch(() => null)) as FavoriteClinicApiListResponse | null
+  const firstDoc = body?.docs?.[0]
+  return toFavoriteIdFromDoc(firstDoc)
+}
+
+async function createFavorite(clinicId: number): Promise<number> {
+  const response = await fetch('/api/favoriteclinics', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'same-origin',
+    body: JSON.stringify({ clinic: clinicId }),
+  })
+
+  if (response.ok) {
+    const body = (await response.json().catch(() => null)) as FavoriteClinicApiDoc | null
+    const favoriteId = toFavoriteIdFromDoc(body)
+    if (favoriteId) return favoriteId
+  }
+
+  const reconciledFavoriteId = await findExistingFavoriteId(clinicId)
+  if (reconciledFavoriteId) return reconciledFavoriteId
+
+  throw new Error(await readErrorMessage(response))
+}
+
+async function deleteFavorite(favoriteId: number): Promise<void> {
+  const response = await fetch(`/api/favoriteclinics/${encodeURIComponent(String(favoriteId))}`, {
+    method: 'DELETE',
+    credentials: 'same-origin',
+  })
+
+  if (!response.ok) {
+    throw new Error(await readErrorMessage(response))
+  }
+}
+
+export function FavoriteClinicButton({
+  clinicId,
+  initialFavoriteId = null,
+  isPatient,
+  loginHref,
+  variant = 'compact',
+  savedLabel = 'Saved',
+  unsavedLabel = 'Save',
+  pendingLabel = 'Saving...',
+  className,
+  onFavoriteChange,
+}: FavoriteClinicButtonProps) {
+  const [favoriteId, setFavoriteId] = React.useState<number | null>(initialFavoriteId)
+  const [isPending, setIsPending] = React.useState(false)
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null)
+  const isFavorite = favoriteId !== null
+  const label = isPending ? pendingLabel : isFavorite ? savedLabel : unsavedLabel
+  const isIconVariant = variant === 'icon'
+  const content = isIconVariant ? <span className="sr-only">{label}</span> : label
+
+  React.useEffect(() => {
+    setFavoriteId(initialFavoriteId ?? null)
+  }, [initialFavoriteId])
+
+  const emitChange = React.useCallback(
+    (change: FavoriteClinicButtonChange) => {
+      onFavoriteChange?.(change)
+    },
+    [onFavoriteChange],
+  )
+
+  const handleToggle = () => {
+    if (isPending) return
+
+    setErrorMessage(null)
+    const previousFavoriteId = favoriteId
+    const nextIsFavorite = !isFavorite
+
+    setIsPending(true)
+    void (async () => {
+      try {
+        if (nextIsFavorite) {
+          const createdFavoriteId = await createFavorite(clinicId)
+          setFavoriteId(createdFavoriteId)
+          emitChange({ isFavorite: true, favoriteId: createdFavoriteId })
+          return
+        }
+
+        if (previousFavoriteId) {
+          await deleteFavorite(previousFavoriteId)
+        }
+
+        setFavoriteId(null)
+        emitChange({ isFavorite: false, favoriteId: null })
+      } catch (error: unknown) {
+        setFavoriteId(previousFavoriteId)
+        setErrorMessage(error instanceof Error ? error.message : 'We could not update your saved clinics.')
+      } finally {
+        setIsPending(false)
+      }
+    })()
+  }
+
+  if (!isPatient) {
+    return (
+      <Button
+        asChild
+        variant="secondary"
+        className={cn(
+          VARIANT_CLASSNAMES[variant],
+          isIconVariant ? 'bg-card/95 text-primary hover:bg-primary/5' : undefined,
+          className,
+        )}
+      >
+        <Link href={loginHref}>
+          <Heart className="size-4" aria-hidden={true} />
+          {isIconVariant ? <span className="sr-only">{unsavedLabel}</span> : unsavedLabel}
+        </Link>
+      </Button>
+    )
+  }
+
+  return (
+    <div className={cn('min-w-0 space-y-1', variant === 'compact' ? 'w-full' : undefined, isIconVariant && 'relative')}>
+      <Button
+        type="button"
+        variant={isIconVariant ? 'secondary' : isFavorite ? 'primary' : 'secondary'}
+        aria-pressed={isFavorite}
+        disabled={isPending}
+        className={cn(
+          VARIANT_CLASSNAMES[variant],
+          isIconVariant && 'bg-card/95 text-primary hover:bg-primary/5',
+          isIconVariant && isFavorite && 'border-primary/40 bg-primary/10 hover:bg-primary/15',
+          className,
+        )}
+        onClick={handleToggle}
+      >
+        <Heart className={cn('size-4', isFavorite ? 'fill-current' : undefined)} aria-hidden={true} />
+        {content}
+      </Button>
+      <p
+        aria-live="polite"
+        className={cn(
+          isIconVariant
+            ? errorMessage
+              ? 'absolute top-full right-0 z-20 mt-1 w-48 rounded-md border border-border bg-card px-2 py-1 text-xs leading-5 text-destructive shadow-sm'
+              : 'sr-only'
+            : 'min-h-5 text-xs leading-5 text-destructive',
+        )}
+      >
+        {errorMessage}
+      </p>
+    </div>
+  )
+}

--- a/src/features/favorites/FavoriteClinicsList.client.tsx
+++ b/src/features/favorites/FavoriteClinicsList.client.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import * as React from 'react'
+import Link from 'next/link'
+import { Heart } from 'lucide-react'
+
+import { Button } from '@/components/atoms/button'
+import { Card, CardContent } from '@/components/atoms/card'
+import { Heading } from '@/components/atoms/Heading'
+import { VerificationBadge } from '@/components/atoms/verification-badge'
+import { Media } from '@/components/molecules/Media'
+import { cn } from '@/utilities/ui'
+
+import { FavoriteClinicButton } from './FavoriteClinicButton'
+import type { FavoriteClinicListItem } from './server'
+
+export function FavoriteClinicsList({ initialItems }: { initialItems: FavoriteClinicListItem[] }) {
+  const [items, setItems] = React.useState(initialItems)
+
+  if (items.length === 0) {
+    return (
+      <Card className="border-dashed">
+        <CardContent className="flex flex-col items-center px-5 py-12 text-center sm:px-8">
+          <span className="mb-5 inline-flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <Heart className="size-5" aria-hidden={true} />
+          </span>
+          <Heading as="h2" align="center" size="h4" className="text-secondary">
+            No saved clinics yet
+          </Heading>
+          <p className="mt-3 max-w-md text-sm leading-6 text-muted-foreground">
+            Save clinics while comparing options and they will appear here for quick access.
+          </p>
+          <Button asChild className="mt-6">
+            <Link href="/listing-comparison">Browse clinics</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-3" aria-label="Saved clinics list">
+      {items.map((item) => (
+        <article
+          key={item.favoriteId}
+          className={cn(
+            'rounded-2xl border border-border bg-card p-4 shadow-xs',
+            'sm:grid sm:grid-cols-[96px_minmax(0,1fr)_auto] sm:items-center sm:gap-5',
+          )}
+        >
+          <div className="relative mb-4 aspect-[16/10] overflow-hidden rounded-xl sm:mb-0 sm:aspect-square">
+            <Media
+              htmlElement={null}
+              src={item.media.src}
+              alt={item.media.alt}
+              fill
+              imgClassName="object-cover"
+              size="(min-width: 640px) 96px, 100vw"
+            />
+          </div>
+
+          <div className="min-w-0 space-y-2">
+            <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
+              <Heading
+                as="h2"
+                align="left"
+                size="h5"
+                className="text-xl leading-tight font-semibold [overflow-wrap:anywhere] text-foreground"
+              >
+                {item.name}
+              </Heading>
+              <VerificationBadge variant={item.verification.variant} className="shrink-0" />
+            </div>
+            <p className="text-sm text-muted-foreground">{item.location}</p>
+            {typeof item.ratingValue === 'number' ? (
+              <p className="text-sm font-medium text-foreground">{item.ratingValue.toFixed(1)} average rating</p>
+            ) : null}
+          </div>
+
+          <div className="mt-4 grid gap-2 sm:mt-0 sm:min-w-36">
+            <Button asChild className="h-10 w-full text-sm font-semibold">
+              <Link href={item.href}>Details</Link>
+            </Button>
+            <FavoriteClinicButton
+              clinicId={item.clinicId}
+              initialFavoriteId={item.favoriteId}
+              isPatient={true}
+              loginHref="/login/patient?next=%2Fpatient%2Ffavorites"
+              variant="list"
+              savedLabel="Remove"
+              unsavedLabel="Save"
+              pendingLabel="Removing..."
+              onFavoriteChange={(change) => {
+                if (!change.isFavorite) {
+                  setItems((current) => current.filter((entry) => entry.favoriteId !== item.favoriteId))
+                }
+              }}
+            />
+          </div>
+        </article>
+      ))}
+    </div>
+  )
+}

--- a/src/features/favorites/redirects.ts
+++ b/src/features/favorites/redirects.ts
@@ -1,0 +1,15 @@
+import { sanitizeInternalRedirectPath } from '@/utilities/routing/sanitizeInternalRedirectPath'
+
+export const PATIENT_LOGIN_PATH = '/login/patient'
+export const PATIENT_LOGIN_FALLBACK_PATH = '/'
+
+export function buildPatientLoginHref(nextPath: string): string {
+  const safeNextPath = sanitizeInternalRedirectPath({
+    nextPath,
+    fallbackPath: PATIENT_LOGIN_FALLBACK_PATH,
+    blockedPaths: [PATIENT_LOGIN_PATH],
+  })
+
+  const params = new URLSearchParams({ next: safeNextPath })
+  return `${PATIENT_LOGIN_PATH}?${params.toString()}`
+}

--- a/src/features/favorites/server.ts
+++ b/src/features/favorites/server.ts
@@ -1,0 +1,211 @@
+import type { Payload } from 'payload'
+
+import { extractSupabaseUserData } from '@/auth/utilities/jwtValidation'
+import type { VerificationBadgeVariant } from '@/components/atoms/verification-badge'
+import { ensurePatientOnAuth } from '@/hooks/ensurePatientOnAuth'
+import type { Clinic, Favoriteclinic, Patient } from '@/payload-types'
+import { resolveMediaDescriptorFromLoadedRelation } from '@/utilities/media/relationMedia'
+import { slugify } from '@/utilities/slugify'
+
+const FAVORITES_PAGE_LIMIT = 100
+const PLACEHOLDER_MEDIA = {
+  src: '/images/placeholder-576-968.svg',
+  alt: 'Clinic placeholder image',
+}
+
+export type FavoriteClinicStateRecord = Record<string, number>
+
+export type FavoriteClinicAuthContext = {
+  isPatient: boolean
+  patient: Patient | null
+}
+
+export type FavoriteClinicListItem = {
+  favoriteId: number
+  clinicId: number
+  name: string
+  href: string
+  location: string
+  media: {
+    src: string
+    alt: string
+  }
+  verification: {
+    variant: VerificationBadgeVariant
+  }
+  ratingValue?: number
+}
+
+function extractRelationId(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+
+  if (value && typeof value === 'object' && 'id' in value) {
+    return extractRelationId((value as { id?: unknown }).id)
+  }
+
+  return null
+}
+
+function isLoadedClinic(value: unknown): value is Clinic {
+  return Boolean(value && typeof value === 'object' && 'id' in value && 'name' in value)
+}
+
+function normalizeVerification(value: unknown): VerificationBadgeVariant {
+  if (value === 'bronze' || value === 'silver' || value === 'gold' || value === 'unverified') {
+    return value
+  }
+
+  return 'unverified'
+}
+
+function resolveClinicLocation(clinic: Clinic): string {
+  const cityRelation = clinic.address?.city
+  const cityName =
+    cityRelation && typeof cityRelation === 'object' && 'name' in cityRelation
+      ? String(cityRelation.name ?? '').trim()
+      : ''
+  const country = typeof clinic.address?.country === 'string' ? clinic.address.country.trim() : ''
+
+  return [cityName, country].filter((item) => item.length > 0).join(', ') || 'Location not listed'
+}
+
+function mapFavoriteToListItem(favorite: Favoriteclinic): FavoriteClinicListItem | null {
+  if (!isLoadedClinic(favorite.clinic)) return null
+
+  const clinic = favorite.clinic
+  const resolvedMedia = resolveMediaDescriptorFromLoadedRelation(clinic.thumbnail, 'clinicMedia')
+  const slug = clinic.slug || slugify(clinic.name)
+
+  return {
+    favoriteId: favorite.id,
+    clinicId: clinic.id,
+    name: clinic.name,
+    href: `/clinics/${encodeURIComponent(slug)}`,
+    location: resolveClinicLocation(clinic),
+    media: {
+      src: resolvedMedia?.url ?? PLACEHOLDER_MEDIA.src,
+      alt:
+        typeof resolvedMedia?.alt === 'string' && resolvedMedia.alt.trim().length > 0
+          ? resolvedMedia.alt
+          : `${clinic.name} image`,
+    },
+    verification: {
+      variant: normalizeVerification(clinic.verification),
+    },
+    ratingValue: typeof clinic.averageRating === 'number' ? clinic.averageRating : undefined,
+  }
+}
+
+export async function resolveFavoriteClinicAuthContext({
+  payload,
+  headers,
+}: {
+  payload: Payload
+  headers?: Headers
+}): Promise<FavoriteClinicAuthContext> {
+  const authData = await extractSupabaseUserData({ headers })
+
+  if (!authData || authData.userType !== 'patient') {
+    return {
+      isPatient: false,
+      patient: null,
+    }
+  }
+
+  try {
+    const patient = (await ensurePatientOnAuth({
+      payload,
+      authData,
+      req: undefined,
+    })) as Patient
+
+    return {
+      isPatient: true,
+      patient,
+    }
+  } catch {
+    return {
+      isPatient: false,
+      patient: null,
+    }
+  }
+}
+
+export async function findFavoriteClinicStateRecord({
+  payload,
+  patientId,
+  clinicIds,
+}: {
+  payload: Payload
+  patientId: number
+  clinicIds: number[]
+}): Promise<FavoriteClinicStateRecord> {
+  const uniqueClinicIds = Array.from(new Set(clinicIds.filter((id) => Number.isFinite(id))))
+  if (uniqueClinicIds.length === 0) return {}
+
+  const result = await payload.find({
+    collection: 'favoriteclinics',
+    depth: 0,
+    limit: uniqueClinicIds.length,
+    pagination: false,
+    overrideAccess: true,
+    where: {
+      and: [
+        {
+          patient: {
+            equals: patientId,
+          },
+        },
+        {
+          clinic: {
+            in: uniqueClinicIds,
+          },
+        },
+      ],
+    },
+    select: {
+      id: true,
+      clinic: true,
+    },
+  })
+
+  return result.docs.reduce<FavoriteClinicStateRecord>((record, favorite) => {
+    const clinicId = extractRelationId((favorite as Favoriteclinic).clinic)
+    if (!clinicId) return record
+
+    record[String(clinicId)] = favorite.id
+    return record
+  }, {})
+}
+
+export async function findPatientFavoriteClinicListItems({
+  payload,
+  patientId,
+}: {
+  payload: Payload
+  patientId: number
+}): Promise<FavoriteClinicListItem[]> {
+  const result = await payload.find({
+    collection: 'favoriteclinics',
+    depth: 2,
+    limit: FAVORITES_PAGE_LIMIT,
+    pagination: false,
+    overrideAccess: true,
+    sort: '-createdAt',
+    where: {
+      patient: {
+        equals: patientId,
+      },
+    },
+  })
+
+  return result.docs.flatMap((favorite) => {
+    const item = mapFavoriteToListItem(favorite as Favoriteclinic)
+    return item ? [item] : []
+  })
+}

--- a/src/stories/fixtures/clinicDetail.ts
+++ b/src/stories/fixtures/clinicDetail.ts
@@ -75,6 +75,7 @@ function buildDoctor(index: number): ClinicDetailDoctor {
 const doctors = Array.from({ length: 13 }, (_, index) => buildDoctor(index))
 
 export const clinicDetailFixture: ClinicDetailData = {
+  clinicId: 1001,
   clinicSlug,
   clinicName: 'Berlin Health Clinic',
   heroImage: {

--- a/src/stories/organisms/FavoriteClinicButton.stories.tsx
+++ b/src/stories/organisms/FavoriteClinicButton.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, within } from '@storybook/test'
+
+import { FavoriteClinicButton } from '@/features/favorites/FavoriteClinicButton'
+
+const meta = {
+  title: 'Domain/Patient/Organisms/FavoriteClinicButton',
+  component: FavoriteClinicButton,
+  args: {
+    clinicId: 1001,
+    isPatient: false,
+    loginHref: '/login/patient?next=%2Fclinics%2Fberlin-health-clinic',
+  },
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: 'Patient-facing control for saving or removing clinics from the favorites collection.',
+      },
+    },
+  },
+  tags: ['autodocs', 'domain:patient', 'layer:organism', 'status:stable', 'used-in:route:/clinics/[slug]'],
+} satisfies Meta<typeof FavoriteClinicButton>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const GuestLoginCta: Story = {
+  args: {
+    isPatient: false,
+    unsavedLabel: 'Save clinic',
+    variant: 'hero',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getByRole('link', { name: 'Save clinic' })).toHaveAttribute(
+      'href',
+      '/login/patient?next=%2Fclinics%2Fberlin-health-clinic',
+    )
+  },
+}
+
+export const PatientSaved: Story = {
+  args: {
+    isPatient: true,
+    initialFavoriteId: 42,
+    variant: 'compact',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getByRole('button', { name: 'Saved' })).toHaveAttribute('aria-pressed', 'true')
+  },
+}
+
+export const ListingIconSaved: Story = {
+  args: {
+    isPatient: true,
+    initialFavoriteId: 42,
+    variant: 'icon',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getByRole('button', { name: 'Saved' })).toHaveAttribute('aria-pressed', 'true')
+  },
+}

--- a/src/stories/organisms/ListingCard.stories.tsx
+++ b/src/stories/organisms/ListingCard.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, within } from '@storybook/test'
 
 import { ListingCard } from '@/components/organisms/Listing'
+import { FavoriteClinicButton } from '@/features/favorites/FavoriteClinicButton'
 import { clinicMedia, makeClinic } from '@/stories/fixtures/listings'
 import { withViewportStory } from '../utils/viewportMatrix'
 
@@ -132,6 +133,33 @@ export const LayoutStressTest: Story = {
     await expect(canvas.getByText(/Istanbul Universitesi Tip Fakultesi/i)).toBeInTheDocument()
     await expect(canvas.getByRole('link', { name: 'Details' })).toHaveAttribute('href')
     await expect(canvas.getByRole('link', { name: 'Compare' })).toHaveAttribute('href')
+  },
+}
+
+export const WithFavoriteAction: Story = {
+  render: () => (
+    <ListingCard
+      data={{
+        ...baseClinic,
+        id: 1001,
+      }}
+      cornerAction={
+        <FavoriteClinicButton
+          clinicId={1001}
+          isPatient={false}
+          loginHref="/login/patient?next=%2Flisting-comparison"
+          variant="icon"
+        />
+      }
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getByRole('link', { name: 'Save' })).toHaveAttribute(
+      'href',
+      '/login/patient?next=%2Flisting-comparison',
+    )
+    await expect(canvas.getByRole('link', { name: 'Details' })).toHaveAttribute('href')
   },
 }
 

--- a/src/stories/templates/ClinicDetailConcepts.stories.tsx
+++ b/src/stories/templates/ClinicDetailConcepts.stories.tsx
@@ -60,6 +60,25 @@ export const Edge_NoReviews_FallbackText: Story = {
   },
 }
 
+export const Main_WithGuestFavoriteAction: Story = {
+  args: {
+    data: clinicDetailFixture,
+    favorite: {
+      isPatient: false,
+      favoriteId: null,
+      loginHref: '/login/patient?next=%2Fclinics%2Fberlin-health-clinic',
+    },
+  },
+  render: (args) => <ClinicDetail {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getByRole('link', { name: 'Save clinic' })).toHaveAttribute(
+      'href',
+      '/login/patient?next=%2Fclinics%2Fberlin-health-clinic',
+    )
+  },
+}
+
 export const MainDefault320: Story = withViewportStory(Main_Default, 'public320', 'Main default / 320')
 export const MainDefault375: Story = withViewportStory(Main_Default, 'public375', 'Main default / 375')
 export const MainDefault640: Story = withViewportStory(Main_Default, 'public640', 'Main default / 640')

--- a/src/utilities/clinicDetail/serverData/mappers.ts
+++ b/src/utilities/clinicDetail/serverData/mappers.ts
@@ -413,6 +413,7 @@ export function mapClinicToClinicDetailData({
   const cityNameById = mapCitiesToNameMap(cities)
 
   return {
+    clinicId: clinic.id,
     clinicSlug: clinic.slug,
     clinicName: clinic.name,
     heroImage: toClinicImage(clinic),

--- a/src/utilities/routing/sanitizeInternalRedirectPath.ts
+++ b/src/utilities/routing/sanitizeInternalRedirectPath.ts
@@ -1,0 +1,43 @@
+export function sanitizeInternalRedirectPath({
+  nextPath,
+  fallbackPath = '/',
+  blockedPaths = [],
+}: {
+  nextPath: string | null | undefined
+  fallbackPath?: string
+  blockedPaths?: string[]
+}): string {
+  if (!nextPath) return fallbackPath
+
+  const trimmed = nextPath.trim()
+  if (!trimmed.startsWith('/') || trimmed.startsWith('//')) return fallbackPath
+  if (trimmed.includes('\r') || trimmed.includes('\n')) return fallbackPath
+
+  try {
+    const parsed = new URL(trimmed, 'http://localhost')
+    if (parsed.origin !== 'http://localhost') return fallbackPath
+
+    const safePath = `${parsed.pathname}${parsed.search}${parsed.hash}`
+    const safePathnameForBlockedComparison =
+      parsed.pathname !== '/' && parsed.pathname.endsWith('/') ? parsed.pathname.slice(0, -1) : parsed.pathname
+    const safePathForBlockedComparison = `${safePathnameForBlockedComparison}${parsed.search}${parsed.hash}`
+    const normalizedBlockedPaths = blockedPaths.map((path) => (path.endsWith('/') ? path.slice(0, -1) : path))
+
+    if (
+      normalizedBlockedPaths.some((path) => {
+        if (!path) return false
+        return (
+          safePathForBlockedComparison === path ||
+          safePathForBlockedComparison.startsWith(`${path}?`) ||
+          safePathForBlockedComparison.startsWith(`${path}#`)
+        )
+      })
+    ) {
+      return fallbackPath
+    }
+
+    return safePath
+  } catch {
+    return fallbackPath
+  }
+}

--- a/tests/unit/app/frontend/patient/login/page.test.tsx
+++ b/tests/unit/app/frontend/patient/login/page.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+;(globalThis as unknown as { React: typeof React }).React = React
+
+describe('Patient LoginPage', () => {
+  type LoginRootElement = React.ReactElement<{ redirectPath: string; children: React.ReactNode }>
+
+  const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null
+
+  const findLoginRootElement = (node: React.ReactNode): LoginRootElement | null => {
+    if (!React.isValidElement(node)) return null
+    if (isObjectRecord(node.props) && typeof node.props.redirectPath === 'string') return node as LoginRootElement
+
+    const children = isObjectRecord(node.props) ? node.props.children : undefined
+    for (const child of React.Children.toArray(children as React.ReactNode)) {
+      const result = findLoginRootElement(child)
+      if (result) return result
+    }
+
+    return null
+  }
+
+  const getLoginPage = async () => {
+    const pageModule = await import('@/app/(frontend)/login/patient/page')
+    return pageModule.default
+  }
+
+  it('passes a safe internal next path to LoginForm.Root', async () => {
+    const LoginPage = await getLoginPage()
+
+    const result = await LoginPage({
+      searchParams: Promise.resolve({
+        next: '/clinics/berlin-health-clinic?from=favorites',
+      }),
+    })
+    const loginRoot = findLoginRootElement(result)
+
+    expect(loginRoot?.props.redirectPath).toBe('/clinics/berlin-health-clinic?from=favorites')
+  })
+
+  it('falls back to home for unsafe next paths', async () => {
+    const LoginPage = await getLoginPage()
+
+    const result = await LoginPage({
+      searchParams: Promise.resolve({
+        next: '//evil.example.com',
+      }),
+    })
+    const loginRoot = findLoginRootElement(result)
+
+    expect(loginRoot?.props.redirectPath).toBe('/')
+  })
+})

--- a/tests/unit/features/favorites/FavoriteClinicButton.test.tsx
+++ b/tests/unit/features/favorites/FavoriteClinicButton.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom'
+
+import React from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { FavoriteClinicButton } from '@/features/favorites/FavoriteClinicButton'
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    ...init,
+  })
+}
+
+describe('FavoriteClinicButton', () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('renders a login link for guests', () => {
+    render(<FavoriteClinicButton clinicId={12} isPatient={false} loginHref="/login/patient?next=%2Fclinics%2Fabc" />)
+
+    const link = screen.getByRole('link', { name: 'Save' })
+    expect(link).toHaveAttribute('href', '/login/patient?next=%2Fclinics%2Fabc')
+  })
+
+  it('renders the icon variant with an accessible name', () => {
+    render(
+      <FavoriteClinicButton
+        clinicId={12}
+        isPatient={false}
+        loginHref="/login/patient?next=%2Flisting-comparison"
+        variant="icon"
+      />,
+    )
+
+    expect(screen.getByRole('link', { name: 'Save' })).toHaveAttribute(
+      'href',
+      '/login/patient?next=%2Flisting-comparison',
+    )
+  })
+
+  it('creates a favorite and reflects the saved state', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ id: 55 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<FavoriteClinicButton clinicId={12} isPatient={true} loginHref="/login/patient?next=%2Fclinics%2Fabc" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Saved' })).toHaveAttribute('aria-pressed', 'true'))
+    expect(fetchMock).toHaveBeenCalledWith('/api/favoriteclinics', expect.objectContaining({ method: 'POST' }))
+  })
+
+  it('deletes a favorite and reflects the unsaved state', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ id: 55 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <FavoriteClinicButton
+        clinicId={12}
+        initialFavoriteId={55}
+        isPatient={true}
+        loginHref="/login/patient?next=%2Fclinics%2Fabc"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Saved' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Save' })).toHaveAttribute('aria-pressed', 'false'))
+    expect(fetchMock).toHaveBeenCalledWith('/api/favoriteclinics/55', expect.objectContaining({ method: 'DELETE' }))
+  })
+
+  it('reconciles duplicate creates by refetching the existing favorite', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ message: 'duplicate' }, { status: 409 }))
+      .mockResolvedValueOnce(jsonResponse({ docs: [{ id: 91 }] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<FavoriteClinicButton clinicId={12} isPatient={true} loginHref="/login/patient?next=%2Fclinics%2Fabc" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Saved' })).toHaveAttribute('aria-pressed', 'true'))
+    expect(fetchMock).toHaveBeenNthCalledWith(2, expect.stringContaining('/api/favoriteclinics?'), expect.any(Object))
+  })
+
+  it('keeps the previous state and shows an inline error when saving fails', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ message: 'Network unavailable' }, { status: 500 }))
+      .mockResolvedValueOnce(jsonResponse({ docs: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<FavoriteClinicButton clinicId={12} isPatient={true} loginHref="/login/patient?next=%2Fclinics%2Fabc" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(screen.getByText('Network unavailable')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: 'Save' })).toHaveAttribute('aria-pressed', 'false')
+  })
+})

--- a/tests/unit/utilities/routing/sanitizeInternalRedirectPath.test.ts
+++ b/tests/unit/utilities/routing/sanitizeInternalRedirectPath.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeInternalRedirectPath } from '@/utilities/routing/sanitizeInternalRedirectPath'
+
+describe('sanitizeInternalRedirectPath', () => {
+  it('allows internal paths with search and hash', () => {
+    expect(
+      sanitizeInternalRedirectPath({
+        nextPath: '/clinics/berlin-health?from=favorites#overview',
+      }),
+    ).toBe('/clinics/berlin-health?from=favorites#overview')
+  })
+
+  it('falls back for external, protocol-relative, newline, and missing paths', () => {
+    const args = {
+      fallbackPath: '/fallback',
+    }
+
+    expect(sanitizeInternalRedirectPath({ ...args, nextPath: 'https://evil.example.com' })).toBe('/fallback')
+    expect(sanitizeInternalRedirectPath({ ...args, nextPath: '//evil.example.com' })).toBe('/fallback')
+    expect(sanitizeInternalRedirectPath({ ...args, nextPath: '/foo\nbar' })).toBe('/fallback')
+    expect(sanitizeInternalRedirectPath({ ...args, nextPath: undefined })).toBe('/fallback')
+  })
+
+  it('falls back for blocked paths', () => {
+    expect(
+      sanitizeInternalRedirectPath({
+        nextPath: '/login/patient?next=/patient/favorites',
+        fallbackPath: '/',
+        blockedPaths: ['/login/patient'],
+      }),
+    ).toBe('/')
+    expect(
+      sanitizeInternalRedirectPath({
+        nextPath: '/login/patient/#return',
+        fallbackPath: '/',
+        blockedPaths: ['/login/patient'],
+      }),
+    ).toBe('/')
+  })
+})


### PR DESCRIPTION
This adds a functional patient Favorites baseline so patients can save clinics from listing and detail pages and manage saved clinics from their account area.

## What changed

- added a patient-scoped Favorites feature layer for auth context, favorite lookup, and saved clinic list mapping
- added a REST-backed FavoriteClinicButton with guest login links, patient create/delete, duplicate reconciliation, pending state, and inline errors
- surfaced Favorites on listing cards as a low-noise heart icon, and on clinic detail as a hero-context save action
- added protected `/patient/favorites` route plus safe patient login `next` redirect handling
- added Storybook states and focused unit coverage for the favorite button and redirect sanitizer

## Validation

- `rtk pnpm format`
- `rtk pnpm check`
- `rtk pnpm vitest tests/unit/utilities/routing/sanitizeInternalRedirectPath.test.ts tests/unit/app/frontend/patient/login/page.test.tsx tests/unit/features/favorites/FavoriteClinicButton.test.tsx tests/unit/components/listingComparisonTemplate.test.tsx`
- `rtk pnpm stories:governance:check`
- `rtk bash -lc "PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build"`
- Playwright listing matrix at `320/375/640/768/1024/1280`: no horizontal overflow, no console errors, favorite icon target is `44x44`

## Screenshots

Local screenshot artifacts were captured in the ignored Playwright output folder:

- Listing mobile favorite icon: `output/playwright/favorites-ui-362-icon/listing-comparison-320.png`
- Listing desktop favorite icon: `output/playwright/favorites-ui-362-icon/listing-comparison-1280.png`
- Broader Favorites route pass: `output/playwright/favorites-ui-362/report.json`

## Development

Closes #362

Follow-up: #1070 tracks the remaining visual polish for the Favorites UI.
