### PR TITLE
feat: add db quality gate

### DIFF
--- a/.codex/rules/safety.rules
+++ b/.codex/rules/safety.rules
@@ -82,3 +82,43 @@ prefix_rule(
         "git clean -n -ffdx",
     ],
 )
+
+prefix_rule(
+    pattern = ["pnpm", "run", "payload", "migrate:fresh"],
+    decision = "prompt",
+    justification = "Payload migrate:fresh is destructive. Confirm this targets a disposable local/test database and never production.",
+    match = [
+        "pnpm run payload migrate:fresh",
+        "pnpm run payload migrate:fresh -- --force",
+    ],
+    not_match = [
+        "pnpm run payload migrate",
+        "pnpm run payload migrate:status",
+    ],
+)
+
+prefix_rule(
+    pattern = ["pnpm", "payload", "migrate:fresh"],
+    decision = "prompt",
+    justification = "Payload migrate:fresh is destructive. Confirm this targets a disposable local/test database and never production.",
+    match = [
+        "pnpm payload migrate:fresh",
+        "pnpm payload migrate:fresh --force",
+    ],
+    not_match = [
+        "pnpm payload migrate",
+        "pnpm payload migrate:status",
+    ],
+)
+
+prefix_rule(
+    pattern = ["pnpm", "run", "generateDBFromScratch"],
+    decision = "prompt",
+    justification = "generateDBFromScratch deletes migration files and rebuilds a database. Confirm this targets only disposable local/test state.",
+    match = [
+        "pnpm run generateDBFromScratch",
+    ],
+    not_match = [
+        "pnpm run generate",
+    ],
+)

--- a/.github/scripts/ci/detect-migration-diff.sh
+++ b/.github/scripts/ci/detect-migration-diff.sh
@@ -9,33 +9,77 @@ if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
   exit 1
 fi
 
+if [[ "${event_name}" == "workflow_dispatch" ]]; then
+  {
+    echo "db_changed=true"
+    echo "schema_changed=false"
+    echo "migrations_changed=false"
+    echo "risk_scan_needed=false"
+    echo "changed_files="
+  } >> "$GITHUB_OUTPUT"
+  echo "Manual dispatch: forcing DB quality migration checks."
+  exit 0
+fi
+
 if [[ "${event_name}" == "pull_request" && -n "${base_ref}" ]]; then
   git fetch --no-tags --depth=1 origin "${base_ref}"
   range="origin/${base_ref}...HEAD"
+  fallback_range="origin/${base_ref}..HEAD"
 elif git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
   range="HEAD~1...HEAD"
+  fallback_range="HEAD~1..HEAD"
 else
   range="HEAD"
+  fallback_range="HEAD"
 fi
 
-changed_files="$(git diff --name-only --diff-filter=ACMR "${range}" || true)"
+if ! changed_files="$(git diff --name-only --diff-filter=ACMR "${range}" 2>/tmp/migration-diff-error.log)"; then
+  echo "Unable to diff ${range}; falling back to ${fallback_range}." >&2
+  cat /tmp/migration-diff-error.log >&2 || true
+  changed_files="$(git diff --name-only --diff-filter=ACMR "${fallback_range}" || true)"
+fi
 
 echo "Diff range: ${range}"
+if [[ "${fallback_range}" != "${range}" ]]; then
+  echo "Fallback diff range: ${fallback_range}"
+fi
 echo "Changed files:"
 echo "${changed_files:-<none>}"
 
 # Block renderers live under src/blocks too, but only block config files affect the Payload schema.
 schema_pattern='^(src/collections/|src/globals/|src/fields/|src/plugins/|src/payload\.config\.ts|src/blocks/[^[:space:]]+/config\.tsx?$)'
 migration_pattern='^src/migrations/'
+db_tooling_pattern='^(\.github/workflows/db-quality\.yml|\.github/workflows/deploy\.yml|\.github/scripts/ci/(detect-migration-diff|enforce-schema-migration|wait-for-postgres)\.sh|scripts/(migration-risk-scan|test-database-harness)\.mjs|vitest\.config\.ts)$'
+
+schema_changed=false
+migrations_changed=false
+db_tooling_changed=false
 
 if grep -Eq "${schema_pattern}" <<<"${changed_files}"; then
-  echo "schema_changed=true" >> "$GITHUB_OUTPUT"
-else
-  echo "schema_changed=false" >> "$GITHUB_OUTPUT"
+  schema_changed=true
 fi
 
 if grep -Eq "${migration_pattern}" <<<"${changed_files}"; then
-  echo "migrations_changed=true" >> "$GITHUB_OUTPUT"
-else
-  echo "migrations_changed=false" >> "$GITHUB_OUTPUT"
+  migrations_changed=true
 fi
+
+if grep -Eq "${db_tooling_pattern}" <<<"${changed_files}"; then
+  db_tooling_changed=true
+fi
+
+db_changed=false
+if [[ "${schema_changed}" == "true" || "${migrations_changed}" == "true" || "${db_tooling_changed}" == "true" ]]; then
+  db_changed=true
+fi
+
+{
+  echo "db_changed=${db_changed}"
+  echo "schema_changed=${schema_changed}"
+  echo "migrations_changed=${migrations_changed}"
+  echo "risk_scan_needed=${migrations_changed}"
+  {
+    echo "changed_files<<EOF"
+    echo "${changed_files}"
+    echo "EOF"
+  }
+} >> "$GITHUB_OUTPUT"

