### PR TITLE
feat: update preview access policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,12 +21,14 @@ PAYLOAD_DB_PUSH=false
 # Used to validate preview requests
 PREVIEW_SECRET=YOUR_SECRET_HERE
 
-# Optional deployment environment override (portable; takes precedence over VERCEL_ENV)
-# Supported values: development | preview | production
+# Deployment environment override used when VERCEL_ENV is unavailable.
+# Required for non-Vercel preview/production runtimes; otherwise runtime defaults to development/test.
+# Supported values: development | preview | production | test
 DEPLOYMENT_ENV=development
 
-# Optional public deployment environment override for edge/runtime parity (middleware)
-# Supported values: development | preview | production
+# Public deployment environment override used when NEXT_PUBLIC_VERCEL_ENV is unavailable.
+# Keep this aligned with DEPLOYMENT_ENV for non-Vercel preview/production runtimes.
+# Supported values: development | preview | production | test
 NEXT_PUBLIC_DEPLOYMENT_ENV=development
 
 # Optional global logo overrides for frontend chrome

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,7 +18,7 @@ A production-ready Next.js front-end with:
   - [Search](#search)
   - [Redirects](#redirects)
   - [PostHog Analytics](#posthog-analytics)
-  - [Preview Redirect Blocker](#preview-redirect-blocker)
+  - [Preview Access Policy](#preview-access-policy)
   - [Draft Preview](#draft-preview)
   - [Live Preview](#live-preview)
   - [On-demand Revalidation](#on-demand-revalidation)
@@ -138,19 +138,21 @@ Production can enable a temporary public landing mode through a server-side envi
 - Platform sessions (`app_metadata.user_type === "platform"`) keep normal access
 
 Priority behavior:
-- If Temporary Landing Mode and Preview Guard are both active, Temporary Landing Mode takes precedence for non-platform sessions.
-- Preview Guard continues to use login redirects for requests not intercepted by Temporary Landing Mode.
+- Temporary Landing Mode takes precedence over normal preview access behavior for non-platform sessions.
+- Preview Guard is currently disabled in runtime policy; preview access no longer redirects through the guard.
 
-## Preview Redirect Blocker
+## Preview Access Policy
 
-Preview deployments can enable a temporary in-app redirect blocker (Preview Guard) to restrict frontend access.
+Preview deployments use a runtime policy for auth recovery and search-index protection.
 
-- Active when runtime resolves to `preview` (`VERCEL_ENV` → `DEPLOYMENT_ENV` fallback)
-- Non-platform sessions are redirected to `/admin/login?message=preview-login-required&next=...`
-- Intended as a temporary fallback when external deployment protection is unavailable
+- Runtime resolves to `preview` from `VERCEL_ENV` first, then `DEPLOYMENT_ENV`
+- `NODE_ENV` is not used as a preview or production deployment signal
+- Non-Vercel preview/production runtimes must set `DEPLOYMENT_ENV` explicitly
+- Preview Guard login redirects are disabled by `RUNTIME_POLICY.preview.auth.enablePreviewGuard`
+- Preview runtime still enables preview-specific admin recovery and search-index blocking
 
 Implementation and usage:
-- [Setup: Run Local Dev with Preview Redirect Blocker](./setup.md#run-local-dev-with-preview-redirect-blocker)
+- [Setup: Run Local Dev in Preview Runtime](./setup.md#run-local-dev-in-preview-runtime)
 - [Preview Guard Technical Notes](../src/features/previewGuard/README.md)
 - [Preview Admin Recovery Decision Flow](../src/auth/README.md#preview-runtime-admin-recovery-flow)
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -38,9 +38,9 @@ This repo uses a single command to regenerate all generated Payload artifacts (a
 
 Run this after changing Payload config/plugins, collection schemas, or when your branch pulls in Payload-related dependency updates.
 
-### Run Local Dev with Preview Redirect Blocker
+### Run Local Dev in Preview Runtime
 
-Use the redirect blocker when you want to simulate preview-only access rules locally:
+Use preview runtime when you want to simulate hosted preview behavior locally:
 
 ```bash
 pnpm dev:redirect-blocker
@@ -51,10 +51,11 @@ This command sets:
 - `NEXT_PUBLIC_DEPLOYMENT_ENV=preview`
 
 Result:
-- Requests without a platform staff session are redirected to `/admin/login?message=preview-login-required&next=...`.
+- Preview-specific runtime policy applies, including search-index blocking and preview admin recovery.
+- Preview Guard login redirects are disabled by runtime policy.
 
 See also:
-- [Features: Preview Redirect Blocker](./features.md#preview-redirect-blocker)
+- [Features: Preview Access Policy](./features.md#preview-access-policy)
 - [Preview Guard Technical Notes](../src/features/previewGuard/README.md)
 
 ### Migrations

--- a/next-sitemap.config.cjs
+++ b/next-sitemap.config.cjs
@@ -9,9 +9,7 @@ const normalizeEnvValue = (value) => {
 }
 
 const isPreviewRuntime =
-  (normalizeEnvValue(process.env.VERCEL_ENV) ??
-    normalizeEnvValue(process.env.DEPLOYMENT_ENV) ??
-    normalizeEnvValue(process.env.NODE_ENV)) === 'preview'
+  (normalizeEnvValue(process.env.VERCEL_ENV) ?? normalizeEnvValue(process.env.DEPLOYMENT_ENV)) === 'preview'
 const isTemporaryLandingModeEnabled = ['1', 'on', 'true', 'yes'].includes(
   normalizeEnvValue(process.env.TEMPORARY_LANDING_MODE_ENABLED) ?? '',
 )

--- a/next.config.js
+++ b/next.config.js
@@ -18,9 +18,7 @@ const normalizeEnvValue = (value) => {
 }
 
 const isPreviewRuntime =
-  (normalizeEnvValue(process.env.VERCEL_ENV) ??
-    normalizeEnvValue(process.env.DEPLOYMENT_ENV) ??
-    normalizeEnvValue(process.env.NODE_ENV)) === 'preview'
+  (normalizeEnvValue(process.env.VERCEL_ENV) ?? normalizeEnvValue(process.env.DEPLOYMENT_ENV)) === 'preview'
 const isTemporaryLandingModeEnabled = ['1', 'on', 'true', 'yes'].includes(
   normalizeEnvValue(process.env.TEMPORARY_LANDING_MODE_ENABLED) ?? '',
 )

--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -49,6 +49,7 @@ The system supports three user types with different access patterns:
 ## Preview Runtime Admin Recovery Flow
 
 This flow is active when runtime resolves to `preview` (`VERCEL_ENV` -> `DEPLOYMENT_ENV` fallback).
+`NODE_ENV` is not used as a preview or production deployment signal.
 
 ### Key Rules
 
@@ -68,7 +69,7 @@ This flow is active when runtime resolves to `preview` (`VERCEL_ENV` -> `DEPLOYM
 6. If no, redirect to `/admin/first-admin` (login blocked until first admin is provisioned).
 7. If session exists:
 8. Branch: session `user_type` is `platform`?
-9. If no (`clinic`/other), preview guard blocks admin frontend access.
+9. If no (`clinic`/other), normal staff login rules apply; the preview login guard is disabled by runtime policy.
 10. If yes, redirect to `/admin` to run strategy-based provisioning.
 11. In strategy: find Payload user by `supabaseUserId`.
 12. If found, login succeeds.
@@ -110,8 +111,8 @@ flowchart TD
   M -- "Found" --> N["Update Payload supabaseUserId, then login"]
   M -- "Missing" --> O["Create Payload user + profile, then login"]
 
-  C -- "Yes, clinic user" --> P["Preview Guard keeps platform-only restriction"]
-  P --> Q["Clinic user does not pass preview guard"]
+  C -- "Yes, clinic user" --> P["Normal clinic staff login rules apply"]
+  P --> Q["Approved clinic users can continue to /admin"]
 ```
 
 ### First Admin Recovery Decision (Preview)

--- a/src/features/previewGuard/README.md
+++ b/src/features/previewGuard/README.md
@@ -4,15 +4,17 @@
 
 - Provide a temporary in-app guard for preview deployments when external deployment protection is unavailable.
 - Restrict access to frontend pages to platform staff sessions only.
+- Current status: disabled for preview runtime by `RUNTIME_POLICY.preview.auth.enablePreviewGuard=false`.
 
 ## Activation
 
 - Runtime resolves to `preview` (server: `VERCEL_ENV` → `DEPLOYMENT_ENV` fallback).
 - No feature flag toggle: behavior is controlled by the central runtime policy in code.
+- `NODE_ENV` is not used as a preview or production deployment signal.
 
 ## Behavior
 
-- Guard applies to frontend page routes matched by `src/proxy.ts`.
+- When enabled in runtime policy, guard applies to frontend page routes matched by `src/proxy.ts`.
 - Exempt routes: `/admin/login`, `/admin/first-admin`.
 - Allowed users: Supabase users with `app_metadata.user_type === "platform"`.
 - Unauthorized users are redirected to `/admin/login?message=preview-login-required&next=...`.

--- a/src/features/runtimePolicy/index.ts
+++ b/src/features/runtimePolicy/index.ts
@@ -52,6 +52,11 @@ const toRuntimeEnvironment = (value: string | null): RuntimeEnvironment => {
   return 'unknown'
 }
 
+const toNodeRuntimeEnvironment = (value: string | null): RuntimeEnvironment => {
+  if (value === 'test') return 'test'
+  return 'development'
+}
+
 const toRuntimeClass = (runtimeEnvironment: RuntimeEnvironment): RuntimeClass => {
   return runtimeEnvironment === 'preview' ? 'preview' : 'nonPreview'
 }
@@ -60,7 +65,7 @@ export const RUNTIME_POLICY: Record<RuntimeClass, RuntimePolicy> = {
   preview: {
     auth: {
       allowPlatformEmailReconcile: true,
-      enablePreviewGuard: true,
+      enablePreviewGuard: false,
     },
     logging: {
       defaultLevel: 'info',
@@ -107,21 +112,21 @@ const SEED_RUNTIME_POLICY: Record<SeedRuntimeEnvironment, SeedRuntimePolicy> = {
 }
 
 export const resolveServerRuntimeEnvironment = (env: ServerRuntimeEnvInput = process.env): RuntimeEnvironment => {
-  const runtimeValue =
-    normalizeEnvValue(env.VERCEL_ENV) ?? normalizeEnvValue(env.DEPLOYMENT_ENV) ?? normalizeEnvValue(env.NODE_ENV)
-
+  const runtimeValue = normalizeEnvValue(env.VERCEL_ENV) ?? normalizeEnvValue(env.DEPLOYMENT_ENV)
   const runtimeEnvironment = toRuntimeEnvironment(runtimeValue)
-  return runtimeEnvironment === 'unknown' ? 'development' : runtimeEnvironment
+  return runtimeEnvironment === 'unknown'
+    ? toNodeRuntimeEnvironment(normalizeEnvValue(env.NODE_ENV))
+    : runtimeEnvironment
 }
 
 export const resolveClientRuntimeEnvironment = (env: ClientRuntimeEnvInput = process.env): RuntimeEnvironment => {
   const runtimeValue =
-    normalizeEnvValue(env.NEXT_PUBLIC_VERCEL_ENV) ??
-    normalizeEnvValue(env.NEXT_PUBLIC_DEPLOYMENT_ENV) ??
-    normalizeEnvValue(env.NODE_ENV)
+    normalizeEnvValue(env.NEXT_PUBLIC_VERCEL_ENV) ?? normalizeEnvValue(env.NEXT_PUBLIC_DEPLOYMENT_ENV)
 
   const runtimeEnvironment = toRuntimeEnvironment(runtimeValue)
-  return runtimeEnvironment === 'unknown' ? 'development' : runtimeEnvironment
+  return runtimeEnvironment === 'unknown'
+    ? toNodeRuntimeEnvironment(normalizeEnvValue(env.NODE_ENV))
+    : runtimeEnvironment
 }
 
 export const resolveRuntimeClass = (env: ServerRuntimeEnvInput = process.env): RuntimeClass => {

--- a/tests/unit/app/frontend/admin/login/page.test.ts
+++ b/tests/unit/app/frontend/admin/login/page.test.ts
@@ -398,12 +398,20 @@ describe('Admin LoginPage', () => {
     expect(logoElement?.props.showPreviewBadge).toBe(true)
   })
 
-  it('does not redirect clinic users when preview guard is enabled', async () => {
+  it('redirects approved clinic users in preview runtime when preview guard is disabled', async () => {
     const { extractSupabaseUserData } = await import('@/auth/utilities/jwtValidation')
+    const { findUserBySupabaseId, isClinicUserApproved } = await import('@/auth/utilities/userLookup')
     const { redirect } = await import('next/navigation')
     const LoginPage = await getPageModule()
 
     process.env.DEPLOYMENT_ENV = 'preview'
+    vi.mocked(findUserBySupabaseId).mockResolvedValue(
+      makeStaffUser({
+        id: 3,
+        userType: 'clinic',
+      }),
+    )
+    vi.mocked(isClinicUserApproved).mockResolvedValue(true)
     vi.mocked(extractSupabaseUserData).mockResolvedValue({
       supabaseUserId: 'clinic-user',
       userEmail: 'clinic@example.com',
@@ -412,15 +420,8 @@ describe('Admin LoginPage', () => {
       lastName: 'User',
     })
 
-    const result = await LoginPage()
-    const pageElement = result as LoginPageElement
-    const rootElement = getLoginRootElement(pageElement)
-    const rootChildren = React.Children.toArray(rootElement.props.children) as React.ReactElement<{
-      message?: string
-    }>[]
-    const statusElement = rootChildren[1]
+    await LoginPage()
 
-    expect(redirect).not.toHaveBeenCalled()
-    expect(statusElement?.props.message).toBe('This preview deployment is restricted to platform staff accounts.')
+    expect(redirect).toHaveBeenCalledWith('/admin')
   })
 })

--- a/tests/unit/app/frontend/previewLock.middleware.test.ts
+++ b/tests/unit/app/frontend/previewLock.middleware.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 
-import { PREVIEW_GUARD_LOCK_REQUEST_HEADER, PREVIEW_GUARD_LOGIN_REQUIRED_MESSAGE_KEY } from '@/features/previewGuard'
+import { PREVIEW_GUARD_LOCK_REQUEST_HEADER } from '@/features/previewGuard'
 import { SEARCH_ROBOTS_HEADER, SEARCH_ROBOTS_HEADER_VALUE } from '@/features/searchIndexing'
 import { TEMPORARY_LANDING_MODE_REQUEST_HEADER } from '@/features/temporaryLandingMode'
 
@@ -47,35 +47,30 @@ describe('preview lock proxy', () => {
     process.env = originalEnv
   })
 
-  it('redirects unauthenticated preview users to admin login', async () => {
+  it('allows unauthenticated preview users when preview guard is disabled', async () => {
     process.env.DEPLOYMENT_ENV = 'preview'
     const request = new NextRequest('https://example.com/posts/example?foo=bar')
 
     const response = await proxy(request)
 
-    expect(response.status).toBe(307)
-    const redirectLocation = response.headers.get('location')
-    expect(redirectLocation).toBeTruthy()
-
-    const redirectUrl = new URL(redirectLocation as string)
-    expect(redirectUrl.pathname).toBe('/admin/login')
-    expect(redirectUrl.searchParams.get('message')).toBe(PREVIEW_GUARD_LOGIN_REQUIRED_MESSAGE_KEY)
-    expect(redirectUrl.searchParams.get('next')).toBe('/posts/example?foo=bar')
-    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
+    expect(response.status).toBe(200)
+    expect(response.headers.get('location')).toBeNull()
+    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBeNull()
+    expect(mocks.createServerClient).not.toHaveBeenCalled()
   })
 
-  it('allows unauthenticated preview users on exempt routes and sets lock header', async () => {
+  it('does not set preview lock headers on exempt routes while guard is disabled', async () => {
     process.env.DEPLOYMENT_ENV = 'preview'
     const request = new NextRequest('https://example.com/admin/login')
 
     const response = await proxy(request)
 
     expect(response.status).toBe(200)
-    expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBe('1')
-    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
+    expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBeNull()
+    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBeNull()
   })
 
-  it('redirects authenticated clinic users in preview guard', async () => {
+  it('does not consult Supabase for preview guard while guard is disabled', async () => {
     process.env.DEPLOYMENT_ENV = 'preview'
     mocks.getUser.mockResolvedValue({
       data: { user: { id: 'user-1', app_metadata: { user_type: 'clinic' } } },
@@ -85,25 +80,8 @@ describe('preview lock proxy', () => {
     const request = new NextRequest('https://example.com/posts/example')
     const response = await proxy(request)
 
-    expect(response.status).toBe(307)
-    const redirectLocation = response.headers.get('location')
-    const redirectUrl = new URL(redirectLocation as string)
-    expect(redirectUrl.pathname).toBe('/admin/login')
-    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
-  })
-
-  it('allows authenticated platform users', async () => {
-    process.env.DEPLOYMENT_ENV = 'preview'
-    mocks.getUser.mockResolvedValue({
-      data: { user: { id: 'user-2', app_metadata: { user_type: 'platform' } } },
-      error: null,
-    })
-
-    const request = new NextRequest('https://example.com/posts/example')
-    const response = await proxy(request)
-
     expect(response.status).toBe(200)
-    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
+    expect(mocks.getUser).not.toHaveBeenCalled()
   })
 
   it('does not enforce preview lock outside preview environments', async () => {
@@ -229,7 +207,7 @@ describe('preview lock proxy', () => {
     expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
   })
 
-  it('prioritizes temporary landing mode over preview redirects', async () => {
+  it('prioritizes temporary landing mode over preview runtime passthrough', async () => {
     process.env.TEMPORARY_LANDING_MODE_ENABLED = 'true'
     process.env.DEPLOYMENT_ENV = 'preview'
 

--- a/tests/unit/features/previewGuard/index.test.ts
+++ b/tests/unit/features/previewGuard/index.test.ts
@@ -62,22 +62,14 @@ describe('previewGuard feature', () => {
     ).toBe(false)
   })
 
-  it('enables guard only for preview deployments', () => {
+  it('keeps preview guard disabled for preview deployments', () => {
     expect(
       isPreviewGuardEnabled({
         DEPLOYMENT_ENV: 'preview',
         VERCEL_ENV: undefined,
         NODE_ENV: 'production',
       }),
-    ).toBe(true)
-
-    expect(
-      isPreviewGuardEnabled({
-        DEPLOYMENT_ENV: 'preview',
-        VERCEL_ENV: undefined,
-        NODE_ENV: 'production',
-      }),
-    ).toBe(true)
+    ).toBe(false)
 
     expect(
       isPreviewGuardEnabled({

--- a/tests/unit/features/runtimePolicy/index.test.ts
+++ b/tests/unit/features/runtimePolicy/index.test.ts
@@ -39,6 +39,12 @@ describe('runtimePolicy', () => {
     ).toBe('nonPreview')
   })
 
+  it('uses NODE_ENV only for development and test fallback', () => {
+    expect(resolveServerRuntimeEnvironment({ NODE_ENV: 'preview' })).toBe('development')
+    expect(resolveServerRuntimeEnvironment({ NODE_ENV: 'production' })).toBe('development')
+    expect(resolveServerRuntimeEnvironment({ NODE_ENV: 'test' })).toBe('test')
+  })
+
   it('uses NEXT_PUBLIC envs for client runtime resolution', () => {
     const runtimeEnvironment = resolveClientRuntimeEnvironment({
       NEXT_PUBLIC_VERCEL_ENV: undefined,
@@ -55,8 +61,14 @@ describe('runtimePolicy', () => {
     expect(runtimeClass).toBe('preview')
   })
 
+  it('uses NODE_ENV only for client development and test fallback', () => {
+    expect(resolveClientRuntimeEnvironment({ NODE_ENV: 'preview' })).toBe('development')
+    expect(resolveClientRuntimeEnvironment({ NODE_ENV: 'production' })).toBe('development')
+    expect(resolveClientRuntimeEnvironment({ NODE_ENV: 'test' })).toBe('test')
+  })
+
   it('exposes fixed auth/logging policy profiles', () => {
-    expect(RUNTIME_POLICY.preview.auth.enablePreviewGuard).toBe(true)
+    expect(RUNTIME_POLICY.preview.auth.enablePreviewGuard).toBe(false)
     expect(RUNTIME_POLICY.preview.logging.defaultLevel).toBe('info')
     expect(RUNTIME_POLICY.nonPreview.auth.allowPlatformEmailReconcile).toBe(false)
     expect(RUNTIME_POLICY.nonPreview.logging.defaultLevel).toBe('warn')

--- a/tests/unit/scripts/seed-run.test.ts
+++ b/tests/unit/scripts/seed-run.test.ts
@@ -66,7 +66,7 @@ describe('seed-run runtime detection', () => {
     expect(result).toBe('preview')
   })
 
-  it('falls back to DEPLOYMENT_ENV before NODE_ENV', () => {
+  it('uses DEPLOYMENT_ENV before NODE_ENV fallback', () => {
     const result = resolveSeedRuntimeEnv(undefined, {
       DEPLOYMENT_ENV: 'preview',
       NODE_ENV: 'production',
@@ -75,11 +75,15 @@ describe('seed-run runtime detection', () => {
     expect(result).toBe('preview')
   })
 
-  it('falls back to NODE_ENV and defaults to development', () => {
+  it('uses NODE_ENV only for test fallback and defaults to development', () => {
     const fromNode = resolveSeedRuntimeEnv(undefined, { NODE_ENV: 'test' } as unknown as NodeJS.ProcessEnv)
+    const fromProductionNode = resolveSeedRuntimeEnv(undefined, {
+      NODE_ENV: 'production',
+    } as unknown as NodeJS.ProcessEnv)
     const defaulted = resolveSeedRuntimeEnv(undefined, { NODE_ENV: 'staging' } as unknown as NodeJS.ProcessEnv)
 
     expect(fromNode).toBe('test')
+    expect(fromProductionNode).toBe('development')
     expect(defaulted).toBe('development')
   })
 })


### PR DESCRIPTION
Preview staff login now follows the updated access requirement while preview-only safety policies stay active.

## What changed
- disable Preview Guard login redirects in the preview runtime policy
- stop using `NODE_ENV` as a preview or production deployment signal
- keep `NODE_ENV=test` as a test fallback and otherwise default unresolved runtime to development
- align Next.js/sitemap preview checks, env examples, docs, and unit coverage with the updated runtime policy

## Validation
- `pnpm format`
- `pnpm vitest run tests/unit/features/runtimePolicy/index.test.ts tests/unit/features/previewGuard/index.test.ts tests/unit/app/frontend/previewLock.middleware.test.ts tests/unit/app/frontend/admin/login/page.test.ts tests/unit/scripts/seed-run.test.ts tests/unit/features/searchIndexing/index.test.ts tests/unit/utilities/loggingShared.test.ts`
- `pnpm check`
- `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build` (passed with the local Node 25 vs repo Node 24 engine warning)
- `pnpm docs:check`
- `git diff --check`
- `detect-secrets-hook --baseline .secrets.baseline <changed files>`

## Development
Closes #1072
