### PR TITLE
fix(components): isolate mobile header menu state

### DIFF
--- a/src/components/templates/Header/Nav/index.tsx
+++ b/src/components/templates/Header/Nav/index.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/utilities/ui'
 import { UiLink } from '@/components/molecules/Link'
 import type { HeaderNavItem } from '@/utilities/normalizeNavItems'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/atoms/accordion'
+import { useMobileMenuState } from './useMobileMenuState'
 
 const getNavItemKey = (item: HeaderNavItem, index: number): string =>
   item.href ?? `group-${index}-${item.label ?? 'item'}`
@@ -177,10 +178,20 @@ const MobileMenu: React.FC<{
 
 export const HeaderNav: React.FC<{ navItems: HeaderNavItem[] }> = ({ navItems }) => {
   const items = navItems || []
+  const hasMobileMenuItems = items.length > 0
   const desktopNavRef = useRef<HTMLElement>(null)
+  const mobileMenuButtonRef = useRef<HTMLButtonElement>(null)
   const closeDelayRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [openIndex, setOpenIndex] = useState<number | null>(null)
-  const [mobileOpen, setMobileOpen] = useState(false)
+  const getHeaderLogoLink = useCallback(() => document.querySelector<HTMLAnchorElement>('header a[href="/"]'), [])
+  const {
+    close: closeMobileMenu,
+    isOpen: isMobileMenuOpen,
+    toggle: toggleMobileMenu,
+  } = useMobileMenuState(hasMobileMenuItems, {
+    getFallbackFocusTarget: getHeaderLogoLink,
+    menuButtonRef: mobileMenuButtonRef,
+  })
 
   const clearCloseDelay = useCallback(() => {
     if (!closeDelayRef.current) return
@@ -210,44 +221,6 @@ export const HeaderNav: React.FC<{ navItems: HeaderNavItem[] }> = ({ navItems })
   )
 
   useEffect(() => clearCloseDelay, [clearCloseDelay])
-
-  useEffect(() => {
-    if (!mobileOpen) return
-
-    const previousOverflow = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
-
-    return () => {
-      document.body.style.overflow = previousOverflow
-    }
-  }, [mobileOpen])
-
-  useEffect(() => {
-    if (!mobileOpen) return
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setMobileOpen(false)
-      }
-    }
-
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [mobileOpen])
-
-  useEffect(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
-
-    const mediaQuery = window.matchMedia('(min-width: 1024px)')
-    const handleChange = (event: MediaQueryListEvent) => {
-      if (event.matches) {
-        setMobileOpen(false)
-      }
-    }
-
-    mediaQuery.addEventListener('change', handleChange)
-    return () => mediaQuery.removeEventListener('change', handleChange)
-  }, [])
 
   // Close desktop dropdown on outside click
   useEffect(() => {
@@ -304,20 +277,22 @@ export const HeaderNav: React.FC<{ navItems: HeaderNavItem[] }> = ({ navItems })
         })}
       </nav>
 
-      {/* Mobile hamburger toggle */}
-      <button
-        type="button"
-        className="inline-flex size-11 items-center justify-center rounded-md text-foreground transition-colors hover:bg-zinc-100 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden lg:hidden"
-        aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
-        aria-controls={mobileMenuId}
-        aria-expanded={mobileOpen}
-        onClick={() => setMobileOpen((prev) => !prev)}
-      >
-        {mobileOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
-      </button>
+      {hasMobileMenuItems ? (
+        <button
+          ref={mobileMenuButtonRef}
+          type="button"
+          className="inline-flex size-11 items-center justify-center rounded-md text-foreground transition-colors hover:bg-zinc-100 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden lg:hidden"
+          aria-label={isMobileMenuOpen ? 'Close menu' : 'Open menu'}
+          aria-controls={mobileMenuId}
+          aria-expanded={isMobileMenuOpen}
+          onClick={toggleMobileMenu}
+        >
+          {isMobileMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+        </button>
+      ) : null}
 
       {/* Mobile panel */}
-      <MobileMenu navItems={items} open={mobileOpen} onClose={() => setMobileOpen(false)} />
+      {hasMobileMenuItems ? <MobileMenu navItems={items} open={isMobileMenuOpen} onClose={closeMobileMenu} /> : null}
     </>
   )
 }

