### PR TITLE
feat: add collection planning skill

### DIFF
--- a/.codex/skills/findmydoc-collection-planner/SKILL.md
+++ b/.codex/skills/findmydoc-collection-planner/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: findmydoc-collection-planner
+description: Plan and safely implement Payload CMS collections for the findmydoc website. Use when Codex is asked to create, change, evaluate, or implement a new Payload collection, join collection, media collection, collection access model, permission-matrix row, collection tests, Payload migration, or CMS/admin data model in this repository. Default to discovery, questions, recommendation, and a proposed plan before editing unless the user explicitly provides an approved plan and asks for implementation.
+---
+
+# findmydoc Collection Planner
+
+## Overview
+
+Use this skill to prevent accidental or overbuilt Payload collections in findmydoc. The default behavior is planning-first: inspect the repo, ask only decision-changing questions, recommend the smallest coherent model, and propose a plan before implementation.
+
+This skill does not require or activate the technical Plan Mode. It works as a native workflow in normal Codex sessions.
+
+## Planning Gate
+
+- Do not edit files when the user asks for a new or unclear collection design and no approved plan exists.
+- Treat technical Plan Mode as optional. If it is not active, keep using this planning-first workflow in the current session.
+- First run repo discovery, then summarize facts, ask targeted questions, recommend an approach, and produce one `<proposed_plan>`.
+- After the proposed plan, ask in normal prose whether the user wants it implemented.
+- If the user explicitly provides an approved plan or says to implement a previously proposed plan, proceed to implementation using the checklist in `references/collection-planning-playbook.md`.
+- If the requested change is obviously tiny and fully specified, still run discovery and state why no questions are needed before proposing or implementing.
+
+## Workflow
+
+1. Read applicable instructions:
+   - `AGENTS.md`
+   - `src/AGENTS.md`
+   - `src/collections/AGENTS.md`
+   - `tests/AGENTS.md` when tests are in scope
+   - `docs/guides/AGENTS.md` when operator guides may change
+2. Read `references/collection-planning-playbook.md`.
+3. Read `references/payload-field-modeling.md` before deciding fields, joins, access, hooks, validation, or indexes.
+4. Run a cross-reference scan before asking questions:
+   - similar collections, slugs, relationships, joins, and `defaultPopulate`
+   - existing access helpers and field access helpers
+   - existing hooks and lifecycle utilities
+   - permission matrix entries and unit access matrix tests
+   - integration contract registry, lifecycle tests, seeds, and operator docs
+5. Summarize discovery in concrete facts:
+   - existing patterns that fit
+   - likely affected domains
+   - whether the feature looks like a new collection, field, join collection, global, media collection, or extension of an existing collection
+6. Ask questions only when answers would change schema, access, lifecycle, migration, tests, or docs:
+   - ask at most 3 questions per round
+   - include a recommended default for each question
+   - do not ask questions answerable from repo inspection
+7. Recommend the smallest coherent solution:
+   - name the preferred model
+   - briefly name rejected alternatives
+   - call out hooks or helpers that would reduce custom logic
+   - mark unresolved assumptions explicitly
+8. Produce a `<proposed_plan>` with implementation changes, validation, and assumptions.
+9. After the plan, ask whether to implement it.
+
+## Anti-Overengineering Check
+
+Before recommending a new collection, explicitly test these alternatives:
+
+- Add a field to an existing collection.
+- Use a relationship field instead of a join collection.
+- Use a join collection only when the relationship needs attributes, ownership, deduplication, or lifecycle hooks.
+- Use a Payload global for singleton platform settings.
+- Use field validation instead of a hook when no side effects or cross-document checks are needed.
+- Reuse an existing access helper or hook before adding a new one.
+- Avoid storing computed values unless query performance, sorting, or admin visibility requires persistence.
+
+## Output Contract
+
+When planning, respond in German for the user-facing explanation and keep code/file names in English. Use this sequence:
+
+1. `Discovery`: short facts with file references.
+2. `Questions`: only if required, max 3.
+3. `Recommendation`: preferred model plus small alternatives.
+4. `<proposed_plan>`: complete enough to implement without new decisions.
+5. Follow-up question: ask whether the user wants implementation.
+
+When implementing an approved plan, skip the question phase unless the approved plan is incomplete or contradicted by repo discovery.
+
+## Resources
+
+- `references/collection-planning-playbook.md`: discovery commands, decision rules, question bank, implementation checklist, and validation guidance for findmydoc Payload collection work.
+- `references/payload-field-modeling.md`: concise Payload CMS collection and field modeling reference with field choices, access, hooks, validation, joins, indexes, and findmydoc-specific defaults.

