### PR TITLE
fix(auth): centralize internal redirect sanitization

### DIFF
--- a/src/app/(frontend)/next/preview/route.ts
+++ b/src/app/(frontend)/next/preview/route.ts
@@ -5,6 +5,7 @@ import { draftMode } from 'next/headers'
 import { redirect } from 'next/navigation'
 
 import configPromise from '@payload-config'
+import { sanitizeInternalRedirectPath } from '@/utilities/routing/sanitizeInternalRedirectPath'
 
 /**
  * Route handler to enable Next.js draft (preview) mode for a specific document.
@@ -29,15 +30,12 @@ export async function GET(request: NextRequest): Promise<Response> {
     return new Response('Insufficient search params', { status: 404 })
   }
 
-  let previewUrl: URL
+  const safePath = sanitizeInternalRedirectPath({
+    nextPath: path,
+    fallbackPath: '',
+  })
 
-  try {
-    previewUrl = new URL(path, request.url)
-  } catch {
-    return new Response('This endpoint can only be used for relative previews', { status: 500 })
-  }
-
-  if (previewUrl.origin !== request.nextUrl.origin) {
+  if (!safePath) {
     return new Response('This endpoint can only be used for relative previews', { status: 500 })
   }
 
@@ -64,5 +62,5 @@ export async function GET(request: NextRequest): Promise<Response> {
 
   draft.enable()
 
-  redirect(path)
+  redirect(safePath)
 }

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,10 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/auth/utilities/supaBaseServer'
+import { sanitizeInternalRedirectPath } from '@/utilities/routing/sanitizeInternalRedirectPath'
 
 export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url)
   const code = requestUrl.searchParams.get('code')
-  const next = requestUrl.searchParams.get('next') ?? '/auth/password/reset/complete'
+  const next = sanitizeInternalRedirectPath({
+    nextPath: requestUrl.searchParams.get('next'),
+    fallbackPath: '/auth/password/reset/complete',
+  })
 
   if (code) {
     const supabase = await createClient()

--- a/src/features/previewGuard/index.ts
+++ b/src/features/previewGuard/index.ts
@@ -1,5 +1,6 @@
 import type { User } from '@supabase/supabase-js'
 import { resolveRuntimeClass, resolveServerRuntimeEnvironment } from '@/features/runtimePolicy'
+import { sanitizeInternalRedirectPath } from '@/utilities/routing/sanitizeInternalRedirectPath'
 
 export const PREVIEW_GUARD_LOCK_REQUEST_HEADER = 'x-preview-guard-lock'
 export const PREVIEW_GUARD_LOGIN_REQUIRED_MESSAGE_KEY = 'preview-login-required'
@@ -48,22 +49,9 @@ export const buildPreviewGuardLoginRedirect = (url: URL): string => {
 }
 
 export const sanitizePreviewGuardNextPath = (nextPath: string | null | undefined): string => {
-  if (!nextPath) return PREVIEW_GUARD_FALLBACK_REDIRECT
-
-  const trimmed = nextPath.trim()
-  if (!trimmed.startsWith('/') || trimmed.startsWith('//')) return PREVIEW_GUARD_FALLBACK_REDIRECT
-  if (trimmed.includes('\r') || trimmed.includes('\n')) return PREVIEW_GUARD_FALLBACK_REDIRECT
-
-  try {
-    const parsed = new URL(trimmed, 'http://localhost')
-    if (parsed.origin !== 'http://localhost') return PREVIEW_GUARD_FALLBACK_REDIRECT
-
-    const safePath = `${parsed.pathname}${parsed.search}${parsed.hash}`
-    if (normalizePathname(parsed.pathname) === PREVIEW_GUARD_LOGIN_PATH) {
-      return PREVIEW_GUARD_FALLBACK_REDIRECT
-    }
-    return safePath
-  } catch {
-    return PREVIEW_GUARD_FALLBACK_REDIRECT
-  }
+  return sanitizeInternalRedirectPath({
+    nextPath,
+    fallbackPath: PREVIEW_GUARD_FALLBACK_REDIRECT,
+    blockedPaths: [PREVIEW_GUARD_LOGIN_PATH],
+  })
 }

--- a/src/utilities/routing/sanitizeInternalRedirectPath.ts
+++ b/src/utilities/routing/sanitizeInternalRedirectPath.ts
@@ -1,3 +1,5 @@
+const hasControlCharacters = (value: string): boolean => /[\u0000-\u001F\u007F]/.test(value)
+
 export function sanitizeInternalRedirectPath({
   nextPath,
   fallbackPath = '/',
@@ -11,7 +13,7 @@ export function sanitizeInternalRedirectPath({
 
   const trimmed = nextPath.trim()
   if (!trimmed.startsWith('/') || trimmed.startsWith('//')) return fallbackPath
-  if (trimmed.includes('\r') || trimmed.includes('\n')) return fallbackPath
+  if (hasControlCharacters(trimmed)) return fallbackPath
 
   try {
     const parsed = new URL(trimmed, 'http://localhost')

--- a/tests/unit/app/auth/callback/route.test.ts
+++ b/tests/unit/app/auth/callback/route.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const { exchangeCodeForSessionMock } = vi.hoisted(() => ({
+  exchangeCodeForSessionMock: vi.fn().mockResolvedValue({ error: null }),
+}))
+
+vi.mock('@/auth/utilities/supaBaseServer', () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: {
+      exchangeCodeForSession: exchangeCodeForSessionMock,
+    },
+  }),
+}))
+
+import { GET } from '@/app/auth/callback/route'
+
+describe('GET /auth/callback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('falls back to internal reset path for protocol-relative next path', async () => {
+    const request = new NextRequest('http://localhost/auth/callback?next=//evil.example')
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('http://localhost/auth/password/reset/complete')
+    expect(exchangeCodeForSessionMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to internal reset path for absolute external next path', async () => {
+    const request = new NextRequest('http://localhost/auth/callback?next=https://evil.example/path')
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('http://localhost/auth/password/reset/complete')
+    expect(exchangeCodeForSessionMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/app/frontend/next/preview/route.test.ts
+++ b/tests/unit/app/frontend/next/preview/route.test.ts
@@ -61,4 +61,43 @@ describe('GET /next/preview', () => {
     expect(authMock).not.toHaveBeenCalled()
     expect(redirectMock).not.toHaveBeenCalled()
   })
+
+  it('rejects paths with control characters before auth or redirects', async () => {
+    const request = new NextRequest(
+      'http://localhost/next/preview?path=%2Fposts%2Fhello%0Aworld&collection=posts&slug=hello-world&previewSecret=test-secret',
+    )
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(500)
+    await expect(response.text()).resolves.toBe('This endpoint can only be used for relative previews')
+    expect(authMock).not.toHaveBeenCalled()
+    expect(redirectMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects same-origin absolute URLs before auth or redirects', async () => {
+    const request = new NextRequest(
+      'http://localhost/next/preview?path=http%3A%2F%2Flocalhost%2Fposts%2Fhello-world&collection=posts&slug=hello-world&previewSecret=test-secret',
+    )
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(500)
+    await expect(response.text()).resolves.toBe('This endpoint can only be used for relative previews')
+    expect(authMock).not.toHaveBeenCalled()
+    expect(redirectMock).not.toHaveBeenCalled()
+  })
+
+  it('redirects with the sanitized relative path after auth succeeds', async () => {
+    authMock.mockResolvedValue({ id: 'user-1' })
+
+    const request = new NextRequest(
+      'http://localhost/next/preview?path=%2Fposts%2Fhello-world%3Fpreview%3D1%23draft&collection=posts&slug=hello-world&previewSecret=test-secret',
+    )
+
+    await GET(request)
+
+    expect(authMock).toHaveBeenCalledOnce()
+    expect(redirectMock).toHaveBeenCalledWith('/posts/hello-world?preview=1#draft')
+  })
 })

--- a/tests/unit/utilities/routing/sanitizeInternalRedirectPath.test.ts
+++ b/tests/unit/utilities/routing/sanitizeInternalRedirectPath.test.ts
@@ -11,7 +11,7 @@ describe('sanitizeInternalRedirectPath', () => {
     ).toBe('/clinics/berlin-health?from=favorites#overview')
   })
 
-  it('falls back for external, protocol-relative, newline, and missing paths', () => {
+  it('falls back for external, protocol-relative, control-character, and missing paths', () => {
     const args = {
       fallbackPath: '/fallback',
     }
@@ -19,6 +19,8 @@ describe('sanitizeInternalRedirectPath', () => {
     expect(sanitizeInternalRedirectPath({ ...args, nextPath: 'https://evil.example.com' })).toBe('/fallback')
     expect(sanitizeInternalRedirectPath({ ...args, nextPath: '//evil.example.com' })).toBe('/fallback')
     expect(sanitizeInternalRedirectPath({ ...args, nextPath: '/foo\nbar' })).toBe('/fallback')
+    expect(sanitizeInternalRedirectPath({ ...args, nextPath: '/foo\tbar' })).toBe('/fallback')
+    expect(sanitizeInternalRedirectPath({ ...args, nextPath: '/foo\u0000bar' })).toBe('/fallback')
     expect(sanitizeInternalRedirectPath({ ...args, nextPath: undefined })).toBe('/fallback')
   })
 


### PR DESCRIPTION
Centralize redirect target validation for auth and preview flows so unsafe query-provided paths are handled consistently.

## What changed
- Reused `sanitizeInternalRedirectPath` in `/auth/callback` for the `next` query target.
- Reused the same sanitizer in `/next/preview` and redirected with the sanitized relative path.
- Reduced `sanitizePreviewGuardNextPath` to a thin wrapper around the shared sanitizer.
- Hardened the shared sanitizer against all ASCII control characters.
- Added focused regression coverage for auth callback, preview route, preview guard, and sanitizer behavior.

## Validation
- `pnpm vitest run tests/unit/app/auth/callback/route.test.ts tests/unit/app/frontend/next/preview/route.test.ts tests/unit/features/previewGuard/index.test.ts tests/unit/utilities/routing/sanitizeInternalRedirectPath.test.ts`
- `pnpm format`
- `pnpm check`
- `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build`

## Development
Closes #1131