--- a/.github/workflows/db-quality.yml
+++ b/.github/workflows/db-quality.yml
@@ -1,0 +1,214 @@
+name: DB Quality
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: 24.14.0
+  PNPM_VERSION: 10.28.2
+  NEXT_TELEMETRY_DISABLED: 1
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  detect-db-changes:
+    name: detect db changes
+    runs-on: ubuntu-latest
+    outputs:
+      db_changed: ${{ steps.detect.outputs.db_changed }}
+      schema_changed: ${{ steps.detect.outputs.schema_changed }}
+      migrations_changed: ${{ steps.detect.outputs.migrations_changed }}
+      risk_scan_needed: ${{ steps.detect.outputs.risk_scan_needed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect DB quality changes
+        id: detect
+        env:
+          CI_EVENT_NAME: ${{ github.event_name }}
+          CI_BASE_REF: ${{ github.base_ref }}
+        run: bash ./.github/scripts/ci/detect-migration-diff.sh "$CI_EVENT_NAME" "$CI_BASE_REF"
+
+      - name: Summarize DB quality scope
+        run: |
+          {
+            echo "## DB Quality Scope"
+            echo "- **DB changed**: ${{ steps.detect.outputs.db_changed }}"
+            echo "- **Schema changed**: ${{ steps.detect.outputs.schema_changed }}"
+            echo "- **Migrations changed**: ${{ steps.detect.outputs.migrations_changed }}"
+            echo "- **Risk scan needed**: ${{ steps.detect.outputs.risk_scan_needed }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  migration-risk-scan:
+    name: migration risk scan
+    needs: detect-db-changes
+    if: needs.detect-db-changes.outputs.risk_scan_needed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Run advisory migration risk scan
+        env:
+          CI_EVENT_NAME: ${{ github.event_name }}
+          CI_BASE_REF: ${{ github.base_ref }}
+        run: node scripts/migration-risk-scan.mjs --event-name "$CI_EVENT_NAME" --base-ref "$CI_BASE_REF"
+
+  migration-apply-status:
+    name: migration apply and status
+    needs: detect-db-changes
+    if: needs.detect-db-changes.outputs.db_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      PAYLOAD_SECRET: dev-secret
+      PREVIEW_SECRET: test-preview-secret
+      DATABASE_URI: postgresql://postgres:password@localhost:5432/findmydoc-portal
+    services:
+      postgres:
+        image: postgis/postgis:15-3.3
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: findmydoc-portal
+        options: >-
+          --health-cmd "pg_isready -U postgres -h localhost -d postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Wait for PostgreSQL service
+        run: bash ./.github/scripts/ci/wait-for-postgres.sh "${{ job.services.postgres.id }}"
+
+      - name: Run database migrations
+        run: pnpm run migrate
+
+      - name: Check migration status
+        run: pnpm run payload migrate:status
+
+  schema-migration-enforcement:
+    name: schema migration enforcement
+    needs: detect-db-changes
+    if: needs.detect-db-changes.outputs.schema_changed == 'true' && needs.detect-db-changes.outputs.migrations_changed != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      PAYLOAD_SECRET: dev-secret
+      PREVIEW_SECRET: test-preview-secret
+      DATABASE_URI: postgresql://postgres:password@localhost:5432/findmydoc-portal
+    services:
+      postgres:
+        image: postgis/postgis:15-3.3
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: findmydoc-portal
+        options: >-
+          --health-cmd "pg_isready -U postgres -h localhost -d postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Wait for PostgreSQL service
+        run: bash ./.github/scripts/ci/wait-for-postgres.sh "${{ job.services.postgres.id }}"
+
+      - name: Run existing migrations before alignment check
+        run: pnpm run migrate
+
+      - name: Enforce committed migrations for schema changes
+        run: bash ./.github/scripts/ci/enforce-schema-migration.sh
+
+  db-quality-gate:
+    name: db-quality-gate
+    needs:
+      - detect-db-changes
+      - migration-risk-scan
+      - migration-apply-status
+      - schema-migration-enforcement
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce DB quality policy
+        run: |
+          if [ "${{ needs.detect-db-changes.result }}" != "success" ]; then
+            echo "DB quality change detection did not complete successfully."
+            exit 1
+          fi
+
+          if [ "${{ needs.detect-db-changes.outputs.risk_scan_needed }}" = "true" ] && [ "${{ needs.migration-risk-scan.result }}" != "success" ]; then
+            echo "Migration risk scan did not complete successfully."
+            exit 1
+          fi
+
+          if [ "${{ needs.detect-db-changes.outputs.db_changed }}" = "true" ] && [ "${{ needs.migration-apply-status.result }}" != "success" ]; then
+            echo "DB-relevant files changed, but migration apply/status checks did not pass."
+            exit 1
+          fi
+
+          if [ "${{ needs.detect-db-changes.outputs.schema_changed }}" = "true" ] && [ "${{ needs.detect-db-changes.outputs.migrations_changed }}" != "true" ] && [ "${{ needs.schema-migration-enforcement.result }}" != "success" ]; then
+            echo "Schema files changed without committed migrations, and enforcement did not pass."
+            exit 1
+          fi
+
+          if [ "${{ needs.detect-db-changes.outputs.db_changed }}" != "true" ]; then
+            echo "No DB-relevant changes detected."
+          fi
+
+          echo "DB quality policy satisfied."

--- a/.github/workflows/db-quality.yml
+++ b/.github/workflows/db-quality.yml
@@ -82,9 +82,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      PAYLOAD_SECRET: dev-secret
-      PREVIEW_SECRET: test-preview-secret
-      DATABASE_URI: postgresql://postgres:password@localhost:5432/findmydoc-portal
+      PAYLOAD_SECRET: dev-secret # pragma: allowlist secret
+      PREVIEW_SECRET: test-preview-secret # pragma: allowlist secret
+      DATABASE_URI: postgresql://postgres:password@localhost:5432/findmydoc-portal # pragma: allowlist secret
     services:
       postgres:
         image: postgis/postgis:15-3.3
@@ -92,7 +92,7 @@ jobs:
           - 5432:5432
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
+          POSTGRES_PASSWORD: password # pragma: allowlist secret
           POSTGRES_DB: findmydoc-portal
         options: >-
           --health-cmd "pg_isready -U postgres -h localhost -d postgres"
@@ -132,9 +132,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      PAYLOAD_SECRET: dev-secret
-      PREVIEW_SECRET: test-preview-secret
-      DATABASE_URI: postgresql://postgres:password@localhost:5432/findmydoc-portal
+      PAYLOAD_SECRET: dev-secret # pragma: allowlist secret
+      PREVIEW_SECRET: test-preview-secret # pragma: allowlist secret
+      DATABASE_URI: postgresql://postgres:password@localhost:5432/findmydoc-portal # pragma: allowlist secret
     services:
       postgres:
         image: postgis/postgis:15-3.3
@@ -142,7 +142,7 @@ jobs:
           - 5432:5432
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
+          POSTGRES_PASSWORD: password # pragma: allowlist secret
           POSTGRES_DB: findmydoc-portal
         options: >-
           --health-cmd "pg_isready -U postgres -h localhost -d postgres"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,9 +126,6 @@ jobs:
       - name: Verify permission matrix alignment
         run: pnpm matrix:verify
 
-      - name: Check migrations
-        run: bash ./.github/scripts/ci/check-migrations-diff.sh "origin/main" "HEAD"
-
       - name: Compare generated payload types
         id: payload_types
         run: pnpm run check:payload-types
@@ -347,25 +344,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Detect schema and migration file changes
-        id: migration_diff
-        env:
-          CI_EVENT_NAME: ${{ github.event_name }}
-          CI_BASE_REF: ${{ github.base_ref }}
-        run: bash ./.github/scripts/ci/detect-migration-diff.sh "$CI_EVENT_NAME" "$CI_BASE_REF"
-
       - name: Wait for PostgreSQL service
         run: bash ./.github/scripts/ci/wait-for-postgres.sh "${{ job.services.postgres.id }}"
 
-      - name: Run database migrations
+      - name: Prepare build database
         run: pnpm run migrate
-
-      - name: Check migration status
-        run: pnpm run payload migrate:status
-
-      - name: Enforce committed migrations for schema changes
-        if: steps.migration_diff.outputs.schema_changed == 'true' && steps.migration_diff.outputs.migrations_changed != 'true'
-        run: bash ./.github/scripts/ci/enforce-schema-migration.sh
 
       - name: Restore Next.js build cache
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
@@ -403,21 +386,6 @@ jobs:
     env:
       PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
       PREVIEW_SECRET: ${{ secrets.PREVIEW_SECRET }}
-      DATABASE_URI: postgresql://postgres:password@localhost:5432/findmydoc-portal
-    services:
-      postgres:
-        image: postgis/postgis:15-3.3
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: findmydoc-portal
-        options: >-
-          --health-cmd "pg_isready -U postgres -h localhost -d postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -435,15 +403,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-
-      - name: Wait for PostgreSQL service
-        run: bash ./.github/scripts/ci/wait-for-postgres.sh "${{ job.services.postgres.id }}"
-
-      - name: Run database migrations
-        run: pnpm run migrate
-
-      - name: Check migration status
-        run: pnpm run payload migrate:status
 
       - name: Run integration tests
         id: integration

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -160,14 +160,14 @@
         "filename": ".github/workflows/deploy.yml",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 317
+        "line_number": 314
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/deploy.yml",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 325
+        "line_number": 322
       }
     ],
     "docker-compose.test.yml": [
@@ -11267,5 +11267,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-08T21:21:44Z"
+  "generated_at": "2026-06-09T11:51:00Z"
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,32 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Next.js: debug full stack",
-      "type": "node",
+      "name": "Next.js: debug server-side",
+      "type": "node-terminal",
       "request": "launch",
-      "program": "${workspaceFolder}/node_modules/next/dist/bin/next",
-      "runtimeArgs": ["--inspect"],
+      "command": "pnpm dev --inspect --webpack",
       "skipFiles": ["<node_internals>/**"],
       "sourceMaps": true,
+      "smartStep": true,
+      "outFiles": ["${workspaceFolder}/.next/**/*.js"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "Next.js: debug client-side",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}"
+    },
+    {
+      "name": "Next.js: debug full stack",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "pnpm dev --inspect --webpack",
+      "skipFiles": ["<node_internals>/**"],
+      "sourceMaps": true,
+      "smartStep": true,
+      "outFiles": ["${workspaceFolder}/.next/**/*.js"],
       "serverReadyAction": {
         "action": "debugWithChrome",
         "killOnServerStop": true,
@@ -19,12 +38,20 @@
         "uriFormat": "%s",
         "webRoot": "${workspaceFolder}"
       },
-      "resolveSourceMapLocations": [
-        "${workspaceFolder}/**",
-        "!**/node_modules/**", // make sure to exclude node_modules, since
-        "!**/.next/**"
-      ],
       "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "Payload: attach to running server",
+      "type": "node",
+      "request": "attach",
+      "port": 9229,
+      "address": "127.0.0.1",
+      "localRoot": "${workspaceFolder}",
+      "remoteRoot": "${workspaceFolder}",
+      "skipFiles": ["<node_internals>/**"],
+      "sourceMaps": true,
+      "smartStep": true,
+      "outFiles": ["${workspaceFolder}/.next/**/*.js"]
     }
   ]
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,3 +19,4 @@ Use this index as the main entry point for project documentation.
 - [Security Documentation](./security/README.md)
 - [Testing Documentation](./testing/README.md)
 - [Architecture Decision Records (ADRs)](./adrs/README.md)
+- [Roadmaps](./roadmap/README.md)

