### PR TITLE
fix(frontend): add fixed contact route

### DIFF
--- a/src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts
+++ b/src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts
@@ -25,6 +25,10 @@ const getPagesSitemap = unstable_cache(
         loc: `${SITE_URL}/posts`,
         lastmod: dateFallback,
       },
+      {
+        loc: `${SITE_URL}/contact`,
+        lastmod: dateFallback,
+      },
     ]
 
     const sitemap = results

--- a/src/app/(frontend)/contact/page.tsx
+++ b/src/app/(frontend)/contact/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from 'next'
+
+import { LandingContact } from '@/components/organisms/Landing/LandingContact'
+import { createSiteMetadata } from '@/utilities/generateMeta'
+
+const CONTACT_TITLE = 'Contact findmydoc'
+const CONTACT_DESCRIPTION =
+  'Send us your request about clinic comparisons, patient support, clinic partnerships, or platform questions.'
+
+const TRACKING_QUERY_FIELDS = ['clinic', 'source'] as const
+const MAX_TRACKING_VALUE_LENGTH = 200
+
+type ContactSearchParams = Record<string, string | string[] | undefined>
+type TrackingQueryField = (typeof TRACKING_QUERY_FIELDS)[number]
+
+export const metadata: Metadata = {
+  ...createSiteMetadata({
+    title: 'Contact',
+    description: CONTACT_DESCRIPTION,
+    path: '/contact',
+  }),
+  alternates: {
+    canonical: '/contact',
+  },
+}
+
+function readSearchParamValue(value: string | string[] | undefined): string | null {
+  const rawValue = Array.isArray(value) ? value[0] : value
+  const normalizedValue = rawValue?.trim()
+
+  if (!normalizedValue) return null
+
+  return normalizedValue.slice(0, MAX_TRACKING_VALUE_LENGTH)
+}
+
+function buildTrackingFields(searchParams: ContactSearchParams): Partial<Record<TrackingQueryField, string>> {
+  return Object.fromEntries(
+    TRACKING_QUERY_FIELDS.flatMap((field) => {
+      const value = readSearchParamValue(searchParams[field])
+
+      return value ? [[field, value]] : []
+    }),
+  ) as Partial<Record<TrackingQueryField, string>>
+}
+
+export default async function ContactPage({
+  searchParams: searchParamsPromise,
+}: {
+  searchParams?: Promise<ContactSearchParams>
+} = {}) {
+  const searchParams = (await searchParamsPromise) ?? {}
+  const trackingFields = buildTrackingFields(searchParams)
+
+  return (
+    <main>
+      <LandingContact
+        title={CONTACT_TITLE}
+        description={CONTACT_DESCRIPTION}
+        headingAs="h1"
+        trackingFields={trackingFields}
+      />
+    </main>
+  )
+}

