### PR TITLE
fix: prevent cookie consent overlap on auth pages

### DIFF
--- a/src/components/organisms/CookieConsent/CookieConsentBanner.client.tsx
+++ b/src/components/organisms/CookieConsent/CookieConsentBanner.client.tsx
@@ -21,19 +21,25 @@ export function CookieConsentBanner({
 }: CookieConsentBannerProps) {
   return (
     <div
-      className={`fixed inset-x-0 bottom-0 z-50 px-2.5 sm:px-6 sm:pt-4 sm:[padding-bottom:calc(env(safe-area-inset-bottom)+1rem)] lg:px-8 ${
+      className={
         compact
-          ? 'pt-1.5 [padding-bottom:calc(env(safe-area-inset-bottom)+0.25rem)]'
-          : 'pt-2 [padding-bottom:calc(env(safe-area-inset-bottom)+0.625rem)]'
-      }`}
+          ? 'relative z-50 px-2.5 pt-1 [padding-bottom:calc(env(safe-area-inset-bottom)+0.25rem)] sm:px-6 lg:px-8'
+          : 'fixed inset-x-0 bottom-0 z-50 px-2.5 pt-2 [padding-bottom:calc(env(safe-area-inset-bottom)+0.625rem)] sm:px-6 sm:pt-4 sm:[padding-bottom:calc(env(safe-area-inset-bottom)+1rem)] lg:px-8'
+      }
     >
       <div className="mx-auto w-full max-w-6xl">
-        <div className="max-h-[calc(100svh-0.75rem)] overflow-y-auto overscroll-contain rounded-3xl border border-border/70 bg-background/95 shadow-[0_30px_80px_rgba(0,0,0,0.18)] backdrop-blur-xl sm:max-h-none">
+        <div
+          className={
+            compact
+              ? 'overflow-hidden rounded-xl border border-border/70 bg-background/95 shadow-[0_16px_42px_rgba(0,0,0,0.16)] backdrop-blur-xl'
+              : 'max-h-[calc(100svh-0.75rem)] overflow-y-auto overscroll-contain rounded-3xl border border-border/70 bg-background/95 shadow-[0_30px_80px_rgba(0,0,0,0.18)] backdrop-blur-xl sm:max-h-none'
+          }
+        >
           <div className="bg-linear-to-r from-primary/10 via-background to-accent/10 p-1">
             {compact ? (
-              <div className="rounded-[1.35rem] bg-background/95 p-2.5">
-                <div className="space-y-2">
-                  <Heading as="h2" align="left" size="h4" className="text-sm leading-tight sm:text-base">
+              <div className="rounded-lg bg-background/95 p-1.5 sm:p-2">
+                <div>
+                  <Heading as="h2" align="left" size="h4" className="sr-only">
                     {config.banner.title}
                   </Heading>
                   <p className="sr-only">{config.banner.description}</p>
@@ -41,7 +47,7 @@ export function CookieConsentBanner({
                     <Button
                       type="button"
                       variant="primary"
-                      className="h-9 w-full rounded-full px-2 text-[11px] whitespace-nowrap sm:text-sm"
+                      className="h-8 w-full rounded-full px-1 text-[10px] whitespace-nowrap sm:text-xs"
                       onClick={onAcceptAll}
                     >
                       {config.banner.acceptLabel}
@@ -49,7 +55,7 @@ export function CookieConsentBanner({
                     <Button
                       type="button"
                       variant="secondary"
-                      className="h-9 w-full rounded-full px-2 text-[11px] whitespace-nowrap sm:text-sm"
+                      className="h-8 w-full rounded-full px-1 text-[10px] whitespace-nowrap sm:text-xs"
                       onClick={onRejectAll}
                     >
                       {config.banner.rejectLabel}
@@ -57,7 +63,7 @@ export function CookieConsentBanner({
                     <Button
                       type="button"
                       variant="ghost"
-                      className="h-9 w-full rounded-full px-2 text-[11px] whitespace-nowrap sm:text-sm"
+                      className="h-8 w-full rounded-full px-1 text-[10px] whitespace-nowrap sm:text-xs"
                       onClick={onCustomize}
                     >
                       {config.banner.customizeLabel}

--- a/src/components/organisms/CookieConsent/CookieConsentLauncher.client.tsx
+++ b/src/components/organisms/CookieConsent/CookieConsentLauncher.client.tsx
@@ -5,13 +5,20 @@ import { Cookie } from 'lucide-react'
 import { Button } from '@/components/atoms/button'
 
 type CookieConsentLauncherProps = {
+  compact?: boolean
   label: string
   onOpenSettings: () => void
 }
 
-export function CookieConsentLauncher({ label, onOpenSettings }: CookieConsentLauncherProps) {
+export function CookieConsentLauncher({ compact = false, label, onOpenSettings }: CookieConsentLauncherProps) {
   return (
-    <div className="fixed right-3 [bottom:calc(env(safe-area-inset-bottom)+0.875rem)] z-40 sm:right-6 sm:[bottom:calc(env(safe-area-inset-bottom)+1.5rem)]">
+    <div
+      className={
+        compact
+          ? 'relative z-40 flex justify-end px-3 pb-[calc(env(safe-area-inset-bottom)+0.875rem)] sm:px-6 sm:pb-[calc(env(safe-area-inset-bottom)+1.5rem)]'
+          : 'fixed right-3 [bottom:calc(env(safe-area-inset-bottom)+0.875rem)] z-40 sm:right-6 sm:[bottom:calc(env(safe-area-inset-bottom)+1.5rem)]'
+      }
+    >
       <Button
         type="button"
         variant="outline"

--- a/src/components/organisms/CookieConsent/CookieConsentManager.client.tsx
+++ b/src/components/organisms/CookieConsent/CookieConsentManager.client.tsx
@@ -40,7 +40,11 @@ export function CookieConsentManager({ config, initialConsent }: CookieConsentMa
       ) : null}
 
       {controller.isLauncherVisible ? (
-        <CookieConsentLauncher label={config.reopenLabel} onOpenSettings={controller.openSettings} />
+        <CookieConsentLauncher
+          compact={useCompactBanner}
+          label={config.reopenLabel}
+          onOpenSettings={controller.openSettings}
+        />
       ) : null}
 
       <CookieConsentDialog


### PR DESCRIPTION
Cookie consent controls now use a compact, non-overlapping layout on compact authentication pages.

## What changed

- Render the compact cookie banner as part of page flow instead of a fixed bottom overlay.
- Reduce compact banner spacing and button size so consent actions remain available on narrow mobile viewports.
- Apply the same compact placement to the cookie settings launcher on compact auth-style pages.
- Keep the existing consent behavior unchanged: accepting, rejecting, customizing, categories, and persistence are not modified.

## Why

Compact form pages have limited vertical space on mobile. Fixed bottom consent controls can compete with form content and primary actions, making the page feel crowded or partially obstructed. This change keeps consent controls visible while preserving form usability.

## Validation

- `pnpm format`
- `pnpm vitest tests/unit/components/cookieConsentManager.test.tsx --run`
- `pnpm check`
- `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build`
- Playwright screenshot at 375px mobile viewport

## Screenshots

Local Playwright screenshot captured under `output/playwright/cookie-consent-auth-layout/`:

- `login-patient-375-cookie-compact.png`

## Development

Closes #1148.
