### PR TITLE
fix: align public surface tokens

### DIFF
--- a/src/app/(frontend)/AGENTS.md
+++ b/src/app/(frontend)/AGENTS.md
@@ -40,6 +40,7 @@
 - Keep component variants in code (CVA), not semantic global CSS classes.
 - Avoid inline styles unless no other option exists.
 - Use design tokens and utility composition before arbitrary values.
+- Public route canvas, shared chrome, and structural page bands must use the site surface tokens (`site-canvas`, `site-chrome`, `site-section`, `site-divider`); reserve raw `bg-white`, `bg-muted/*`, and local divider colors for cards, panels, media overlays, or intentionally contrasting content sections.
 
 ## Heading Rule
 

--- a/src/app/(frontend)/_components/PublicAuthRouteShell.tsx
+++ b/src/app/(frontend)/_components/PublicAuthRouteShell.tsx
@@ -13,7 +13,7 @@ export function PublicAuthRouteShell({ children, className }: PublicAuthRouteShe
   return (
     <section
       className={cn(
-        'px-5 pt-4 pb-[calc(env(safe-area-inset-bottom)+4.5rem)] sm:px-6 sm:pt-5 sm:pb-[calc(env(safe-area-inset-bottom)+5rem)] md:px-8 md:pt-8 md:pb-16',
+        'bg-site-canvas px-5 pt-4 pb-[calc(env(safe-area-inset-bottom)+4.5rem)] sm:px-6 sm:pt-5 sm:pb-[calc(env(safe-area-inset-bottom)+5rem)] md:px-8 md:pt-8 md:pb-16',
         className,
       )}
     >

--- a/src/app/(frontend)/auth/password/reset/complete/page.tsx
+++ b/src/app/(frontend)/auth/password/reset/complete/page.tsx
@@ -14,7 +14,7 @@ export default async function CompleteResetPage({ searchParams }: { searchParams
   const params = await searchParams
 
   return (
-    <main className="min-h-screen bg-muted/20 py-12">
+    <main className="min-h-screen bg-site-canvas py-12">
       <div className="mx-auto max-w-4xl px-4">
         <div className="mb-6">
           <Link href="/login/patient" className="text-sm text-primary hover:underline">

--- a/src/app/(frontend)/auth/password/reset/page.tsx
+++ b/src/app/(frontend)/auth/password/reset/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = createSiteMetadata({
 
 export default function ResetPasswordPage() {
   return (
-    <main className="min-h-screen bg-muted/20 py-12">
+    <main className="min-h-screen bg-site-canvas py-12">
       <div className="mx-auto max-w-4xl px-4">
         <div className="mb-6">
           <Link href="/login/patient" className="text-sm text-primary hover:underline">

--- a/src/app/(frontend)/globals.css
+++ b/src/app/(frontend)/globals.css
@@ -41,6 +41,12 @@
   --input: #e2e8f0;
   --ring: #0076ff;
 
+  /* Public site surfaces */
+  --site-canvas: var(--muted);
+  --site-chrome: var(--muted);
+  --site-section: var(--muted);
+  --site-divider: var(--border);
+
   --destructive: #ef4444;
   --destructive-foreground: #ffffff;
 
@@ -103,6 +109,11 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+
+  --color-site-canvas: var(--site-canvas);
+  --color-site-chrome: var(--site-chrome);
+  --color-site-section: var(--site-section);
+  --color-site-divider: var(--site-divider);
 
   --color-card: var(--card);
   --color-card-foreground: var(--card-foreground);

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -99,7 +99,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           </>
         ) : null}
       </head>
-      <body className="min-h-screen bg-background text-foreground antialiased">
+      <body className="min-h-screen bg-site-canvas text-foreground antialiased">
         <div className="flex min-h-screen min-h-svh flex-col">
           <AdminBar adminBarProps={{ preview: isEnabled }} />
 

--- a/src/app/(frontend)/patient/favorites/page.tsx
+++ b/src/app/(frontend)/patient/favorites/page.tsx
@@ -36,7 +36,7 @@ export default async function PatientFavoritesPage() {
   })
 
   return (
-    <main className="bg-muted/30 py-8 sm:py-12 lg:py-14">
+    <main className="bg-site-section py-8 sm:py-12 lg:py-14">
       <Container>
         <FavoriteClinicsList initialItems={items} />
       </Container>

--- a/src/components/organisms/Blog/BlogCardCollection/index.tsx
+++ b/src/components/organisms/Blog/BlogCardCollection/index.tsx
@@ -86,7 +86,7 @@ export const BlogCardCollection: React.FC<BlogCardCollectionProps> = ({
   }
 
   return (
-    <section className={cn('py-16 sm:py-20', isBlue ? 'bg-primary' : 'bg-white')}>
+    <section className={cn('py-16 sm:py-20', isBlue ? 'bg-primary' : 'bg-site-canvas')}>
       <Container>
         <div className="mb-8 flex flex-col gap-4 text-center sm:mb-10">
           <Heading as="h2" size="section" align="center" variant={isBlue ? 'white' : 'default'}>

--- a/src/components/organisms/Contact/PublicContactSection.tsx
+++ b/src/components/organisms/Contact/PublicContactSection.tsx
@@ -46,10 +46,7 @@ export const PublicContactSection: React.FC<PublicContactSectionProps> = ({
     contactConsent ?? 'By sending this request, you agree that findmydoc may contact you about your inquiry.'
 
   return (
-    <section id={id} className="relative overflow-hidden py-20">
-      <div className="absolute inset-0 bg-linear-to-br from-sky-50 via-white to-slate-50" aria-hidden="true" />
-      <div className="absolute inset-x-0 top-0 h-px bg-slate-200/70" aria-hidden="true" />
-
+    <section id={id} className="relative overflow-hidden bg-site-canvas py-20">
       <Container className="relative z-10">
         <div className="grid gap-10 lg:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)] lg:items-start">
           <SectionHeading

--- a/src/components/organisms/Heroes/LandingHero/index.tsx
+++ b/src/components/organisms/Heroes/LandingHero/index.tsx
@@ -43,7 +43,7 @@ export const LandingHero: React.FC<LandingHeroProps> = ({
   return (
     <section
       className={cn(
-        'relative flex items-center justify-center bg-white py-14 sm:py-20',
+        'relative flex items-center justify-center bg-site-canvas py-14 sm:py-20',
         isClinicLanding ? 'min-h-[34rem] overflow-hidden sm:min-h-[48rem]' : 'min-h-[32rem] md:min-h-[39rem] md:pb-28',
       )}
     >
@@ -58,7 +58,7 @@ export const LandingHero: React.FC<LandingHeroProps> = ({
             className="object-cover object-center"
             priority
           />
-          <div className="absolute inset-0 bg-white/75" />
+          <div className="absolute inset-0 bg-site-canvas/75" />
         </div>
       ) : null}
 

--- a/src/components/organisms/Landing/LandingCategories.tsx
+++ b/src/components/organisms/Landing/LandingCategories.tsx
@@ -42,9 +42,9 @@ export function LandingCategories({
   }))
 
   return (
-    <section className="bg-muted/30 py-20">
+    <section className="bg-site-section py-20">
       <Container>
-        <header className="mb-12 flex flex-col items-center gap-6 border-b border-border/60 pb-6 text-center">
+        <header className="mb-12 flex flex-col items-center gap-6 border-b border-site-divider/60 pb-6 text-center">
           <SectionHeading
             title={title}
             description={description}

--- a/src/components/organisms/Landing/LandingFeatures.tsx
+++ b/src/components/organisms/Landing/LandingFeatures.tsx
@@ -43,7 +43,7 @@ export const LandingFeatures: React.FC<LandingFeaturesProps> = ({
   return (
     <SectionBackground
       as="section"
-      className={cn('py-14 sm:py-16 md:py-20', isGreen ? 'bg-accent' : 'bg-white')}
+      className={cn('py-14 sm:py-16 md:py-20', isGreen ? 'bg-accent' : 'bg-site-canvas')}
       media={
         backgroundImage
           ? {

--- a/src/components/organisms/Landing/LandingPricing.tsx
+++ b/src/components/organisms/Landing/LandingPricing.tsx
@@ -37,8 +37,11 @@ export const LandingPricing: React.FC<LandingPricingProps> = ({ plans, title, de
   const compactPlans = plans.filter((plan) => plan.layout === 'compact')
 
   return (
-    <section className="relative overflow-hidden bg-muted/30 py-20">
-      <div className="absolute inset-0 bg-linear-to-br from-sky-50/70 via-white to-emerald-50/40" aria-hidden="true" />
+    <section className="relative overflow-hidden bg-site-section py-20">
+      <div
+        className="absolute inset-0 bg-linear-to-br from-site-section via-site-canvas to-site-section"
+        aria-hidden="true"
+      />
 
       <Container className="relative z-10">
         <div className="mb-14">

--- a/src/components/organisms/Landing/LandingProcess.tsx
+++ b/src/components/organisms/Landing/LandingProcess.tsx
@@ -525,7 +525,7 @@ export const LandingProcess: React.FC<LandingProcessProps> = ({
   if (steps.length === 0) return null
 
   return (
-    <section className="bg-white py-16 sm:py-20">
+    <section className="bg-site-canvas py-16 sm:py-20">
       <Container>
         <SectionHeading className="mb-16" title={title} description={subtitle} size="section" align="center" />
 

--- a/src/components/organisms/Landing/LandingTeam.tsx
+++ b/src/components/organisms/Landing/LandingTeam.tsx
@@ -27,7 +27,7 @@ type LandingTeamProps = {
 
 export const LandingTeam: React.FC<LandingTeamProps> = ({ team, title, description }) => {
   return (
-    <section className="bg-white py-20">
+    <section className="bg-site-canvas py-20">
       <Container>
         <SectionHeading className="mb-16" title={title} description={description} size="section" align="center" />
 

--- a/src/components/organisms/Landing/LandingTestimonials.tsx
+++ b/src/components/organisms/Landing/LandingTestimonials.tsx
@@ -20,7 +20,7 @@ export const LandingTestimonials: React.FC<LandingTestimonialsProps> = ({
   className,
 }) => {
   return (
-    <section className={cn('bg-white py-16 sm:py-20', className)}>
+    <section className={cn('bg-site-canvas py-16 sm:py-20', className)}>
       <Container>
         <SectionHeading
           className="mb-10 sm:mb-12 md:mb-16"

--- a/src/components/templates/ClinicDetailConcepts/ClinicDetail.tsx
+++ b/src/components/templates/ClinicDetailConcepts/ClinicDetail.tsx
@@ -138,7 +138,7 @@ export function ClinicDetail({
   }, [data.doctors, handleContactDoctor])
 
   return (
-    <main className={cn('overflow-x-clip bg-muted text-foreground', className)}>
+    <main className={cn('overflow-x-clip bg-site-canvas text-foreground', className)}>
       <Container className="pt-10 pb-14 lg:pt-20 lg:pb-64">
         {/* Figma parity requires fixed card/image dimensions for the hero composition and overlap behavior. */}
         <HeroOverviewSection

--- a/src/components/templates/Footer/Component.tsx
+++ b/src/components/templates/Footer/Component.tsx
@@ -37,16 +37,16 @@ export const Footer: React.FC<FooterProps> = ({ footerGroups, logoSrc, showPrevi
   const visibleMobileFooterGroups = mobileFooterGroups.filter((group) => group.items.length > 0)
 
   return (
-    <footer className="mt-auto border-t border-border/60 bg-background text-foreground">
+    <footer className="mt-auto bg-site-chrome text-foreground">
       <Container className="py-8 sm:py-12">
         <div className="flex flex-col gap-8 sm:gap-12">
           <div className="flex flex-col gap-8 md:hidden">
             <Logo loading="lazy" priority="low" src={logoSrc} showPreviewBadge={showPreviewBadge} />
 
             {visibleMobileFooterGroups.length > 0 ? (
-              <Accordion type="multiple" className="rounded-2xl border border-border/70 bg-card">
+              <Accordion type="multiple" className="rounded-2xl border border-site-divider/70 bg-card">
                 {visibleMobileFooterGroups.map((group) => (
-                  <AccordionItem key={group.title} value={group.title} className="border-border/70 px-4">
+                  <AccordionItem key={group.title} value={group.title} className="border-site-divider/70 px-4">
                     <AccordionTrigger className="min-h-11 py-4 text-base font-semibold text-foreground hover:no-underline">
                       {group.title}
                     </AccordionTrigger>
@@ -72,7 +72,7 @@ export const Footer: React.FC<FooterProps> = ({ footerGroups, logoSrc, showPrevi
               </nav>
             ) : null}
 
-            <div className="flex flex-col items-start gap-4 border-t border-border/60 pt-4">
+            <div className="flex flex-col items-start gap-4 border-t border-site-divider/60 pt-4">
               <div className="flex flex-wrap items-center gap-4">
                 <SocialLink href="https://meta.com" aria-label="Meta" platform="meta" variant="outline" />
                 <SocialLink href="https://x.com" aria-label="X" platform="x" variant="outline" />

--- a/src/components/templates/Header/Component.tsx
+++ b/src/components/templates/Header/Component.tsx
@@ -14,7 +14,7 @@ interface HeaderProps {
 }
 
 export const Header: React.FC<HeaderProps> = ({ navItems, logoSrc, rightActions, showPreviewBadge = false }) => (
-  <header className="relative z-40 bg-white [--site-header-height:4.25rem] sm:[--site-header-height:5.5rem]">
+  <header className="relative z-40 bg-site-chrome [--site-header-height:4.25rem] sm:[--site-header-height:5.5rem]">
     <Container className="flex items-center justify-between gap-2 px-3 py-3 min-[375px]:px-6 sm:gap-3 sm:px-8 sm:py-4 lg:px-12 xl:px-20 2xl:px-32">
       <Link href="/" className="shrink-0">
         <Logo

--- a/src/components/templates/Header/Nav/index.tsx
+++ b/src/components/templates/Header/Nav/index.tsx
@@ -69,7 +69,7 @@ const DesktopDropdown: React.FC<{
       </button>
 
       {open && (
-        <div className="absolute top-full left-0 z-50 mt-2 min-w-52 rounded-md border border-zinc-200 bg-white p-2 shadow-sm">
+        <div className="absolute top-full left-0 z-50 mt-2 min-w-52 rounded-md border border-site-divider bg-card p-2 shadow-sm">
           <ul className="space-y-1">
             {item.subItems?.map((sub) => {
               const newTabProps = sub.newTab ? { rel: 'noopener noreferrer' as const, target: '_blank' as const } : {}
@@ -77,7 +77,7 @@ const DesktopDropdown: React.FC<{
                 <li key={sub.href}>
                   <Link
                     href={sub.href}
-                    className="block rounded-sm px-3 py-2 text-foreground transition-colors hover:bg-zinc-200/70 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden"
+                    className="block rounded-sm px-3 py-2 text-foreground transition-colors hover:bg-site-section hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden"
                     onClick={onClose}
                     {...newTabProps}
                   >
@@ -107,7 +107,7 @@ const MobileMenu: React.FC<{
   return (
     <nav
       id={mobileMenuId}
-      className="fixed inset-x-0 top-[var(--site-header-height)] bottom-0 z-[60] border-t border-border bg-zinc-50/98 shadow-lg backdrop-blur lg:hidden"
+      className="fixed inset-x-0 top-[var(--site-header-height)] bottom-0 z-[60] border-t border-site-divider/70 bg-site-chrome/98 shadow-lg backdrop-blur lg:hidden"
       aria-label="Mobile navigation"
     >
       <div className="flex h-full flex-col overflow-y-auto overscroll-contain px-5 pt-3 pb-[calc(env(safe-area-inset-bottom)+1rem)]">
@@ -117,7 +117,7 @@ const MobileMenu: React.FC<{
           if (item.subItems && item.subItems.length > 0) {
             return (
               <Accordion key={itemKey} type="single" collapsible>
-                <AccordionItem value={`mobile-${itemKey}`} className="border-border/70">
+                <AccordionItem value={`mobile-${itemKey}`} className="border-site-divider/70">
                   <AccordionTrigger className="min-h-11 py-3 text-base font-semibold text-foreground hover:text-foreground hover:no-underline">
                     {item.label}
                   </AccordionTrigger>
@@ -131,7 +131,7 @@ const MobileMenu: React.FC<{
                           <Link
                             key={sub.href}
                             href={sub.href}
-                            className="min-h-11 rounded-sm px-3 py-3 text-sm text-foreground transition-colors hover:bg-zinc-100 hover:text-foreground"
+                            className="min-h-11 rounded-sm px-3 py-3 text-sm text-foreground transition-colors hover:bg-site-section hover:text-foreground"
                             onClick={onClose}
                             {...newTabProps}
                           >
@@ -281,7 +281,7 @@ export const HeaderNav: React.FC<{ navItems: HeaderNavItem[] }> = ({ navItems })
         <button
           ref={mobileMenuButtonRef}
           type="button"
-          className="inline-flex size-11 items-center justify-center rounded-md text-foreground transition-colors hover:bg-zinc-100 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden lg:hidden"
+          className="inline-flex size-11 items-center justify-center rounded-md text-foreground transition-colors hover:bg-site-section hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden lg:hidden"
           aria-label={isMobileMenuOpen ? 'Close menu' : 'Open menu'}
           aria-controls={mobileMenuId}
           aria-expanded={isMobileMenuOpen}

--- a/src/components/templates/ListingComparison/Component.tsx
+++ b/src/components/templates/ListingComparison/Component.tsx
@@ -61,7 +61,7 @@ export function ListingComparison({
       <FeatureHero {...hero} />
 
       <main>
-        <section className="bg-muted/30 py-12" aria-label="Clinic filters and results">
+        <section className="bg-site-section py-12" aria-label="Clinic filters and results">
           <Container>
             <div className="grid gap-8 lg:grid-cols-[minmax(0,320px)_minmax(0,1fr)] lg:items-start">
               <div id={filtersContainerId} className="order-1 min-w-0 lg:order-1" aria-label="Filters">


### PR DESCRIPTION
Align public page surfaces so shared header, footer, and route canvas colors stay consistent across public templates.

## What changed

- Added global public surface tokens for canvas, chrome, structural sections, and dividers.
- Updated RootLayout, Header, Footer, mobile navigation, Contact, ListingComparison, ClinicDetail, auth/favorites shells, landing structural bands, and blog collection surfaces to use the tokens.
- Removed the global footer top line and the local Contact gradient/top-divider treatment.
- Added a frontend AGENTS rule that keeps public route canvas/chrome on the shared surface tokens while reserving raw white/muted utilities for cards, panels, overlays, and intentionally contrasting areas.

## Validation

- `rtk pnpm format`
- `rtk pnpm ai:slop-check`
- `rtk pnpm check`
- `rtk env PAYLOAD_SECRET=dev-secret pnpm build`
- `rtk detect-secrets-hook --baseline .secrets.baseline <changed files>`
- Playwright/browser QA across `320`, `375`, `640`, `768`, `1024`, and `1280` for `/contact`, `/listing-comparison`, `/login/patient`, and `/patient/favorites` redirect state.
- Mobile navigation open/close verified at `375px`.

## Screenshots

Local screenshot evidence was captured under `output/playwright/surface-fix/` for Contact mobile, ListingComparison desktop, clinic detail Storybook, and mobile nav open state.

## Development

Closes #1179