--- a/src/components/organisms/Landing/LandingContact.tsx
+++ b/src/components/organisms/Landing/LandingContact.tsx
@@ -4,6 +4,7 @@ import { Container } from '@/components/molecules/Container'
 import { SectionHeading } from '@/components/molecules/SectionHeading'
 import {
   HoldingPageContactForm,
+  type ContactTrackingFields,
   type HoldingPageContactSubmitter,
 } from '@/components/templates/HoldingPageConcept/ContactForm.client'
 import {
@@ -19,9 +20,12 @@ type LandingContactProps = {
   contactFormSlug?: string
   contactMode?: 'compact' | 'full'
   description: string
+  headingAs?: 'h1' | 'h2' | 'h3'
+  id?: string
   onSubmitContact?: HoldingPageContactSubmitter
   primaryCtaLabel?: string
   title: string
+  trackingFields?: ContactTrackingFields
 }
 
 export const LandingContact: React.FC<LandingContactProps> = ({
@@ -31,15 +35,18 @@ export const LandingContact: React.FC<LandingContactProps> = ({
   contactFormSlug,
   contactMode = 'full',
   description,
+  headingAs,
+  id = 'contact',
   onSubmitContact,
   primaryCtaLabel = 'Send message',
   title,
+  trackingFields,
 }) => {
   const consentCopy =
     contactConsent ?? 'By sending this request, you agree that findmydoc may contact you about your inquiry.'
 
   return (
-    <section className="relative overflow-hidden py-20">
+    <section id={id} className="relative overflow-hidden py-20">
       <div className="absolute inset-0 bg-linear-to-br from-sky-50 via-white to-slate-50" aria-hidden="true" />
       <div className="absolute inset-x-0 top-0 h-px bg-slate-200/70" aria-hidden="true" />
 
@@ -50,13 +57,13 @@ export const LandingContact: React.FC<LandingContactProps> = ({
             description={description}
             size="section"
             align="left"
-            headingAs="h2"
+            headingAs={headingAs ?? 'h2'}
             titleClassName="max-w-xl"
             descriptionClassName="max-w-xl"
           />
 
           <div className="rounded-[32px] border border-slate-200/80 bg-white/92 p-5 shadow-[0_30px_100px_-56px_rgba(15,23,42,0.28)] backdrop-blur-xl sm:p-6">
-            <div className="mb-5 flex items-start justify-between gap-4">
+            <div className="mb-5 flex flex-col items-start gap-3 sm:flex-row sm:justify-between sm:gap-4">
               <div>
                 <p className="text-xs font-semibold tracking-[0.28em] text-slate-500 uppercase">{contactEyebrow}</p>
                 <p className="mt-2 text-sm leading-6 text-slate-600">
@@ -76,6 +83,7 @@ export const LandingContact: React.FC<LandingContactProps> = ({
               labels={contactFormLabels ?? DEFAULT_CONTACT_FORM_LABELS}
               onSubmitContact={onSubmitContact}
               primaryCtaLabel={primaryCtaLabel}
+              trackingFields={trackingFields}
             />
 
             <p className="mt-4 text-xs leading-5 text-slate-500">{consentCopy}</p>

--- a/src/components/templates/HoldingPageConcept/ContactForm.client.tsx
+++ b/src/components/templates/HoldingPageConcept/ContactForm.client.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type FormEvent, useState } from 'react'
+import { type FormEvent, useId, useRef, useState } from 'react'
 
 import { Button } from '@/components/atoms/button'
 import { Input } from '@/components/atoms/input'
@@ -11,7 +11,9 @@ import {
   type HoldingPageContactFormLabels,
 } from './contactForm.shared'
 
-type ContactFormPayload = { email: string } | { name: string; email: string; message: string }
+export type ContactTrackingFields = Record<string, string>
+
+type ContactFormPayload = ContactTrackingFields & ({ email: string } | { name: string; email: string; message: string })
 
 export type HoldingPageContactSubmitter = (
   targetSlug: string,
@@ -25,6 +27,14 @@ type ContactFormProps = {
   labels?: HoldingPageContactFormLabels
   onSubmitContact?: HoldingPageContactSubmitter
   primaryCtaLabel: string
+  trackingFields?: ContactTrackingFields
+}
+
+type ContactFieldName = 'name' | 'email' | 'message'
+
+type ContactValidationResult = {
+  field: ContactFieldName
+  message: string
 }
 
 const submitContactForm: HoldingPageContactSubmitter = async (targetSlug, payload, genericErrorMessage) => {
@@ -44,35 +54,82 @@ const submitContactForm: HoldingPageContactSubmitter = async (targetSlug, payloa
   }
 }
 
+const normalizeTrackingFields = (trackingFields?: ContactTrackingFields): ContactTrackingFields => {
+  if (!trackingFields) return {}
+
+  return Object.fromEntries(
+    Object.entries(trackingFields).flatMap(([field, value]) => {
+      const normalizedField = field.trim()
+      const normalizedValue = value.trim()
+
+      if (!normalizedField || !normalizedValue) return []
+
+      return [[normalizedField, normalizedValue]]
+    }),
+  )
+}
+
 export function HoldingPageContactForm({
   contactMode,
   contactFormSlug,
   labels,
   onSubmitContact = submitContactForm,
   primaryCtaLabel,
+  trackingFields,
 }: ContactFormProps) {
   const isCompactContact = contactMode === 'compact'
   const targetSlug = contactFormSlug?.trim() || DEFAULT_CONTACT_FORM_SLUG
   const copy = labels ?? DEFAULT_CONTACT_FORM_LABELS
+  const formId = useId()
+  const fieldErrorId = `${formId}-field-error`
+  const statusMessageId = `${formId}-status`
+  const nameInputId = `${formId}-name`
+  const emailInputId = `${formId}-email`
+  const messageInputId = `${formId}-message`
+  const nameLabel = copy.namePlaceholder.trim() || DEFAULT_CONTACT_FORM_LABELS.namePlaceholder
+  const emailLabel = copy.emailPlaceholder.trim() || DEFAULT_CONTACT_FORM_LABELS.emailPlaceholder
+  const messageLabel = copy.messagePlaceholder.trim() || DEFAULT_CONTACT_FORM_LABELS.messagePlaceholder
+
+  const nameInputRef = useRef<HTMLInputElement>(null)
+  const emailInputRef = useRef<HTMLInputElement>(null)
+  const messageInputRef = useRef<HTMLTextAreaElement>(null)
 
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [message, setMessage] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [invalidField, setInvalidField] = useState<ContactFieldName | null>(null)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [submitSuccess, setSubmitSuccess] = useState<string | null>(null)
 
   const resetMessages = () => {
+    setInvalidField(null)
     setSubmitError(null)
     setSubmitSuccess(null)
   }
 
-  const validate = (): string | null => {
-    if (!email.trim()) return copy.emailRequiredMessage
-    if (!isCompactContact && !name.trim()) return copy.nameRequiredMessage
-    if (!isCompactContact && !message.trim()) return copy.messageRequiredMessage
+  const validate = (): ContactValidationResult | null => {
+    if (!isCompactContact && !name.trim()) return { field: 'name', message: copy.nameRequiredMessage }
+    if (!email.trim()) return { field: 'email', message: copy.emailRequiredMessage }
+    if (!isCompactContact && !message.trim()) return { field: 'message', message: copy.messageRequiredMessage }
     return null
   }
+
+  const focusField = (field: ContactFieldName) => {
+    const fieldRef = field === 'name' ? nameInputRef : field === 'email' ? emailInputRef : messageInputRef
+
+    fieldRef.current?.focus()
+  }
+
+  const getFieldAriaDescribedBy = (field: ContactFieldName) =>
+    invalidField === field && submitError ? fieldErrorId : undefined
+
+  const renderFieldError = (field: ContactFieldName) =>
+    invalidField === field && submitError ? (
+      <p id={fieldErrorId} role="alert" className="text-xs leading-5 text-red-600">
+        {submitError}
+      </p>
+    ) : null
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -80,13 +137,16 @@ export function HoldingPageContactForm({
 
     const validationError = validate()
     if (validationError) {
-      setSubmitError(validationError)
+      setInvalidField(validationError.field)
+      setSubmitError(validationError.message)
+      focusField(validationError.field)
       return
     }
 
+    const trackingPayload = normalizeTrackingFields(trackingFields)
     const payload = isCompactContact
-      ? { email: email.trim() }
-      : { name: name.trim(), email: email.trim(), message: message.trim() }
+      ? { ...trackingPayload, email: email.trim() }
+      : { ...trackingPayload, name: name.trim(), email: email.trim(), message: message.trim() }
 
     setIsSubmitting(true)
 
@@ -108,49 +168,93 @@ export function HoldingPageContactForm({
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-3">
+    <form onSubmit={handleSubmit} className="space-y-3" noValidate>
       {isCompactContact ? null : (
+        <div className="space-y-1.5">
+          <label htmlFor={nameInputId} className="text-xs font-medium text-slate-700">
+            {nameLabel}
+          </label>
+          <Input
+            id={nameInputId}
+            aria-describedby={getFieldAriaDescribedBy('name')}
+            aria-invalid={invalidField === 'name' || undefined}
+            aria-required="true"
+            name="name"
+            ref={nameInputRef}
+            required
+            value={name}
+            onChange={(event) => {
+              setName(event.target.value)
+              resetMessages()
+            }}
+            placeholder={nameLabel}
+            autoComplete="name"
+            className="h-12 rounded-xl border-slate-200 bg-slate-50/90 text-slate-950 placeholder:text-slate-400"
+          />
+          {renderFieldError('name')}
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        <label htmlFor={emailInputId} className="text-xs font-medium text-slate-700">
+          {emailLabel}
+        </label>
         <Input
-          aria-label="Name"
-          name="name"
-          value={name}
+          id={emailInputId}
+          aria-describedby={getFieldAriaDescribedBy('email')}
+          aria-invalid={invalidField === 'email' || undefined}
+          aria-required="true"
+          name="email"
+          ref={emailInputRef}
+          required
+          type="email"
+          value={email}
           onChange={(event) => {
-            setName(event.target.value)
+            setEmail(event.target.value)
             resetMessages()
           }}
-          placeholder={copy.namePlaceholder}
-          autoComplete="name"
+          placeholder={emailLabel}
+          autoComplete="email"
           className="h-12 rounded-xl border-slate-200 bg-slate-50/90 text-slate-950 placeholder:text-slate-400"
         />
-      )}
-
-      <Input
-        aria-label="Email"
-        name="email"
-        type="email"
-        value={email}
-        onChange={(event) => {
-          setEmail(event.target.value)
-          resetMessages()
-        }}
-        placeholder={copy.emailPlaceholder}
-        autoComplete="email"
-        className="h-12 rounded-xl border-slate-200 bg-slate-50/90 text-slate-950 placeholder:text-slate-400"
-      />
+        {renderFieldError('email')}
+      </div>
 
       {isCompactContact ? null : (
-        <Textarea
-          aria-label="Message"
-          name="message"
-          value={message}
-          onChange={(event) => {
-            setMessage(event.target.value)
-            resetMessages()
-          }}
-          placeholder={copy.messagePlaceholder}
-          className="min-h-28 rounded-xl border-slate-200 bg-slate-50/90 text-slate-950 placeholder:text-slate-400 sm:min-h-32"
-        />
+        <div className="space-y-1.5">
+          <label htmlFor={messageInputId} className="text-xs font-medium text-slate-700">
+            {messageLabel}
+          </label>
+          <Textarea
+            id={messageInputId}
+            aria-describedby={getFieldAriaDescribedBy('message')}
+            aria-invalid={invalidField === 'message' || undefined}
+            aria-required="true"
+            name="message"
+            ref={messageInputRef}
+            required
+            value={message}
+            onChange={(event) => {
+              setMessage(event.target.value)
+              resetMessages()
+            }}
+            placeholder={messageLabel}
+            className="min-h-28 rounded-xl border-slate-200 bg-slate-50/90 text-slate-950 placeholder:text-slate-400 sm:min-h-32"
+          />
+          {renderFieldError('message')}
+        </div>
       )}
+
+      {submitSuccess ? (
+        <p id={statusMessageId} role="status" className="text-xs leading-5 text-emerald-700">
+          {submitSuccess}
+        </p>
+      ) : null}
+      {!invalidField && submitError ? (
+        <p id={statusMessageId} role="alert" className="text-xs leading-5 text-red-600">
+          {submitError}
+        </p>
+      ) : null}
 
       <Button
         type="submit"
@@ -161,9 +265,6 @@ export function HoldingPageContactForm({
       >
         {isSubmitting ? copy.submittingLabel : primaryCtaLabel}
       </Button>
-
-      {submitSuccess ? <p className="text-xs leading-5 text-emerald-700">{submitSuccess}</p> : null}
-      {submitError ? <p className="text-xs leading-5 text-red-600">{submitError}</p> : null}
     </form>
   )
 }

--- a/src/stories/organisms/Landing/LandingContact.stories.tsx
+++ b/src/stories/organisms/Landing/LandingContact.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect, userEvent, waitFor, within } from '@storybook/test'
+import { expect, fn, userEvent, waitFor, within } from '@storybook/test'
 
 import { LandingContact } from '@/components/organisms/Landing'
 import { withViewportStory } from '../../utils/viewportMatrix'
 
-const submitContact = () => new Promise<void>((resolve) => setTimeout(resolve, 120))
+const submitContact = fn(async () => undefined)
 
 const meta = {
   title: 'Domain/Landing/Organisms/LandingContact',
@@ -17,6 +17,9 @@ const meta = {
     onSubmitContact: submitContact,
     title: 'Contact',
     description: 'Reach out to learn how we can help your clinic grow.',
+    trackingFields: {
+      source: 'storybook',
+    },
   },
 } satisfies Meta<typeof LandingContact>
 
@@ -43,13 +46,14 @@ export const Default1024: Story = withViewportStory(Default, 'public1024', 'Defa
 export const Default1280: Story = withViewportStory(Default, 'public1280', 'Default / 1280')
 
 const validationAndSubmitBase: Story = {
-  play: async ({ canvasElement }) => {
+  play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement)
+    const onSubmitContact = args.onSubmitContact
 
     await userEvent.click(canvas.getByRole('button', { name: 'Send message' }))
 
     await waitFor(() => {
-      expect(canvas.getByText('Email is required.')).toBeInTheDocument()
+      expect(canvas.getByText('Name is required.')).toBeInTheDocument()
     })
 
     await userEvent.type(canvas.getByLabelText('Name'), 'Alex Morgan')
@@ -62,6 +66,16 @@ const validationAndSubmitBase: Story = {
     await userEvent.click(canvas.getByRole('button', { name: 'Send message' }))
 
     await waitFor(() => {
+      expect(onSubmitContact).toHaveBeenCalledWith(
+        'holding-contact',
+        {
+          source: 'storybook',
+          name: 'Alex Morgan',
+          email: 'alex@findmydoc.com',
+          message: 'I would like to discuss partnership options for our clinic.',
+        },
+        'Could not send your request right now.',
+      )
       expect(canvas.getByText('Your request has been sent successfully.')).toBeInTheDocument()
     })
   },

--- a/src/stories/templates/HoldingPageConcept.stories.tsx
+++ b/src/stories/templates/HoldingPageConcept.stories.tsx
@@ -158,7 +158,7 @@ const mobileStressSubmitBase: Story = {
     await userEvent.click(canvas.getByRole('button', { name: String(args.primaryCtaLabel) }))
 
     await waitFor(() => {
-      expect(canvas.getByText('Email is required.')).toBeInTheDocument()
+      expect(canvas.getByText('Name is required.')).toBeInTheDocument()
     })
 
     await userEvent.type(canvas.getByLabelText('Name'), 'Taylor Brooks')

--- a/tests/unit/app/frontend/contact.page.test.tsx
+++ b/tests/unit/app/frontend/contact.page.test.tsx
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  createSiteMetadataMock: vi.fn((args: unknown) => args),
+  landingContactComponent: vi.fn(() => null),
+}))
+
+vi.mock('@/components/organisms/Landing/LandingContact', () => ({
+  LandingContact: mocks.landingContactComponent,
+}))
+
+vi.mock('@/utilities/generateMeta', () => ({
+  createSiteMetadata: mocks.createSiteMetadataMock,
+}))
+
+describe('frontend contact page route', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('sets metadata for the canonical contact route', async () => {
+    const pageModule = await import('@/app/(frontend)/contact/page')
+
+    expect(pageModule.metadata).toEqual({
+      title: 'Contact',
+      description:
+        'Send us your request about clinic comparisons, patient support, clinic partnerships, or platform questions.',
+      path: '/contact',
+      alternates: {
+        canonical: '/contact',
+      },
+    })
+    expect(mocks.createSiteMetadataMock).toHaveBeenCalledWith({
+      title: 'Contact',
+      description:
+        'Send us your request about clinic comparisons, patient support, clinic partnerships, or platform questions.',
+      path: '/contact',
+    })
+  })
+
+  it('renders the shared contact form with an h1 and allowed tracking fields', async () => {
+    const pageModule = await import('@/app/(frontend)/contact/page')
+
+    const result = await pageModule.default({
+      searchParams: Promise.resolve({
+        clinic: [' berlin-health-clinic ', 'ignored-second-value'],
+        source: 'clinic-detail',
+        ignored: 'not-forwarded',
+      }),
+    })
+
+    expect(result.type).toBe('main')
+    expect(result.props.children.type).toBe(mocks.landingContactComponent)
+    expect(result.props.children.props).toMatchObject({
+      title: 'Contact findmydoc',
+      headingAs: 'h1',
+      trackingFields: {
+        clinic: 'berlin-health-clinic',
+        source: 'clinic-detail',
+      },
+    })
+    expect(result.props.children.props.trackingFields).not.toHaveProperty('ignored')
+  })
+})

--- a/tests/unit/app/frontend/sitemap.routes.test.ts
+++ b/tests/unit/app/frontend/sitemap.routes.test.ts
@@ -79,4 +79,20 @@ describe('frontend sitemap routes', () => {
       },
     })
   })
+
+  it('includes fixed public routes in the pages sitemap', async () => {
+    routeMocks.findPageSitemapDocs.mockResolvedValue([])
+    const request = new Request('https://findmydoc.eu/pages-sitemap.xml')
+    const { GET } = await import('@/app/(frontend)/(sitemaps)/pages-sitemap.xml/route')
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(body.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ loc: expect.stringMatching(/\/posts$/) }),
+        expect.objectContaining({ loc: expect.stringMatching(/\/contact$/) }),
+      ]),
+    )
+  })
 })

--- a/tests/unit/components/landingContact.test.tsx
+++ b/tests/unit/components/landingContact.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import React from 'react'
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { LandingContact } from '@/components/organisms/Landing/LandingContact'
+import { DEFAULT_CONTACT_FORM_LABELS } from '@/components/templates/HoldingPageConcept/contactForm.shared'
+
+describe('LandingContact', () => {
+  it('can render as the page h1 and submit tracking fields with the contact payload', async () => {
+    const submitContact = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <LandingContact
+        title="Contact findmydoc"
+        description="Send a request."
+        headingAs="h1"
+        trackingFields={{
+          clinic: 'berlin-health-clinic',
+          empty: '',
+          source: 'clinic-detail',
+        }}
+        onSubmitContact={submitContact}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Contact findmydoc' })).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Jane Doe' } })
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'jane@example.com' } })
+    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'I want to contact this clinic.' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    await waitFor(() => {
+      expect(submitContact).toHaveBeenCalledWith(
+        'holding-contact',
+        {
+          clinic: 'berlin-health-clinic',
+          source: 'clinic-detail',
+          name: 'Jane Doe',
+          email: 'jane@example.com',
+          message: 'I want to contact this clinic.',
+        },
+        'Could not send your request right now.',
+      )
+    })
+  })
+
+  it('uses localized field labels and links validation errors to the invalid field', async () => {
+    render(
+      <LandingContact
+        title="Contact findmydoc"
+        description="Send a request."
+        contactFormLabels={{
+          ...DEFAULT_CONTACT_FORM_LABELS,
+          emailPlaceholder: 'E-Mail-Adresse',
+          emailRequiredMessage: 'E-Mail-Adresse ist erforderlich.',
+          messagePlaceholder: 'Nachricht',
+          namePlaceholder: 'Name',
+        }}
+      />,
+    )
+
+    const nameField = screen.getByLabelText('Name')
+    const emailField = screen.getByLabelText('E-Mail-Adresse')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    const validationError = await screen.findByRole('alert')
+
+    expect(screen.getByText('Name')).toBeVisible()
+    expect(screen.getByText('E-Mail-Adresse')).toBeVisible()
+    expect(emailField).toBeRequired()
+    expect(validationError).toHaveTextContent('Name is required.')
+    expect(nameField).toHaveAttribute('aria-invalid', 'true')
+    expect(nameField).toHaveAttribute('aria-describedby', validationError.id)
+  })
+})


