### PR TITLE
fix: refresh clickable card navigation options

### DIFF
--- a/src/utilities/useClickableCard.ts
+++ b/src/utilities/useClickableCard.ts
@@ -62,27 +62,23 @@ function useClickableCard<T extends HTMLElement>({
   const hasActiveParent = useRef<boolean>(false)
   const pressedButton = useRef<number>(0)
 
-  const handleMouseDown = useCallback(
-    (e: MouseEvent) => {
-      if (e.target) {
-        const target = e.target as Element
+  const handleMouseDown = useCallback((e: MouseEvent) => {
+    if (e.target) {
+      const target = e.target as Element
 
-        const timeNow = +new Date()
-        const parent = target?.closest('a')
+      const timeNow = +new Date()
+      const parent = target?.closest('a')
 
-        pressedButton.current = e.button
+      pressedButton.current = e.button
 
-        if (!parent) {
-          hasActiveParent.current = false
-          timeDown.current = timeNow
-        } else {
-          hasActiveParent.current = true
-        }
+      if (!parent) {
+        hasActiveParent.current = false
+        timeDown.current = timeNow
+      } else {
+        hasActiveParent.current = true
       }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [router, cardRef, linkRef, timeDown],
-  )
+    }
+  }, [])
 
   const handleMouseUp = useCallback(
     (e: MouseEvent) => {
@@ -102,8 +98,7 @@ function useClickableCard<T extends HTMLElement>({
         }
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [router, cardRef, linkRef, timeDown],
+    [external, newTab, router, scroll],
   )
 
   useEffect(() => {
@@ -123,8 +118,7 @@ function useClickableCard<T extends HTMLElement>({
     return () => {
       abortController.abort()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cardRef, linkRef, router])
+  }, [handleMouseDown, handleMouseUp])
 
   return {
     cardRef,

--- a/tests/unit/utilities/useClickableCard.test.tsx
+++ b/tests/unit/utilities/useClickableCard.test.tsx
@@ -13,9 +13,14 @@ vi.mock('next/navigation', () => ({
   }),
 }))
 
-function ClickableCardHarness() {
+type ClickableCardHarnessProps = {
+  scroll?: boolean
+}
+
+function ClickableCardHarness({ scroll = true }: ClickableCardHarnessProps) {
   const { cardRef, linkRef } = useClickableCard<HTMLDivElement>({
     external: false,
+    scroll,
   })
 
   return (
@@ -55,5 +60,21 @@ describe('useClickableCard', () => {
     fireEvent.mouseUp(card, { button: 0, metaKey: true })
 
     expect(pushMock).not.toHaveBeenCalled()
+  })
+
+  it('uses updated navigation options after rerender', () => {
+    const { rerender } = render(<ClickableCardHarness scroll />)
+
+    rerender(<ClickableCardHarness scroll={false} />)
+
+    const card = screen.getByTestId('card')
+
+    fireEvent.mouseDown(card, { button: 0 })
+    fireEvent.mouseUp(card, { button: 0 })
+
+    const [href, options] = pushMock.mock.calls[0] ?? []
+    expect(typeof href).toBe('string')
+    expect(href).toMatch(/^http:\/\/localhost(?::\d+)?\/target$/)
+    expect(options).toEqual({ scroll: false })
   })
 })


### PR DESCRIPTION
Clickable card navigation now respects updated hook options after rerenders.

## What changed
- refreshed the useClickableCard event listener dependencies so clicks use current scroll, external, and newTab values
- added a rerender-focused unit test that reproduces the stale-closure bug and locks in the fix

## Validation
- pnpm vitest tests/unit/utilities/useClickableCard.test.tsx
- pnpm check
- pnpm build
- pnpm format

## Development
- Closes #1166
