### PR TITLE
fix: handle protocol-relative social preview image urls

### DIFF
--- a/src/utilities/socialPreview.ts
+++ b/src/utilities/socialPreview.ts
@@ -30,6 +30,9 @@ export type SocialPreviewImage = {
 
 export const getAbsoluteSiteURL = (pathOrURL = '/') => {
   if (/^https?:\/\//i.test(pathOrURL)) return pathOrURL
+  if (pathOrURL.startsWith('//')) {
+    return `${new URL(getServerSideURL()).protocol}${pathOrURL}`
+  }
 
   const normalizedPath = pathOrURL.startsWith('/') ? pathOrURL : `/${pathOrURL}`
   return `${getServerSideURL().replace(/\/+$/, '')}${normalizedPath}`

--- a/tests/unit/utilities/socialPreview.test.ts
+++ b/tests/unit/utilities/socialPreview.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/utilities/getURL', () => ({
+  getServerSideURL: vi.fn(() => 'https://findmydoc.eu/'),
+}))
+
+describe('socialPreview', () => {
+  it('keeps absolute http(s) URLs unchanged', async () => {
+    const { getAbsoluteSiteURL } = await import('@/utilities/socialPreview')
+
+    expect(getAbsoluteSiteURL('https://cdn.example.com/og.jpg')).toBe('https://cdn.example.com/og.jpg')
+  })
+
+  it('converts protocol-relative URLs to absolute URLs', async () => {
+    const { getAbsoluteSiteURL } = await import('@/utilities/socialPreview')
+
+    expect(getAbsoluteSiteURL('//cdn.example.com/og.jpg')).toBe('https://cdn.example.com/og.jpg')
+  })
+
+  it('builds absolute URLs for internal paths', async () => {
+    const { getAbsoluteSiteURL } = await import('@/utilities/socialPreview')
+
+    expect(getAbsoluteSiteURL('/care')).toBe('https://findmydoc.eu/care')
+  })
+})


### PR DESCRIPTION
social previews keep valid image URLs when protocol-relative sources are provided.

## What changed
- add protocol-relative URL handling in `getAbsoluteSiteURL` within `src/utilities/socialPreview.ts`
- convert `//...` URLs into absolute URLs with the current server protocol
- add unit regression tests in `tests/unit/utilities/socialPreview.test.ts` for absolute, protocol-relative, and internal path inputs

## Validation
- `pnpm format`
- `pnpm check`
- `pnpm vitest run tests/unit/utilities/socialPreview.test.ts` *(fails in this environment due to known tsx IPC EPERM in unit global setup)*

## Development
- Closes #1097
