### PR TITLE
fix: block root when slash path is disallowed

### DIFF
--- a/src/utilities/routing/sanitizeInternalRedirectPath.ts
+++ b/src/utilities/routing/sanitizeInternalRedirectPath.ts
@@ -21,7 +21,9 @@ export function sanitizeInternalRedirectPath({
     const safePathnameForBlockedComparison =
       parsed.pathname !== '/' && parsed.pathname.endsWith('/') ? parsed.pathname.slice(0, -1) : parsed.pathname
     const safePathForBlockedComparison = `${safePathnameForBlockedComparison}${parsed.search}${parsed.hash}`
-    const normalizedBlockedPaths = blockedPaths.map((path) => (path.endsWith('/') ? path.slice(0, -1) : path))
+    const normalizedBlockedPaths = blockedPaths.map((path) =>
+      path !== '/' && path.endsWith('/') ? path.slice(0, -1) : path,
+    )
 
     if (
       normalizedBlockedPaths.some((path) => {

--- a/tests/unit/utilities/routing/sanitizeInternalRedirectPath.test.ts
+++ b/tests/unit/utilities/routing/sanitizeInternalRedirectPath.test.ts
@@ -38,4 +38,14 @@ describe('sanitizeInternalRedirectPath', () => {
       }),
     ).toBe('/')
   })
+
+  it('keeps root blocked when blockedPaths includes slash', () => {
+    expect(
+      sanitizeInternalRedirectPath({
+        nextPath: '/',
+        fallbackPath: '/fallback',
+        blockedPaths: ['/'],
+      }),
+    ).toBe('/fallback')
+  })
 })


### PR DESCRIPTION
This prevents unintended root redirects when callers explicitly block `/`.

## What changed
- preserve `/` during blocked-path normalization in `sanitizeInternalRedirectPath`
- add a regression test that verifies `blockedPaths: ["/"]` falls back correctly

## Validation
- `pnpm format`
- `pnpm check`
- `pnpm vitest run tests/unit/utilities/routing/sanitizeInternalRedirectPath.test.ts` *(blocked in this environment: permission-matrix setup exit 255)*

## Development
- Closes #1079
