### PR TITLE
feat: group chunked seed jobs in dashboard

### DIFF
--- a/src/components/organisms/DeveloperDashboard/Seeding/SeedingCardView.tsx
+++ b/src/components/organisms/DeveloperDashboard/Seeding/SeedingCardView.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/endpoints/seed/utils/labels'
 import { resolveClientRuntimeClass, resolveClientRuntimeEnvironment } from '@/features/runtimePolicy'
 import type { SeedRunSnapshot } from '@/endpoints/seed/utils/state'
+import { buildSeedJobSummaries, formatRetryBatchLabel } from './seedJobSummaries'
 
 export type SeedingCardMode = 'development' | 'preview' | 'test' | 'production'
 
@@ -184,6 +185,7 @@ export const SeedingCardView: React.FC<SeedingCardViewProps> = (props) => {
   const runId = props.run?.runId ?? null
   const runTitle = props.run ? (props.run.title ?? formatSeedRunTitle(props.run.type, props.run.reset)) : null
   const isRunningRun = props.run?.status === 'running'
+  const jobSummaries = React.useMemo(() => buildSeedJobSummaries(props.run?.jobs ?? []), [props.run?.jobs])
 
   React.useEffect(() => {
     setIsQueueCollapsed(false)
@@ -191,6 +193,7 @@ export const SeedingCardView: React.FC<SeedingCardViewProps> = (props) => {
 
   const rootCardStyle: React.CSSProperties = {
     display: 'block',
+    overflowX: 'clip',
   }
 
   const toolbarStyle: React.CSSProperties = {
@@ -345,10 +348,15 @@ export const SeedingCardView: React.FC<SeedingCardViewProps> = (props) => {
   const jobTitleStyle: React.CSSProperties = {
     display: 'flex',
     justifyContent: 'space-between',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     gap: '0.5rem',
     fontWeight: 600,
     marginBottom: '0.25rem',
+  }
+
+  const jobTitleTextStyle: React.CSSProperties = {
+    minWidth: 0,
+    overflowWrap: 'anywhere',
   }
 
   const jobStatusActionsStyle: React.CSSProperties = {
@@ -356,6 +364,18 @@ export const SeedingCardView: React.FC<SeedingCardViewProps> = (props) => {
     alignItems: 'center',
     gap: '0.25rem',
     flexShrink: 0,
+    flexWrap: 'wrap',
+    justifyContent: 'flex-end',
+  }
+
+  const batchProgressStyle: React.CSSProperties = {
+    marginTop: '0.25rem',
+    color: 'var(--theme-elevation-700)',
+  }
+
+  const jobIssueStyle: React.CSSProperties = {
+    marginTop: '0.25rem',
+    color: 'var(--theme-elevation-700)',
   }
 
   const logPanelStyle: React.CSSProperties = {
@@ -439,6 +459,13 @@ export const SeedingCardView: React.FC<SeedingCardViewProps> = (props) => {
 
         @keyframes seedRunningSpin {
           to { transform: rotate(360deg); }
+        }
+
+        .seed-touch-action {
+          min-height: 44px !important;
+          min-width: 44px !important;
+          align-items: center !important;
+          justify-content: center !important;
         }
       `}</style>
       <Heading as="h4" align="left">
@@ -530,9 +557,10 @@ export const SeedingCardView: React.FC<SeedingCardViewProps> = (props) => {
               <PayloadButton
                 buttonStyle="subtle"
                 margin={false}
-                size="xsmall"
+                size="small"
                 tooltip="Retry unfinished jobs"
                 aria-label="Retry unfinished jobs"
+                className="seed-touch-action"
                 onClick={props.onRetryUnfinishedJobs}
               >
                 Retry unfinished jobs
@@ -544,8 +572,9 @@ export const SeedingCardView: React.FC<SeedingCardViewProps> = (props) => {
                 aria-expanded={!isQueueCollapsed}
                 buttonStyle="subtle"
                 margin={false}
-                size="xsmall"
+                size="small"
                 tooltip={isQueueCollapsed ? 'Expand queue' : 'Collapse queue'}
+                className="seed-touch-action"
                 onClick={() => setIsQueueCollapsed((value) => !value)}
               >
                 {isQueueCollapsed ? 'Expand queue' : 'Collapse queue'}
@@ -581,50 +610,64 @@ export const SeedingCardView: React.FC<SeedingCardViewProps> = (props) => {
               </div>
             ) : null}
             <div style={{ fontSize: '0.8125rem', fontWeight: 600, color: 'var(--theme-elevation-700)' }}>
-              Jobs ({props.run.jobs.length})
+              Seed units ({jobSummaries.length}) · {props.run.jobs.length} jobs
             </div>
             <div style={jobSummaryGridStyle}>
-              {props.run.jobs.map((job) => (
+              {jobSummaries.map((jobSummary) => (
                 <div
-                  key={job.id}
-                  style={jobCardStyle(job.status)}
-                  aria-busy={job.status === 'running' ? true : undefined}
+                  key={jobSummary.id}
+                  style={jobCardStyle(jobSummary.status)}
+                  aria-busy={jobSummary.status === 'running' ? true : undefined}
                 >
                   <div style={jobTitleStyle}>
-                    <span>
-                      {job.order}. {job.title ?? formatSeedJobTitle(job.stepName, job.chunkIndex, job.chunkTotal)}
+                    <span style={jobTitleTextStyle}>
+                      {jobSummary.order}. {jobSummary.title}
                     </span>
                     <span style={jobStatusActionsStyle}>
-                      {job.status === 'running' ? (
+                      {jobSummary.status === 'running' ? (
                         <span style={jobRunningBadgeStyle}>
                           <Loader2 size={12} style={statusRunningIconStyle} aria-hidden />
-                          <span style={statusRunningTextStyle}>{formatJobStatus(job.status)}</span>
+                          <span style={statusRunningTextStyle}>{formatJobStatus(jobSummary.status)}</span>
                         </span>
                       ) : (
-                        <span style={{ color: getJobStatusColor(job.status) }}>{formatJobStatus(job.status)}</span>
+                        <span style={{ color: getJobStatusColor(jobSummary.status) }}>
+                          {formatJobStatus(jobSummary.status)}
+                        </span>
                       )}
-                      {job.status === 'failed' || job.status === 'cancelled' ? (
+                      {jobSummary.retryableJobs.map((job) => (
                         <PayloadButton
                           aria-label={`Retry ${job.title ?? formatSeedJobTitle(job.stepName, job.chunkIndex, job.chunkTotal)}`}
                           buttonStyle="subtle"
                           margin={false}
-                          size="xsmall"
+                          size="small"
                           tooltip={`Retry ${job.title ?? formatSeedJobTitle(job.stepName, job.chunkIndex, job.chunkTotal)}`}
+                          className="seed-touch-action"
                           onClick={() => props.onRetryJob(job.id)}
                         >
                           <RotateCcw size={14} />
+                          <span>Retry {formatRetryBatchLabel(job)}</span>
                         </PayloadButton>
-                      ) : null}
+                      ))}
                     </span>
                   </div>
+                  {jobSummary.isBatchGroup &&
+                  typeof jobSummary.chunkIndex === 'number' &&
+                  typeof jobSummary.chunkTotal === 'number' ? (
+                    <div style={batchProgressStyle}>
+                      Batch {jobSummary.chunkIndex}/{jobSummary.chunkTotal}
+                    </div>
+                  ) : null}
                   <div style={{ color: 'var(--theme-elevation-700)' }}>
-                    {formatSeedChangeSummary(job.created, job.updated)}
+                    {formatSeedChangeSummary(jobSummary.created, jobSummary.updated)}
                   </div>
-                  {(job.warnings.length > 0 || job.failures.length > 0) && (
+                  {jobSummary.isBatchGroup && jobSummary.issueLabels.length > 0 ? (
+                    <div style={jobIssueStyle}>{jobSummary.issueLabels.join(' · ')}</div>
+                  ) : null}
+                  {(jobSummary.warningCount > 0 || jobSummary.failureCount > 0) && (
                     <div style={{ marginTop: '0.25rem', color: 'var(--theme-elevation-700)' }}>
-                      {job.warnings.length > 0 ? `${job.warnings.length} warning(s)` : ''}
-                      {job.warnings.length > 0 && job.failures.length > 0 ? ' · ' : ''}
-                      {job.failures.length > 0 ? `${job.failures.length} failure(s)` : ''}
+                      {jobSummary.warningCount > 0 ? `${jobSummary.warningCount} warning(s)` : ''}
+                      {jobSummary.warningCount > 0 && jobSummary.failureCount > 0 ? ' · ' : ''}
+                      {jobSummary.failureCount > 0 ? `${jobSummary.failureCount} failure(s)` : ''}
                     </div>
                   )}
                 </div>

--- a/src/components/organisms/DeveloperDashboard/Seeding/seedJobSummaries.ts
+++ b/src/components/organisms/DeveloperDashboard/Seeding/seedJobSummaries.ts
@@ -1,0 +1,146 @@
+import { formatSeedJobTitle, formatSeedStepTitle } from '@/endpoints/seed/utils/labels'
+import type { SeedRunSnapshot } from '@/endpoints/seed/utils/state'
+
+export type SeedJob = SeedRunSnapshot['jobs'][number]
+
+export type SeedJobSummary = {
+  id: string
+  order: number
+  title: string
+  status: SeedJob['status']
+  jobs: SeedJob[]
+  created: number
+  updated: number
+  warningCount: number
+  failureCount: number
+  chunkIndex?: number
+  chunkTotal?: number
+  retryableJobs: SeedJob[]
+  issueLabels: string[]
+  isBatchGroup: boolean
+}
+
+const formatJobStatus = (status: SeedJob['status']): string => {
+  if (status === 'succeeded') return 'succeeded'
+  if (status === 'failed') return 'failed'
+  if (status === 'cancelled') return 'cancelled'
+  if (status === 'skipped') return 'skipped'
+  if (status === 'running') return 'running'
+  return 'queued'
+}
+
+const isTerminalJobStatus = (status: SeedJob['status']): boolean => {
+  return status === 'succeeded' || status === 'failed' || status === 'cancelled' || status === 'skipped'
+}
+
+const isBatchJob = (job: SeedJob): boolean => {
+  return typeof job.chunkTotal === 'number' && job.chunkTotal > 1
+}
+
+const getSeedUnitKey = (job: SeedJob): string => {
+  if (!isBatchJob(job)) return `job:${job.id}`
+
+  return ['batch', job.kind, job.stepName, job.collection ?? '', job.fileName ?? ''].join(':')
+}
+
+const resolveSeedUnitStatus = (jobs: SeedJob[]): SeedJob['status'] => {
+  if (jobs.some((job) => job.status === 'failed')) return 'failed'
+  if (jobs.some((job) => job.status === 'cancelled')) return 'cancelled'
+  if (jobs.some((job) => job.status === 'running')) return 'running'
+  if (jobs.some((job) => isTerminalJobStatus(job.status)) && jobs.some((job) => job.status === 'queued')) {
+    return 'running'
+  }
+  if (jobs.every((job) => job.status === 'skipped')) return 'skipped'
+  if (jobs.every((job) => job.status === 'succeeded' || job.status === 'skipped')) return 'succeeded'
+  return 'queued'
+}
+
+const resolveSeedUnitChunkIndex = (jobs: SeedJob[]): number | undefined => {
+  const runningChunkIndex = jobs.find((job) => job.status === 'running')?.chunkIndex
+  if (typeof runningChunkIndex === 'number') return runningChunkIndex
+
+  const completedChunks = jobs.filter((job) => isTerminalJobStatus(job.status)).length
+  if (completedChunks > 0) return completedChunks
+
+  return jobs.find((job) => typeof job.chunkIndex === 'number')?.chunkIndex
+}
+
+const formatBatchLabel = (job: SeedJob): string => {
+  if (typeof job.chunkIndex === 'number' && typeof job.chunkTotal === 'number' && job.chunkTotal > 1) {
+    return `Batch ${job.chunkIndex}/${job.chunkTotal}`
+  }
+
+  return job.title ?? formatSeedJobTitle(job.stepName, job.chunkIndex, job.chunkTotal)
+}
+
+export const formatRetryBatchLabel = (job: SeedJob): string => {
+  if (typeof job.chunkIndex === 'number' && typeof job.chunkTotal === 'number' && job.chunkTotal > 1) {
+    return `${job.chunkIndex}/${job.chunkTotal}`
+  }
+
+  return 'job'
+}
+
+const buildIssueLabel = (job: SeedJob): string | null => {
+  const issueParts: string[] = []
+
+  if (job.status === 'failed' || job.status === 'cancelled') {
+    issueParts.push(formatJobStatus(job.status))
+  }
+  if (job.warnings.length > 0) {
+    issueParts.push(`${job.warnings.length} warning(s)`)
+  }
+  if (job.failures.length > 0) {
+    issueParts.push(`${job.failures.length} failure(s)`)
+  }
+
+  if (issueParts.length === 0) return null
+
+  return `${formatBatchLabel(job)}: ${issueParts.join(', ')}`
+}
+
+export const buildSeedJobSummaries = (jobs: SeedJob[]): SeedJobSummary[] => {
+  const groups = new Map<string, SeedJob[]>()
+  const order: string[] = []
+
+  for (const job of jobs) {
+    const key = getSeedUnitKey(job)
+    if (!groups.has(key)) {
+      groups.set(key, [])
+      order.push(key)
+    }
+    groups.get(key)!.push(job)
+  }
+
+  return order.map((key) => {
+    const groupedJobs = [...groups.get(key)!].sort((a, b) => a.order - b.order)
+    const firstJob = groupedJobs[0]!
+    const isBatchGroup = groupedJobs.some(isBatchJob)
+    const title = isBatchGroup
+      ? formatSeedStepTitle(firstJob.stepName)
+      : (firstJob.title ?? formatSeedJobTitle(firstJob.stepName, firstJob.chunkIndex, firstJob.chunkTotal))
+    const chunkTotal = isBatchGroup
+      ? Math.max(...groupedJobs.map((job) => job.chunkTotal ?? groupedJobs.length))
+      : undefined
+
+    return {
+      id: isBatchGroup ? key : firstJob.id,
+      order: firstJob.order,
+      title,
+      status: resolveSeedUnitStatus(groupedJobs),
+      jobs: groupedJobs,
+      created: groupedJobs.reduce((total, job) => total + job.created, 0),
+      updated: groupedJobs.reduce((total, job) => total + job.updated, 0),
+      warningCount: groupedJobs.reduce((total, job) => total + job.warnings.length, 0),
+      failureCount: groupedJobs.reduce((total, job) => total + job.failures.length, 0),
+      chunkIndex: isBatchGroup ? resolveSeedUnitChunkIndex(groupedJobs) : undefined,
+      chunkTotal,
+      retryableJobs: groupedJobs.filter((job) => job.status === 'failed' || job.status === 'cancelled'),
+      issueLabels: groupedJobs.flatMap((job) => {
+        const issueLabel = buildIssueLabel(job)
+        return issueLabel ? [issueLabel] : []
+      }),
+      isBatchGroup,
+    }
+  })
+}

--- a/src/stories/organisms/SeedingCard.stories.tsx
+++ b/src/stories/organisms/SeedingCard.stories.tsx
@@ -114,6 +114,97 @@ const createSeedRunSummary = (type: 'baseline' | 'demo', reset: boolean): SeedRu
   }
 }
 
+const createDenseChunkedSeedRunSummary = (): SeedRunSummary => {
+  const runId = 'story-dense-chunks'
+  const now = new Date().toISOString()
+  const chunkedJobs = [1, 2, 3, 4, 5, 6].map((chunkIndex) => ({
+    id: `cities-${chunkIndex}`,
+    order: chunkIndex,
+    status: chunkIndex < 4 ? ('succeeded' as const) : chunkIndex === 4 ? ('running' as const) : ('queued' as const),
+    input: {} as SeedRunSummary['jobs'][number]['input'],
+    queue: `seed:${runId}`,
+    title: formatSeedJobTitle('cities', chunkIndex, 6),
+    stepName: 'cities',
+    kind: 'collection' as const,
+    collection: 'cities',
+    fileName: 'cities',
+    chunkIndex,
+    chunkTotal: 6,
+    createdAt: now,
+    startedAt: chunkIndex <= 4 ? now : undefined,
+    completedAt: chunkIndex < 4 ? now : undefined,
+    created: chunkIndex < 4 ? 2 : 0,
+    updated: chunkIndex < 4 ? 1 : 0,
+    warnings: chunkIndex === 2 ? ['Minor warning'] : [],
+    failures: [],
+  }))
+  const singleJobs: SeedRunSummary['jobs'] = [
+    {
+      id: 'settings',
+      order: 7,
+      status: 'queued',
+      input: {} as SeedRunSummary['jobs'][number]['input'],
+      queue: `seed:${runId}`,
+      title: formatSeedJobTitle('globals'),
+      stepName: 'globals',
+      kind: 'globals',
+      fileName: 'globals',
+      createdAt: now,
+      created: 0,
+      updated: 0,
+      warnings: [],
+      failures: [],
+    },
+    {
+      id: 'treatments',
+      order: 8,
+      status: 'queued',
+      input: {} as SeedRunSummary['jobs'][number]['input'],
+      queue: `seed:${runId}`,
+      title: formatSeedJobTitle('treatments'),
+      stepName: 'treatments',
+      kind: 'collection',
+      collection: 'treatments',
+      fileName: 'treatments',
+      chunkIndex: 1,
+      chunkTotal: 1,
+      createdAt: now,
+      created: 0,
+      updated: 0,
+      warnings: [],
+      failures: [],
+    },
+  ]
+  const jobs = [...chunkedJobs, ...singleJobs]
+
+  return {
+    runId,
+    type: 'baseline',
+    reset: false,
+    queue: `seed:${runId}`,
+    title: formatSeedRunTitle('baseline', false),
+    status: 'running',
+    createdAt: now,
+    startedAt: now,
+    completedAt: undefined,
+    totalJobs: jobs.length,
+    completedJobs: 3,
+    succeededJobs: 3,
+    failedJobs: 0,
+    cancelledJobs: 0,
+    activeJobId: 'cities-4',
+    activeStepName: formatSeedJobTitle('cities', 4, 6),
+    jobs,
+    logs: [{ id: 'summary', at: now, severity: 'INFO', text: `Started ${formatSeedJobTitle('cities', 4, 6)}`, runId }],
+    warnings: [],
+    failures: [],
+    totals: { created: 6, updated: 3 },
+    progress: { completed: 3, total: jobs.length, percent: 38 },
+    jobIds: jobs.map((job) => job.id),
+    hasActiveJob: true,
+  }
+}
+
 const meta: Meta<typeof SeedingCardView> = {
   title: 'Domain/Platform/Organisms/SeedingCard',
   component: SeedingCardView,
@@ -176,7 +267,7 @@ export const RunningWithJobs: Story = {
     const canvas = within(canvasElement)
     expect(canvas.getByRole('progressbar', { name: 'Seed progress' })).toHaveAttribute('aria-valuenow', '50')
     expect(canvas.getByText(/1\/2 jobs · 50%/)).toBeInTheDocument()
-    expect(canvas.getByText(/Jobs \(2\)/)).toBeInTheDocument()
+    expect(canvas.getByText(/Seed units \(1\) · 2 jobs/)).toBeInTheDocument()
     expect(canvas.getByText(/^Status running$/)).toBeInTheDocument()
     expect(canvas.getByText('Role:')).toBeInTheDocument()
     expect(canvas.getByText('Seed:')).toBeInTheDocument()
@@ -184,7 +275,28 @@ export const RunningWithJobs: Story = {
     expect(canvas.getByText('Running')).toBeInTheDocument()
     expect(canvas.getByText('Current step:')).toBeInTheDocument()
     expect(canvas.getByText(formatSeedStepTitle('platformContentMedia (1/2)'))).toBeInTheDocument()
+    expect(canvas.getByText(`1. ${formatSeedStepTitle('platformContentMedia')}`)).toBeInTheDocument()
+    expect(canvas.getByText('Batch 1/2')).toBeInTheDocument()
     expect(canvas.getByText(formatSeedChangeSummary(1, 0))).toBeInTheDocument()
+  },
+}
+
+export const DenseChunkedQueue: Story = {
+  args: {
+    run: createDenseChunkedSeedRunSummary(),
+    logLines: [{ id: 'summary', severity: 'INFO', text: `Started ${formatSeedJobTitle('cities', 4, 6)}` }],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    expect(canvas.getByText(/3\/8 jobs · 38%/)).toBeInTheDocument()
+    expect(canvas.getByText(/Seed units \(3\) · 8 jobs/)).toBeInTheDocument()
+    expect(canvas.getByText(`1. ${formatSeedStepTitle('cities')}`)).toBeInTheDocument()
+    expect(canvas.getByText('Batch 4/6')).toBeInTheDocument()
+    expect(canvas.getByText(formatSeedChangeSummary(6, 3))).toBeInTheDocument()
+    expect(canvas.getByText('Batch 2/6: 1 warning(s)')).toBeInTheDocument()
+    expect(canvas.getByText(`7. ${formatSeedStepTitle('globals')}`)).toBeInTheDocument()
+    expect(canvas.getByText(`8. ${formatSeedStepTitle('treatments')}`)).toBeInTheDocument()
+    expect(canvas.queryByText(`2. ${formatSeedJobTitle('cities', 2, 6)}`)).not.toBeInTheDocument()
   },
 }
 
@@ -200,7 +312,7 @@ export const CollapsedQueue: Story = {
     const canvas = within(canvasElement)
     await userEvent.click(canvas.getByRole('button', { name: 'Collapse queue' }))
     expect(canvas.getByRole('button', { name: 'Expand queue' })).toBeInTheDocument()
-    expect(canvas.queryByText(/Jobs \(2\)/)).not.toBeInTheDocument()
+    expect(canvas.queryByText(/Seed units \(1\) · 2 jobs/)).not.toBeInTheDocument()
     expect(canvas.queryByText('Current step:')).not.toBeInTheDocument()
     expect(canvas.queryByText(formatSeedStepTitle('platformContentMedia (1/2)'))).not.toBeInTheDocument()
     expect(canvas.getByRole('progressbar', { name: 'Seed progress' })).toHaveAttribute('aria-valuenow', '50')
@@ -212,10 +324,11 @@ const partialFailureBase = createSeedRunSummary('baseline', false)
 const failedSeedRun: SeedRunSummary = {
   ...partialFailureBase,
   status: 'partial' as const,
-  completedJobs: 2,
+  totalJobs: 3,
+  completedJobs: 3,
   succeededJobs: 1,
   failedJobs: 1,
-  cancelledJobs: 0,
+  cancelledJobs: 1,
   activeJobId: undefined,
   activeStepName: undefined,
   jobs: [
@@ -225,18 +338,36 @@ const failedSeedRun: SeedRunSummary = {
       completedAt: new Date().toISOString(),
       created: 1,
       updated: 0,
+      chunkTotal: 3,
     },
     {
       ...partialFailureBase.jobs[1]!,
       status: 'failed' as const,
+      title: formatSeedJobTitle('platformContentMedia', 2, 3),
+      chunkTotal: 3,
       completedAt: new Date().toISOString(),
       created: 0,
       updated: 2,
       failures: ['Storage upload failed after retry.'],
       error: 'Storage upload failed after retry.',
     },
+    {
+      ...partialFailureBase.jobs[1]!,
+      id: 'job-3',
+      order: 3,
+      status: 'cancelled' as const,
+      title: formatSeedJobTitle('platformContentMedia', 3, 3),
+      chunkIndex: 3,
+      chunkTotal: 3,
+      completedAt: new Date().toISOString(),
+      created: 0,
+      updated: 0,
+      failures: [],
+      error: undefined,
+    },
   ],
-  progress: { completed: 2, total: 2, percent: 100 },
+  progress: { completed: 3, total: 3, percent: 100 },
+  jobIds: ['job-1', 'job-2', 'job-3'],
   hasActiveJob: false,
 }
 
@@ -263,13 +394,17 @@ export const PartialFailure: Story = {
     expect(canvas.getByText('Seed:')).toBeInTheDocument()
     expect(canvas.getByText('Baseline seed')).toBeInTheDocument()
     expect(canvas.getByText('partial')).toBeInTheDocument()
-    expect(canvas.getByText(formatSeedChangeSummary(1, 0))).toBeInTheDocument()
-    expect(canvas.getByText(formatSeedChangeSummary(0, 2))).toBeInTheDocument()
-    expect(canvas.getByText(/^succeeded$/)).toBeInTheDocument()
+    expect(canvas.getByText(formatSeedChangeSummary(1, 2))).toBeInTheDocument()
     expect(canvas.getByText(/^failed$/)).toBeInTheDocument()
+    expect(canvas.getByText('Batch 2/3: failed, 1 failure(s) · Batch 3/3: cancelled')).toBeInTheDocument()
+    expect(canvas.getByText('Retry 2/3')).toBeInTheDocument()
+    expect(canvas.getByText('Retry 3/3')).toBeInTheDocument()
     expect(canvas.getByRole('button', { name: 'Retry unfinished jobs' })).toBeInTheDocument()
     expect(
-      canvas.getByRole('button', { name: `Retry ${formatSeedJobTitle('platformContentMedia', 2, 2)}` }),
+      canvas.getByRole('button', { name: `Retry ${formatSeedJobTitle('platformContentMedia', 2, 3)}` }),
+    ).toBeInTheDocument()
+    expect(
+      canvas.getByRole('button', { name: `Retry ${formatSeedJobTitle('platformContentMedia', 3, 3)}` }),
     ).toBeInTheDocument()
   },
 }

--- a/tests/unit/components/seedJobSummaries.test.ts
+++ b/tests/unit/components/seedJobSummaries.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildSeedJobSummaries,
+  formatRetryBatchLabel,
+  type SeedJob,
+} from '@/components/organisms/DeveloperDashboard/Seeding/seedJobSummaries'
+import { formatSeedJobTitle, formatSeedStepTitle } from '@/endpoints/seed/utils/labels'
+
+const createJob = (overrides: Partial<SeedJob> & Pick<SeedJob, 'id' | 'order' | 'stepName'>): SeedJob => {
+  return {
+    id: overrides.id,
+    order: overrides.order,
+    status: overrides.status ?? 'queued',
+    input: {} as SeedJob['input'],
+    queue: overrides.queue ?? 'seed:run-1',
+    title:
+      overrides.title ??
+      formatSeedJobTitle(overrides.stepName, overrides.chunkIndex ?? undefined, overrides.chunkTotal ?? undefined),
+    stepName: overrides.stepName,
+    kind: overrides.kind ?? 'collection',
+    collection: overrides.collection,
+    fileName: overrides.fileName,
+    chunkIndex: overrides.chunkIndex,
+    chunkTotal: overrides.chunkTotal,
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+    startedAt: overrides.startedAt,
+    completedAt: overrides.completedAt,
+    created: overrides.created ?? 0,
+    updated: overrides.updated ?? 0,
+    warnings: overrides.warnings ?? [],
+    failures: overrides.failures ?? [],
+    error: overrides.error,
+    output: overrides.output,
+  }
+}
+
+describe('seedJobSummaries', () => {
+  it('groups chunked jobs by seed unit and sums visible counts', () => {
+    const summaries = buildSeedJobSummaries([
+      createJob({
+        id: 'cities-1',
+        order: 1,
+        status: 'succeeded',
+        stepName: 'cities',
+        collection: 'cities',
+        fileName: 'cities',
+        chunkIndex: 1,
+        chunkTotal: 4,
+        created: 2,
+        updated: 1,
+      }),
+      createJob({
+        id: 'cities-2',
+        order: 2,
+        status: 'running',
+        stepName: 'cities',
+        collection: 'cities',
+        fileName: 'cities',
+        chunkIndex: 2,
+        chunkTotal: 4,
+        created: 3,
+        updated: 0,
+        warnings: ['large chunk'],
+      }),
+      createJob({
+        id: 'settings',
+        order: 3,
+        status: 'queued',
+        stepName: 'globals',
+        kind: 'globals',
+        fileName: 'globals',
+      }),
+    ])
+
+    expect(summaries).toHaveLength(2)
+    expect(summaries[0]).toMatchObject({
+      id: 'batch:collection:cities:cities:cities',
+      order: 1,
+      title: formatSeedStepTitle('cities'),
+      status: 'running',
+      created: 5,
+      updated: 1,
+      warningCount: 1,
+      failureCount: 0,
+      chunkIndex: 2,
+      chunkTotal: 4,
+      issueLabels: ['Batch 2/4: 1 warning(s)'],
+      isBatchGroup: true,
+    })
+    expect(summaries[1]).toMatchObject({
+      id: 'settings',
+      title: formatSeedJobTitle('globals'),
+      status: 'queued',
+      isBatchGroup: false,
+    })
+  })
+
+  it('prioritizes failed and cancelled grouped statuses before running progress', () => {
+    const summaries = buildSeedJobSummaries([
+      createJob({
+        id: 'media-1',
+        order: 1,
+        status: 'succeeded',
+        stepName: 'platformContentMedia',
+        collection: 'platformContentMedia',
+        fileName: 'platformContentMedia',
+        chunkIndex: 1,
+        chunkTotal: 3,
+        created: 1,
+      }),
+      createJob({
+        id: 'media-2',
+        order: 2,
+        status: 'failed',
+        stepName: 'platformContentMedia',
+        collection: 'platformContentMedia',
+        fileName: 'platformContentMedia',
+        chunkIndex: 2,
+        chunkTotal: 3,
+        updated: 2,
+        failures: ['upload failed'],
+      }),
+      createJob({
+        id: 'media-3',
+        order: 3,
+        status: 'cancelled',
+        stepName: 'platformContentMedia',
+        collection: 'platformContentMedia',
+        fileName: 'platformContentMedia',
+        chunkIndex: 3,
+        chunkTotal: 3,
+      }),
+    ])
+
+    expect(summaries).toHaveLength(1)
+    expect(summaries[0]).toMatchObject({
+      status: 'failed',
+      created: 1,
+      updated: 2,
+      failureCount: 1,
+      chunkIndex: 3,
+      chunkTotal: 3,
+      retryableJobs: [expect.objectContaining({ id: 'media-2' }), expect.objectContaining({ id: 'media-3' })],
+      issueLabels: ['Batch 2/3: failed, 1 failure(s)', 'Batch 3/3: cancelled'],
+    })
+  })
+
+  it('keeps non-chunked jobs separate even when step names match', () => {
+    const summaries = buildSeedJobSummaries([
+      createJob({
+        id: 'treatments-1',
+        order: 1,
+        stepName: 'treatments',
+        collection: 'treatments',
+        fileName: 'treatments',
+        chunkIndex: 1,
+        chunkTotal: 1,
+      }),
+      createJob({
+        id: 'treatments-2',
+        order: 2,
+        stepName: 'treatments',
+        collection: 'treatments',
+        fileName: 'treatments',
+        chunkIndex: 1,
+        chunkTotal: 1,
+      }),
+    ])
+
+    expect(summaries).toHaveLength(2)
+    expect(summaries.map((summary) => summary.id)).toEqual(['treatments-1', 'treatments-2'])
+    expect(summaries.every((summary) => !summary.isBatchGroup)).toBe(true)
+  })
+
+  it('formats retry labels with compact batch context', () => {
+    expect(
+      formatRetryBatchLabel(
+        createJob({
+          id: 'chunk',
+          order: 1,
+          stepName: 'cities',
+          chunkIndex: 2,
+          chunkTotal: 4,
+        }),
+      ),
+    ).toBe('2/4')
+    expect(formatRetryBatchLabel(createJob({ id: 'single', order: 1, stepName: 'cities' }))).toBe('job')
+  })
+})

--- a/tests/unit/components/seedingCardView.test.tsx
+++ b/tests/unit/components/seedingCardView.test.tsx
@@ -217,7 +217,7 @@ describe('SeedingCardView', () => {
     expect(screen.getByText('Error example')).toBeInTheDocument()
   })
 
-  it('shows run progress, status and job cards', () => {
+  it('shows run progress, status and seed unit cards', () => {
     const run = createRun({
       status: 'running',
       progress: { completed: 1, total: 2, percent: 50 },
@@ -244,14 +244,59 @@ describe('SeedingCardView', () => {
     expect(screen.getByText(/^Status running$/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Collapse queue' })).toBeInTheDocument()
     expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '50')
-    expect(screen.getByText(/Jobs \(2\)/)).toBeInTheDocument()
+    expect(screen.getByText(/Seed units \(1\) · 2 jobs/)).toBeInTheDocument()
     expect(screen.getByText('Current step:')).toBeInTheDocument()
     expect(screen.getByText(formatSeedStepTitle('platformContentMedia (1/2)'))).toBeInTheDocument()
-    expect(screen.getByText(`1. ${formatSeedStepTitle('platformContentMedia (1/2)')}`)).toBeInTheDocument()
-    expect(screen.getByText(`2. ${formatSeedStepTitle('platformContentMedia (2/2)')}`)).toBeInTheDocument()
+    expect(screen.getByText(`1. ${formatSeedStepTitle('platformContentMedia')}`)).toBeInTheDocument()
+    expect(screen.getByText('Batch 1/2')).toBeInTheDocument()
     expect(screen.getByText(formatSeedChangeSummary(1, 0))).toBeInTheDocument()
     expect(screen.getByText(/^running$/)).toBeInTheDocument()
-    expect(screen.getByText(/^queued$/)).toBeInTheDocument()
+    expect(screen.queryByText(`2. ${formatSeedStepTitle('platformContentMedia (2/2)')}`)).not.toBeInTheDocument()
+  })
+
+  it('groups any chunked seed step and sums batch changes', () => {
+    const now = new Date().toISOString()
+    const run = createRun({
+      status: 'running',
+      progress: { completed: 2, total: 4, percent: 50 },
+      completedJobs: 2,
+      succeededJobs: 2,
+      activeJobId: 'city-job-3',
+      activeStepName: 'cities (3/4)',
+      jobs: [1, 2, 3, 4].map((chunkIndex) => ({
+        id: `city-job-${chunkIndex}`,
+        order: chunkIndex,
+        status: chunkIndex < 3 ? ('succeeded' as const) : chunkIndex === 3 ? ('running' as const) : ('queued' as const),
+        input: {} as SeedRunSummary['jobs'][number]['input'],
+        queue: 'seed:run-1',
+        title: formatSeedJobTitle('cities', chunkIndex, 4),
+        stepName: 'cities',
+        kind: 'collection' as const,
+        collection: 'cities',
+        fileName: 'cities',
+        chunkIndex,
+        chunkTotal: 4,
+        createdAt: now,
+        startedAt: chunkIndex <= 3 ? now : undefined,
+        completedAt: chunkIndex < 3 ? now : undefined,
+        created: chunkIndex < 3 ? chunkIndex : 0,
+        updated: chunkIndex < 3 ? 1 : 0,
+        warnings: chunkIndex === 2 ? ['Minor warning'] : [],
+        failures: [],
+      })),
+      totals: { created: 3, updated: 2 },
+      jobIds: ['city-job-1', 'city-job-2', 'city-job-3', 'city-job-4'],
+    })
+
+    render(<SeedingCardView {...baseProps} run={run} />)
+
+    expect(screen.getByText(/Seed units \(1\) · 4 jobs/)).toBeInTheDocument()
+    expect(screen.getByText(`1. ${formatSeedStepTitle('cities')}`)).toBeInTheDocument()
+    expect(screen.getByText('Batch 3/4')).toBeInTheDocument()
+    expect(screen.getByText(formatSeedChangeSummary(3, 2))).toBeInTheDocument()
+    expect(screen.getByText('Batch 2/4: 1 warning(s)')).toBeInTheDocument()
+    expect(screen.getByText('1 warning(s)')).toBeInTheDocument()
+    expect(screen.queryByText(`2. ${formatSeedJobTitle('cities', 2, 4)}`)).not.toBeInTheDocument()
   })
 
   it('shows retry actions for failed and cancelled jobs', () => {
@@ -259,11 +304,11 @@ describe('SeedingCardView', () => {
     const onRetryJob = vi.fn()
     const run = createRun({
       status: 'partial',
-      progress: { completed: 2, total: 2, percent: 100 },
-      completedJobs: 2,
+      progress: { completed: 3, total: 3, percent: 100 },
+      completedJobs: 3,
       succeededJobs: 1,
       failedJobs: 1,
-      cancelledJobs: 0,
+      cancelledJobs: 1,
       activeJobId: undefined,
       activeStepName: undefined,
       hasActiveJob: false,
@@ -280,7 +325,7 @@ describe('SeedingCardView', () => {
           collection: 'platformContentMedia',
           fileName: 'platformContentMedia',
           chunkIndex: 1,
-          chunkTotal: 2,
+          chunkTotal: 3,
           createdAt: new Date().toISOString(),
           startedAt: new Date().toISOString(),
           completedAt: new Date().toISOString(),
@@ -295,13 +340,13 @@ describe('SeedingCardView', () => {
           status: 'failed',
           input: {} as SeedRunSummary['jobs'][number]['input'],
           queue: 'seed:run-1',
-          title: formatSeedJobTitle('platformContentMedia', 2, 2),
+          title: formatSeedJobTitle('platformContentMedia', 2, 3),
           stepName: 'platformContentMedia',
           kind: 'collection' as const,
           collection: 'platformContentMedia',
           fileName: 'platformContentMedia',
           chunkIndex: 2,
-          chunkTotal: 2,
+          chunkTotal: 3,
           createdAt: new Date().toISOString(),
           startedAt: new Date().toISOString(),
           completedAt: new Date().toISOString(),
@@ -311,9 +356,30 @@ describe('SeedingCardView', () => {
           failures: ['Storage upload failed after retry.'],
           error: 'Storage upload failed after retry.',
         },
+        {
+          id: 'job-3',
+          order: 3,
+          status: 'cancelled',
+          input: {} as SeedRunSummary['jobs'][number]['input'],
+          queue: 'seed:run-1',
+          title: formatSeedJobTitle('platformContentMedia', 3, 3),
+          stepName: 'platformContentMedia',
+          kind: 'collection' as const,
+          collection: 'platformContentMedia',
+          fileName: 'platformContentMedia',
+          chunkIndex: 3,
+          chunkTotal: 3,
+          createdAt: new Date().toISOString(),
+          startedAt: new Date().toISOString(),
+          completedAt: new Date().toISOString(),
+          created: 0,
+          updated: 0,
+          warnings: [],
+          failures: [],
+        },
       ],
       logs: [],
-      jobIds: ['job-1', 'job-2'],
+      jobIds: ['job-1', 'job-2', 'job-3'],
     })
 
     render(
@@ -327,14 +393,25 @@ describe('SeedingCardView', () => {
 
     expect(screen.getByRole('button', { name: 'Retry unfinished jobs' })).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: `Retry ${formatSeedJobTitle('platformContentMedia', 2, 2)}` }),
+      screen.getByRole('button', { name: `Retry ${formatSeedJobTitle('platformContentMedia', 2, 3)}` }),
     ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: `Retry ${formatSeedJobTitle('platformContentMedia', 3, 3)}` }),
+    ).toBeInTheDocument()
+    expect(screen.getByText(formatSeedChangeSummary(1, 2))).toBeInTheDocument()
+    expect(screen.getByText(/^failed$/)).toBeInTheDocument()
+    expect(screen.getByText('Batch 2/3: failed, 1 failure(s) · Batch 3/3: cancelled')).toBeInTheDocument()
+    expect(screen.getByText('Retry 2/3')).toBeInTheDocument()
+    expect(screen.getByText('Retry 3/3')).toBeInTheDocument()
+    expect(screen.getByText('1 failure(s)')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Retry unfinished jobs' }))
-    fireEvent.click(screen.getByRole('button', { name: `Retry ${formatSeedJobTitle('platformContentMedia', 2, 2)}` }))
+    fireEvent.click(screen.getByRole('button', { name: `Retry ${formatSeedJobTitle('platformContentMedia', 2, 3)}` }))
+    fireEvent.click(screen.getByRole('button', { name: `Retry ${formatSeedJobTitle('platformContentMedia', 3, 3)}` }))
 
     expect(onRetryUnfinishedJobs).toHaveBeenCalledTimes(1)
     expect(onRetryJob).toHaveBeenCalledWith('job-2')
+    expect(onRetryJob).toHaveBeenCalledWith('job-3')
   })
 
   it('collapses the queue to keep only the progress summary visible', () => {
@@ -348,7 +425,7 @@ describe('SeedingCardView', () => {
     render(<SeedingCardView {...baseProps} run={run} />)
 
     expect(screen.getByRole('button', { name: 'Collapse queue' })).toBeInTheDocument()
-    expect(screen.getByText(/Jobs \(2\)/)).toBeInTheDocument()
+    expect(screen.getByText(/Seed units \(1\) · 2 jobs/)).toBeInTheDocument()
     expect(screen.getByText('Current step:')).toBeInTheDocument()
     expect(screen.getByText('Baseline seed')).toBeInTheDocument()
     expect(screen.getByText(formatSeedStepTitle('platformContentMedia (1/2)'))).toBeInTheDocument()
@@ -356,9 +433,9 @@ describe('SeedingCardView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Collapse queue' }))
 
     expect(screen.getByRole('button', { name: 'Expand queue' })).toBeInTheDocument()
-    expect(screen.queryByText(/Jobs \(2\)/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Seed units \(1\) · 2 jobs/)).not.toBeInTheDocument()
     expect(screen.queryByText('Current step:')).not.toBeInTheDocument()
-    expect(screen.queryByText(`1. ${formatSeedStepTitle('platformContentMedia (1/2)')}`)).not.toBeInTheDocument()
+    expect(screen.queryByText(`1. ${formatSeedStepTitle('platformContentMedia')}`)).not.toBeInTheDocument()
     expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '50')
   })
 


### PR DESCRIPTION
Group chunked seed jobs into one visual seed unit so long batch-based seed steps no longer flood the Developer Dashboard queue.

## What changed

- Add generic seed job summary helpers for grouping chunked jobs by kind, step name, collection, and file name.
- Update the Seeding Card queue to show `Seed units (n) · m jobs`, batch progress, aggregate added/updated counts, warning/failure totals, and per-chunk retry actions.
- Add unit coverage for generic non-media grouping, aggregation, mixed statuses, and retry labels.
- Add a dense Storybook queue scenario with a generic chunked seed group plus normal single jobs.

## Validation

- `pnpm format`
- `pnpm vitest tests/unit/components/seedJobSummaries.test.ts tests/unit/components/seedingCardView.test.tsx`
- `pnpm check`
- `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build`

Node warning observed locally: current Node is `v26.0.0`, while the project expects `>=24.0.0 <25`. Commands still completed successfully.

## Screenshots

Local Playwright artifacts captured during UI verification:

- `output/playwright/seed-batch-grouping/dense-*.png`
- `output/playwright/seed-batch-grouping/partial-*.png`

Checked viewports: 320, 375, 640, 768, 1024, and 1280 px. Dense and partial queue states had no horizontal overflow after the final fixes, and retry/collapse controls met the 44 px touch target check on narrow mobile viewports.

## Development

Closes findmydoc-platform/website#1086

Related planning follow-up: findmydoc-platform/payload-seed-dashboard#1
