### PR TITLE
docs: mark repository as proprietary source-available

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+This repository is proprietary and source-available. See [LICENSE.md](./LICENSE.md).
+
+Contributions are accepted only under findmydoc's proprietary terms. Do not submit issues, pull requests, patches, suggestions, documentation changes, designs, code, configuration, or any other contribution unless you agree to these terms.
+
+By submitting a contribution to this repository, you confirm that:
+
+- You have the right to submit the contribution.
+- You grant findmydoc a perpetual, irrevocable, worldwide, royalty-free right to use, copy, modify, publish, distribute, redistribute, sublicense, and create derivative works from the contribution as part of this proprietary project.
+- You understand that findmydoc may accept, reject, modify, or remove the contribution at its discretion.
+- You understand that submitting a contribution does not grant you any license to use, copy, modify, publish, distribute, redistribute, sublicense, or create derivative works from this repository or any findmydoc code.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,11 @@
+# Proprietary License
+
+Copyright (c) findmydoc. All rights reserved.
+
+This repository is proprietary and source-available. The source code may be visible for review by people with access to this repository, but the project is not open source and no rights are granted through public visibility.
+
+Unless findmydoc gives prior written permission, you may not use, copy, modify, merge, publish, distribute, redistribute, sublicense, sell, host, deploy, execute, or create derivative works from any part of this repository.
+
+No rights are granted by implication, estoppel, or otherwise. All rights not expressly granted in writing by findmydoc are reserved.
+
+Third-party dependencies are licensed under their respective terms. Nothing in this license changes any third-party license.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 The findmydoc portal is a PayloadCMS‑powered platform that helps international patients discover trusted clinics and specialists.
 
+## License
+
+This repository is proprietary and source-available. The source code may be visible, but the project is not open source and no permission is given to use, copy, modify, publish, distribute, redistribute, sublicense, or create derivative works from any part of this repository.
+
+All rights are reserved by findmydoc. See [LICENSE.md](./LICENSE.md) for the full license terms and [CONTRIBUTING.md](./CONTRIBUTING.md) for contribution terms.
+
 ## Quick Start
 
 1. git clone https://github.com/findmydoc-platform/website.git

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "findmydoc-portal",
+  "private": true,
   "version": "1.0.0",
   "description": "International patient clinic discovery platform built with PayloadCMS and Next.js",
-  "license": "MIT",
+  "license": "UNLICENSED",
   "type": "module",
   "scripts": {
     "build": "cross-env NODE_OPTIONS=--no-deprecation next build --webpack",


### PR DESCRIPTION
Clarifies that the repository is source-available but remains proprietary and not open source.

## What changed

- Marked the npm package as private and UNLICENSED.
- Added proprietary LICENSE.md terms with all rights reserved by findmydoc.
- Added CONTRIBUTING.md terms for proprietary contributions.
- Added a README license section linking to the license and contribution terms.

## Validation

- rtk pnpm format
- rtk rg -n '"license": "MIT"|MIT License|open-source license|Open Source license' package.json README.md LICENSE.md CONTRIBUTING.md
- rtk node -e "const p=require('./package.json'); if (p.license !== 'UNLICENSED' || p.private !== true) process.exit(1)"

Note: pnpm format reported the existing local Node engine warning because this machine is running Node v26.0.0 while package.json requires >=24.0.0 <25.

## Development

Closes #1092
