### PR TITLE
fix(frontend): stabilize mobile blog cards

### DIFF
--- a/src/components/organisms/Blog/BlogCard/Overlay.tsx
+++ b/src/components/organisms/Blog/BlogCard/Overlay.tsx
@@ -45,68 +45,75 @@ export const Overlay: React.FC<OverlayProps> = ({
   const viaOpacity = Math.max(fromOpacity - 0.4, 0)
 
   return (
-    <Link href={href} className={cn('group block', className)}>
-      <article className="relative aspect-[5/4] overflow-hidden rounded-3xl sm:aspect-[21/9] sm:rounded-4xl">
-        {/* Background Image */}
-        <Image
-          src={resolvedImage.src}
-          alt={resolvedImage.alt || 'Blog placeholder'}
-          fill
-          className="object-cover transition-transform duration-700 group-hover:scale-105"
-          sizes={imageSizes}
-          quality={imageQuality}
-        />
+    <Link
+      href={href}
+      aria-label={title}
+      className={cn(
+        'group block rounded-3xl focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none sm:rounded-4xl',
+        className,
+      )}
+    >
+      <article className="relative overflow-hidden rounded-3xl border border-border/50 bg-card shadow-sm ring-1 ring-black/5 sm:aspect-[21/9] sm:rounded-4xl sm:border-0 sm:bg-transparent sm:shadow-none sm:ring-0">
+        <div className="relative aspect-[16/10] overflow-hidden sm:absolute sm:inset-0 sm:aspect-auto">
+          <Image
+            src={resolvedImage.src}
+            alt=""
+            fill
+            className="object-cover transition-transform duration-700 group-hover:scale-105"
+            sizes={imageSizes}
+            quality={imageQuality}
+            priority
+          />
 
-        {/* Gradient Overlay */}
-        <div
-          className="absolute inset-0"
-          style={{
-            backgroundImage: `linear-gradient(to top, rgba(0,0,0,${fromOpacity}), rgba(0,0,0,${viaOpacity}), rgba(0,0,0,0))`,
-          }}
-        />
+          <div
+            className="absolute inset-0 hidden sm:block"
+            style={{
+              backgroundImage: `linear-gradient(to top, rgba(0,0,0,${fromOpacity}), rgba(0,0,0,${viaOpacity}), rgba(0,0,0,0))`,
+            }}
+          />
 
-        {/* Category Badge - Top Left */}
-        {category && (
-          <div className="absolute top-4 left-4 sm:top-6 sm:left-6">
-            <span className="inline-block rounded-full bg-white px-3 py-1 text-[11px] font-semibold text-foreground shadow-md sm:px-4 sm:py-1.5 sm:text-xs">
-              {category}
-            </span>
-          </div>
-        )}
+          {category && (
+            <div className="absolute top-3 right-3 left-3 sm:top-6 sm:right-auto sm:left-6">
+              <span
+                title={category}
+                className="line-clamp-2 max-w-full rounded-full bg-white px-3 py-1 text-[11px] leading-tight font-semibold break-words text-foreground shadow-md sm:px-4 sm:py-1.5 sm:text-xs"
+              >
+                {category}
+              </span>
+            </div>
+          )}
+        </div>
 
-        {/* Content Overlay - Bottom */}
-        <div className="absolute right-0 bottom-0 left-0 p-4 sm:p-6 md:p-8">
+        <div className="p-4 sm:absolute sm:right-0 sm:bottom-0 sm:left-0 sm:px-6 sm:pt-6 sm:pb-4 md:p-8">
           <Heading
             as="h3"
             size="h3"
             align="left"
-            variant="white"
-            className="mb-2 line-clamp-3 max-w-[92%] text-xl transition-colors group-hover:text-white/90 sm:mb-3 sm:line-clamp-2 sm:max-w-[80%]"
+            className="mb-2 line-clamp-3 text-xl leading-tight transition-colors group-hover:text-primary sm:mb-3 sm:line-clamp-2 sm:max-w-[80%] sm:text-2xl sm:text-white sm:group-hover:text-white/90 md:text-3xl lg:text-4xl"
           >
             {title}
           </Heading>
 
           {excerpt && (
-            <p className="mb-3 line-clamp-3 max-w-[92%] text-sm leading-relaxed text-white/80 sm:mb-4 sm:line-clamp-2 sm:max-w-[80%] md:text-base">
+            <p className="mb-4 line-clamp-3 text-sm leading-relaxed text-foreground/75 sm:line-clamp-2 sm:max-w-[80%] sm:text-white/80 md:text-base">
               {excerpt}
             </p>
           )}
 
-          {/* Author Row */}
-          <div className="flex items-center gap-3 sm:gap-4">
-            <div className="relative h-9 w-9 overflow-hidden rounded-full ring-2 ring-white/30 sm:h-10 sm:w-10">
+          <div className="flex min-w-0 items-center gap-3 sm:gap-4">
+            <div className="relative h-9 w-9 flex-shrink-0 overflow-hidden rounded-full ring-2 ring-border/40 sm:h-10 sm:w-10 sm:ring-white/30">
               <FallbackImage
                 src={authorAvatar}
                 fallbackSrc={avatarFallback}
-                alt={authorName}
+                alt=""
                 fill
                 sizes="40px"
                 className="object-cover"
               />
             </div>
-            <div className="flex flex-col">
-              <span className="text-sm font-medium text-white">{authorName}</span>
-              {dateLabel && <span className="text-xs text-white/60">{dateLabel}</span>}
+            <div className="flex min-w-0 flex-col">
+              <span className="truncate text-sm font-medium text-foreground sm:text-white">{authorName}</span>
+              {dateLabel && <span className="truncate text-xs text-foreground/70 sm:text-white/60">{dateLabel}</span>}
             </div>
           </div>
         </div>

--- a/src/components/organisms/Blog/BlogCard/Simple.tsx
+++ b/src/components/organisms/Blog/BlogCard/Simple.tsx
@@ -31,13 +31,20 @@ export const Simple: React.FC<BlogCardBaseProps> = ({
   const authorName = author?.name || 'findmydoc Editorial Team'
 
   return (
-    <Link href={href} className={cn('group block', className)}>
+    <Link
+      href={href}
+      aria-label={title}
+      className={cn(
+        'group block rounded-3xl focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none',
+        className,
+      )}
+    >
       <article className="flex h-full flex-col">
         {/* Image with Category Overlay */}
         <div className="relative mb-4 aspect-[4/3] overflow-hidden rounded-3xl">
           <Image
             src={resolvedImage.src}
-            alt={resolvedImage.alt || 'Blog placeholder'}
+            alt=""
             fill
             className="object-cover transition-transform duration-500 group-hover:scale-105"
             sizes={imageSizes}
@@ -46,8 +53,11 @@ export const Simple: React.FC<BlogCardBaseProps> = ({
 
           {/* Category Badge - Top Right */}
           {category && (
-            <div className="absolute top-3 right-3 sm:top-4 sm:right-4">
-              <span className="inline-block rounded-full bg-white px-2.5 py-1 text-[11px] font-semibold text-foreground shadow-sm sm:px-3 sm:text-xs">
+            <div className="absolute top-3 right-3 left-3 flex justify-end sm:top-4 sm:right-4 sm:left-4">
+              <span
+                title={category}
+                className="line-clamp-2 max-w-full rounded-full bg-white px-2.5 py-1 text-[11px] leading-tight font-semibold break-words text-foreground shadow-sm sm:px-3 sm:text-xs"
+              >
                 {category}
               </span>
             </div>
@@ -78,10 +88,13 @@ export const Simple: React.FC<BlogCardBaseProps> = ({
         </div>
 
         {/* Author Name and Date - No Avatar */}
-        <div className="mt-auto flex min-h-[2.5rem] flex-col items-start gap-1 border-t border-border/30 pt-3 text-sm sm:flex-row sm:items-center sm:justify-between sm:gap-3">
-          <span className="w-full truncate font-medium text-foreground sm:w-auto">{authorName}</span>
+        <div className="mt-auto flex min-h-[2.5rem] min-w-0 flex-col items-start gap-1 border-t border-border/30 pt-3 text-sm sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+          <span className="w-full min-w-0 truncate font-medium text-foreground sm:flex-1 sm:basis-0">{authorName}</span>
           <span
-            className={cn('text-xs text-muted-foreground sm:ml-3 sm:flex-shrink-0', !dateLabel && 'opacity-0')}
+            className={cn(
+              'max-w-full truncate text-xs text-muted-foreground sm:ml-3 sm:flex-shrink-0',
+              !dateLabel && 'opacity-0',
+            )}
             aria-hidden={!dateLabel}
           >
             {dateLabel || '\u00A0'}

--- a/src/stories/organisms/BlogCard.stories.tsx
+++ b/src/stories/organisms/BlogCard.stories.tsx
@@ -28,6 +28,14 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+const expectElementContained = (element: HTMLElement, container: HTMLElement) => {
+  const elementRect = element.getBoundingClientRect()
+  const containerRect = container.getBoundingClientRect()
+
+  expect(elementRect.left).toBeGreaterThanOrEqual(containerRect.left - 1)
+  expect(elementRect.right).toBeLessThanOrEqual(containerRect.right + 1)
+}
+
 const mockPost: BlogCardBaseProps = {
   title: 'Die Zukunft der Telemedizin in Deutschland',
   excerpt:
@@ -43,6 +51,33 @@ const mockPost: BlogCardBaseProps = {
   author: {
     name: 'Dr. med. Sarah Schmidt',
     avatar: getStoryImageSrc(storyPortraits.doctor),
+  },
+}
+
+const denseOverlayPost: BlogCardBaseProps = {
+  ...mockPost,
+  title: 'Cardiology diagnostics abroad: reading your results with confidence',
+  excerpt:
+    'Know what to ask about ECGs, imaging notes, lab references, and follow-up planning so you return home with clear next steps.',
+  href: '/posts/cardiology-diagnostics-reading-results',
+  dateLabel: '28. Januar 2026',
+  category: 'International cardiology diagnostics and imaging results guidance',
+  image: {
+    src: getStoryImageSrc(storyClinicImages.blog.diagnostics),
+    alt: 'Cardiology diagnostics monitor',
+  },
+  author: {
+    name: 'Seed Admin International Care Coordination',
+    avatar: getStoryImageSrc(storyPortraits.accountMenuAvatar),
+  },
+}
+
+const denseSimplePost: BlogCardBaseProps = {
+  ...denseOverlayPost,
+  href: '/posts/dense-simple-cardiology-diagnostics',
+  image: {
+    src: getStoryImageSrc(storyClinicImages.blog.consultation),
+    alt: 'International clinic consultation',
   },
 }
 
@@ -62,10 +97,35 @@ export const Overlay: StoryObj<typeof BlogCard.Overlay> = {
   args: mockPost,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
-    await expect(canvas.getByRole('link')).toBeInTheDocument()
+    await expect(canvas.getByRole('link', { name: 'Die Zukunft der Telemedizin in Deutschland' })).toBeInTheDocument()
     await expect(canvas.getByText('Die Zukunft der Telemedizin in Deutschland')).toBeInTheDocument()
     await expect(canvas.getByText('Gesundheitstechnologie')).toBeInTheDocument()
-    await expect(canvas.getByAltText('Dr. med. Sarah Schmidt')).toBeInTheDocument()
+    await expect(canvas.getByText('Dr. med. Sarah Schmidt')).toBeInTheDocument()
+  },
+}
+
+export const DenseOverlay: StoryObj<typeof BlogCard.Overlay> = {
+  render: (args) => (
+    <div style={{ maxWidth: '1200px' }}>
+      <BlogCard.Overlay {...args} />
+    </div>
+  ),
+  args: denseOverlayPost,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const link = canvas.getByRole('link', {
+      name: 'Cardiology diagnostics abroad: reading your results with confidence',
+    })
+    await expect(link).toBeInTheDocument()
+    await expect(
+      canvas.getByText('Cardiology diagnostics abroad: reading your results with confidence'),
+    ).toBeInTheDocument()
+    await expect(
+      canvas.getByText('International cardiology diagnostics and imaging results guidance'),
+    ).toBeInTheDocument()
+    await expect(canvas.getByText('Seed Admin International Care Coordination')).toBeInTheDocument()
+    expectElementContained(canvas.getByText('International cardiology diagnostics and imaging results guidance'), link)
+    expectElementContained(canvas.getByText('Seed Admin International Care Coordination'), link)
   },
 }
 
@@ -91,9 +151,32 @@ export const Simple: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
-    await expect(canvas.getByRole('link')).toBeInTheDocument()
+    await expect(canvas.getByRole('link', { name: 'Die Zukunft der Telemedizin in Deutschland' })).toBeInTheDocument()
     await expect(canvas.getByText('Die Zukunft der Telemedizin in Deutschland')).toBeInTheDocument()
     await expect(canvas.getByText('15. Januar 2026')).toBeInTheDocument()
+  },
+}
+
+export const DenseSimple: Story = {
+  render: (args) => (
+    <div style={{ maxWidth: '400px' }}>
+      <BlogCard.Simple {...args} />
+    </div>
+  ),
+  args: denseSimplePost,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const link = canvas.getByRole('link', {
+      name: 'Cardiology diagnostics abroad: reading your results with confidence',
+    })
+
+    await expect(link).toBeInTheDocument()
+    await expect(
+      canvas.getByText('International cardiology diagnostics and imaging results guidance'),
+    ).toBeInTheDocument()
+    await expect(canvas.getByText('Seed Admin International Care Coordination')).toBeInTheDocument()
+    expectElementContained(canvas.getByText('International cardiology diagnostics and imaging results guidance'), link)
+    expectElementContained(canvas.getByText('Seed Admin International Care Coordination'), link)
   },
 }
 
@@ -196,11 +279,12 @@ const fallbackOverlayBase: StoryObj<typeof BlogCard.Overlay> = {
     },
   },
   play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement)
-    const authorAvatar = canvas.getByAltText('Dr. med. Sarah Schmidt')
-
     await waitFor(() => {
-      const avatarSrc = authorAvatar.getAttribute('src') ?? ''
+      const authorAvatar = Array.from(canvasElement.querySelectorAll('img')).find((image) => {
+        const imageSrc = image.getAttribute('src') ?? ''
+        return imageSrc.includes('author-avatar') || imageSrc.includes('avatar-placeholder')
+      })
+      const avatarSrc = authorAvatar?.getAttribute('src') ?? ''
       expect(avatarSrc).toContain('avatar-placeholder')
     })
   },
@@ -214,6 +298,37 @@ export const Overlay640: StoryObj<typeof BlogCard.Overlay> = withViewportStory(O
 export const Overlay768: StoryObj<typeof BlogCard.Overlay> = withViewportStory(Overlay, 'public768', 'Overlay / 768')
 export const Overlay1024: StoryObj<typeof BlogCard.Overlay> = withViewportStory(Overlay, 'public1024', 'Overlay / 1024')
 export const Overlay1280: StoryObj<typeof BlogCard.Overlay> = withViewportStory(Overlay, 'public1280', 'Overlay / 1280')
+
+export const DenseOverlay320: StoryObj<typeof BlogCard.Overlay> = withViewportStory(
+  DenseOverlay,
+  'public320',
+  'Dense overlay / 320',
+)
+export const DenseOverlay375: StoryObj<typeof BlogCard.Overlay> = withViewportStory(
+  DenseOverlay,
+  'public375',
+  'Dense overlay / 375',
+)
+export const DenseOverlay640: StoryObj<typeof BlogCard.Overlay> = withViewportStory(
+  DenseOverlay,
+  'public640',
+  'Dense overlay / 640',
+)
+export const DenseOverlay768: StoryObj<typeof BlogCard.Overlay> = withViewportStory(
+  DenseOverlay,
+  'public768',
+  'Dense overlay / 768',
+)
+export const DenseOverlay1024: StoryObj<typeof BlogCard.Overlay> = withViewportStory(
+  DenseOverlay,
+  'public1024',
+  'Dense overlay / 1024',
+)
+export const DenseOverlay1280: StoryObj<typeof BlogCard.Overlay> = withViewportStory(
+  DenseOverlay,
+  'public1280',
+  'Dense overlay / 1280',
+)
 
 export const FallbackOverlay320: StoryObj<typeof BlogCard.Overlay> = withViewportStory(
   fallbackOverlayBase,
@@ -252,6 +367,13 @@ export const Simple640: Story = withViewportStory(Simple, 'public640', 'Simple /
 export const Simple768: Story = withViewportStory(Simple, 'public768', 'Simple / 768')
 export const Simple1024: Story = withViewportStory(Simple, 'public1024', 'Simple / 1024')
 export const Simple1280: Story = withViewportStory(Simple, 'public1280', 'Simple / 1280')
+
+export const DenseSimple320: Story = withViewportStory(DenseSimple, 'public320', 'Dense simple / 320')
+export const DenseSimple375: Story = withViewportStory(DenseSimple, 'public375', 'Dense simple / 375')
+export const DenseSimple640: Story = withViewportStory(DenseSimple, 'public640', 'Dense simple / 640')
+export const DenseSimple768: Story = withViewportStory(DenseSimple, 'public768', 'Dense simple / 768')
+export const DenseSimple1024: Story = withViewportStory(DenseSimple, 'public1024', 'Dense simple / 1024')
+export const DenseSimple1280: Story = withViewportStory(DenseSimple, 'public1280', 'Dense simple / 1280')
 
 export const Overview320: StoryObj<typeof BlogCard.Overview> = withViewportStory(
   Overview,


### PR DESCRIPTION
Mobile readers can now scan blog cards on `/posts` without the featured article layout breaking on narrow screens.

## What changed
- Render the featured blog card as a stacked mobile card below `sm`, while keeping the existing full-bleed overlay treatment from `sm` upward.
- Make featured and simple category pills width-safe with two-line wrapping for longer medical labels.
- Improve card link accessibility with title-only link names, decorative image alt text, visible focus rings, and stronger mobile text contrast.
- Add dense BlogCard stories for long title, category, excerpt, and author metadata across the responsive viewport matrix.

## Validation
- `pnpm format`
- `pnpm check`
- `pnpm stories:governance:check`
- `pnpm exec vitest --project storybook run src/stories/organisms/BlogCard.stories.tsx`
- `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build`
- Playwright route QA for `/posts` at `320`, `375`, `640`, `768`, `1024`, `1280`, `640x360`, and `667x375`
- Storybook Playwright QA for `DenseOverlay` and `DenseSimple` at `320`, `375`, `640`, `768`, `1024`, and `1280`
- Specialist reviews: mobile UI, accessibility, Storybook, Web Vitals, and design reviewer; no remaining findings `>=5/10`
- `detect-secrets-hook --baseline .secrets.baseline` on changed PR files

## Screenshots
- `output/playwright/blog-cards/posts-320.png`
- `output/playwright/blog-cards/posts-320-more-articles.png`
- `output/playwright/blog-cards/posts-1280.png`
- `output/playwright/blog-cards/storybook-dense-overlay-320.png`
- `output/playwright/blog-cards/storybook-dense-simple-320.png`

## Development
Fixes #1136
