### PR TITLE
fix(cookie-consent): keep launcher fixed

### DIFF
--- a/tests/unit/components/cookieConsentLauncher.test.tsx
+++ b/tests/unit/components/cookieConsentLauncher.test.tsx
@@ -1,0 +1,17 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { CookieConsentLauncher } from '@/components/organisms/CookieConsent/CookieConsentLauncher.client'
+
+describe('CookieConsentLauncher', () => {
+  it('keeps the launcher fixed on auth routes', () => {
+    render(<CookieConsentLauncher label="Cookie settings" onOpenSettings={() => {}} />)
+
+    expect(screen.getByRole('button', { name: 'Cookie settings' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cookie settings' }).parentElement).toHaveClass('fixed')
+    expect(screen.getByRole('button', { name: 'Cookie settings' }).parentElement).not.toHaveClass('relative')
+  })
+})


### PR DESCRIPTION
This keeps the cookie consent reopen launcher fixed on auth routes so it does not scroll with page content.

## What changed
- Adds regression coverage for `CookieConsentLauncher` staying `fixed`.

## Validation
- `pnpm format`
- `pnpm check`

## Development
- Related issue: #1155