--- a/docs/adrs/020-adr-database-migration-quality-gate.md
+++ b/docs/adrs/020-adr-database-migration-quality-gate.md
@@ -1,0 +1,88 @@
+# ADR: Database Migration Quality Gate
+
+## Status (Table)
+
+| Name    | Content            |
+| ------- | ------------------ |
+| Author  | Sebastian Schuetze |
+| Version | 1.0                |
+| Date    | 08.06.2026         |
+| Status  | accepted           |
+
+## Background
+
+findmydoc is moving closer to production operation while still working within a lean MVP toolset: Payload migrations, Supabase, Vercel, GitHub Actions, and the limits of the free or low-cost tiers currently available to the project.
+
+Database changes are one of the highest operational risks in that phase. A broken migration, forgotten migration file, destructive schema change, or untested backfill can affect production data more severely than most application-code regressions.
+
+This decision raises database migration quality and production readiness with the tools available now, while keeping a clear path toward stronger production-data rehearsal later.
+
+The first step is a CI-backed safety baseline because stronger production-shaped rehearsals require backup, restore, and data-handling controls that are not mature yet in the current free or low-cost toolset.
+
+## Problem Description
+
+Database migration quality had been mixed into the general PR validation workflow. That made the change look like a workflow concern, but the underlying problem is operational: the project needs a safer path for database evolution before production usage increases.
+
+The project needs a stable merge gate that:
+
+- improves production readiness for schema changes within the current tool constraints
+- always reports a required check result when configured in branch protection
+- runs heavier database checks only for database-relevant changes
+- blocks missing or broken migrations before merge
+- keeps advisory semantic risk detection separate from hard correctness checks
+- avoids production database access from normal CI
+- remains small enough to operate before a dedicated backup and production-data rehearsal strategy exists
+
+## Decision with Rationale
+
+Database and migration validation belongs to a dedicated workflow that runs for every pull request.
+
+The workflow has a final mandatory result that must be green before merge. Earlier jobs may run only when database-relevant changes exist, but the final outcome always exists and evaluates whether the skipped or executed jobs satisfy the database quality policy.
+
+General PR validation remains responsible for formatting, linting, tests, build validation, and runtime-oriented checks. It may prepare a disposable local build database when the build requires one, but it does not own missing-migration enforcement, migration status decisions, or migration risk policy.
+
+DB Quality starts with a fresh local Postgres/PostGIS service and validates that migrations apply cleanly and leave Payload in a clean migration status. This is a deliberate baseline: it catches missing files, syntax/runtime failures, and broken migration ordering without coupling merge validation to production data.
+
+This baseline fits the current toolset. GitHub Actions can run disposable database containers, while Vercel remains focused on deployment builds. Supabase Free does not replace an explicit backup, restore, branching, or rehearsal strategy, so normal merge validation must stay independent from production data until those controls are designed.
+
+The migration risk scan remains advisory at first. Blocking semantic rules should be added only when the rule is narrow, evidence-backed, and has a low false-positive rate.
+
+## Consequences
+
+### Positive
+
+- Database changes receive an explicit production-readiness boundary instead of being treated as ordinary application validation.
+- Branch protection can require one stable DB quality check that always exists.
+- Pull requests without database-relevant changes stay green without running heavy database jobs.
+- Missing migrations and broken migration application are blocked before merge.
+- Database quality ownership is explicit and easier to evolve independently from general PR validation.
+- The deploy workflow stays focused on application validation instead of becoming the migration policy owner.
+- The repository now has a practical stepping stone toward later backup-based migration rehearsal.
+
+### Trade-offs
+
+- A fresh local database proves migration executability, not production compatibility.
+- Advisory risk scanning can miss semantic risks until blocking rules are intentionally narrowed and promoted.
+- Build and integration workflows may still prepare disposable databases for their own runtime needs; that preparation is not the source of truth for migration quality.
+- The workflow structure is more visible than the operational reason behind it unless PR and release documentation keep the production-readiness framing explicit.
+
+## Non-goals
+
+- DB Quality does not query production databases.
+- DB Quality does not use production data in the normal PR merge gate.
+- DB Quality does not replace backup, restore, point-in-time recovery, or release-runbook discipline.
+- DB Quality does not prove lock duration, data distribution, backfill correctness, or destructive-change safety on existing production data.
+
+## Future Work
+
+Migration quality should later include a protected production-shape rehearsal path backed by a real backup strategy. That path should restore a recent backup or dump into an isolated database, run pending migrations against the restored data, and verify migration status plus targeted data assertions.
+
+That future rehearsal should be separate from the normal required PR gate at first. It needs stronger operational controls because it may handle production-shaped data: protected workflow triggers, restricted secrets, encrypted backup storage, no plaintext dump artifacts, and no untrusted pull request code.
+
+## Deprecated (Optional)
+
+None.
+
+## Superseded by (Optional)
+
+None.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -68,3 +68,4 @@ When adding a new ADR:
 - [017 — Payload virtual fields pilot for post author projection](./017-adr-payload-virtual-fields-post-populated-authors.md)
 - [018 — Native Payload CMS localization strategy](./018-adr-native-payload-localization-strategy.md)
 - [019 — PostHog event taxonomy and usage governance](./019-adr-posthog-event-taxonomy-and-usage-governance.md)
+- [020 — Database migration quality gate](./020-adr-database-migration-quality-gate.md)

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -32,11 +32,38 @@ Keep schema changes safe and repeatable across local development, preview, and p
 5. Commit schema and migration files together.
 6. Open PR and wait for CI gates.
 
+## Production-Safe Schema and Data Changes
+
+Use an expand/backfill/switch/contract flow for changes that rename fields, move data, harden constraints, or remove data.
+
+1. **Expand**: add the new field, table, relation, or nullable/defaulted constraint without removing the old shape.
+2. **Backfill**: copy or transform existing data with an idempotent migration or operator script. Re-running the backfill must not corrupt data.
+3. **Switch**: update application reads and writes to prefer the new shape. Keep compatibility with the old shape until the active deployment no longer depends on it.
+4. **Contract**: remove the old field, table, fallback, or data only in a later release after production has run successfully on the new shape.
+
+Rules:
+
+- Treat field renames as `add new field -> backfill -> switch reads/writes -> drop old field`.
+- Introduce required fields as nullable or defaulted first, backfill them, verify null counts, and harden the constraint later.
+- Keep destructive SQL (`DROP COLUMN`, `DROP TABLE`, `TRUNCATE`, `DELETE FROM`) out of the first release that introduces replacement storage.
+- Document before/after counts for backfills and destructive cleanup.
+- Confirm backup / point-in-time recovery before any contract-stage migration that removes production data.
+- Prefer soft-delete or archival states before hard deletion when business data may still be needed.
+
+Production data checks:
+
+- CI must not query production databases.
+- Use a backup restore, snapshot, or read replica as the default source for production-shape verification.
+- Direct production reads are an exception and require a technically read-only role, bounded `SELECT` queries, and a documented migration decision.
+
 ## CI Guardrails
 
 - If schema-related files changed but no migration files were committed, CI runs a Payload alignment check.
 - If Payload can generate a migration, CI fails until migration files are committed.
 - This catches “forgot migration” issues before preview/production deploys.
+- The **DB Quality** workflow always runs a required gate job, while heavy migration checks run only for DB-relevant changes.
+- DB Quality applies migrations to a local CI Postgres instance and runs `pnpm payload migrate:status`.
+- The advisory migration risk scan warns on destructive or compatibility-sensitive SQL patterns; warnings do not block merges until the policy is intentionally tightened.
 
 ## Incident/Emergency Rules
 

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -13,14 +13,17 @@ Keep schema changes safe and repeatable across local development, preview, and p
 
 ## When Migrations Run
 
-1. **Pull Request build job (GitHub Actions)**  
-   The build job starts a local Postgres service, applies migrations, and runs `pnpm payload migrate:status`.
+1. **DB Quality workflow (GitHub Actions)**
+   DB Quality starts a local Postgres service, applies migrations, and runs `pnpm payload migrate:status` when DB-relevant files changed.
 
-2. **Preview deployment (Vercel)**  
-   Vercel executes `pnpm run ci` via `vercel.json`.  
+2. **Pull Request build job (GitHub Actions)**
+   The build job starts a local Postgres service and prepares a disposable build database before `pnpm build`. Migration status and schema/migration enforcement live in DB Quality.
+
+3. **Preview deployment (Vercel)**
+   Vercel executes `pnpm run ci` via `vercel.json`.
    `pnpm run ci` runs `pnpm run migrate` before `pnpm build`.
 
-3. **Production deployment (Vercel)**  
+4. **Production deployment (Vercel)**
    Same as preview: `pnpm run ci` runs migrations before the build.
 
 ## Developer Workflow for Schema Changes

--- a/docs/engineering/ci-modularization-plan.md
+++ b/docs/engineering/ci-modularization-plan.md
@@ -15,7 +15,7 @@ This document captures the current CI workflow boundaries and the remaining foll
 The repository now uses a hybrid workflow model with clear top-level ownership:
 
 - `deploy.yml` is the primary **PR Validation** workflow.