--- a/src/components/templates/Header/Nav/useMobileMenuState.ts
+++ b/src/components/templates/Header/Nav/useMobileMenuState.ts
@@ -1,0 +1,90 @@
+'use client'
+
+import { useCallback, useEffect, useState, type RefObject } from 'react'
+
+type UseMobileMenuStateOptions = {
+  getFallbackFocusTarget?: () => HTMLElement | null
+  menuButtonRef?: RefObject<HTMLButtonElement | null>
+}
+
+export function useMobileMenuState(
+  hasMenuItems: boolean,
+  { getFallbackFocusTarget, menuButtonRef }: UseMobileMenuStateOptions = {},
+) {
+  const [requestedOpen, setRequestedOpen] = useState(false)
+  const isOpen = hasMenuItems && requestedOpen
+
+  const focusMenuButton = useCallback(() => {
+    menuButtonRef?.current?.focus({ preventScroll: true })
+  }, [menuButtonRef])
+
+  const focusFallbackTarget = useCallback(() => {
+    getFallbackFocusTarget?.()?.focus({ preventScroll: true })
+  }, [getFallbackFocusTarget])
+
+  const close = useCallback(
+    ({ returnFocus = false }: { returnFocus?: boolean } = {}) => {
+      setRequestedOpen(false)
+
+      if (returnFocus) {
+        focusMenuButton()
+      }
+    },
+    [focusMenuButton],
+  )
+
+  const toggle = useCallback(() => {
+    setRequestedOpen((current) => !current)
+  }, [])
+
+  useEffect(() => {
+    if (!hasMenuItems && requestedOpen) {
+      setRequestedOpen(false)
+      focusFallbackTarget()
+    }
+  }, [focusFallbackTarget, hasMenuItems, requestedOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    return () => {
+      document.body.style.overflow = previousOverflow
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        close({ returnFocus: true })
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [close, isOpen])
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+
+    const mediaQuery = window.matchMedia('(min-width: 1024px)')
+    const handleChange = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        close()
+      }
+    }
+
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [close])
+
+  return {
+    close,
+    isOpen,
+    toggle,
+  }
+}

--- a/src/stories/templates/Header.stories.tsx
+++ b/src/stories/templates/Header.stories.tsx
@@ -68,6 +68,21 @@ export const CompactNav: Story = {
   },
 }
 
