### PR TITLE
fix(frontend): enable native clinic map interaction

### DIFF
--- a/src/components/organisms/ClinicDetail/ClinicLocationSection.tsx
+++ b/src/components/organisms/ClinicDetail/ClinicLocationSection.tsx
@@ -21,14 +21,35 @@ type ClinicLocationSectionProps = {
   clinicName: string
   location: ClinicLocation
   mapHref?: string
+  mapEmbedHref?: string
   isOpenStreetMapAllowed?: boolean
   onContactClick?: () => void
+}
+
+function PreviewMapInteractionGuard() {
+  return (
+    <div
+      className="pointer-events-none absolute inset-0"
+      aria-hidden="true"
+      data-testid="map-preview-interaction-guard"
+    >
+      <div
+        className="pointer-events-auto absolute top-0 right-[72px] left-0 h-[120px] touch-pan-y"
+        data-testid="map-preview-interaction-guard-top"
+      />
+      <div
+        className="pointer-events-auto absolute top-[120px] right-0 bottom-0 left-0 touch-pan-y"
+        data-testid="map-preview-interaction-guard-body"
+      />
+    </div>
+  )
 }
 
 export function ClinicLocationSection({
   clinicName,
   location,
   mapHref,
+  mapEmbedHref,
   isOpenStreetMapAllowed = true,
   onContactClick,
 }: ClinicLocationSectionProps) {
@@ -41,8 +62,8 @@ export function ClinicLocationSection({
     [isOpenStreetMapAllowed, location, mapHref],
   )
   const openStreetMapEmbedHref = React.useMemo(
-    () => (isOpenStreetMapAllowed ? buildOpenStreetMapEmbedHref(location) : undefined),
-    [isOpenStreetMapAllowed, location],
+    () => (isOpenStreetMapAllowed ? mapEmbedHref?.trim() || buildOpenStreetMapEmbedHref(location) : undefined),
+    [isOpenStreetMapAllowed, location, mapEmbedHref],
   )
   const openStreetMapDirectionsHref = React.useMemo(
     () => (isOpenStreetMapAllowed ? buildOpenStreetMapDirectionsHref(location) : undefined),
@@ -50,7 +71,7 @@ export function ClinicLocationSection({
   )
 
   const renderMapFrame = React.useCallback(
-    (interactive: boolean) => {
+    (interactive: boolean, embedHref?: string) => {
       if (!isOpenStreetMapAllowed) {
         return (
           <div className="flex h-full items-center justify-center bg-linear-to-br from-primary/12 via-background to-primary/20">
@@ -61,16 +82,23 @@ export function ClinicLocationSection({
         )
       }
 
-      if (openStreetMapEmbedHref) {
+      if (embedHref) {
+        const iframeTitle = interactive ? `Interactive map of ${clinicName}` : `Map preview of ${clinicName}`
+
         return (
           <>
             <iframe
-              title={`Map of ${clinicName}`}
-              src={openStreetMapEmbedHref}
-              className={cn('h-full w-full border-0 contrast-90 saturate-75', !interactive && 'pointer-events-none')}
+              title={iframeTitle}
+              src={embedHref}
+              className={cn(
+                'h-full w-full border-0 contrast-90 saturate-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary',
+                interactive ? 'touch-pan-x touch-pan-y' : 'select-none',
+              )}
               loading="lazy"
               referrerPolicy="no-referrer-when-downgrade"
+              tabIndex={interactive ? -1 : 0}
             />
+            {interactive ? null : <PreviewMapInteractionGuard />}
             <div
               className="pointer-events-none absolute inset-0 bg-linear-to-b from-primary/7 via-transparent to-primary/10 mix-blend-multiply"
               aria-hidden="true"
@@ -88,7 +116,7 @@ export function ClinicLocationSection({
         </div>
       )
     },
-    [clinicName, isOpenStreetMapAllowed, openStreetMapEmbedHref],
+    [clinicName, isOpenStreetMapAllowed],
   )
 
   React.useEffect(() => {
@@ -107,8 +135,8 @@ export function ClinicLocationSection({
 
   if (!openStreetMapViewHref && !location.fullAddress) return null
 
-  const previewMapFrame = renderMapFrame(false)
-  const expandedMapFrame = renderMapFrame(true)
+  const previewMapFrame = renderMapFrame(false, openStreetMapEmbedHref)
+  const expandedMapFrame = renderMapFrame(true, openStreetMapEmbedHref)
 
   return (
     <Dialog open={isMapOverlayOpen} onOpenChange={setIsMapOverlayOpen}>
@@ -164,10 +192,10 @@ export function ClinicLocationSection({
         </div>
 
         <DialogContent
-          className="flex h-[88vh] w-[min(calc(100vw-2rem),1400px)] max-w-[1400px] flex-col overflow-hidden border-primary/25 bg-background/96 p-0 shadow-brand-soft sm:w-[min(calc(100vw-4rem),1400px)]"
+          className="flex h-[min(88dvh,900px)] max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-[1400px] flex-col overflow-hidden border-primary/25 bg-background/96 p-0 shadow-brand-soft sm:max-h-[calc(100dvh-4rem)] sm:w-[min(calc(100vw-4rem),1400px)]"
           overlayClassName="bg-secondary/35 backdrop-blur-sm"
         >
-          <DialogHeader className="gap-4 border-b border-primary/15 p-4 text-left sm:p-6">
+          <DialogHeader className="gap-4 space-y-0 border-b border-primary/15 p-4 text-left sm:flex-row sm:items-start sm:justify-between sm:p-6">
             <div className="space-y-1">
               <DialogTitle asChild>
                 <Heading as="h3" align="left" size="h5" className="text-secondary">
@@ -179,7 +207,19 @@ export function ClinicLocationSection({
               </DialogDescription>
             </div>
 
-            <div className="flex flex-wrap justify-end gap-2 pr-10">
+            <div className="flex w-full flex-wrap gap-2 pr-10 sm:w-auto sm:justify-end">
+              {isOpenStreetMapAllowed && openStreetMapViewHref ? (
+                <Button asChild size="sm" variant="secondary">
+                  <a
+                    href={openStreetMapViewHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="View map in OpenStreetMap"
+                  >
+                    View map
+                  </a>
+                </Button>
+              ) : null}
               {isOpenStreetMapAllowed && (openStreetMapDirectionsHref || openStreetMapViewHref) ? (
                 <Button asChild size="sm">
                   <a
@@ -213,13 +253,13 @@ export function ClinicLocationSection({
             </div>
           </DialogHeader>
 
-          <div className="relative min-h-0 flex-1 p-4 sm:p-6">
-            <div className="relative h-full overflow-hidden rounded-2xl border border-primary/20">
+          <div className="relative min-h-0 flex-1 p-3 sm:p-6">
+            <div className="relative h-full min-h-0 overflow-hidden rounded-lg border border-primary/20 sm:rounded-2xl">
               {expandedMapFrame}
             </div>
           </div>
 
-          <div className="px-4 pb-4 sm:px-6 sm:pb-6">
+          <div className="px-3 pb-3 sm:px-6 sm:pb-6">
             <p className="text-xs text-secondary/55">Map data © OpenStreetMap contributors</p>
           </div>
         </DialogContent>

--- a/src/stories/templates/ClinicLocationMapVariations.stories.tsx
+++ b/src/stories/templates/ClinicLocationMapVariations.stories.tsx
@@ -1,11 +1,80 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect, fn, screen, userEvent, within } from '@storybook/test'
+import { expect, fn, userEvent, within } from '@storybook/test'
 
 import { ClinicLocationSection } from '@/components/organisms/ClinicDetail'
 import { buildOpenStreetMapHref } from '@/components/templates/ClinicDetailConcepts'
 import { clinicDetailFixture } from '@/stories/fixtures/clinicDetail'
 
 const mapHref = buildOpenStreetMapHref(clinicDetailFixture.location)
+const mapEmbedHref = `data:text/html;charset=utf-8,${encodeURIComponent(`
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+      }
+
+      body {
+        align-items: center;
+        background:
+          linear-gradient(90deg, rgb(210 221 230 / 0.7) 1px, transparent 1px),
+          linear-gradient(rgb(210 221 230 / 0.7) 1px, transparent 1px),
+          linear-gradient(135deg, #eef6f1, #dfe9f8);
+        background-size:
+          48px 48px,
+          48px 48px,
+          cover;
+        color: #0f2e46;
+        display: flex;
+        font-family: system-ui, sans-serif;
+        justify-content: center;
+      }
+
+      .zoom {
+        position: absolute;
+        right: 12px;
+        top: 12px;
+      }
+
+      .zoom button {
+        background: white;
+        border: 1px solid rgb(15 46 70 / 0.22);
+        color: #0f2e46;
+        display: block;
+        font: 700 18px/1 system-ui, sans-serif;
+        height: 30px;
+        width: 30px;
+      }
+
+      .marker {
+        align-items: center;
+        background: #6ea64c;
+        border: 3px solid white;
+        border-radius: 999px;
+        box-shadow: 0 12px 24px rgb(15 46 70 / 0.24);
+        color: white;
+        display: flex;
+        font-size: 14px;
+        font-weight: 700;
+        height: 48px;
+        justify-content: center;
+        width: 48px;
+      }
+    </style>
+  </head>
+  <body aria-label="Mock OpenStreetMap embed">
+    <div class="zoom" aria-label="Native map zoom controls">
+      <button type="button" aria-label="Zoom in">+</button>
+      <button type="button" aria-label="Zoom out">-</button>
+    </div>
+    <div class="marker" aria-hidden="true">OSM</div>
+  </body>
+</html>
+`)}`
 
 const meta = {
   title: 'Domain/Clinic/Templates/ClinicDetail/Map Location',
@@ -14,6 +83,7 @@ const meta = {
     clinicName: clinicDetailFixture.clinicName,
     location: clinicDetailFixture.location,
     mapHref,
+    mapEmbedHref,
     isOpenStreetMapAllowed: true,
     onContactClick: fn(),
   },
@@ -40,10 +110,27 @@ export const HeroMapFloatingCard: Story = {
     await expect(canvas.getByRole('heading', { name: 'Clinic Location' })).toBeInTheDocument()
     await expect(canvas.getByRole('link', { name: 'Directions' })).toBeInTheDocument()
     await expect(canvas.getByRole('button', { name: 'Contact' })).toBeInTheDocument()
+    await expect(canvas.getByTitle(`Map preview of ${clinicDetailFixture.clinicName}`)).not.toHaveClass(
+      /pointer-events-none/,
+    )
+    await expect(canvas.getByTitle(`Map preview of ${clinicDetailFixture.clinicName}`)).toHaveAttribute('tabindex', '0')
+    await expect(canvas.getByTestId('map-preview-interaction-guard')).toBeInTheDocument()
+    await expect(canvas.getByTestId('map-preview-interaction-guard-top')).toHaveClass(/right-\[72px\]/)
+    await expect(canvas.getByTestId('map-preview-interaction-guard-body')).toHaveClass(/top-\[120px\]/)
 
     await userEvent.click(canvas.getByRole('button', { name: 'Expand map' }))
-    await expect(screen.getByRole('button', { name: 'Close map' })).toBeInTheDocument()
-    await userEvent.click(screen.getByRole('button', { name: 'Close map' }))
+    const page = within(document.body)
+
+    await expect(page.getByRole('button', { name: 'Close map' })).toBeInTheDocument()
+    const interactiveMap = page.getByTitle(`Interactive map of ${clinicDetailFixture.clinicName}`)
+
+    await expect(page.getByRole('link', { name: 'View map in OpenStreetMap' })).toBeInTheDocument()
+    await expect(interactiveMap).not.toHaveClass(/pointer-events-none/)
+    await expect(page.queryByRole('group', { name: 'Expanded map keyboard controls' })).not.toBeInTheDocument()
+    await expect(page.queryByRole('button', { name: 'Pan map north' })).not.toBeInTheDocument()
+    await expect(page.queryByRole('button', { name: 'Zoom map in' })).not.toBeInTheDocument()
+    await expect(page.queryByRole('button', { name: 'Reset map view' })).not.toBeInTheDocument()
+    await userEvent.click(page.getByRole('button', { name: 'Close map' }))
     await expect(canvas.getByRole('button', { name: 'Expand map' })).toBeInTheDocument()
   },
 }

--- a/tests/e2e/public/clinic-detail.public-smoke.spec.ts
+++ b/tests/e2e/public/clinic-detail.public-smoke.spec.ts
@@ -56,12 +56,61 @@ test.describe('clinic detail map dialog', () => {
     await page.waitForLoadState('networkidle')
     await expect(page.getByRole('heading', { name: 'Clinic Location' })).toBeVisible()
 
+    const previewMap = page.getByTitle(/Map preview of/)
+    await expect(previewMap).toBeVisible()
+    await expect(previewMap).not.toHaveClass(/pointer-events-none/)
+    await expect(previewMap).toHaveAttribute('tabindex', '0')
+    await expect(page.getByTestId('map-preview-interaction-guard')).toBeAttached()
+    await expect(page.getByTestId('map-preview-interaction-guard-top')).toHaveClass(/right-\[72px\]/)
+    await expect(page.getByTestId('map-preview-interaction-guard-body')).toHaveClass(/top-\[120px\]/)
+
+    await previewMap.scrollIntoViewIfNeeded()
+    const previewMapBox = await previewMap.boundingBox()
+    expect(previewMapBox).not.toBeNull()
+    if (previewMapBox) {
+      const previewZoomPoint = {
+        x: previewMapBox.x + previewMapBox.width - 24,
+        y: previewMapBox.y + 24,
+      }
+
+      await expect
+        .poll(
+          async () =>
+            page.evaluate(({ x, y }) => {
+              const element = document.elementFromPoint(x, y)
+
+              return {
+                tagName: element?.tagName,
+                title: element?.getAttribute('title'),
+              }
+            }, previewZoomPoint),
+          { message: 'preview zoom hit target should remain inside the iframe' },
+        )
+        .toEqual(
+          expect.objectContaining({
+            tagName: 'IFRAME',
+          }),
+        )
+
+      await page.mouse.click(previewZoomPoint.x, previewZoomPoint.y)
+    }
+
     const expandMapButton = page.getByRole('button', { name: 'Expand map' })
     await expandMapButton.click()
 
-    await expect(page.getByRole('dialog', { name: 'Expanded Map View' })).toBeVisible()
-    await expect(page.getByRole('link', { name: 'Directions' })).toBeVisible()
+    const dialog = page.getByRole('dialog', { name: 'Expanded Map View' })
+    const interactiveMap = dialog.getByTitle(/Interactive map of/)
 
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByRole('link', { name: 'View map in OpenStreetMap' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Directions' })).toBeVisible()
+    await expect(interactiveMap).toBeVisible()
+    await expect(interactiveMap).not.toHaveClass(/pointer-events-none/)
+    await expect(interactiveMap).toHaveAttribute('tabindex', '-1')
+    await expect(dialog.getByRole('group', { name: 'Expanded map keyboard controls' })).not.toBeVisible()
+    await expect(dialog.getByRole('button', { name: 'Pan map north' })).not.toBeVisible()
+    await expect(dialog.getByRole('button', { name: 'Zoom map in' })).not.toBeVisible()
+    await expect(dialog.getByRole('button', { name: 'Reset map view' })).not.toBeVisible()
     await page.keyboard.press('Escape')
 
     await expect(page.getByRole('dialog', { name: 'Expanded Map View' })).not.toBeVisible()

--- a/tests/unit/components/clinicLocationSection.test.tsx
+++ b/tests/unit/components/clinicLocationSection.test.tsx
@@ -23,7 +23,8 @@ describe('ClinicLocationSection', () => {
     expect(screen.getByText('OpenStreetMap is hidden until optional cookies are accepted.')).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'Directions' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Expand map' })).not.toBeInTheDocument()
-    expect(screen.queryByTitle('Map of Test Clinic')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('Map preview of Test Clinic')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('Interactive map of Test Clinic')).not.toBeInTheDocument()
   })
 
   it('opens the expanded map inside an accessible dialog', () => {
@@ -37,9 +38,28 @@ describe('ClinicLocationSection', () => {
       />,
     )
 
+    const previewMap = screen.getByTitle('Map preview of Test Clinic')
+
+    expect(previewMap).not.toHaveClass('pointer-events-none')
+    expect(previewMap).toHaveAttribute('tabindex', '0')
+    expect(screen.getByTestId('map-preview-interaction-guard')).toBeInTheDocument()
+    expect(screen.getByTestId('map-preview-interaction-guard-top')).toHaveClass('right-[72px]', 'h-[120px]')
+    expect(screen.getByTestId('map-preview-interaction-guard-body')).toHaveClass('top-[120px]')
+
     fireEvent.click(screen.getByRole('button', { name: 'Expand map' }))
 
-    expect(screen.getByRole('dialog', { name: 'Expanded Map View' })).toBeInTheDocument()
+    const dialog = screen.getByRole('dialog', { name: 'Expanded Map View' })
+    const expandedMap = screen.getByTitle('Interactive map of Test Clinic')
+
+    expect(dialog).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'View map in OpenStreetMap' })).toBeInTheDocument()
+    expect(expandedMap).not.toHaveClass('pointer-events-none')
+    expect(expandedMap).toHaveAttribute('tabindex', '-1')
+    expect(screen.getByTestId('map-preview-interaction-guard')).toBeInTheDocument()
+    expect(screen.queryByRole('group', { name: 'Expanded map keyboard controls' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Pan map north' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Zoom map in' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Reset map view' })).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Close map' }))
 


### PR DESCRIPTION
The clinic detail map now supports native OpenStreetMap interaction without app-owned map controls.

## What changed

- keep the expanded map iframe pointer/touch interactive for native OSM drag and zoom behavior
- keep the inline preview mostly scroll-safe while leaving the native OSM zoom-control corner clickable
- make the preview iframe keyboard-focusable, while the expanded dialog iframe stays `tabIndex={-1}`
- add a keyboard-accessible `View map` fallback beside `Directions` in the expanded dialog
- keep map stories isolated from live OSM iframe traffic with a local mock embed
- cover preview zoom availability, guard geometry, dialog behavior, and absence of app-owned pan/zoom/reset controls in unit, Storybook, and public smoke tests

## Validation

- `rtk pnpm format`
- `rtk pnpm vitest tests/unit/components/clinicLocationSection.test.tsx tests/unit/utilities/openStreetMap.test.ts`
- `rtk pnpm vitest --project storybook run src/stories/templates/ClinicLocationMapVariations.stories.tsx`
- `rtk pnpm stories:governance:check`
- `rtk pnpm tests:e2e --project=public-smoke tests/e2e/public/clinic-detail.public-smoke.spec.ts`
- `rtk pnpm check`
- `rtk env PAYLOAD_SECRET=dev-secret pnpm build`
- `rtk detect-secrets-hook --baseline .secrets.baseline src/components/organisms/ClinicDetail/ClinicLocationSection.tsx src/stories/templates/ClinicLocationMapVariations.stories.tsx tests/e2e/public/clinic-detail.public-smoke.spec.ts tests/unit/components/clinicLocationSection.test.tsx`
- `rtk git diff --check`

## Screenshots

- Preview zoom controls: `output/playwright/issue235-preview-zoom-buttons-playwright.png`
- Mobile dialog: `output/playwright/issue235-map-dialog-native-mobile.png`
- Short mobile dialog: `output/playwright/issue235-map-dialog-native-short-mobile.png`
- Desktop dialog: `output/playwright/issue235-map-dialog-native-desktop.png`

## Development

Closes #1171
References findmydoc-platform/management#235