### PR DESCRIPTION
Fixes the public `/contact` route so existing navigation and clinic-detail CTAs no longer depend on a CMS page being seeded.

## What changed

- Add a fixed Next.js `/contact` route that renders the existing contact section with `h1` semantics and canonical metadata.
- Preserve existing `/contact` links and pass whitelisted `clinic`/`source` query context into the contact submission payload.
- Add `/contact` to the pages sitemap.
- Improve contact form accessibility and mobile error visibility with persistent labels, required state, field-scoped errors, and visible submit status messaging.
- Extend unit and Storybook coverage for route metadata, sitemap inclusion, query context, validation, and submit payloads.

## Validation

- `rtk pnpm format`
- `rtk pnpm vitest tests/unit/app/frontend/contact.page.test.tsx tests/unit/components/landingContact.test.tsx tests/unit/app/frontend/sitemap.routes.test.ts tests/unit/utilities/clinicDetailServerData.contract.test.ts tests/unit/utilities/landingPageContent.test.ts --run`
- `rtk pnpm vitest --project storybook src/stories/organisms/Landing/LandingContact.stories.tsx --run`
- `rtk pnpm check`
- `rtk env PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build`
- `rtk detect-secrets-hook --baseline .secrets.baseline ...`

## Screenshots

- Mobile contact route: `output/playwright/contact-route-404/contact-route-375-accepted.png`
- Desktop contact route: `output/playwright/contact-route-404/contact-route-desktop-header.png`
- Mobile invalid submit: `output/playwright/contact-route-404/contact-route-375-invalid-visible.png`
- Mobile API error submit: `output/playwright/contact-route-404/contact-route-375-api-error-visible.png`

## Reviewers

- Mobile UI: no remaining findings `>=5/10`
- Accessibility: no remaining findings `>=5/10`
- SEO: no findings `>=5/10`
- Storybook: no findings `>=5/10`

## Development

Closes #1127

Management issue: https://github.com/findmydoc-platform/management/issues/231