+const emptyNavigationBase: Story = {
+  args: {
+    navItems: [],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    expect(canvas.queryByRole('button', { name: /open menu/i })).not.toBeInTheDocument()
+    expect(canvas.queryByLabelText('Mobile navigation')).not.toBeInTheDocument()
+  },
+}
+
+/** Header without CMS navigation items on mobile. */
+export const EmptyNavigation: Story = withViewportStory(emptyNavigationBase, 'public375', 'Empty navigation / 375')
+
 /** Header with submenu items on selected top-level entries. */
 export const WithSubmenus: Story = {
   args: {

--- a/src/stories/templates/HeaderNav.stories.tsx
+++ b/src/stories/templates/HeaderNav.stories.tsx
@@ -76,12 +76,20 @@ export const Default: Story = {
   },
 }
 
-/** Empty state with no navigation items. */
-export const Empty: Story = {
+const emptyBase: Story = {
   args: {
     navItems: [],
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    expect(canvas.queryByRole('button', { name: /open menu/i })).not.toBeInTheDocument()
+    expect(canvas.queryByLabelText('Mobile navigation')).not.toBeInTheDocument()
+  },
 }
+
+/** Empty mobile state with no navigation items. */
+export const Empty: Story = withViewportStory(emptyBase, 'public375', 'Empty navigation / 375')
 
 /** Navigation items with dropdown submenus on selected entries. */
 export const WithSubmenus: Story = {

--- a/tests/unit/components/templates/header.test.tsx
+++ b/tests/unit/components/templates/header.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from 'react'
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { Header } from '@/components/templates/Header/Component'
@@ -22,6 +22,60 @@ describe('Header template', () => {
     render(<Header navItems={navItems} />)
 
     expect(screen.getByRole('link', { name: 'About' })).toBeInTheDocument()
+  })
+
+  it('does not render the mobile menu button without nav items', () => {
+    render(<Header navItems={[]} />)
+
+    expect(screen.queryByRole('button', { name: 'Open menu' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('navigation', { name: 'Mobile navigation' })).not.toBeInTheDocument()
+  })
+
+  it('opens the mobile navigation when nav items are available', () => {
+    render(<Header navItems={navItems} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }))
+
+    const mobileNavigation = screen.getByRole('navigation', { name: 'Mobile navigation' })
+    expect(screen.getByRole('button', { name: 'Close menu' })).toBeInTheDocument()
+    expect(within(mobileNavigation).getByRole('link', { name: 'About' })).toBeInTheDocument()
+  })
+
+  it('clears mobile scroll lock and moves focus to the logo when nav items become unavailable', async () => {
+    document.body.style.overflow = ''
+    const { rerender } = render(<Header navItems={navItems} />)
+    const logoLink = screen.getByRole('link', { name: 'findmydoc' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }))
+
+    const mobileLink = within(screen.getByRole('navigation', { name: 'Mobile navigation' })).getByRole('link', {
+      name: 'About',
+    })
+    mobileLink.focus()
+    expect(mobileLink).toHaveFocus()
+
+    await waitFor(() => expect(document.body.style.overflow).toBe('hidden'))
+
+    rerender(<Header navItems={[]} />)
+
+    await waitFor(() => expect(document.body.style.overflow).toBe(''))
+    await waitFor(() => expect(logoLink).toHaveFocus())
+    expect(screen.queryByRole('button', { name: 'Close menu' })).not.toBeInTheDocument()
+  })
+
+  it('returns focus to the mobile menu button after Escape closes the menu', async () => {
+    render(<Header navItems={navItems} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }))
+    const mobileLink = within(screen.getByRole('navigation', { name: 'Mobile navigation' })).getByRole('link', {
+      name: 'About',
+    })
+    mobileLink.focus()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    await waitFor(() => expect(screen.queryByRole('navigation', { name: 'Mobile navigation' })).not.toBeInTheDocument())
+    expect(screen.getByRole('button', { name: 'Open menu' })).toHaveFocus()
   })
 
   it('applies custom logo source', () => {


### PR DESCRIPTION
Mobile header menu behavior is isolated into a focused hook with deterministic focus and empty-state coverage.

## What changed
- Extracted mobile header menu state into `useMobileMenuState`.
- Preserved scroll-lock cleanup, Escape close behavior, and desktop breakpoint closing in the hook.
- Added focus return to the menu button on Escape and a logo fallback when nav items disappear while the menu is open.
- Hid the mobile menu trigger and panel when no nav items exist.
- Added unit and Storybook coverage for open, empty, Escape, focus, and mobile viewport states.

## Validation
- `rtk pnpm format`
- `rtk pnpm exec vitest run tests/unit/components/templates/header.test.tsx`
- `rtk pnpm exec vitest run --project storybook src/stories/templates/HeaderNav.stories.tsx src/stories/templates/Header.stories.tsx`
- `rtk pnpm stories:governance:check`
- `rtk pnpm check`
- `rtk env PAYLOAD_SECRET=dev-secret pnpm build`
- Playwright mobile QA on `/clinics/manual-contact-test-clinic` and `/contact` at 320, 375, 375-short, 640, 768, and 1024 widths

## Screenshots
- Captured locally under `output/playwright/header-refactor/` for the mobile cookie banner, account menu, and footer states.

## Development
Fixes #1163
