### PR TITLE
fix: centralize first-separator parsing

### DIFF
--- a/src/components/organisms/Landing/LandingCategories.shared.ts
+++ b/src/components/organisms/Landing/LandingCategories.shared.ts
@@ -1,5 +1,7 @@
 import type { ImageProps } from 'next/image'
 
+import { splitRelativeHrefParts } from '@/utilities/urlParts'
+
 export type LandingCategory = {
   label: string
   value: string
@@ -106,13 +108,7 @@ export function buildCategoryTabs(categories: LandingCategory[]): LandingCategor
 export function withSpecialtyQuery(href: string, specialtyId: string | null) {
   if (!href.startsWith('/') || href.startsWith('//')) return href
 
-  const hashIndex = href.indexOf('#')
-  const pathAndQuery = hashIndex >= 0 ? href.slice(0, hashIndex) : href
-  const hash = hashIndex >= 0 ? href.slice(hashIndex + 1) : ''
-  const queryIndex = pathAndQuery.indexOf('?')
-  const pathnameValue = queryIndex >= 0 ? pathAndQuery.slice(0, queryIndex) : pathAndQuery
-  const query = queryIndex >= 0 ? pathAndQuery.slice(queryIndex + 1) : ''
-  const pathname = pathnameValue.length > 0 ? pathnameValue : '/'
+  const { pathname, query, hash } = splitRelativeHrefParts(href)
   const params = new URLSearchParams(query)
 
   if (specialtyId) {

--- a/src/utilities/listingComparison/serverData/presentation.ts
+++ b/src/utilities/listingComparison/serverData/presentation.ts
@@ -6,6 +6,7 @@ import type { ListingCardData } from '@/components/organisms/Listing'
 import type { Clinic } from '@/payload-types'
 import { resolveMediaDescriptorFromLoadedRelation } from '@/utilities/media/relationMedia'
 import { slugify } from '@/utilities/slugify'
+import { splitUrlQuery } from '@/utilities/urlParts'
 import { resolveScopedPriceFrom } from './pricing'
 import { extractRelationId } from './relations'
 import type { CityMeta, ClinicPresentationMeta, ClinicRow } from './types'
@@ -39,7 +40,7 @@ function hasAvailableClinicMedia(url: string | null | undefined): boolean {
   if (!url) return false
   if (!url.startsWith(CLINIC_MEDIA_API_PREFIX)) return true
 
-  const rawFileName = url.slice(CLINIC_MEDIA_API_PREFIX.length).split('?')[0] ?? ''
+  const { path: rawFileName } = splitUrlQuery(url.slice(CLINIC_MEDIA_API_PREFIX.length))
   const fileName = decodeURIComponent(rawFileName).replace(/^\/+/, '')
 
   if (!fileName) {

--- a/src/utilities/media/resolveMediaImage.ts
+++ b/src/utilities/media/resolveMediaImage.ts
@@ -1,3 +1,5 @@
+import { splitUrlQuery } from '@/utilities/urlParts'
+
 type MediaSize = {
   url?: string | null
   width?: number | null
@@ -24,9 +26,7 @@ const DEFAULT_SIZE_ORDER = ['xlarge', 'large', 'medium', 'small', 'thumbnail']
 const normalizePayloadApiFileUrl = (src: string): string => {
   if (!src.includes('/api/') || !src.includes('/file/')) return src
 
-  const queryStartIndex = src.indexOf('?')
-  const pathPart = queryStartIndex === -1 ? src : src.slice(0, queryStartIndex)
-  const queryPart = queryStartIndex === -1 ? undefined : src.slice(queryStartIndex + 1)
+  const { path: pathPart, query } = splitUrlQuery(src)
   const marker = '/file/'
   const markerIndex = pathPart.indexOf(marker)
 
@@ -41,7 +41,7 @@ const normalizePayloadApiFileUrl = (src: string): string => {
     .map((segment) => encodeURIComponent(segment))
     .join('/')
 
-  return queryPart ? `${prefix}${normalizedPath}?${queryPart}` : `${prefix}${normalizedPath}`
+  return query ? `${prefix}${normalizedPath}?${query}` : `${prefix}${normalizedPath}`
 }
 
 export function resolveMediaImage(

--- a/src/utilities/urlParts.ts
+++ b/src/utilities/urlParts.ts
@@ -1,0 +1,58 @@
+export type UrlQueryParts = {
+  path: string
+  query: string
+}
+
+export type UrlHashParts = {
+  pathAndQuery: string
+  hash: string
+}
+
+export type RelativeHrefParts = {
+  pathname: string
+  query: string
+  hash: string
+}
+
+export function splitUrlQuery(value: string): UrlQueryParts {
+  const queryIndex = value.indexOf('?')
+
+  if (queryIndex < 0) {
+    return {
+      path: value,
+      query: '',
+    }
+  }
+
+  return {
+    path: value.slice(0, queryIndex),
+    query: value.slice(queryIndex + 1),
+  }
+}
+
+export function splitUrlHash(value: string): UrlHashParts {
+  const hashIndex = value.indexOf('#')
+
+  if (hashIndex < 0) {
+    return {
+      pathAndQuery: value,
+      hash: '',
+    }
+  }
+
+  return {
+    pathAndQuery: value.slice(0, hashIndex),
+    hash: value.slice(hashIndex + 1),
+  }
+}
+
+export function splitRelativeHrefParts(href: string): RelativeHrefParts {
+  const { pathAndQuery, hash } = splitUrlHash(href)
+  const { path, query } = splitUrlQuery(pathAndQuery)
+
+  return {
+    pathname: path.length > 0 ? path : '/',
+    query,
+    hash,
+  }
+}

--- a/src/utilities/urlParts.ts
+++ b/src/utilities/urlParts.ts
@@ -1,14 +1,14 @@
-export type UrlQueryParts = {
+type UrlQueryParts = {
   path: string
   query: string
 }
 
-export type UrlHashParts = {
+type UrlHashParts = {
   pathAndQuery: string
   hash: string
 }
 
-export type RelativeHrefParts = {
+type RelativeHrefParts = {
   pathname: string
   query: string
   hash: string
@@ -30,7 +30,7 @@ export function splitUrlQuery(value: string): UrlQueryParts {
   }
 }
 
-export function splitUrlHash(value: string): UrlHashParts {
+function splitUrlHash(value: string): UrlHashParts {
   const hashIndex = value.indexOf('#')
 
   if (hashIndex < 0) {

--- a/tests/unit/app/useListingComparisonUrlState.test.tsx
+++ b/tests/unit/app/useListingComparisonUrlState.test.tsx
@@ -39,8 +39,7 @@ function HookHarness({
 }
 
 function getQueryParamsFromHref(href: string): URLSearchParams {
-  const [, rawQuery = ''] = href.split('?')
-  return new URLSearchParams(rawQuery)
+  return new URL(href, 'http://localhost').searchParams
 }
 
 describe('useListingComparisonUrlState', () => {

--- a/tests/unit/utilities/listingComparisonPresentation.test.ts
+++ b/tests/unit/utilities/listingComparisonPresentation.test.ts
@@ -85,4 +85,23 @@ describe('mapListingCardResults media resolution', () => {
 
     expect(result[0]?.media.src).toBe('/images/placeholder-576-968.svg')
   })
+
+  it('preserves full query content when checking clinic media availability', () => {
+    const existsSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+
+    const clinic = buildClinic({
+      id: 4,
+      name: 'Delta Clinic',
+      thumbnail: {
+        id: 104,
+        url: '/api/clinicMedia/file/path%2Fimage.jpg?note=first?second&lang=de',
+        alt: 'Delta image',
+      },
+    })
+
+    const result = mapListingCardResults([buildRow(clinic)], new Map())
+
+    expect(result[0]?.media.src).toBe('/api/clinicMedia/file/path%2Fimage.jpg?note=first?second&lang=de')
+    expect(existsSyncSpy).toHaveBeenCalledWith(expect.stringMatching(/public\/clinic-media\/path\/image\.jpg$/))
+  })
 })

--- a/tests/unit/utilities/urlParts.test.ts
+++ b/tests/unit/utilities/urlParts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { splitRelativeHrefParts, splitUrlHash, splitUrlQuery } from '@/utilities/urlParts'
+import { splitRelativeHrefParts, splitUrlQuery } from '@/utilities/urlParts'
 
 describe('urlParts', () => {
   it('splits query content only at the first question mark', () => {
@@ -11,8 +11,9 @@ describe('urlParts', () => {
   })
 
   it('splits hash content only at the first hash mark', () => {
-    expect(splitUrlHash('/listing-comparison#overview#details')).toEqual({
-      pathAndQuery: '/listing-comparison',
+    expect(splitRelativeHrefParts('/listing-comparison#overview#details')).toEqual({
+      pathname: '/listing-comparison',
+      query: '',
       hash: 'overview#details',
     })
   })

--- a/tests/unit/utilities/urlParts.test.ts
+++ b/tests/unit/utilities/urlParts.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { splitRelativeHrefParts, splitUrlHash, splitUrlQuery } from '@/utilities/urlParts'
+
+describe('urlParts', () => {
+  it('splits query content only at the first question mark', () => {
+    expect(splitUrlQuery('/api/file/image.jpg?note=first?second&lang=de')).toEqual({
+      path: '/api/file/image.jpg',
+      query: 'note=first?second&lang=de',
+    })
+  })
+
+  it('splits hash content only at the first hash mark', () => {
+    expect(splitUrlHash('/listing-comparison#overview#details')).toEqual({
+      pathAndQuery: '/listing-comparison',
+      hash: 'overview#details',
+    })
+  })
+
+  it('splits relative hrefs into pathname, query, and hash parts', () => {
+    expect(splitRelativeHrefParts('/listing-comparison?note=first?second#overview#details')).toEqual({
+      pathname: '/listing-comparison',
+      query: 'note=first?second',
+      hash: 'overview#details',
+    })
+  })
+
+  it('normalizes an empty relative pathname to root', () => {
+    expect(splitRelativeHrefParts('?specialty=nose')).toEqual({
+      pathname: '/',
+      query: 'specialty=nose',
+      hash: '',
+    })
+  })
+})


### PR DESCRIPTION
Centralize first-separator URL parsing so repeated query and hash truncation fixes reuse one tested helper.

## What changed

- Added `splitUrlQuery`, `splitUrlHash`, and `splitRelativeHrefParts` in `src/utilities/urlParts.ts`.
- Reused the helper in landing specialty href rewriting, Payload media URL normalization, and listing comparison clinic media availability checks.
- Added focused utility coverage and removed the last raw `split('?')` test helper pattern.

## Validation

- `pnpm vitest run tests/unit/utilities/urlParts.test.ts tests/unit/components/landingCategoriesShared.test.ts tests/unit/utilities/resolveMediaImage.test.ts tests/unit/utilities/listingComparisonPresentation.test.ts tests/unit/app/useListingComparisonUrlState.test.tsx`
- `pnpm format`
- `pnpm check`
- `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build`

## Development

Closes #1083