--- a/.codex/skills/findmydoc-collection-planner/agents/openai.yaml
+++ b/.codex/skills/findmydoc-collection-planner/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'findmydoc Collection Planner'
+  short_description: 'Plan findmydoc Payload collections'
+  default_prompt: 'Use $findmydoc-collection-planner to evaluate, question, recommend, and plan a new findmydoc Payload collection before implementation.'

--- a/.codex/skills/findmydoc-collection-planner/references/collection-planning-playbook.md
+++ b/.codex/skills/findmydoc-collection-planner/references/collection-planning-playbook.md
@@ -1,0 +1,130 @@
+# findmydoc Collection Planning Playbook
+
+## Discovery Scan
+
+Use `rtk rg` before asking the user questions. Prefer targeted searches:
+
+```bash
+rtk rg "slug:|relationTo:|collection:|defaultPopulate|indexes:|trash:|stableIdField|stableIdBeforeChangeHook" src/collections src/payload.config.ts
+rtk rg "export const .*: CollectionConfig|access:|platformOr|isPlatform|isClinic|isPatient|fieldAccess" src/collections src/access
+rtk rg "makePermissionSuite|permissionMatrix|collectionContractRegistry" src/security tests/unit/access-matrix tests/integration/contracts
+rtk rg "collection: '<slug>'|collection: \"<slug>\"|ensureBaseline|cleanupTestEntities|testSlug" tests src/endpoints docs
+rtk rg "overrideAccess|context|req\\.payload|virtual:|versions:|drafts:|filterOptions|maxDepth|slugField" src tests
+rtk rg "revalidate|audit|createdBy|editedBy|beforeChangeAssignClinicFromUser|updateAverage|stableIdBeforeChangeHook" src/collections src/hooks tests
+```
+
+Scan these files when relevant:
+
+- master data: `src/collections/Treatments.ts`, `Categories.ts`, `Tags.ts`, `MedicalSpecialties.ts`
+- clinic-owned data: `src/collections/Doctors.ts`, `ClinicTreatments/index.ts`, `ClinicGalleryEntries/index.ts`
+- moderated/public data: `src/collections/Clinics.ts`, `Reviews.ts`
+- media: `src/collections/*Media/index.ts` and `src/collections/common/mediaCollection.ts`
+- access source of truth: `src/security/permission-matrix.config.ts`
+- test registration: `tests/integration/contracts/collectionContractRegistry.ts`
+
+## Decision Rules
+
+Recommend a new collection only when the data has independent lifecycle, permissions, relationships, audit needs, indexing needs, or CMS ownership.
+
+Prefer smaller shapes when possible:
+
+- field: simple attribute of one existing record
+- relationship: link with no relationship-specific fields
+- join collection: relationship has fields such as price, status, sort order, ownership, source, or uniqueness
+- global: singleton settings or platform-wide configuration
+- media collection: upload ownership, storage path, or file access differs from existing media collections
+- hook: side effect, cross-document validation, denormalization, ownership stamping, or audit trail
+- field validation: local value checks with no side effects
+
+## Question Bank
+
+Ask only questions that change implementation. Use no more than 3 per round.
+
+High-value questions:
+
+- Who owns and edits this data: Platform, Clinic Staff, Patients, or the system?
+- Who can read it publicly, and is there an approved/published state?
+- Is this standalone data or an attribute of an existing collection?
+- Does the relationship need its own fields, uniqueness, ordering, status, or audit trail?
+- Should records be soft-deleted with `trash: true`?
+- Does it need baseline seed data, demo seed data, or no seed data?
+- Is this shown to patients, used only in admin, or used by automation?
+- Which existing collection is the source of truth if data overlaps?
+- Is this value a fixed business enum, or should operators manage it as dynamic content?
+- Should this value be stored, virtual, or derived when read?
+- Will hooks run nested Payload operations that need shared `req` transaction context or `context` loop guards?
+
+Avoid questions about file locations, helper names, or test patterns when the repo answers them.
+
+## Recommended Payload Patterns
+
+Reuse existing helpers:
+
+- `anyone`: public read
+- `isPlatformBasicUser`: platform-only create/update/delete
+- `platformOnlyOrApproved`: platform reads all, others read approved clinics
+- `platformOnlyOrApprovedReviews`: review visibility
+- `platformOrAssignedClinicMutation`: platform or assigned clinic create
+- `platformOrOwnClinicResource`: platform or own-clinic resource scope
+- `platformOnlyFieldAccess`: platform-only field mutation
+- `beforeChangeAssignClinicFromUser({ clinicField: 'clinic' })`: clinic ownership stamping
+- `stableIdField()` plus `stableIdBeforeChangeHook`: stable seed/import identifiers
+
+Collection defaults to consider:
+
+- `timestamps: true`
+- `trash: true` unless destructive deletion is explicitly required
+- `admin.group`, `useAsTitle`, `defaultColumns`, and concise `admin.description`
+- `defaultPopulate` for records commonly referenced by public pages or joins
+- unique compound `indexes` for join collections
+
+## Planning Output
+
+A planning response should include:
+
+- concrete discovery facts with paths
+- likely model type and why
+- anti-overengineering alternatives checked
+- access model by role
+- hook/helper suggestions
+- migration/test/doc impact
+- explicit assumptions
+- one `<proposed_plan>` block
+- a short implementation question after the plan
+
+## Implementation Checklist After Approval
+
+When the user approves implementation:
+
+- create or update collection config under `src/collections/**`
+- register it in `src/payload.config.ts`
+- update `src/security/permission-matrix.config.ts`
+- add `tests/unit/access-matrix/<slug>.permission.test.ts`
+- add focused integration lifecycle/access/hook tests
+- update `tests/integration/contracts/collectionContractRegistry.ts`
+- create Payload migration with `pnpm payload migrate:create <migration_name>` for schema changes
+- update seeds or `docs/guides/**` only when the behavior changes those flows
+
+Never hand-write Payload migration files from scratch.
+
+## Validation
+
+For planning-only skill edits:
+
+```bash
+rtk pnpm format
+rtk python3 /Users/razorspoint/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/findmydoc-collection-planner
+```
+
+For actual approved collection implementation, choose from:
+
+```bash
+rtk pnpm matrix:derive json
+rtk pnpm matrix:verify
+rtk pnpm vitest run tests/unit/access-matrix/<slug>.permission.test.ts
+rtk pnpm vitest run tests/integration/<domain>.lifecycle.test.ts
+rtk pnpm check
+rtk pnpm build
+```
+
+Run `pnpm build` when build-relevant sources, Payload config, routing, or tooling output changes.

