### PR TITLE
fix: trim whitespace for absolute social preview URLs

### DIFF
--- a/src/utilities/socialPreview.ts
+++ b/src/utilities/socialPreview.ts
@@ -29,12 +29,14 @@ export type SocialPreviewImage = {
 }
 
 export const getAbsoluteSiteURL = (pathOrURL = '/') => {
-  if (/^https?:\/\//i.test(pathOrURL)) return pathOrURL
-  if (pathOrURL.startsWith('//')) {
-    return `${new URL(getServerSideURL()).protocol}${pathOrURL}`
+  const normalizedInput = pathOrURL.trim()
+
+  if (/^https?:\/\//i.test(normalizedInput)) return normalizedInput
+  if (normalizedInput.startsWith('//')) {
+    return `${new URL(getServerSideURL()).protocol}${normalizedInput}`
   }
 
-  const normalizedPath = pathOrURL.startsWith('/') ? pathOrURL : `/${pathOrURL}`
+  const normalizedPath = normalizedInput.startsWith('/') ? normalizedInput : `/${normalizedInput}`
   return `${getServerSideURL().replace(/\/+$/, '')}${normalizedPath}`
 }
 

--- a/tests/unit/utilities/socialPreview.test.ts
+++ b/tests/unit/utilities/socialPreview.test.ts
@@ -11,6 +11,12 @@ describe('socialPreview', () => {
     expect(getAbsoluteSiteURL('https://cdn.example.com/og.jpg')).toBe('https://cdn.example.com/og.jpg')
   })
 
+  it('trims whitespace around absolute URLs', async () => {
+    const { getAbsoluteSiteURL } = await import('@/utilities/socialPreview')
+
+    expect(getAbsoluteSiteURL('  https://cdn.example.com/og.jpg  ')).toBe('https://cdn.example.com/og.jpg')
+  })
+
   it('converts protocol-relative URLs to absolute URLs', async () => {
     const { getAbsoluteSiteURL } = await import('@/utilities/socialPreview')
 


### PR DESCRIPTION
Social previews now keep valid absolute image URLs even when CMS input includes accidental surrounding whitespace.

## What changed
- trim `pathOrURL` once at the `getAbsoluteSiteURL` boundary in `src/utilities/socialPreview.ts`
- reuse normalized input for absolute URL detection, protocol-relative normalization, and internal path joining
- add regression coverage in `tests/unit/utilities/socialPreview.test.ts` for whitespace-wrapped absolute URLs

## Validation
- `pnpm format`
- `pnpm check`
- `pnpm vitest run tests/unit/utilities/socialPreview.test.ts` *(fails in sandbox due known unit global setup IPC permission error: `listen EPERM ... tsx ... .pipe`)*

## Development
- Closes #1153