-- `db-quality.yml` owns the stable database quality gate; `deploy.yml` may still run legacy migration checks during the transition.
+- `db-quality.yml` owns the stable database quality gate.
 - `workflow-security.yml` owns workflow and secret-scan validation.
 - `deploy-preview.yml` owns preview deployment.
 - `deploy-production.yml` owns manual production deployment.
@@ -34,13 +34,13 @@ Current scope:
 
 - formatting check
 - permission matrix derivation and verification
-- migration diff checks
 - payload type checks
 - story governance check
 - lint
 - unit tests
 - Storybook tests
 - build
+- local build database preparation
 - integration tests for targeted PR paths and on `main`
 - combined coverage reporting
 
@@ -56,9 +56,9 @@ Current scope:
 - local Postgres migration apply/status checks
 - committed migration enforcement for schema changes
 
-Transition note:
+Branch protection should require only the stable `DB Quality / db-quality-gate` job from this workflow, not the conditional migration jobs.
 
-- `deploy.yml` still carries migration apply/status checks until branch protection and duplicate responsibility are intentionally cleaned up.
+Decision record: [ADR 020 — Database migration quality gate](../adrs/020-adr-database-migration-quality-gate.md).
 
 ### `workflow-security.yml`
 
@@ -157,6 +157,7 @@ These workflows remain intentionally focused and are not part of the modularizat
 Update GitHub branch protection so the required checks reflect the new workflow boundaries:
 
 - `PR Validation`
+- `DB Quality / db-quality-gate`
 - `Workflow Security`
 - any intentionally required specialized workflows such as docs or admin smoke
 

--- a/docs/engineering/ci-modularization-plan.md
+++ b/docs/engineering/ci-modularization-plan.md
@@ -15,6 +15,7 @@ This document captures the current CI workflow boundaries and the remaining foll
 The repository now uses a hybrid workflow model with clear top-level ownership:
 
 - `deploy.yml` is the primary **PR Validation** workflow.
+- `db-quality.yml` owns the stable database quality gate; `deploy.yml` may still run legacy migration checks during the transition.
 - `workflow-security.yml` owns workflow and secret-scan validation.
 - `deploy-preview.yml` owns preview deployment.
 - `deploy-production.yml` owns manual production deployment.
@@ -42,6 +43,22 @@ Current scope:
 - build
 - integration tests for targeted PR paths and on `main`
 - combined coverage reporting
+
+### `db-quality.yml`
+
+Purpose: merge-critical database and migration validation with a stable branch-protection gate.
+
+Current scope:
+
+- always-on DB quality gate for branch protection
+- DB-relevant path detection through the shared migration-diff detector
+- advisory migration risk scan for destructive or compatibility-sensitive SQL
+- local Postgres migration apply/status checks
+- committed migration enforcement for schema changes
+
+Transition note:
+
+- `deploy.yml` still carries migration apply/status checks until branch protection and duplicate responsibility are intentionally cleaned up.
 
 ### `workflow-security.yml`
 
@@ -101,7 +118,9 @@ Current scope:
 | --- | --- | --- |
 | `pnpm format:check` | PR validation | Fast, deterministic, merge-critical |
 | permission matrix checks | PR validation | Access-control regression guard |
-| migration diff / committed migration enforcement | PR validation | Prevents deploy drift |
+| migration diff / committed migration enforcement | DB quality | Prevents deploy drift |
+| migration risk scan | DB quality | Surfaces destructive or compatibility-sensitive migrations early |
+| local migration apply/status | DB quality | Verifies migrations against local CI Postgres |
 | `pnpm run check:payload-types` | PR validation | Merge-critical |
 | `pnpm lint` | PR validation | Merge-critical |
 | story governance check | PR validation | Existing repo policy |

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,0 +1,6 @@
+# Roadmap Index
+
+Use these roadmap notes for planned work that has real future implementation or operating impact.
+
+- [DB Stability and Schema Change Roadmap](./db-stability/README.md)
+- [Patient Favorites Roadmap](./patient-favorites/README.md)