--- a/.codex/skills/findmydoc-collection-planner/references/payload-field-modeling.md
+++ b/.codex/skills/findmydoc-collection-planner/references/payload-field-modeling.md
@@ -1,0 +1,109 @@
+# Payload Field Modeling Reference
+
+Use this reference when planning or implementing collection fields. It is intentionally concise; rely on the repo's existing patterns first, then use this as a guardrail for Payload-specific choices.
+
+Official Payload docs to re-check when uncertain:
+
+- Collection config: `https://payloadcms.com/docs/configuration/collections`
+- Fields overview: `https://payloadcms.com/docs/fields/overview`
+- Relationship field: `https://payloadcms.com/docs/fields/relationship`
+- Join field: `https://payloadcms.com/docs/fields/join`
+- Collection access: `https://payloadcms.com/docs/access-control/collections`
+- Collection hooks: `https://payloadcms.com/docs/hooks/collections`
+- Field hooks: `https://payloadcms.com/docs/hooks/fields`
+- Indexes: `https://payloadcms.com/docs/database/indexes`
+
+## Collection Config Fields
+
+For each new collection, decide these before coding:
+
+- `slug`: stable API name; changing it later is a migration and code update.
+- `labels`: add when the slug is compact or user-facing names need spaces.
+- `admin.group`: keep navigation aligned with existing groups such as `Medical Network` or `Platform Management`.
+- `admin.useAsTitle`: choose a readable top-level field; avoid `id` unless no better title exists.
+- `admin.defaultColumns`: include fields operators scan most often.
+- `admin.description`: short, plain, operator-facing purpose.
+- `defaultPopulate`: include only small fields needed when this collection is referenced often.
+- `access`: define create/read/update/delete, and `admin` only when auth/admin behavior needs it.
+- `hooks`: use for lifecycle behavior, ownership stamping, denormalization, audit trails, or cross-document validation.
+- `timestamps`: usually `true` for domain data.
+- `trash`: usually `true` for domain records unless permanent deletion is required.
+- `fields`: schema and Admin UI surface.
+- `indexes`: use for frequent filters/sorts and unique relationship pairs.
+
+## Field Type Choices
+
+Prefer the simplest field that matches the data:
+
+- `text`: names, short strings, URLs when custom validation is enough.
+- `textarea`: longer plain text without rich formatting.
+- `richText`: patient/operator content needing formatting.
+- `email`: emails; prefer over text for email values.
+- `number`: prices, ratings, numeric metrics; set `min`/`max` where meaningful.
+- `date`: timestamps or business dates; use hooks for automatic audit timestamps.
+- `checkbox`: booleans.
+- `select`: controlled single or multi-choice values; centralize reusable option lists.
+- `relationship`: reference another collection when the relationship has no extra attributes.
+- `upload`: reference a media collection for files/images.
+- `join`: virtual reverse view of another collection's relationship/upload field; it does not create the relationship by itself.
+- `group`: nested object that belongs to the parent document.
+- `array`: repeated homogeneous objects owned by the parent document.
+- `tabs`: Admin UI organization for larger documents; not a domain concept.
+- `row` and `collapsible`: Admin presentation only; do not use to imply data ownership.
+- `point`: map coordinates.
+- `json` or `code`: last resort for flexible data; avoid when typed fields are known.
+- `blocks`: editorial page/content composition, not normal domain records.
+
+## Relationship vs Join Collection vs Join Field
+
+- Use a `relationship` field when the link has no attributes.
+- Use a dedicated join collection when the link needs attributes such as price, role, status, ordering, source, provenance, uniqueness, ownership, or hooks.
+- Use a `join` field on the parent only to expose the reverse side of an existing relationship/upload for Admin/API convenience.
+- For join collections, add a unique compound `indexes` entry when duplicate pairs should be impossible.
+
+## Official Payload Skill Lessons
+
+Use these Payload-specific pitfalls as extra checks; do not copy generic official examples into findmydoc code.
+
+- Select vs relationship: treat categories, tags, topics, labels, authors, assignees, reviewers, and values that operators may add/edit/remove as candidate relationship collections. Use `select` for fixed business enums such as internal user types, payment states, priorities, or draft/published states where code depends on the values.
+- Computed values: check `virtual: true` and `afterRead` before persisting computed fields. Persist computed values only when sorting, filtering, query performance, or Admin visibility requires storage.
+- Local API access: Payload Local API operations bypass access control by default. When operating on behalf of a user, explicitly consider `overrideAccess: false`.
+- Hook transactions: pass `req` into nested Payload operations inside hooks when those operations should share request context and transaction behavior.
+- Hook loops: use `context` flags when a hook writes data that can trigger the same hook path again.
+- Relationship ergonomics: consider `filterOptions` to constrain selectable related docs and `maxDepth` to keep populated responses bounded.
+- Draft workflows: recommend `versions` or `drafts` only for editorial or real publish workflows, not ordinary operational records.
+- Upload fields: reference an upload collection only after confirming the media collection, ownership model, storage path, and file-read access.
+
+## Field Options to Consider
+
+- `required`: use for data that must exist for valid business behavior, not just UI convenience.
+- `unique`: only for true global uniqueness; remember this affects duplication and migrations.
+- `index`: add when filtering/sorting often or access rules depend on the field.
+- `localized`: use for patient-facing content when translations differ by locale.
+- `defaultValue`: use for safe initial states such as `draft` or `pending`.
+- `min`/`max`: ratings, bounded numbers, and numeric sanity checks.
+- `hasMany`: relationship/select/upload arrays; consider whether ordering matters.
+- `admin.description`: explain what to enter, not implementation history.
+- `admin.position: 'sidebar'`: secondary metadata, status, ratings, or computed values.
+- `admin.readOnly`: computed or system-managed fields; still enforce writes with hooks/access if needed.
+- `admin.condition`: hide fields for irrelevant roles, but do not rely on UI hiding for security.
+- `access`: field-level rules for sensitive or platform-only fields.
+- `hooks`: field-local derivation, normalization, or validation that belongs to one field.
+- `validate`: local value checks that do not require database reads or side effects.
+
+## Hooks vs Validation vs Access
+
+- Use `validate` for local checks on a field value.
+- Use field hooks for normalization or derivation of one field.
+- Use collection hooks for cross-field, cross-document, ownership, audit, denormalization, or side effects.
+- Use access functions for authorization and row-level filters; Payload access can return booleans or query constraints.
+- Use Admin UI conditions only for operator ergonomics, never as the only enforcement.
+
+## findmydoc Defaults
+
+- Prefer `stableIdField()` and `stableIdBeforeChangeHook` for seed/importable domain collections.
+- Prefer `trash: true` for clinic, doctor, treatment, review, content, and media domain records.
+- Reuse access helpers from `src/access/**`; add new helpers only when no existing scope matches.
+- Keep clinic-owned records scoped through existing clinic assignment helpers where possible.
+- Keep computed fields read-only in Admin and update them via hooks or reusable utilities.
+- Keep field descriptions short, plain, and useful for first-time clinic users.


### PR DESCRIPTION
Adds a planning-first Codex skill for safer findmydoc Payload collection work.

## What changed

- Add the repo-local `findmydoc-collection-planner` skill.
- Document discovery-first collection planning, targeted questions, recommendations, and proposed-plan flow.
- Add Payload-specific collection and field modeling guidance based on official Payload skill lessons.

## Validation

- `rtk python3 /Users/razorspoint/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/findmydoc-collection-planner`
- `rtk pnpm format`
- `pnpm check` and `pnpm build` not run because this only changes `.codex/skills/**` documentation.

## Development

Closes #1157