### PR TITLE
fix: only block exact preview login redirect target

### DIFF
--- a/src/features/previewGuard/index.ts
+++ b/src/features/previewGuard/index.ts
@@ -59,7 +59,9 @@ export const sanitizePreviewGuardNextPath = (nextPath: string | null | undefined
     if (parsed.origin !== 'http://localhost') return PREVIEW_GUARD_FALLBACK_REDIRECT
 
     const safePath = `${parsed.pathname}${parsed.search}${parsed.hash}`
-    if (safePath.startsWith(PREVIEW_GUARD_LOGIN_PATH)) return PREVIEW_GUARD_FALLBACK_REDIRECT
+    if (normalizePathname(parsed.pathname) === PREVIEW_GUARD_LOGIN_PATH) {
+      return PREVIEW_GUARD_FALLBACK_REDIRECT
+    }
     return safePath
   } catch {
     return PREVIEW_GUARD_FALLBACK_REDIRECT

--- a/tests/unit/features/previewGuard/index.test.ts
+++ b/tests/unit/features/previewGuard/index.test.ts
@@ -109,4 +109,8 @@ describe('previewGuard feature', () => {
     expect(sanitizePreviewGuardNextPath('/foo\nbar')).toBe(PREVIEW_GUARD_FALLBACK_REDIRECT)
     expect(sanitizePreviewGuardNextPath(undefined)).toBe(PREVIEW_GUARD_FALLBACK_REDIRECT)
   })
+
+  it('keeps paths that only share the login prefix', () => {
+    expect(sanitizePreviewGuardNextPath('/admin/login-help')).toBe('/admin/login-help')
+  })
 })


### PR DESCRIPTION
fixes an overbroad preview-guard redirect block that rejected valid internal routes like `/admin/login-help`.

## What changed
- replaced prefix-based blocking in `sanitizePreviewGuardNextPath` with exact-path blocking for `/admin/login`
- kept existing newline, protocol-relative, and external-origin protections unchanged
- added a regression test to ensure `/admin/login-help` remains an allowed internal redirect target

## Validation
- `pnpm format`
- `pnpm check`
- `pnpm vitest run tests/unit/features/previewGuard/index.test.ts` *(blocked in sandbox before this retry due tsx IPC permission issue; unchanged test environment caveat)*

## Development
- https://github.com/findmydoc-platform/website/issues/1088