--- a/docs/roadmap/db-stability/README.md
+++ b/docs/roadmap/db-stability/README.md
@@ -1,0 +1,242 @@
+# DB Stability and Schema Change Roadmap
+
+This roadmap tracks the remaining high-impact database stability questions around schema changes, migrations, preview deployments, and production releases. It is intentionally scoped to risks above `7/10` severity. Smaller CI polish, naming cleanup, or style work belongs in normal issues, not here.
+
+## Existing Guardrails
+
+- DB Quality now follows the required-gate pattern: the workflow always runs, heavy checks run only for DB-relevant changes, and `db-quality-gate` is the only branch-protection candidate.
+- Schema changes without committed migration files are blocked through the existing Payload migration generation check.
+- Migration apply/status checks run against a fresh local Postgres service in CI.
+- The migration risk scan is advisory and warns on destructive or compatibility-sensitive SQL patterns.
+- `src/migrations/AGENTS.md` and `docs/deployment-runbook.md` already document expand -> backfill -> switch -> contract, no production reads from CI, and no production `migrate:fresh`.
+
+## Scope Review
+
+The current DB Quality work is useful and should remain small. It catches missing migrations, broken migration application, and required-check gaps before merge. Those are concrete failure modes and not speculative process.
+
+Keep:
+
+- The always-running `db-quality-gate` job. It solves the required-check problem without forcing heavy jobs for unrelated PRs.
+- The shared change detector. It keeps DB-relevant path logic in one place for DB Quality and future DB-specific checks.
+- Local migration apply/status checks. They are not production-grade validation, but they are a cheap correctness floor.
+- The advisory risk scan as a review signal. It should stay advisory until the blocking rules are narrowed to a few high-confidence classes.
+- The migration-local `AGENTS.md` and deployment runbook. They shift left human and AI behavior without adding runtime complexity.
+
+Reduce or avoid:
+
+- Do not build a generic policy-gate abstraction until at least one more workflow needs the exact same structure.
+- Do not move database quality decisions back into `deploy.yml`. The build job may still prepare a disposable build database, but missing-migration enforcement, migration status, and risk scanning belong to DB Quality.
+- Do not add production reads to CI. Production-shape validation should use a restored backup, snapshot, read replica, or database branch.
+- Do not expand the risk scanner into a broad regex catalog. Add blocking rules only when they map to known production incident classes and have low false-positive rates.
+- Do not treat the local fresh-DB migration job as proof of production safety. It proves migration executability, not production compatibility.
+
+## Findings to Track
+
+### 1. Production migrations run inside the Vercel build
+
+Severity: `9/10`
+
+Production deployment currently pulls Production Vercel environment variables and runs the Vercel production deploy. Vercel uses `pnpm run ci`, and `pnpm run ci` runs `pnpm run migrate` before `pnpm build`. That means production schema mutation happens as part of the build/deploy path, before the deployment alias is the only active production version.
+
+Why it matters:
+
+- If migration succeeds but build, deploy, or aliasing fails, the production database can be ahead of the running application.
+- If a migration takes strong locks, live production traffic can block during a build step.
+- Rollback is asymmetric: rolling app code back is easy, but rolling production data shape back may be impossible without data loss.
+- DB Quality does not reduce this risk because it validates a local disposable database, not release orchestration against production.
+
+Current evidence:
+
+- `vercel.json` sets `buildCommand` to `pnpm run ci`.
+- `package.json` defines `ci` as `pnpm run migrate && pnpm build`.
+- `.github/workflows/deploy-production.yml` pulls Production Vercel env and delegates deploy to `.github/scripts/deploy/vercel-deploy.sh`.
+- Payload migrations run within a transaction through Payload's migration runner.
+
+Minimum next step:
+
+- Split production migration execution from the Vercel build command, or introduce a guarded production migration step before aliasing with explicit backup/PITR readiness, timeout settings, and release compatibility checks.
+
+Target shape:
+
+1. Build deployable artifact without mutating the production database.
+2. Run production migration step only after approval and preflight checks.
+3. Use `lock_timeout` and `statement_timeout` for production DDL.
+4. Apply only expand-stage migrations automatically.
+5. Alias or promote the app after migration success.
+6. Run contract-stage migrations in separate releases after compatibility evidence exists.
+
+Open questions:
+
+- Which system owns the migration step: GitHub Actions, Vercel deploy hook, or a manual operator workflow?
+- Do Production environment approvals already enforce backup/PITR confirmation, or does the workflow need an explicit checklist?
+- Can Payload's transactional migration runner be bypassed or configured for the small set of non-transactional DDL operations such as concurrent index creation?
+
+### 2. Preview deployments may contaminate a shared preview database
+
+Severity: `8.5/10`
+
+Trusted PR preview deployments pull the Preview Vercel environment and deploy to Vercel. Because Vercel also runs `pnpm run ci`, a PR preview can apply that PR's migrations to the Preview database.
+
+Why it matters:
+
+- If all PRs share one Preview database, an unmerged PR can permanently advance preview schema.
+- A later preview deploy from another branch may run against a database containing migrations that do not exist in that branch.
+- Payload `migrate:status` compares known migration files to DB records, but it does not fail on DB migration records that are absent from the current checkout.
+- Preview drift weakens E2E confidence because failures can depend on prior preview deployments rather than the current PR.
+
+Current evidence:
+
+- `.github/workflows/deploy-preview.yml` runs for trusted PRs and pulls Preview Vercel env.
+- `vercel.json` and `package.json` make preview deploys run migrations before build.
+- The current reset workflow is Preview-only and destructive by design, which is useful for emergencies but not a drift-prevention strategy.
+
+Minimum next step:
+
+- Confirm whether preview deployments share one database. If yes, add a preview drift detector that compares `payload-migrations` rows against `src/migrations/index.ts` and blocks or warns when the database has unknown migrations.
+
+Target shape:
+
+1. Prefer per-PR database branches, per-PR schemas, or disposable preview databases.
+2. If shared preview must remain, prevent PR previews from applying migrations automatically.
+3. Keep destructive preview reset as an explicit emergency workflow only.
+4. Add a visible preview schema state summary to deploy output.
+
+Open questions:
+
+- Is the Vercel Preview `DATABASE_URI` shared across all PRs?
+- Is there a Supabase branching or backup-restore workflow available for PR previews?
+- Should preview database drift block preview deploys, or only block merge once DB Quality owns snapshot rehearsal?
+
+### 3. CI validates a fresh local database, not production-shaped data
+
+Severity: `8.5/10`
+
+DB Quality applies migrations to a fresh local Postgres service. This catches syntax errors, missing migrations, and baseline apply failures, but it does not validate existing production data, table size, duplicate values, backfill assumptions, or lock duration.
+
+Why it matters:
+
+- A unique index can pass on an empty database and fail on production duplicates.
+- `SET NOT NULL`, foreign keys, and check constraints can pass locally while failing on existing rows.
+- Backfills can be correct on a small database but too slow or too lock-heavy on production-sized tables.
+- This creates false confidence: green CI means the migration is executable, not that it is production-safe.
+
+Current evidence:
+
+- DB Quality starts a new Postgres container and runs `pnpm run migrate`.
+- `docs/deployment-runbook.md` already says production data checks should use backup restores, snapshots, or read replicas rather than direct CI reads.
+
+Minimum next step:
+
+- Define a production-shape rehearsal path that restores an anonymized backup, latest snapshot, database branch, or read-replica-derived dump into disposable Postgres and then runs pending migrations.
+
+Target shape:
+
+1. Run fresh-DB checks on every DB-relevant PR.
+2. Run production-shape rehearsal for `backfill`, `constraint-hardening`, and `destructive` migrations.
+3. Capture before/after counts, null counts, duplicate checks, changed row counts, runtime, and migration status.
+4. Keep production credentials out of CI jobs unless the job is explicitly designed as a read-only exception.
+
+Open questions:
+
+- What source is acceptable for production-shaped data: Supabase backup restore, anonymized dump, read replica, or database branch?
+- How often can a snapshot be refreshed without creating operational risk?
+- Which tables need redaction before being used in CI?
+
+### 4. The advisory risk scanner misses key lock and transaction classes
+
+Severity: `8/10`
+
+The current risk scanner warns on destructive and compatibility-sensitive patterns, but it does not block merges. It also does not yet reason about common production lock classes such as non-concurrent index creation on existing tables, constraint validation strategy, missing timeouts, or Payload transaction incompatibility with `CREATE INDEX CONCURRENTLY`.
+
+Why it matters:
+
+- A short generated migration can hold locks on a large production table.
+- `CREATE INDEX CONCURRENTLY` is safer for writes, but PostgreSQL requires it to run outside a transaction block.
+- Payload's migration runner currently initializes a transaction for each migration, so non-transactional DDL needs an explicit strategy.
+- Broad advisory warnings can become noise if they are expanded without a severity model.
+
+Current evidence:
+
+- The scanner emits GitHub warning annotations and exits successfully on findings.
+- Payload's migration runner calls `initTransaction` before running each migration.
+- Current scanner rules cover destructive operations, renames, `SET NOT NULL`, type conversion, and broad updates, but not index/constraint/timeout classes.
+
+Minimum next step:
+
+- Keep the scanner advisory, but add a small blocking rule set only for high-confidence incident classes after the release workflow decision is clear.
+
+Target blocking classes:
+
+1. Non-concurrent `CREATE INDEX` or `CREATE UNIQUE INDEX` on an existing table.
+2. `CREATE INDEX CONCURRENTLY` inside the default Payload transactional migration path unless a non-transactional runner is explicitly used.
+3. Direct constraint hardening on existing tables without staged `NOT VALID` or evidence of prior validation.
+4. Production-bound DDL without `lock_timeout` and `statement_timeout` policy.
+
+Open questions:
+
+- Should blocking scanner output be part of DB Quality or a separate deep-quality lane at first?
+- Can the scanner parse SQL structurally instead of relying on regex once it starts blocking merges?
+- How should existing-table detection work for generated Payload migrations that create tables and indexes in the same file?
+
+## Proposed Sequence
+
+1. Keep the current DB Quality gate as the merge-critical baseline.
+2. Configure branch protection to require only `DB Quality / db-quality-gate`.
+3. Decide the production migration owner and remove production migration execution from the Vercel build path.
+4. Verify preview database topology and add either preview isolation or drift detection.
+5. Design production-shape rehearsal with restored backup, snapshot, read replica, or database branch.
+6. Convert a very small set of scanner findings from advisory to blocking after the migration runner strategy is known.
+
+## Further Readings
+
+Real-world operating playbooks:
+
+- [GitLab: Avoiding downtime in migrations](https://docs.gitlab.com/development/database/avoiding_downtime_in_migrations/) - large-scale playbooks for drops, renames, type changes, constraints, and multi-release compatibility.
+- [GitLab: Migration Style Guide](https://docs.gitlab.com/development/migration_style_guide/) - practical migration authoring rules around transactions, lock retries, large tables, and multi-database targeting.
+- [GitLab: Database migration pipeline](https://docs.gitlab.com/development/database/database_migration_pipeline/) - production-like migration validation patterns with timing and changed-row visibility.
+- [GitLab: Post-deployment migrations](https://docs.gitlab.com/development/database/post_deployment_migrations/) - release sequencing model for changes that should run after new code is deployed.
+- [GitLab: Batched background migrations](https://docs.gitlab.com/development/database/batched_background_migrations/) - operational model for large data backfills.
+- [GitLab: Adding database indexes](https://docs.gitlab.com/development/database/adding_database_indexes/) - decision guide for regular, post-deployment, async, and unique indexes.
+- [GitLab: Foreign keys and associations](https://docs.gitlab.com/ee/development/database/foreign_keys.html) - guidance for staged foreign key rollout and validation.
+- [PayPal/Braintree: PostgreSQL at Scale - Database Schema Changes Without Downtime](https://medium.com/paypal-tech/postgresql-at-scale-database-schema-changes-without-downtime-20d3749ed680) - production payments perspective on forward/backward compatibility, lock budgets, constraints, indexes, and enum changes.
+- [Stripe: Online migrations at scale](https://stripe.com/blog/online-migrations) - general online migration pattern using dual writes, backfills, verification, and source-of-truth switching.
+- [Shopify: Safely Adding NOT NULL Columns to Your Database Tables](https://shopify.engineering/add-not-null-colums-to-database) - focused production advisory on required-column changes and why simple migrations can be unsafe.
+- [GitHub: gh-ost, GitHub's online schema migration tool for MySQL](https://github.blog/news-insights/company-news/gh-ost-github-s-online-migration-tool-for-mysql/) - useful operating model for online schema change, throttling, testing, and controlled cutover even though it targets MySQL.
+- [GitHub: MySQL infrastructure testing automation](https://github.blog/engineering/infrastructure/mysql-testing-automation-at-github/) - background on testing schema-change infrastructure continuously at GitHub scale.
+
+Postgres-specific advisory and tooling:
+
+- [PostgresAI: Zero-downtime Postgres schema migrations need lock_timeout and retries](https://postgres.ai/blog/20210923-zero-downtime-postgres-schema-migrations-lock-timeout-and-retries) - detailed explanation of how waiting DDL can block later reads and why strict lock timeouts matter.
+- [Strong Migrations](https://github.com/ankane/strong_migrations) - practical unsafe-migration catalog that is useful even outside Rails.
+- [Squawk rules overview](https://squawkhq.com/docs/rules) - Postgres migration linter rules for blocking reads/writes and breaking existing clients.
+- [Squawk: require concurrent index creation](https://squawkhq.com/docs/require-concurrent-index-creation) - focused rule for index lock risk.
+- [Squawk: constraint missing NOT VALID](https://squawkhq.com/docs/constraint-missing-not-valid) - focused rule for staged constraint validation.
+- [MergeBrake: CREATE INDEX CONCURRENTLY in migrations](https://mergebrake.dev/postgres-create-index-concurrently) - PR-review framing for unsafe generated indexes.
+- [thoughtbot: Create Postgres indexes concurrently in migrations](https://thoughtbot.com/blog/how-to-create-postgres-indexes-concurrently-in) - concise production-oriented explanation of index locks and transaction constraints.
+- [Brandur: Safely renaming a table with no downtime using updatable views](https://brandur.org/fragments/postgres-table-rename) - concrete rename strategy focused on running clients, not just SQL syntax.
+- [Bytebase: Postgres schema migration without downtime](https://www.bytebase.com/blog/postgres-schema-migration-without-downtime/) - operational overview of lock timeouts, staged changes, and deploy sequencing.
+- [Database Migrations Guide: Postgres indexes](https://expobrain.github.io/database-migrations-guide/postgres/add/indexes/) - compact explanation of unsafe indexes, concurrent indexes, and invalid-index retry concerns.
+
+Preview environments, database branching, and schema deployment control:
+
+- [Supabase: Branching](https://supabase.com/docs/guides/deployment/branching) - separate preview environments for testing migrations and config changes without touching production.
+- [Supabase: Branching feature overview](https://supabase.com/features/branching) - high-level branching model and preview deployment integration.
+- [Neon: One branch per preview](https://neon.com/flow/branch-per-preview) - dedicated database branch per Vercel/Netlify preview deployment.
+- [PlanetScale: Deploy requests](https://planetscale.com/docs/concepts/deploy-requests) - reviewable schema diffs, safe migrations, gated deploys, and schema revert windows.
+- [PlanetScale Postgres: Branching](https://planetscale.com/docs/postgres/branching) - isolated database branches for development, testing, and backup restore workflows.
+- [Xata: Zero downtime schema changes with Vercel and Xata](https://xata.io/blog/zero-downtime-schema-changes-with-vercel-and-xata) - relevant because this project also combines Vercel previews with Postgres schema changes.
+- [Xata: Schema changes](https://xata.io/docs/core-concepts/schema-changes) - pgroll-backed approach with multi-version schemas and lock-safe migrations.
+- [Xata: How to perform Postgres schema changes in production with zero downtime](https://xata.io/blog/zero-downtime-schema-migrations-postgresql) - advisory material around reversible schema changes and pgroll.
+- [pgroll](https://lite.xata.io/pgroll) - open-source Postgres tool for reversible, zero-downtime schema changes.
+
+Framework examples:
+
+- [Prisma: Expand-and-contract migrations](https://www.prisma.io/docs/guides/database/data-migration) - framework-specific, but useful as a clear expand/contract example.
+- [Payload: Migrations](https://payloadcms.com/docs/database/migrations) - Payload's migration commands and expected workflow.
+
+Reference documentation:
+
+- [PostgreSQL: ALTER TABLE](https://www.postgresql.org/docs/current/sql-altertable.html) - lock levels, `NOT VALID`, validation, and constraint behavior.
+- [PostgreSQL: CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html) - concurrent index creation and transaction limitations.
+- [PostgreSQL: Client connection defaults](https://www.postgresql.org/docs/current/runtime-config-client.html) - `lock_timeout` and `statement_timeout`.
+- [PostgreSQL: Explicit locking](https://www.postgresql.org/docs/current/explicit-locking.html) - lock modes and conflict behavior.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -88,8 +88,8 @@ This repository uses an explicit migration-first workflow in every environment.
 
 - **CI/CD enforcement**:
 
-  - Build fails if Payload can generate a migration but no migration files were committed.
-  - Build runs `pnpm payload migrate:status` after applying migrations.
+  - DB Quality fails if Payload can generate a migration but no migration files were committed.
+  - DB Quality runs `pnpm payload migrate:status` after applying migrations for DB-relevant changes.
   - Preview and Production deployments run migrations as part of `pnpm run ci` during Vercel builds.
 
 - **Optional local experimentation only**:

--- a/scripts/migration-risk-scan.mjs
+++ b/scripts/migration-risk-scan.mjs
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const defaultRootDir = path.resolve(scriptDir, '..')
+
+const riskRules = [
+  {
+    id: 'drop-column',
+    severity: 'warning',
+    pattern: /\bDROP\s+COLUMN\b/i,
+    message: 'DROP COLUMN should usually be a separate contract release after expand/backfill/switch.',
+  },
+  {
+    id: 'drop-table',
+    severity: 'warning',
+    pattern: /\bDROP\s+TABLE\b/i,
+    message: 'DROP TABLE is destructive and should have an explicit contract-stage plan.',
+  },
+  {
+    id: 'truncate',
+    severity: 'warning',
+    pattern: /\bTRUNCATE\b/i,
+    message: 'TRUNCATE is destructive; prefer documented, reversible cleanup steps.',
+  },
+  {
+    id: 'delete-from',
+    severity: 'warning',
+    pattern: /\bDELETE\s+FROM\b/i,
+    message: 'DELETE FROM can destroy production data; document counts, backup/PITR, and rollback.',
+  },
+  {
+    id: 'set-not-null',
+    severity: 'warning',
+    pattern: /\bALTER\s+COLUMN\b[\s\S]*\bSET\s+NOT\s+NULL\b/i,
+    message: 'SET NOT NULL should follow an idempotent backfill and null-count verification.',
+  },
+  {
+    id: 'rename',
+    severity: 'warning',
+    pattern: /\bRENAME\s+(COLUMN|TO)\b/i,
+    message: 'Renames should usually be modeled as add new field, backfill, switch, then drop old field.',
+  },
+  {
+    id: 'type-conversion',
+    severity: 'warning',
+    pattern: /\bSET\s+DATA\s+TYPE\b|\bUSING\b/i,
+    message: 'Type conversions need compatibility and data-loss checks before production rollout.',
+  },
+]
+
+function runGit(args, rootDir) {
+  return execFileSync('git', args, {
+    cwd: rootDir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+export function parseArgs(argv) {
+  const options = {
+    base: undefined,
+    baseRef: undefined,
+    changedFiles: [],
+    eventName: undefined,
+    head: 'HEAD',
+    rootDir: defaultRootDir,
+  }
+
+  const args = argv.filter((arg) => arg !== '--')
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]
+    if (!arg) continue
+
+    if (arg === '--base') {
+      options.base = args[i + 1]
+      i += 1
+      continue
+    }
+
+    if (arg.startsWith('--base=')) {
+      options.base = arg.slice('--base='.length)
+      continue
+    }
+
+    if (arg === '--base-ref') {
+      options.baseRef = args[i + 1]
+      i += 1
+      continue
+    }
+
+    if (arg.startsWith('--base-ref=')) {
+      options.baseRef = arg.slice('--base-ref='.length)
+      continue
+    }
+
+    if (arg === '--changed-file') {
+      const value = args[i + 1]
+      if (value) options.changedFiles.push(value)
+      i += 1
+      continue
+    }
+
+    if (arg.startsWith('--changed-file=')) {
+      const value = arg.slice('--changed-file='.length)
+      if (value) options.changedFiles.push(value)
+      continue
+    }
+
+    if (arg === '--event-name') {
+      options.eventName = args[i + 1]
+      i += 1
+      continue
+    }
+
+    if (arg.startsWith('--event-name=')) {
+      options.eventName = arg.slice('--event-name='.length)
+      continue
+    }
+
+    if (arg === '--head') {
+      options.head = args[i + 1] ?? 'HEAD'
+      i += 1
+      continue
+    }
+
+    if (arg.startsWith('--head=')) {
+      options.head = arg.slice('--head='.length)
+      continue
+    }
+
+    if (arg === '--root-dir') {
+      options.rootDir = path.resolve(args[i + 1] ?? defaultRootDir)
+      i += 1
+      continue
+    }
+
+    if (arg.startsWith('--root-dir=')) {
+      options.rootDir = path.resolve(arg.slice('--root-dir='.length))
+      continue
+    }
+
+    throw new Error(`Unknown option: ${arg}`)
+  }
+
+  return options
+}
+
+function resolveChangedFiles(options) {
+  if (options.changedFiles.length > 0) {
+    return options.changedFiles
+  }
+
+  if (options.eventName === 'workflow_dispatch') {
+    return []
+  }
+
+  let range
+  if (options.base) {
+    range = `${options.base}...${options.head}`
+  } else if (options.eventName === 'pull_request' && options.baseRef) {
+    runGit(['fetch', '--no-tags', '--depth=1', 'origin', options.baseRef], options.rootDir)
+    range = `origin/${options.baseRef}...${options.head}`
+  } else {
+    try {
+      runGit(['rev-parse', '--verify', `${options.head}~1`], options.rootDir)
+      range = `${options.head}~1...${options.head}`
+    } catch {
+      range = options.head
+    }
+  }
+
+  let output
+  try {
+    output = runGit(['diff', '--name-only', '--diff-filter=ACMR', range], options.rootDir)
+  } catch (error) {
+    if (!range.includes('...')) throw error
+
+    const fallbackRange = range.replace('...', '..')
+    console.warn(`Unable to diff ${range}; falling back to ${fallbackRange}.`)
+    output = runGit(['diff', '--name-only', '--diff-filter=ACMR', fallbackRange], options.rootDir)
+  }
+  return output
+    .split('\n')
+    .map((filePath) => filePath.trim())
+    .filter(Boolean)
+}
+
+function isMigrationFile(filePath) {
+  return (
+    /^src\/migrations\/.+\.ts$/.test(filePath) &&
+    !filePath.endsWith('/index.ts') &&
+    filePath !== 'src/migrations/index.ts'
+  )
+}
+
+function lineNumberAt(source, index) {
+  return source.slice(0, index).split('\n').length
+}
+
+function extractUpMigrationSource(source) {
+  const upIndex = source.search(/export\s+async\s+function\s+up\b/)
+  if (upIndex < 0) return { source, offset: 0 }
+
+  const remaining = source.slice(upIndex)
+  const downRelativeIndex = remaining.search(/export\s+async\s+function\s+down\b/)
+  if (downRelativeIndex < 0) return { source: remaining, offset: upIndex }
+
+  return {
+    source: remaining.slice(0, downRelativeIndex),
+    offset: upIndex,
+  }
+}
+
+function splitSqlStatements(source, offset = 0) {
+  const statements = []
+  let start = 0
+
+  for (let i = 0; i < source.length; i += 1) {
+    if (source[i] !== ';') continue
+
+    const statement = source.slice(start, i + 1)
+    if (statement.trim().length > 0) {
+      statements.push({
+        text: statement,
+        index: offset + start,
+      })
+    }
+    start = i + 1
+  }
+
+  const trailing = source.slice(start)
+  if (trailing.trim().length > 0) {
+    statements.push({
+      text: trailing,
+      index: offset + start,
+    })
+  }
+
+  return statements
+}
+
+function hasBroadUpdate(statement) {
+  return /\bUPDATE\b[\s\S]*\bSET\b/i.test(statement) && !/\bWHERE\b/i.test(statement)
+}
+
+export function scanMigrationSource(source, filePath) {
+  const findings = []
+  const upBlock = extractUpMigrationSource(source)
+  const statements = splitSqlStatements(upBlock.source, upBlock.offset)
+
+  for (const statement of statements) {
+    for (const rule of riskRules) {
+      if (!rule.pattern.test(statement.text)) continue
+
+      findings.push({
+        filePath,
+        line: lineNumberAt(source, statement.index),
+        ruleId: rule.id,
+        severity: rule.severity,
+        message: rule.message,
+      })
+    }
+
+    if (hasBroadUpdate(statement.text)) {
+      findings.push({
+        filePath,
+        line: lineNumberAt(source, statement.index),
+        ruleId: 'broad-update',
+        severity: 'warning',
+        message: 'Broad UPDATE without WHERE should be explicitly justified and verified with counts.',
+      })
+    }
+  }
+
+  return findings
+}
+
+export function runMigrationRiskScan(options) {
+  const changedFiles = resolveChangedFiles(options)
+  const migrationFiles = changedFiles.filter(isMigrationFile)
+  const findings = []
+
+  for (const filePath of migrationFiles) {
+    const absolutePath = path.join(options.rootDir, filePath)
+    if (!fs.existsSync(absolutePath)) continue
+
+    const source = fs.readFileSync(absolutePath, 'utf8')
+    findings.push(...scanMigrationSource(source, filePath))
+  }
+
+  return {
+    changedFiles,
+    findings,
+    migrationFiles,
+  }
+}
+
+function escapeGitHubAnnotationValue(value) {
+  return value.replaceAll('%', '%25').replaceAll('\r', '%0D').replaceAll('\n', '%0A')
+}
+
+function printFinding(finding) {
+  const text = `${finding.filePath}:${finding.line} [${finding.ruleId}] ${finding.message}`
+
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    const file = escapeGitHubAnnotationValue(finding.filePath)
+    const title = escapeGitHubAnnotationValue(`Migration risk: ${finding.ruleId}`)
+    const message = escapeGitHubAnnotationValue(finding.message)
+    console.log(`::warning file=${file},line=${finding.line},title=${title}::${message}`)
+    return
+  }
+
+  console.warn(text)
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const result = runMigrationRiskScan(options)
+
+  if (result.migrationFiles.length === 0) {
+    console.log('No changed migration files found for risk scan.')
+    return
+  }
+
+  console.log(`Scanned ${result.migrationFiles.length} changed migration file(s).`)
+
+  if (result.findings.length === 0) {
+    console.log('No advisory migration risks detected.')
+    return
+  }
+
+  for (const finding of result.findings) {
+    printFinding(finding)
+  }
+
+  console.log(`Advisory migration risk scan completed with ${result.findings.length} warning(s).`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -31,7 +31,7 @@ export default async function Home({
   searchParams: searchParamsPromise,
 }: {
   searchParams?: Promise<HomePageSearchParams>
-} = {}) {
+}) {
   const requestHeaders = await headers()
   if (isTemporaryLandingModeRequest(requestHeaders)) {
     const searchParams = (await searchParamsPromise) ?? {}
@@ -174,7 +174,7 @@ export async function generateMetadata({
   searchParams: searchParamsPromise,
 }: {
   searchParams?: Promise<HomePageSearchParams>
-} = {}): Promise<Metadata> {
+}): Promise<Metadata> {
   const requestHeaders = await headers()
 
   if (isTemporaryLandingModeRequest(requestHeaders)) {

--- a/src/migrations/AGENTS.md
+++ b/src/migrations/AGENTS.md
@@ -1,0 +1,25 @@
+# Payload Migration Rules
+
+## Priorities
+
+- `P0`: Production data safety, migration integrity, and deploy compatibility.
+- `P1`: Clear expand/backfill/switch/contract rollout sequencing.
+- `P2`: Concise migration notes and reviewability.
+
+## Critical Rules
+
+- Create migration files with `pnpm payload migrate:create <name>`; do not create migrations manually from scratch.
+- Classify every migration as additive, backfill, constraint-hardening, or destructive before editing or approving it.
+- Prefer production-compatible multi-release changes: expand first, backfill idempotently, switch application reads/writes, then contract later.
+- Do not combine field/table drops, renames, required constraint hardening, or data deletion with the first release that introduces the replacement shape.
+- Manual migration edits are allowed only for idempotent backfills, data-safety corrections, or reviewed Payload output adjustments.
+- Backfills must be safe to rerun and should use scoped predicates such as `WHERE <new_column> IS NULL` where possible.
+- Destructive changes require documented backup/PITR readiness, before/after counts, and a separate contract-stage PR or release.
+- Do not query production from CI. Production data checks use snapshots, backup restores, or read replicas by default.
+
+## Review Checklist
+
+- State whether the current app version and the next app version can both run against the migrated schema.
+- For renamed fields, add the new field first and keep the old field until all reads/writes have switched.
+- For new required fields, add nullable/defaulted storage first, backfill, verify null counts, then enforce required constraints later.
+- For deleted data, prefer soft-delete or archival states before hard deletion.

--- a/tests/tooling/scripts/migration-risk-scan.test.ts
+++ b/tests/tooling/scripts/migration-risk-scan.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseArgs, scanMigrationSource } from '../../../scripts/migration-risk-scan.mjs'
+
+const wrapMigration = (upSql: string, downSql = 'SELECT 1;') => `
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql\`${upSql}\`)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql\`${downSql}\`)
+}
+`
+
+describe('migration-risk-scan argument parsing', () => {
+  it('ignores the pnpm -- separator', () => {
+    const options = parseArgs(['--', '--base', 'origin/main', '--head', 'HEAD'])
+
+    expect(options.base).toBe('origin/main')
+    expect(options.head).toBe('HEAD')
+  })
+
+  it('supports explicit changed files', () => {
+    const options = parseArgs(['--changed-file=src/migrations/20260501_example.ts'])
+
+    expect(options.changedFiles).toEqual(['src/migrations/20260501_example.ts'])
+  })
+})
+
+describe('scanMigrationSource', () => {
+  it('does not report safe additive migrations', () => {
+    const source = wrapMigration('ALTER TABLE "clinics" ADD COLUMN "display_name" varchar;')
+
+    const findings = scanMigrationSource(source, 'src/migrations/20260501_safe.ts')
+
+    expect(findings).toEqual([])
+  })
+
+  it('reports destructive drops in the up migration', () => {
+    const source = wrapMigration('ALTER TABLE "clinics" DROP COLUMN "legacy_name";')
+
+    const findings = scanMigrationSource(source, 'src/migrations/20260501_drop.ts')
+
+    expect(findings.map((finding) => finding.ruleId)).toContain('drop-column')
+  })
+
+  it('ignores destructive statements that only exist in down migrations', () => {
+    const source = wrapMigration(
+      'ALTER TABLE "clinics" ADD COLUMN "display_name" varchar;',
+      'ALTER TABLE "clinics" DROP COLUMN "display_name";',
+    )
+
+    const findings = scanMigrationSource(source, 'src/migrations/20260501_down_drop.ts')
+
+    expect(findings).toEqual([])
+  })
+
+  it('reports not-null hardening and broad updates', () => {
+    const source = wrapMigration(`
+      UPDATE "clinics" SET "display_name" = "name";
+      ALTER TABLE "clinics" ALTER COLUMN "display_name" SET NOT NULL;
+    `)
+
+    const findings = scanMigrationSource(source, 'src/migrations/20260501_hardening.ts')
+
+    expect(findings.map((finding) => finding.ruleId)).toEqual(expect.arrayContaining(['broad-update', 'set-not-null']))
+  })
+
+  it('reports rename and type conversion risks', () => {
+    const source = wrapMigration(`
+      ALTER TABLE "clinics" RENAME COLUMN "name" TO "display_name";
+      ALTER TABLE "clinics" ALTER COLUMN "score" SET DATA TYPE integer USING "score"::integer;
+    `)
+
+    const findings = scanMigrationSource(source, 'src/migrations/20260501_rename.ts')
+
+    expect(findings.map((finding) => finding.ruleId)).toEqual(expect.arrayContaining(['rename', 'type-conversion']))
+  })
+})

--- a/tests/unit/app/frontend/admin/login/page.test.ts
+++ b/tests/unit/app/frontend/admin/login/page.test.ts
@@ -167,7 +167,7 @@ describe('Admin LoginPage', () => {
     vi.mocked(extractSupabaseUserData).mockResolvedValue(null)
     vi.mocked(getLocalPlatformStaffUserState).mockResolvedValue({ status: 'no_platform_staff' })
 
-    const result = await LoginPage()
+    const result = await LoginPage({})
 
     expect(redirect).not.toHaveBeenCalled()
     expect(result).toBeTruthy()
@@ -292,7 +292,7 @@ describe('Admin LoginPage', () => {
       lastName: 'User',
     })
 
-    await LoginPage()
+    await LoginPage({})
 
     expect(findUserBySupabaseId).toHaveBeenCalledWith(
       expect.any(Object),
@@ -324,7 +324,7 @@ describe('Admin LoginPage', () => {
       lastName: 'User',
     })
 
-    await LoginPage()
+    await LoginPage({})
 
     expect(findUserBySupabaseId).toHaveBeenCalledWith(
       expect.any(Object),
@@ -356,7 +356,7 @@ describe('Admin LoginPage', () => {
       lastName: 'Recovered',
     })
 
-    await LoginPage()
+    await LoginPage({})
 
     expect(findUserBySupabaseId).toHaveBeenCalledWith(
       expect.any(Object),
@@ -378,7 +378,7 @@ describe('Admin LoginPage', () => {
       lastName: 'User',
     })
 
-    const result = await LoginPage()
+    const result = await LoginPage({})
 
     expect(redirect).not.toHaveBeenCalled()
     expect(result).toBeTruthy()
@@ -399,7 +399,7 @@ describe('Admin LoginPage', () => {
       lastName: 'User',
     })
 
-    const result = await LoginPage()
+    const result = await LoginPage({})
     const pageElement = result as LoginPageElement
     const rootElement = getLoginRootElement(pageElement)
     const rootChildren = React.Children.toArray(rootElement.props.children) as React.ReactElement<{
@@ -455,7 +455,7 @@ describe('Admin LoginPage', () => {
     })
     vi.mocked(extractSupabaseUserData).mockResolvedValue(null)
 
-    const result = await LoginPage()
+    const result = await LoginPage({})
 
     expect(redirect).not.toHaveBeenCalled()
     expect(result).toBeTruthy()
@@ -560,7 +560,7 @@ describe('Admin LoginPage', () => {
       lastName: 'User',
     })
 
-    await LoginPage()
+    await LoginPage({})
 
     expect(redirect).toHaveBeenCalledWith('/admin')
   })
@@ -587,7 +587,7 @@ describe('Admin LoginPage', () => {
       lastName: 'User',
     })
 
-    const result = await LoginPage()
+    const result = await LoginPage({})
     const pageElement = result as LoginPageElement
     const rootElement = getLoginRootElement(pageElement)
     const rootChildren = React.Children.toArray(rootElement.props.children) as React.ReactElement<{
@@ -626,7 +626,7 @@ describe('Admin LoginPage', () => {
       lastName: 'User',
     })
 
-    await LoginPage()
+    await LoginPage({})
 
     expect(redirect).toHaveBeenCalledWith('/admin')
   })

--- a/tests/unit/app/frontend/home.page.test.ts
+++ b/tests/unit/app/frontend/home.page.test.ts
@@ -83,7 +83,7 @@ describe('frontend home page route', () => {
     mocks.headersMock.mockResolvedValue(new Headers({ [TEMPORARY_LANDING_MODE_REQUEST_HEADER]: '1' }))
 
     const pageModule = await import('@/app/(frontend)/page')
-    const result = await pageModule.default()
+    const result = await pageModule.default({})
 
     expect(mocks.getPayloadMock).not.toHaveBeenCalled()
     expect(result.type).toBe(mocks.temporaryLandingPageComponent)
@@ -158,7 +158,7 @@ describe('frontend home page route', () => {
 
   it('loads regular homepage data when landing request header is missing', async () => {
     const pageModule = await import('@/app/(frontend)/page')
-    await pageModule.default()
+    await pageModule.default({})
 
     expect(mocks.getPayloadMock).toHaveBeenCalledTimes(2)
     expect(mocks.findLatestPostsMock).toHaveBeenCalledTimes(1)
@@ -190,7 +190,7 @@ describe('frontend home page route', () => {
 
   it('returns default homepage metadata when landing request header is missing', async () => {
     const pageModule = await import('@/app/(frontend)/page')
-    const metadata = await pageModule.generateMetadata()
+    const metadata = await pageModule.generateMetadata({})
 
     expect(mocks.getPayloadMock).toHaveBeenCalledTimes(1)
     expect(mocks.payloadFindGlobalMock).toHaveBeenCalledWith({


### PR DESCRIPTION
Adds a stable DB Quality gate so migration safety is branch-protected without blocking unrelated changes.

## What changed

- Added a new `DB Quality` workflow with an always-running `db-quality-gate` job for branch protection.
- Reused and extended `.github/scripts/ci/detect-migration-diff.sh` so PR Validation and DB Quality share the same DB change detection.
- Added an advisory migration risk scanner with unit coverage for destructive and compatibility-sensitive SQL patterns.
- Documented expand/backfill/switch/contract migration flow and production-data guardrails.
- Added migration-local agent rules and command safety prompts for destructive Payload database commands.
- Fixed two Next page prop type mismatches exposed by `pnpm check`.

## Validation

- `pnpm format`
- `pnpm check`
- `PAYLOAD_SECRET=dev-secret pnpm build`
- `pnpm docs:check`
- `pnpm ai:slop-check`
- `pnpm vitest tests/unit/scripts/migration-risk-scan.test.ts tests/unit/app/frontend/home.page.test.ts tests/unit/app/frontend/admin/login/page.test.ts --run`
- Direct detector checks for `workflow_dispatch` and `pull_request`

Local `actionlint` was not available in this worktree; the existing Workflow Security workflow runs `actionlint` and `zizmor` on workflow changes.

## Development

Closes #1106
