### PR TITLE
fix(admin): allow avatar media id zero

### DIFF
--- a/src/components/organisms/AdminBranding/AdminAccountAvatar.tsx
+++ b/src/components/organisms/AdminBranding/AdminAccountAvatar.tsx
@@ -137,7 +137,7 @@ export const AdminAccountAvatar: React.FC = () => {
   const mediaID = React.useMemo(() => getMediaID(profileImageValue), [profileImageValue])
 
   const mediaEndpoint = React.useMemo(() => {
-    if (embeddedMediaURL || !mediaID) return ''
+    if (embeddedMediaURL || mediaID == null) return ''
     return buildAPIPath(config.routes.api, `/${PROFILE_MEDIA_COLLECTION}/${mediaID}` as `/${string}`)
   }, [config.routes.api, embeddedMediaURL, mediaID])
 

--- a/tests/unit/components/adminAccountAvatar.test.tsx
+++ b/tests/unit/components/adminAccountAvatar.test.tsx
@@ -110,6 +110,31 @@ describe('AdminAccountAvatar', () => {
     expect(avatarImage).toHaveAttribute('src', '/api/userProfileMedia/file/profile-from-media.jpg')
   })
 
+  it('fetches media document when relation id is numeric zero', () => {
+    mockUsePayloadAPI.mockImplementation((url: string) => {
+      if (url === '/api/basicUsers/me') {
+        return buildAPIReturn({
+          user: {
+            profileImage: 0,
+          },
+        })
+      }
+
+      if (url === '/api/userProfileMedia/0') {
+        return buildAPIReturn({
+          url: '/api/userProfileMedia/file/profile-zero.jpg',
+        })
+      }
+
+      return buildAPIReturn({})
+    })
+
+    render(<AdminAccountAvatar />)
+
+    const avatarImage = screen.getByRole('img', { name: 'account avatar' })
+    expect(avatarImage).toHaveAttribute('src', '/api/userProfileMedia/file/profile-zero.jpg')
+  })
+
   it('renders default account icon when no profile image is configured', () => {
     mockUsePayloadAPI.mockImplementation(() => buildAPIReturn({ user: { profileImage: null } }))
 


### PR DESCRIPTION
fixes admin avatar fallback when media relation id is zero.

## What changed
- changed the avatar media-endpoint guard to treat only `null`/`undefined` as missing IDs.
- this allows numeric `0` relation ids to resolve `/api/userProfileMedia/0` correctly.
- added a unit regression test covering `profileImage: 0` in `/me` response.

## Validation
- `pnpm format`
- `pnpm vitest run tests/unit/components/adminAccountAvatar.test.tsx`
- `pnpm check`

## Development
- Closes #1185
