### PR TITLE
fix(frontend): support local mobile dev origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ PAYLOAD_SECRET=YOUR_SECRET_HERE
 # Used to configure CORS, format links and more. No trailing slash
 NEXT_PUBLIC_SERVER_URL=http://localhost:3000
 
+# Optional local dev hosts for mobile testing over LAN, VPN, or Tailscale. Use hostnames without protocol or port.
+NEXT_ALLOWED_DEV_ORIGINS=
+
 # Secret used to authenticate cron jobs
 CRON_SECRET=YOUR_CRON_SECRET_HERE
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -59,6 +59,18 @@ See also:
 - [Features: Preview Access Policy](./features.md#preview-access-policy)
 - [Preview Guard Technical Notes](../src/features/previewGuard/README.md)
 
+### Mobile Testing Over LAN, VPN, or Tailscale
+
+Next.js blocks cross-origin development resources such as `/_next/webpack-hmr` unless the browser host is allowed. The local dev config automatically allows the machine's active RFC1918 IPv4 LAN addresses, so testing on a phone via `http://192.168.x.x:3000` works after the dev server starts.
+
+For VPN or Tailscale hostnames, set your own local value in `.env`:
+
+```bash
+NEXT_ALLOWED_DEV_ORIGINS=your-machine.tailnet.ts.net
+```
+
+Use hostnames only, without `http://` and without `:3000`. Separate multiple hosts with commas. Keep personal Tailscale or VPN hostnames in `.env`; `.env` is ignored by Git, while `.env.local` is tracked in this repository. Restart `pnpm dev` after changing the value.
+
 ### Migrations
 
 This repository uses an explicit migration-first workflow in every environment.

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,8 @@
+import { networkInterfaces } from 'node:os'
 import { withPayload } from '@payloadcms/next/withPayload'
 
 import { IMAGE_LOCAL_PATTERNS, IMAGE_QUALITIES } from './src/imageConfig.js'
+import { getAllowedDevOrigins } from './src/utilities/nextDevOrigins.js'
 import redirects from './redirects.js'
 
 const NEXT_PUBLIC_SERVER_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
@@ -20,9 +22,17 @@ const normalizeEnvValue = (value) => {
 const isPreviewRuntime =
   (normalizeEnvValue(process.env.VERCEL_ENV) ?? normalizeEnvValue(process.env.DEPLOYMENT_ENV)) === 'preview'
 const blockSearchIndexing = isPreviewRuntime
+const isDevelopmentRuntime = process.env.NODE_ENV === 'development'
+
+const allowedDevOrigins = getAllowedDevOrigins({
+  configuredOrigins: process.env.NEXT_ALLOWED_DEV_ORIGINS,
+  isDevelopmentRuntime,
+  networkInterfacesByName: networkInterfaces(),
+})
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  ...(allowedDevOrigins.length > 0 ? { allowedDevOrigins } : {}),
   async headers() {
     return blockSearchIndexing
       ? [

--- a/src/components/templates/Footer/Component.tsx
+++ b/src/components/templates/Footer/Component.tsx
@@ -34,6 +34,7 @@ export const Footer: React.FC<FooterProps> = ({ footerGroups, logoSrc, showPrevi
     ...group,
     items: group.items.filter((link) => !isLegalLink(link.href)),
   }))
+  const visibleMobileFooterGroups = mobileFooterGroups.filter((group) => group.items.length > 0)
 
   return (
     <footer className="mt-auto border-t border-border/60 bg-background text-foreground">
@@ -42,14 +43,14 @@ export const Footer: React.FC<FooterProps> = ({ footerGroups, logoSrc, showPrevi
           <div className="flex flex-col gap-8 md:hidden">
             <Logo loading="lazy" priority="low" src={logoSrc} showPreviewBadge={showPreviewBadge} />
 
-            <Accordion type="multiple" className="rounded-2xl border border-border/70 bg-card">
-              {mobileFooterGroups.map((group) => (
-                <AccordionItem key={group.title} value={group.title} className="border-border/70 px-4">
-                  <AccordionTrigger className="min-h-11 py-4 text-base font-semibold text-foreground hover:no-underline">
-                    {group.title}
-                  </AccordionTrigger>
-                  <AccordionContent className="border-t-0 pt-0 pb-4">
-                    {group.items.length > 0 ? (
+            {visibleMobileFooterGroups.length > 0 ? (
+              <Accordion type="multiple" className="rounded-2xl border border-border/70 bg-card">
+                {visibleMobileFooterGroups.map((group) => (
+                  <AccordionItem key={group.title} value={group.title} className="border-border/70 px-4">
+                    <AccordionTrigger className="min-h-11 py-4 text-base font-semibold text-foreground hover:no-underline">
+                      {group.title}
+                    </AccordionTrigger>
+                    <AccordionContent className="border-t-0 pt-0 pb-4">
                       <ul className="space-y-3">
                         {group.items.map((link) => (
                           <li key={`${group.title}-${link.href}-${link.label ?? ''}`}>
@@ -57,11 +58,11 @@ export const Footer: React.FC<FooterProps> = ({ footerGroups, logoSrc, showPrevi
                           </li>
                         ))}
                       </ul>
-                    ) : null}
-                  </AccordionContent>
-                </AccordionItem>
-              ))}
-            </Accordion>
+                    </AccordionContent>
+                  </AccordionItem>
+                ))}
+              </Accordion>
+            ) : null}
 
             {legalQuickLinks.length > 0 ? (
               <nav aria-label="Footer legal quick links" className="flex flex-wrap items-center gap-x-4 gap-y-2">

--- a/src/utilities/nextDevOrigins.js
+++ b/src/utilities/nextDevOrigins.js
@@ -1,0 +1,48 @@
+export const normalizeAllowedDevOrigin = (value) => {
+  if (!value) return null
+
+  const normalized = value.trim()
+  if (!normalized) return null
+
+  try {
+    const originUrl = new URL(/^[a-z][a-z\d+.-]*:\/\//i.test(normalized) ? normalized : `http://${normalized}`)
+    return originUrl.hostname.toLowerCase()
+  } catch {
+    const [hostname] = normalized.split('/')
+    return hostname?.replace(/:\d+$/, '').trim().toLowerCase() || null
+  }
+}
+
+export const isPrivateIpv4Address = (address) => {
+  const octets = address.split('.').map(Number)
+
+  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
+    return false
+  }
+
+  const [first, second] = octets
+
+  return first === 10 || (first === 172 && second >= 16 && second <= 31) || (first === 192 && second === 168)
+}
+
+export const getLocalIpv4DevOrigins = (networkInterfacesByName) =>
+  Object.values(networkInterfacesByName)
+    .flatMap((interfaces) => interfaces ?? [])
+    .filter(
+      (networkInterface) =>
+        (networkInterface.family === 'IPv4' || networkInterface.family === 4) &&
+        !networkInterface.internal &&
+        isPrivateIpv4Address(networkInterface.address),
+    )
+    .map((networkInterface) => networkInterface.address)
+
+export const getConfiguredDevOrigins = (value) =>
+  (value ?? '').split(',').map(normalizeAllowedDevOrigin).filter(Boolean)
+
+export const getAllowedDevOrigins = ({ configuredOrigins, isDevelopmentRuntime, networkInterfacesByName }) => {
+  if (!isDevelopmentRuntime) return []
+
+  return Array.from(
+    new Set([...getLocalIpv4DevOrigins(networkInterfacesByName), ...getConfiguredDevOrigins(configuredOrigins)]),
+  )
+}

--- a/tests/unit/components/templates/footer.test.tsx
+++ b/tests/unit/components/templates/footer.test.tsx
@@ -69,4 +69,26 @@ describe('Footer template', () => {
     expect(within(legalQuickLinks).getByRole('link', { name: 'Privacy Policy' })).toBeInTheDocument()
     expect(within(legalQuickLinks).queryByRole('link', { name: 'Privacy settings' })).not.toBeInTheDocument()
   })
+
+  it('does not render empty mobile accordion groups when only legal quick links are available', () => {
+    render(
+      <Footer
+        footerGroups={[
+          { title: 'About', items: [] },
+          { title: 'Services', items: [] },
+          {
+            title: 'Information',
+            items: [{ href: '/privacy-policy', label: 'Privacy Policy', appearance: 'inline', newTab: false }],
+          },
+        ]}
+      />,
+    )
+
+    const legalQuickLinks = screen.getByRole('navigation', { name: 'Footer legal quick links' })
+
+    expect(screen.queryByRole('button', { name: 'About' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Services' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Information' })).not.toBeInTheDocument()
+    expect(within(legalQuickLinks).getByRole('link', { name: 'Privacy Policy' })).toBeInTheDocument()
+  })
 })

--- a/tests/unit/config/next-config.test.ts
+++ b/tests/unit/config/next-config.test.ts
@@ -1,9 +1,53 @@
 import { describe, expect, it } from 'vitest'
 
 import nextConfig from '../../../next.config.js'
+import { getAllowedDevOrigins } from '@/utilities/nextDevOrigins.js'
 
 describe('nextConfig', () => {
   it('includes seed assets in API output tracing', () => {
     expect(nextConfig.outputFileTracingIncludes?.['/api/**/*']).toContain('./src/endpoints/seed/assets/**/*')
+  })
+
+  it('auto-allows only private IPv4 dev origins', () => {
+    const allowedDevOrigins = getAllowedDevOrigins({
+      configuredOrigins: '',
+      isDevelopmentRuntime: true,
+      networkInterfacesByName: {
+        en0: [
+          { address: '192.168.0.53', family: 'IPv4', internal: false },
+          { address: '10.0.0.5', family: 'IPv4', internal: false },
+          { address: '172.16.0.5', family: 'IPv4', internal: false },
+          { address: '172.31.255.5', family: 'IPv4', internal: false },
+          { address: '172.32.0.5', family: 'IPv4', internal: false },
+          { address: '100.64.0.5', family: 'IPv4', internal: false },
+          { address: '203.0.113.5', family: 'IPv4', internal: false },
+          { address: '127.0.0.1', family: 'IPv4', internal: true },
+        ],
+      },
+    })
+
+    expect(allowedDevOrigins).toEqual(['192.168.0.53', '10.0.0.5', '172.16.0.5', '172.31.255.5'])
+  })
+
+  it('normalizes configured VPN and Tailscale dev hostnames', () => {
+    const allowedDevOrigins = getAllowedDevOrigins({
+      configuredOrigins: 'https://razorspoint-mac-headless.tail58177a.ts.net:3000,vpn.example.local:3000/path',
+      isDevelopmentRuntime: true,
+      networkInterfacesByName: {},
+    })
+
+    expect(allowedDevOrigins).toEqual(['razorspoint-mac-headless.tail58177a.ts.net', 'vpn.example.local'])
+  })
+
+  it('does not set allowed dev origins outside development', () => {
+    const allowedDevOrigins = getAllowedDevOrigins({
+      configuredOrigins: 'vpn.example.local',
+      isDevelopmentRuntime: false,
+      networkInterfacesByName: {
+        en0: [{ address: '192.168.0.53', family: 'IPv4', internal: false }],
+      },
+    })
+
+    expect(allowedDevOrigins).toEqual([])
   })
 })


### PR DESCRIPTION
Local mobile testing works from main for LAN, VPN, and Tailscale hosts without committing developer-specific hostnames.

## What changed
- Added a development-only allowedDevOrigins helper for RFC1918 LAN addresses and locally configured VPN/Tailscale hostnames.
- Documented NEXT_ALLOWED_DEV_ORIGINS as an empty local-only setting.
- Hid empty mobile footer accordion groups when only legal quick links remain.
- Added unit coverage for dev-origin normalization and footer empty-group behavior.

## Validation
- pnpm format
- pnpm exec vitest run tests/unit/config/next-config.test.ts tests/unit/components/templates/footer.test.tsx
- pnpm check
- PAYLOAD_SECRET=dev-secret pnpm build

## Development
Fixes #1162
Supersedes #1164 because #1164 targeted feature/posthog-event-tracking by mistake.
