### PR TITLE
fix: normalize allowed host casing in href validation

### DIFF
--- a/src/utilities/landing/safeLandingHref.ts
+++ b/src/utilities/landing/safeLandingHref.ts
@@ -22,7 +22,10 @@ const isSafeHttpsHref = (value: string, allowedHosts?: readonly string[]): boole
     const url = new URL(value)
 
     if (url.protocol !== 'https:') return false
-    if (allowedHosts && allowedHosts.length > 0) return hostMatches(url.hostname.toLowerCase(), allowedHosts)
+    if (allowedHosts && allowedHosts.length > 0) {
+      const normalizedAllowedHosts = allowedHosts.map((allowedHost) => allowedHost.toLowerCase())
+      return hostMatches(url.hostname.toLowerCase(), normalizedAllowedHosts)
+    }
 
     return true
   } catch {

--- a/tests/unit/utilities/landing/safeLandingHref.test.ts
+++ b/tests/unit/utilities/landing/safeLandingHref.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeSafeLandingHref } from '@/utilities/landing/safeLandingHref'
+
+describe('safeLandingHref', () => {
+  it('accepts allowed hosts regardless of allowedHosts casing', () => {
+    const href = 'https://sub.example.com/path'
+
+    expect(
+      normalizeSafeLandingHref(href, {
+        allowedHosts: ['EXAMPLE.COM'],
+      }),
+    ).toBe(href)
+  })
+})


### PR DESCRIPTION
fixes host whitelist matching for landing href validation when allowed hosts use uppercase or mixed casing.

## What changed
- normalize `allowedHosts` to lowercase before host comparison in `isSafeHttpsHref`
- add regression test for uppercase whitelist host values in `tests/unit/utilities/landing/safeLandingHref.test.ts`

## Validation
- `pnpm format`
- `pnpm check`

## Development
- Closes #1144
