### PR TITLE
fix(frontend): centralize media image resolution

### DIFF
--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -62,7 +62,12 @@ export default async function Post({ params: paramsPromise, searchParams: search
       : undefined
 
   const heroImage =
-    post.heroImage && typeof post.heroImage === 'object' ? resolveMediaImage(post.heroImage, post.title) : undefined
+    post.heroImage && typeof post.heroImage === 'object'
+      ? resolveMediaImage(post.heroImage, {
+          fallbackAlt: post.title,
+          usage: 'hero',
+        })
+      : undefined
 
   const breadcrumbs = [
     { label: 'Home', href: '/' },

--- a/src/blocks/MediaBlock/Component.tsx
+++ b/src/blocks/MediaBlock/Component.tsx
@@ -4,6 +4,7 @@ import type { MediaBlock as MediaBlockPayload, PlatformContentMedia } from '@/pa
 import { MediaBlock as MediaBlockOrganism } from '@/components/organisms/MediaBlock'
 import RichText from '@/blocks/_shared/RichText'
 import type { ContentLocaleContext } from '@/utilities/contentLocalization'
+import { resolveMediaImage } from '@/utilities/media/resolveMediaImage'
 
 type Props = MediaBlockPayload & {
   breakout?: boolean
@@ -32,17 +33,30 @@ export const MediaBlockComponent: React.FC<Props> = (props) => {
   let width: number | undefined
   let height: number | undefined
   let alt: string | undefined
+  let size: string | undefined
+  let quality: number | undefined
   let type: 'video' | 'image' | undefined
   let captionNode: React.ReactNode
 
   if (media && typeof media === 'object') {
     const m = media as PlatformContentMedia
-    src = m.url || undefined
-    width = m.width || undefined
-    height = m.height || undefined
-    alt = m.alt || undefined
     if (m.mimeType?.includes('video')) {
+      src = m.url || undefined
+      width = m.width || undefined
+      height = m.height || undefined
+      alt = m.alt || undefined
       type = 'video'
+    } else {
+      const image = resolveMediaImage(m, {
+        fallbackAlt: m.alt || undefined,
+        usage: 'content',
+      })
+      src = image?.src
+      width = image?.width
+      height = image?.height
+      alt = image?.alt
+      size = image?.sizes
+      quality = image?.quality
     }
     if (m.caption) {
       captionNode = (
@@ -69,6 +83,8 @@ export const MediaBlockComponent: React.FC<Props> = (props) => {
       width={width}
       height={height}
       alt={alt}
+      size={size}
+      quality={quality}
       type={type}
       caption={captionNode}
     />

--- a/src/components/molecules/Media/ImageMedia/index.tsx
+++ b/src/components/molecules/Media/ImageMedia/index.tsx
@@ -13,6 +13,7 @@ export const ImageMedia: React.FC<MediaProps> = (props) => {
     fill,
     imgClassName,
     priority,
+    quality: qualityFromProps,
     size: sizeFromProps,
     src: srcFromProps,
     loading: loadingFromProps,
@@ -36,7 +37,7 @@ export const ImageMedia: React.FC<MediaProps> = (props) => {
       placeholder="blur"
       blurDataURL={IMAGE_PLACEHOLDER_BLUR}
       priority={priority}
-      quality={DEFAULT_IMAGE_QUALITY}
+      quality={qualityFromProps ?? DEFAULT_IMAGE_QUALITY}
       loading={loading}
       onError={onError}
       sizes={sizes}

--- a/src/components/molecules/Media/types.ts
+++ b/src/components/molecules/Media/types.ts
@@ -12,6 +12,7 @@ export interface Props {
   onLoad?: () => void
   loading?: 'lazy' | 'eager' // for NextImage only
   priority?: boolean // for NextImage only
+  quality?: number // for NextImage only
   ref?: Ref<HTMLImageElement | HTMLVideoElement | null>
   src?: StaticImageData | string
   width?: number

--- a/src/components/organisms/Blog/BlogCard/Enhanced.tsx
+++ b/src/components/organisms/Blog/BlogCard/Enhanced.tsx
@@ -32,7 +32,14 @@ export const Enhanced: React.FC<EnhancedProps> = ({
   className,
 }) => {
   const isDark = variant === 'dark'
-  const resolvedImage = image ?? { src: '/images/blog-placeholder-1600-900.svg', alt: 'Blog placeholder' }
+  const resolvedImage = image ?? {
+    src: '/images/blog-placeholder-1600-900.svg',
+    alt: 'Blog placeholder',
+    sizes: '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw',
+    quality: 70,
+  }
+  const imageSizes = resolvedImage.sizes ?? '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
+  const imageQuality = resolvedImage.quality ?? 70
   const avatarFallback = resolveAvatarPlaceholder({
     persona: 'patient',
   })
@@ -49,7 +56,8 @@ export const Enhanced: React.FC<EnhancedProps> = ({
             alt={resolvedImage.alt || 'Blog placeholder'}
             fill
             className="object-cover transition-transform duration-500 group-hover:scale-105"
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            sizes={imageSizes}
+            quality={imageQuality}
           />
 
           {/* Category Badge - Top Right */}

--- a/src/components/organisms/Blog/BlogCard/Overlay.tsx
+++ b/src/components/organisms/Blog/BlogCard/Overlay.tsx
@@ -27,7 +27,14 @@ export const Overlay: React.FC<OverlayProps> = ({
   overlayOpacity = 80,
   className,
 }) => {
-  const resolvedImage = image ?? { src: '/images/blog-placeholder-1600-900.svg', alt: 'Blog placeholder' }
+  const resolvedImage = image ?? {
+    src: '/images/blog-placeholder-1600-900.svg',
+    alt: 'Blog placeholder',
+    sizes: '(max-width: 768px) 100vw, (max-width: 1200px) 90vw, 1200px',
+    quality: 70,
+  }
+  const imageSizes = resolvedImage.sizes ?? '(max-width: 768px) 100vw, (max-width: 1200px) 90vw, 1200px'
+  const imageQuality = resolvedImage.quality ?? 70
   const avatarFallback = resolveAvatarPlaceholder({
     persona: 'patient',
   })
@@ -46,7 +53,8 @@ export const Overlay: React.FC<OverlayProps> = ({
           alt={resolvedImage.alt || 'Blog placeholder'}
           fill
           className="object-cover transition-transform duration-700 group-hover:scale-105"
-          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 90vw, 1200px"
+          sizes={imageSizes}
+          quality={imageQuality}
         />
 
         {/* Gradient Overlay */}

--- a/src/components/organisms/Blog/BlogCard/Overview.tsx
+++ b/src/components/organisms/Blog/BlogCard/Overview.tsx
@@ -24,7 +24,14 @@ export const Overview: React.FC<BlogCardBaseProps> = ({
   author,
   className,
 }) => {
-  const resolvedImage = image ?? { src: '/images/blog-placeholder-1600-900.svg', alt: 'Blog placeholder' }
+  const resolvedImage = image ?? {
+    src: '/images/blog-placeholder-1600-900.svg',
+    alt: 'Blog placeholder',
+    sizes: '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw',
+    quality: 70,
+  }
+  const imageSizes = resolvedImage.sizes ?? '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
+  const imageQuality = resolvedImage.quality ?? 70
   const avatarFallback = resolveAvatarPlaceholder({
     persona: 'patient',
   })
@@ -40,7 +47,8 @@ export const Overview: React.FC<BlogCardBaseProps> = ({
             alt={resolvedImage.alt || 'Blog placeholder'}
             fill
             className="object-cover transition-transform duration-500 group-hover:scale-105"
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            sizes={imageSizes}
+            quality={imageQuality}
           />
         </div>
 

--- a/src/components/organisms/Blog/BlogCard/Simple.tsx
+++ b/src/components/organisms/Blog/BlogCard/Simple.tsx
@@ -20,7 +20,14 @@ export const Simple: React.FC<BlogCardBaseProps> = ({
   author,
   className,
 }) => {
-  const resolvedImage = image ?? { src: '/images/blog-placeholder-1600-900.svg', alt: 'Blog placeholder' }
+  const resolvedImage = image ?? {
+    src: '/images/blog-placeholder-1600-900.svg',
+    alt: 'Blog placeholder',
+    sizes: '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw',
+    quality: 70,
+  }
+  const imageSizes = resolvedImage.sizes ?? '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
+  const imageQuality = resolvedImage.quality ?? 70
   const authorName = author?.name || 'findmydoc Editorial Team'
 
   return (
@@ -33,7 +40,8 @@ export const Simple: React.FC<BlogCardBaseProps> = ({
             alt={resolvedImage.alt || 'Blog placeholder'}
             fill
             className="object-cover transition-transform duration-500 group-hover:scale-105"
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            sizes={imageSizes}
+            quality={imageQuality}
           />
 
           {/* Category Badge - Top Right */}

--- a/src/components/organisms/Heroes/LandingHero/index.tsx
+++ b/src/components/organisms/Heroes/LandingHero/index.tsx
@@ -6,11 +6,12 @@ import { Container } from '@/components/molecules/Container'
 import { SectionHeading } from '@/components/molecules/SectionHeading'
 import { LandingHeroSearchBarClient } from './LandingHeroSearchBar.client'
 import { cn } from '@/utilities/ui'
+import type { ResolvedMediaImage } from '@/utilities/media/resolveMediaImage'
 
 export type LandingHeroProps = {
   title: string
   description: string
-  image?: string | StaticImageData
+  image?: ResolvedMediaImage | string | StaticImageData
   variant?: 'clinic-landing' | 'homepage'
   socialLinks?: {
     href: string
@@ -33,6 +34,11 @@ export const LandingHero: React.FC<LandingHeroProps> = ({
 }) => {
   const isHomepage = variant === 'homepage'
   const isClinicLanding = variant === 'clinic-landing'
+  const hasResolvedMediaImage = typeof image === 'object' && image !== null && 'alt' in image
+  const imageSrc = hasResolvedMediaImage ? image.src : image
+  const imageAlt = hasResolvedMediaImage ? image.alt : 'Hero Background'
+  const imageSizes = hasResolvedMediaImage ? image.sizes : '100vw'
+  const imageQuality = hasResolvedMediaImage ? image.quality : undefined
 
   return (
     <section
@@ -41,9 +47,17 @@ export const LandingHero: React.FC<LandingHeroProps> = ({
         isClinicLanding ? 'min-h-[34rem] overflow-hidden sm:min-h-[48rem]' : 'min-h-[32rem] md:min-h-[39rem] md:pb-28',
       )}
     >
-      {image ? (
+      {imageSrc ? (
         <div className="absolute inset-0 z-0 overflow-hidden">
-          <Image src={image} alt="Hero Background" fill sizes="100vw" className="object-cover object-center" priority />
+          <Image
+            src={imageSrc}
+            alt={imageAlt}
+            fill
+            sizes={imageSizes}
+            quality={imageQuality}
+            className="object-cover object-center"
+            priority
+          />
           <div className="absolute inset-0 bg-white/75" />
         </div>
       ) : null}

--- a/src/components/organisms/Heroes/PostHero/index.tsx
+++ b/src/components/organisms/Heroes/PostHero/index.tsx
@@ -28,6 +28,8 @@ export type PostHeroProps = {
     alt: string
     width?: number
     height?: number
+    sizes?: string
+    quality?: number
   }
   overlayOpacity?: number
 }
@@ -72,6 +74,8 @@ export const PostHero: React.FC<PostHeroProps> = ({
           alt={resolvedImage.alt}
           width={resolvedImage.width}
           height={resolvedImage.height}
+          sizes={resolvedImage.sizes}
+          quality={resolvedImage.quality}
         />
         <div
           className="pointer-events-none absolute inset-0"

--- a/src/components/organisms/Landing/LandingProcess.tsx
+++ b/src/components/organisms/Landing/LandingProcess.tsx
@@ -78,6 +78,8 @@ type LandingProcessProps = {
   stepImages?: ReadonlyArray<{
     src: StaticImageData | string
     alt: string
+    sizes?: string
+    quality?: number
   }>
   triggerClassName?: string
   tailClassName?: string
@@ -344,6 +346,8 @@ export const LandingProcess: React.FC<LandingProcessProps> = ({
         key: `${step.step}-${index}`,
         src: stepImages?.[index]?.src ?? image,
         alt: stepImages?.[index]?.alt ?? imageAlt,
+        sizes: stepImages?.[index]?.sizes,
+        quality: stepImages?.[index]?.quality,
       })),
     [image, imageAlt, stepImages, steps],
   )
@@ -532,7 +536,8 @@ export const LandingProcess: React.FC<LandingProcessProps> = ({
                 src={resolvedStepImages[0].src}
                 alt={resolvedStepImages[0].alt}
                 fill
-                sizes="100vw"
+                sizes={resolvedStepImages[0].sizes ?? '100vw'}
+                quality={resolvedStepImages[0].quality}
                 className="object-cover"
               />
             </div>
@@ -589,7 +594,8 @@ export const LandingProcess: React.FC<LandingProcessProps> = ({
                         src={stepImage.src}
                         alt={stepImage.alt}
                         fill
-                        sizes="(min-width: 1024px) 50vw, 100vw"
+                        sizes={stepImage.sizes ?? '(min-width: 1024px) 50vw, 100vw'}
+                        quality={stepImage.quality}
                         className="object-cover"
                       />
                     </div>

--- a/src/components/organisms/MediaBlock/index.tsx
+++ b/src/components/organisms/MediaBlock/index.tsx
@@ -18,6 +18,8 @@ export type MediaBlockProps = {
   width?: number
   height?: number
   alt?: string
+  size?: string
+  quality?: number
   type?: 'video' | 'image'
   caption?: React.ReactNode
 }
@@ -34,6 +36,8 @@ export const MediaBlock: React.FC<MediaBlockProps> = (props) => {
     width,
     height,
     alt,
+    size,
+    quality,
     type,
     caption,
   } = props
@@ -49,6 +53,8 @@ export const MediaBlock: React.FC<MediaBlockProps> = (props) => {
           width={width}
           height={height}
           alt={alt}
+          size={size}
+          quality={quality}
           type={type}
         />
       )}

--- a/src/utilities/blog/normalizePost.ts
+++ b/src/utilities/blog/normalizePost.ts
@@ -1,16 +1,12 @@
 import type { Post } from '@/payload-types'
 import { formatDate } from './formatDate'
 import { calculateReadTime } from './calculateReadTime'
-import { resolveMediaImage } from '@/utilities/media/resolveMediaImage'
+import { resolveMediaImage, type ResolvedMediaImage } from '@/utilities/media/resolveMediaImage'
 import { buildPostPath } from '@/utilities/content/postPaths'
 import type { ContentLocaleContext } from '@/utilities/contentLocalization'
 
-export type BlogCardImageProps = {
-  src: string
-  alt: string
-  width?: number
-  height?: number
-}
+export type BlogCardImageProps = Pick<ResolvedMediaImage, 'alt' | 'height' | 'src' | 'width'> &
+  Partial<Pick<ResolvedMediaImage, 'quality' | 'sizes'>>
 
 export type BlogCardAuthorProps = {
   name: string
@@ -48,7 +44,10 @@ export function normalizePost(
 
   // Normalize hero image
   const heroImage = typeof post.heroImage === 'object' && post.heroImage !== null ? post.heroImage : null
-  const imageProps: BlogCardImageProps | undefined = resolveMediaImage(heroImage, post.title)
+  const imageProps: BlogCardImageProps | undefined = resolveMediaImage(heroImage, {
+    fallbackAlt: post.title,
+    usage: 'blogCard',
+  })
 
   // Normalize author (use first populated author from populatedAuthors)
   let authorProps: BlogCardAuthorProps | undefined

--- a/src/utilities/generateMeta.ts
+++ b/src/utilities/generateMeta.ts
@@ -11,6 +11,7 @@ import {
   normalizeSiteDescription,
   type SocialPreviewImage,
 } from './socialPreview'
+import { resolveMediaImage } from './media/resolveMediaImage'
 
 /**
  * Generates an image URL for OpenGraph metadata.
@@ -21,8 +22,11 @@ import {
  */
 const getImageURL = (image?: PlatformContentMedia | Config['db']['defaultIDType'] | null) => {
   if (image && typeof image === 'object' && 'url' in image) {
-    const ogUrl = image.sizes?.og?.url
-    const imageUrl = ogUrl ?? image.url
+    const resolvedImage = resolveMediaImage(image, {
+      fallbackAlt: image.alt ?? undefined,
+      usage: 'og',
+    })
+    const imageUrl = resolvedImage?.src
 
     return imageUrl ? getAbsoluteSiteURL(imageUrl) : null
   }

--- a/src/utilities/landing/landingPageContent.ts
+++ b/src/utilities/landing/landingPageContent.ts
@@ -8,7 +8,7 @@ import type { LandingTestimonial } from '@/components/organisms/Landing/LandingT
 import { resolveHrefFromCMSLink } from '@/blocks/_shared/utils'
 import type { LandingPage, PlatformContentMedia } from '@/payload-types'
 import { getCachedGlobal } from '@/utilities/getGlobals'
-import { resolveMediaImage } from '@/utilities/media/resolveMediaImage'
+import { resolveMediaImage, type ResolvedMediaImage } from '@/utilities/media/resolveMediaImage'
 import { landingSocialHosts, normalizeSafeLandingHref } from './safeLandingHref'
 
 type LandingFeatureIcon = LandingPage['home']['features']['items'][number]['icon']
@@ -26,10 +26,7 @@ type LandingProcessStep = {
   description: string
 }
 
-type LandingProcessStepImage = {
-  src: string
-  alt: string
-}
+type LandingProcessStepImage = ResolvedMediaImage
 
 type SectionIntro = {
   title: string
@@ -37,7 +34,7 @@ type SectionIntro = {
 }
 
 type LandingHeroContent = SectionIntro & {
-  image: string
+  image: ResolvedMediaImage
 }
 
 type LandingFaqContent = SectionIntro & {
@@ -497,21 +494,17 @@ const optionalText = (value: string | null | undefined): string | undefined => {
   return value.trim().length > 0 ? value : undefined
 }
 
-const resolveRequiredLandingImage = (
-  media: unknown,
-  fieldPath: string,
-  fallbackAlt: string,
-): { alt: string; src: string } => {
-  const image = resolveMediaImage(asLoadedMedia(media), fallbackAlt)
+const resolveRequiredLandingImage = (media: unknown, fieldPath: string, fallbackAlt: string): ResolvedMediaImage => {
+  const image = resolveMediaImage(asLoadedMedia(media), {
+    fallbackAlt,
+    usage: 'landingVisual',
+  })
 
   if (!image?.src) {
     throw new Error(`Landing media ${fieldPath} is missing or not populated`)
   }
 
-  return {
-    src: image.src,
-    alt: image.alt || fallbackAlt,
-  }
+  return image
 }
 
 const normalizeFeatures = (
@@ -636,8 +629,11 @@ export const normalizeHomeLandingContent = (landingPages: LandingPage = DEFAULT_
     hero: {
       title: home.hero.title || fallbackHome.hero.title,
       description: home.hero.description || fallbackHome.hero.description,
-      image: resolveRequiredLandingImage(home.hero.image, 'home.hero.image', home.hero.title || fallbackHome.hero.title)
-        .src,
+      image: resolveRequiredLandingImage(
+        home.hero.image,
+        'home.hero.image',
+        home.hero.title || fallbackHome.hero.title,
+      ),
     },
     testimonials: normalizeTestimonials(home.testimonials, fallbackHome.testimonials, 'home.testimonials'),
     testimonialsIntro: {
@@ -680,7 +676,7 @@ export const normalizeClinicPartnerLandingContent = (
         clinicPartners.hero.image,
         'clinicPartners.hero.image',
         clinicPartners.hero.title || fallbackClinicPartners.hero.title,
-      ).src,
+      ),
     },
     features: {
       title: clinicPartners.features.title || fallbackClinicPartners.features.title,

--- a/src/utilities/media/resolveMediaImage.ts
+++ b/src/utilities/media/resolveMediaImage.ts
@@ -19,9 +19,82 @@ export type ResolvedMediaImage = {
   alt: string
   width?: number
   height?: number
+  sizes: string
+  quality: number
 }
 
-const DEFAULT_SIZE_ORDER = ['xlarge', 'large', 'medium', 'small', 'thumbnail']
+export type MediaImageUsage =
+  | 'avatar'
+  | 'authorAvatar'
+  | 'listingCard'
+  | 'blogCard'
+  | 'content'
+  | 'landingVisual'
+  | 'hero'
+  | 'og'
+
+type PayloadImageSize = 'thumbnail' | 'square' | 'small' | 'medium' | 'large' | 'xlarge' | 'og' | 'original'
+
+type InternalMediaImagePolicy = {
+  payloadSizeOrder: PayloadImageSize[]
+  sizes: string
+  quality: number
+  allowThumbnailPrimary?: boolean
+}
+
+const MEDIA_IMAGE_POLICIES = {
+  avatar: {
+    payloadSizeOrder: ['thumbnail', 'square', 'small', 'original'],
+    sizes: '48px',
+    quality: 70,
+    allowThumbnailPrimary: true,
+  },
+  authorAvatar: {
+    payloadSizeOrder: ['thumbnail', 'square', 'small', 'original'],
+    sizes: '40px',
+    quality: 70,
+    allowThumbnailPrimary: true,
+  },
+  listingCard: {
+    payloadSizeOrder: ['medium', 'small', 'large', 'original', 'thumbnail'],
+    sizes: '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw',
+    quality: 70,
+  },
+  blogCard: {
+    payloadSizeOrder: ['large', 'medium', 'small', 'original', 'thumbnail'],
+    sizes: '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw',
+    quality: 70,
+  },
+  content: {
+    payloadSizeOrder: ['large', 'medium', 'original', 'small', 'thumbnail'],
+    sizes: '(max-width: 768px) 100vw, 960px',
+    quality: 70,
+  },
+  landingVisual: {
+    payloadSizeOrder: ['xlarge', 'large', 'original', 'medium', 'small', 'thumbnail'],
+    sizes: '(max-width: 1024px) 100vw, 50vw',
+    quality: 75,
+  },
+  hero: {
+    payloadSizeOrder: ['xlarge', 'large', 'original', 'medium'],
+    sizes: '100vw',
+    quality: 75,
+  },
+  og: {
+    payloadSizeOrder: ['og', 'large', 'original'],
+    sizes: '1200px',
+    quality: 75,
+  },
+} satisfies Record<MediaImageUsage, InternalMediaImagePolicy>
+
+for (const [usage, policy] of Object.entries(MEDIA_IMAGE_POLICIES)) {
+  if (
+    policy.payloadSizeOrder[0] === 'thumbnail' &&
+    (!('allowThumbnailPrimary' in policy) || policy.allowThumbnailPrimary !== true)
+  ) {
+    throw new Error(`Media image policy "${usage}" must explicitly allow thumbnail as its primary size`)
+  }
+}
 
 const normalizePayloadApiFileUrl = (src: string): string => {
   if (!src.includes('/api/') || !src.includes('/file/')) return src
@@ -46,15 +119,31 @@ const normalizePayloadApiFileUrl = (src: string): string => {
 
 export function resolveMediaImage(
   media: MediaLike,
-  fallbackAlt?: string,
-  sizeOrder: string[] = DEFAULT_SIZE_ORDER,
+  options: {
+    fallbackAlt?: string
+    usage: MediaImageUsage
+  },
 ): ResolvedMediaImage | undefined {
   if (!media) return undefined
 
-  const alt = media.alt ?? fallbackAlt ?? ''
+  const policy = MEDIA_IMAGE_POLICIES[options.usage]
+  const alt = media.alt ?? options.fallbackAlt ?? ''
   const sizes = media.sizes ?? {}
 
-  for (const key of sizeOrder) {
+  for (const key of policy.payloadSizeOrder) {
+    if (key === 'original') {
+      if (!media.url) continue
+
+      return {
+        src: normalizePayloadApiFileUrl(media.url),
+        alt,
+        width: media.width ?? undefined,
+        height: media.height ?? undefined,
+        sizes: policy.sizes,
+        quality: policy.quality,
+      }
+    }
+
     const size = sizes[key]
     if (size?.url) {
       return {
@@ -62,16 +151,9 @@ export function resolveMediaImage(
         alt,
         width: size.width ?? undefined,
         height: size.height ?? undefined,
+        sizes: policy.sizes,
+        quality: policy.quality,
       }
-    }
-  }
-
-  if (media.url) {
-    return {
-      src: normalizePayloadApiFileUrl(media.url),
-      alt,
-      width: media.width ?? undefined,
-      height: media.height ?? undefined,
     }
   }
 

--- a/tests/unit/app/frontend/home.page.test.ts
+++ b/tests/unit/app/frontend/home.page.test.ts
@@ -42,9 +42,11 @@ vi.mock('@/utilities/content/serverData', () => ({
 }))
 
 vi.mock('@/utilities/media/resolveMediaImage', () => ({
-  resolveMediaImage: (_media: unknown, fallbackAlt: string) => ({
+  resolveMediaImage: (_media: unknown, options: { fallbackAlt?: string }) => ({
     src: '/seeded-landing-media.jpg',
-    alt: fallbackAlt,
+    alt: options.fallbackAlt ?? '',
+    sizes: '(max-width: 1024px) 100vw, 50vw',
+    quality: 75,
   }),
 }))
 

--- a/tests/unit/app/frontend/post.page.test.tsx
+++ b/tests/unit/app/frontend/post.page.test.tsx
@@ -13,7 +13,7 @@ const mocks = vi.hoisted(() => ({
   postShareActionBarComponent: vi.fn(() => null),
   relatedPostsComponent: vi.fn(() => null),
   richTextComponent: vi.fn(() => null),
-  resolveMediaImageMock: vi.fn(() => undefined),
+  resolveMediaImageMock: vi.fn<() => unknown>(() => undefined),
 }))
 
 vi.mock('next/headers', () => ({
@@ -104,10 +104,20 @@ describe('frontend post detail route', () => {
     mocks.draftModeMock.mockResolvedValue({ isEnabled: false })
     mocks.getPayloadMock.mockResolvedValue({})
     mocks.findPostSlugsMock.mockResolvedValue([{ slug: 'hello-world' }])
+    mocks.resolveMediaImageMock.mockReturnValue({
+      src: '/api/platformContentMedia/file/post-hero.webp',
+      alt: 'Hallo Welt',
+      sizes: '100vw',
+      quality: 75,
+    })
     mocks.findPostBySlugMock.mockResolvedValue({
       slug: 'hello-world',
       title: 'Hallo Welt',
       excerpt: 'Deutscher Auszug.',
+      heroImage: {
+        url: '/api/platformContentMedia/file/post-hero.webp',
+        alt: 'Hallo Welt',
+      },
       content: {
         root: {
           type: 'root',
@@ -136,6 +146,16 @@ describe('frontend post detail route', () => {
       locale: 'de',
       fallbackLocale: 'en',
     })
+    expect(mocks.resolveMediaImageMock).toHaveBeenCalledWith(
+      {
+        url: '/api/platformContentMedia/file/post-hero.webp',
+        alt: 'Hallo Welt',
+      },
+      {
+        fallbackAlt: 'Hallo Welt',
+        usage: 'hero',
+      },
+    )
 
     const redirectElement = findElementByType(result, mocks.payloadRedirectsComponent) as React.ReactElement<{
       disableNotFound?: boolean
@@ -146,11 +166,23 @@ describe('frontend post detail route', () => {
 
     const heroElement = findElementByType(result, mocks.postHeroComponent) as React.ReactElement<{
       breadcrumbs: Array<{ href: string; label: string }>
+      image?: {
+        alt: string
+        quality: number
+        sizes: string
+        src: string
+      }
     }> | null
     expect(heroElement?.props.breadcrumbs).toEqual([
       { label: 'Home', href: '/' },
       { label: 'Blog', href: '/posts?locale=de' },
     ])
+    expect(heroElement?.props.image).toEqual({
+      src: '/api/platformContentMedia/file/post-hero.webp',
+      alt: 'Hallo Welt',
+      sizes: '100vw',
+      quality: 75,
+    })
 
     const shareElement = findElementByType(result, mocks.postShareActionBarComponent) as React.ReactElement<{
       backLink: { href: string; label: string }

--- a/tests/unit/utilities/landingPageContent.test.ts
+++ b/tests/unit/utilities/landingPageContent.test.ts
@@ -64,7 +64,11 @@ describe('landingPageContent normalizers', () => {
 
     const content = normalizeHomeLandingContent(landingPages)
 
-    expect(content.hero.image).toBe('/platform-media/home-hero-large.webp')
+    expect(content.hero.image).toMatchObject({
+      src: '/platform-media/home-hero-large.webp',
+      sizes: '(max-width: 1024px) 100vw, 50vw',
+      quality: 75,
+    })
     expect(content.features.items[0]?.icon).toBe(Target)
     expect('defaultOpenItemId' in content.faq).toBe(false)
     expect(content.faq.items[0]).toEqual({
@@ -87,7 +91,11 @@ describe('landingPageContent normalizers', () => {
   it('keeps pricing data while using CMS media for the clinic partner page', () => {
     const content = normalizeClinicPartnerLandingContent(attachRequiredMedia(cloneDefaultLandingPages()))
 
-    expect(content.hero.image).toBe('/platform-media/clinic-partner-hero-large.webp')
+    expect(content.hero.image).toMatchObject({
+      src: '/platform-media/clinic-partner-hero-large.webp',
+      sizes: '(max-width: 1024px) 100vw, 50vw',
+      quality: 75,
+    })
     expect(content.testimonials[0]?.image).toBe('/platform-media/Alex Morgan.webp')
     expect(content.team[0]?.image).toBe('/platform-media/Volkan Kablan.webp')
     expect(content.pricing.plans[0]?.highlights).toEqual([
@@ -96,6 +104,33 @@ describe('landingPageContent normalizers', () => {
       'Built for clinics scaling inbound demand',
     ])
     expect(content.pricingModel).toHaveLength(3)
+  })
+
+  it('uses original landing media before thumbnail-only generated sizes', () => {
+    const landingPages = attachRequiredMedia(cloneDefaultLandingPages())
+    const firstProcessStep = landingPages.clinicPartners.process.steps[0]
+    if (!firstProcessStep) throw new Error('Expected default clinic partner process step')
+    firstProcessStep.image = {
+      alt: 'Clinic onboarding image',
+      url: '/api/platformContentMedia/file/partner-process-step-1-reach-out-v2.webp',
+      width: 576,
+      height: 968,
+      sizes: {
+        thumbnail: {
+          url: '/api/platformContentMedia/file/partner-process-step-1-reach-out-v2-300x504.webp',
+          width: 300,
+          height: 504,
+        },
+      },
+    } as PlatformContentMedia
+
+    const content = normalizeClinicPartnerLandingContent(landingPages)
+
+    expect(content.process.stepImages[0]?.src).toBe(
+      '/api/platformContentMedia/file/partner-process-step-1-reach-out-v2.webp',
+    )
+    expect(content.process.stepImages[0]?.sizes).toBe('(max-width: 1024px) 100vw, 50vw')
+    expect(content.process.stepImages[0]?.quality).toBe(75)
   })
 
   it('drops unsafe CMS links before they reach public landing components', () => {

--- a/tests/unit/utilities/normalizePost.test.ts
+++ b/tests/unit/utilities/normalizePost.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import type { PlatformContentMedia } from '@/payload-types'
 import { normalizePost } from '@/utilities/blog/normalizePost'
 
 describe('normalizePost', () => {
@@ -27,5 +28,34 @@ describe('normalizePost', () => {
     )
 
     expect(normalized.href).toBe('/posts/hello-world?locale=de')
+  })
+
+  it('uses original blog card media before thumbnail-only generated sizes', () => {
+    const normalized = normalizePost({
+      title: 'Hello World',
+      slug: 'hello-world',
+      heroImage: {
+        alt: 'Blog hero image',
+        url: '/api/platformContentMedia/file/blog-hero.webp',
+        width: 576,
+        height: 968,
+        sizes: {
+          thumbnail: {
+            url: '/api/platformContentMedia/file/blog-hero-300x504.webp',
+            width: 300,
+            height: 504,
+          },
+        },
+      } as PlatformContentMedia,
+    })
+
+    expect(normalized.image).toEqual({
+      src: '/api/platformContentMedia/file/blog-hero.webp',
+      alt: 'Blog hero image',
+      width: 576,
+      height: 968,
+      sizes: '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw',
+      quality: 70,
+    })
   })
 })

--- a/tests/unit/utilities/resolveMediaImage.test.ts
+++ b/tests/unit/utilities/resolveMediaImage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolveMediaImage } from '@/utilities/media/resolveMediaImage'
+import * as mediaImageModule from '@/utilities/media/resolveMediaImage'
+import { resolveMediaImage, type MediaImageUsage } from '@/utilities/media/resolveMediaImage'
 
 describe('resolveMediaImage', () => {
   it('preserves intentionally empty alt text instead of replacing it with fallback text', () => {
@@ -15,8 +16,10 @@ describe('resolveMediaImage', () => {
           },
         },
       },
-      'Fallback alt',
-      ['medium'],
+      {
+        fallbackAlt: 'Fallback alt',
+        usage: 'content',
+      },
     )
 
     expect(image).toEqual({
@@ -24,6 +27,8 @@ describe('resolveMediaImage', () => {
       alt: '',
       width: 640,
       height: 480,
+      sizes: '(max-width: 768px) 100vw, 960px',
+      quality: 70,
     })
   })
 
@@ -35,7 +40,10 @@ describe('resolveMediaImage', () => {
         width: 1200,
         height: 800,
       },
-      'Fallback alt',
+      {
+        fallbackAlt: 'Fallback alt',
+        usage: 'hero',
+      },
     )
 
     expect(image).toEqual({
@@ -43,6 +51,136 @@ describe('resolveMediaImage', () => {
       alt: 'Example',
       width: 1200,
       height: 800,
+      sizes: '100vw',
+      quality: 75,
     })
+  })
+
+  it('prefers the original image before falling back to a thumbnail', () => {
+    const image = resolveMediaImage(
+      {
+        alt: 'Example',
+        url: '/api/platformContentMedia/file/process-step-2-create-profile-v3.webp',
+        width: 576,
+        height: 968,
+        sizes: {
+          thumbnail: {
+            url: '/api/platformContentMedia/file/process-step-2-create-profile-v3-300x504.webp',
+            width: 300,
+            height: 504,
+          },
+        },
+      },
+      {
+        fallbackAlt: 'Fallback alt',
+        usage: 'landingVisual',
+      },
+    )
+
+    expect(image).toEqual({
+      src: '/api/platformContentMedia/file/process-step-2-create-profile-v3.webp',
+      alt: 'Example',
+      width: 576,
+      height: 968,
+      sizes: '(max-width: 1024px) 100vw, 50vw',
+      quality: 75,
+    })
+  })
+
+  it('uses the largest configured public size for large visual contexts', () => {
+    const image = resolveMediaImage(
+      {
+        alt: 'Example',
+        url: '/api/platformContentMedia/file/example.webp',
+        width: 1600,
+        height: 1000,
+        sizes: {
+          medium: {
+            url: '/api/platformContentMedia/file/example-900x563.webp',
+            width: 900,
+            height: 563,
+          },
+          large: {
+            url: '/api/platformContentMedia/file/example-1400x875.webp',
+            width: 1400,
+            height: 875,
+          },
+        },
+      },
+      {
+        fallbackAlt: 'Fallback alt',
+        usage: 'landingVisual',
+      },
+    )
+
+    expect(image).toMatchObject({
+      src: '/api/platformContentMedia/file/example-1400x875.webp',
+      width: 1400,
+      height: 875,
+      sizes: '(max-width: 1024px) 100vw, 50vw',
+      quality: 75,
+    })
+  })
+
+  it('allows thumbnail as the primary size only for avatar contexts', () => {
+    const media = {
+      alt: 'Avatar',
+      url: '/api/userProfileMedia/file/avatar.webp',
+      width: 900,
+      height: 900,
+      sizes: {
+        thumbnail: {
+          url: '/api/userProfileMedia/file/avatar-300x300.webp',
+          width: 300,
+          height: 300,
+        },
+      },
+    }
+
+    expect(resolveMediaImage(media, { fallbackAlt: 'Fallback alt', usage: 'avatar' })).toMatchObject({
+      src: '/api/userProfileMedia/file/avatar-300x300.webp',
+      sizes: '48px',
+    })
+    expect(resolveMediaImage(media, { fallbackAlt: 'Fallback alt', usage: 'hero' })).toMatchObject({
+      src: '/api/userProfileMedia/file/avatar.webp',
+      sizes: '100vw',
+    })
+  })
+
+  it('keeps internal media policies private while every public usage resolves', () => {
+    expect('MEDIA_IMAGE_POLICIES' in mediaImageModule).toBe(false)
+
+    const usages: MediaImageUsage[] = [
+      'avatar',
+      'authorAvatar',
+      'listingCard',
+      'blogCard',
+      'content',
+      'landingVisual',
+      'hero',
+      'og',
+    ]
+
+    for (const usage of usages) {
+      expect(
+        resolveMediaImage(
+          {
+            alt: 'Example',
+            url: `/api/platformContentMedia/file/${usage}.webp`,
+            width: 1200,
+            height: 800,
+          },
+          {
+            fallbackAlt: 'Fallback alt',
+            usage,
+          },
+        ),
+      ).toEqual(
+        expect.objectContaining({
+          alt: 'Example',
+          src: `/api/platformContentMedia/file/${usage}.webp`,
+        }),
+      )
+    }
   })
 })


### PR DESCRIPTION
CMS-backed public images now resolve through a central usage-specific policy, so large visual contexts stop scaling thumbnail-sized assets.

## What changed
- added a strict public media image resolver interface with private usage policies for avatar, card, content, landing, hero, and OG image contexts
- routed landing visuals, blog cards, post heroes, content media blocks, and OG metadata through the resolver output
- passed resolver-provided sizes and quality values into rendered Next/Image paths
- added regression coverage for original-before-thumbnail selection, private policy exports, landing process images, blog cards, and post heroes

## Validation
- pnpm format
- pnpm vitest --run tests/unit/utilities/resolveMediaImage.test.ts tests/unit/utilities/landingPageContent.test.ts tests/unit/utilities/normalizePost.test.ts tests/unit/app/frontend/post.page.test.tsx tests/unit/app/frontend/home.page.test.ts tests/unit/utilities/generateMeta.test.ts
- pnpm check
- PAYLOAD_SECRET=dev-secret pnpm build

Build notes: local build exits 0. It logs the existing local environment warning `NEXT_PUBLIC_SUPABASE_URL is not defined` during static generation and the Node engine warning for Node 26 versus the repo Node 24 range.

## Screenshots
- Local Playwright check saved `output/playwright/media-policy-partners-process-mobile.png`; local CMS media files are absent in this worktree, so the screenshot shows missing media while DOM inspection confirmed the resolver-selected original URL, `sizes`, and `q=75` image request.

## Development
Fixes #1120
