### PR TITLE
ci: delay dependabot auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+      day: 'tuesday'
+      time: '08:00'
+      timezone: 'Europe/Berlin'
+    cooldown:
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 30
     commit-message:
       prefix: 'chore'
       prefix-development: 'build'
@@ -41,6 +48,11 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+      day: 'wednesday'
+      time: '08:00'
+      timezone: 'Europe/Berlin'
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: 'chore'
       include: 'scope'
@@ -52,6 +64,11 @@ updates:
     directory: '/.github'
     schedule:
       interval: 'weekly'
+      day: 'thursday'
+      time: '08:00'
+      timezone: 'Europe/Berlin'
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: 'chore'
       include: 'scope'

--- a/.github/scripts/dependabot-enable-delayed-automerge.sh
+++ b/.github/scripts/dependabot-enable-delayed-automerge.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+label="${AUTOMERGE_LABEL:-automerge:dependencies}"
+minimum_age_hours="${MINIMUM_AGE_HOURS:-48}"
+
+if ! [[ "$minimum_age_hours" =~ ^[0-9]+$ ]]; then
+  echo "MINIMUM_AGE_HOURS must be a non-negative integer" >&2
+  exit 1
+fi
+
+gh label create "$label" \
+  --description "Dependency PRs eligible for delayed auto-merge" \
+  --color "0E8A16" \
+  --force
+
+prs_json="$(
+  gh pr list \
+    --author "app/dependabot" \
+    --base "main" \
+    --state "open" \
+    --label "$label" \
+    --json "autoMergeRequest,createdAt,isDraft,number,title" \
+    --limit 100
+)"
+
+if [ "$(jq 'length' <<< "$prs_json")" -eq 0 ]; then
+  echo "No delayed Dependabot auto-merge candidates found."
+  exit 0
+fi
+
+now_epoch="$(date -u +%s)"
+
+jq -c '.[]' <<< "$prs_json" | while read -r pr; do
+  number="$(jq -r '.number' <<< "$pr")"
+  title="$(jq -r '.title' <<< "$pr")"
+  created_at="$(jq -r '.createdAt' <<< "$pr")"
+  created_epoch="$(date -u -d "$created_at" +%s)"
+  age_hours="$(((now_epoch - created_epoch) / 3600))"
+
+  if [ "$(jq -r '.isDraft' <<< "$pr")" = "true" ]; then
+    echo "Skipping #$number because it is a draft: $title"
+    continue
+  fi
+
+  if [ "$(jq -r '.autoMergeRequest != null' <<< "$pr")" = "true" ]; then
+    echo "Skipping #$number because auto-merge is already enabled: $title"
+    continue
+  fi
+
+  if [ "$age_hours" -lt "$minimum_age_hours" ]; then
+    echo "Skipping #$number because it is ${age_hours}h old; requires ${minimum_age_hours}h: $title"
+    continue
+  fi
+
+  echo "Enabling auto-merge for #$number (${age_hours}h old): $title"
+  gh pr merge --auto --squash "$number"
+done

--- a/.github/scripts/dependabot-enable-delayed-automerge.sh
+++ b/.github/scripts/dependabot-enable-delayed-automerge.sh
@@ -29,21 +29,21 @@ if [ "$(jq 'length' <<< "$prs_json")" -eq 0 ]; then
   exit 0
 fi
 
-now_epoch="$(date -u +%s)"
+now_epoch="$(date --utc +%s)"
 
-jq -c '.[]' <<< "$prs_json" | while read -r pr; do
-  number="$(jq -r '.number' <<< "$pr")"
-  title="$(jq -r '.title' <<< "$pr")"
-  created_at="$(jq -r '.createdAt' <<< "$pr")"
-  created_epoch="$(date -u -d "$created_at" +%s)"
+jq --compact-output '.[]' <<< "$prs_json" | while read -r pr; do
+  number="$(jq --raw-output '.number' <<< "$pr")"
+  title="$(jq --raw-output '.title' <<< "$pr")"
+  created_at="$(jq --raw-output '.createdAt' <<< "$pr")"
+  created_epoch="$(date --utc --date "$created_at" +%s)"
   age_hours="$(((now_epoch - created_epoch) / 3600))"
 
-  if [ "$(jq -r '.isDraft' <<< "$pr")" = "true" ]; then
+  if [ "$(jq --raw-output '.isDraft' <<< "$pr")" = "true" ]; then
     echo "Skipping #$number because it is a draft: $title"
     continue
   fi
 
-  if [ "$(jq -r '.autoMergeRequest != null' <<< "$pr")" = "true" ]; then
+  if [ "$(jq --raw-output '.autoMergeRequest != null' <<< "$pr")" = "true" ]; then
     echo "Skipping #$number because auto-merge is already enabled: $title"
     continue
   fi

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,19 +7,32 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+  schedule:
+    - cron: '20 7 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      minimum_age_hours:
+        description: 'Minimum PR age before enabling auto-merge'
+        required: false
+        default: '48'
+        type: string
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
-  auto-merge:
-    name: enable auto-merge for safe dependabot updates
+  mark-auto-merge-candidate:
+    name: mark safe dependabot updates
     if: |
+      github.event_name == 'pull_request' &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
@@ -27,12 +40,50 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge for minor and patch updates
+      - name: Mark minor and patch updates for delayed auto-merge
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          AUTOMERGE_LABEL: 'automerge:dependencies'
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh pr merge --auto --squash "$PR_NUMBER"
+        run: |
+          gh label create "$AUTOMERGE_LABEL" \
+            --description "Dependency PRs eligible for delayed auto-merge" \
+            --color "0E8A16" \
+            --force
+          gh issue edit "$PR_NUMBER" --add-label "$AUTOMERGE_LABEL"
+
+      - name: Remove delayed auto-merge marker from other updates
+        if: |
+          steps.metadata.outputs.update-type != 'version-update:semver-patch' &&
+          steps.metadata.outputs.update-type != 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          AUTOMERGE_LABEL: 'automerge:dependencies'
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh issue edit "$PR_NUMBER" --remove-label "$AUTOMERGE_LABEL" || true
+
+  enable-delayed-auto-merge:
+    name: enable delayed auto-merge
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    env:
+      AUTOMERGE_LABEL: 'automerge:dependencies'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      MINIMUM_AGE_HOURS: ${{ github.event_name == 'workflow_dispatch' && inputs.minimum_age_hours || '48' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Enable auto-merge for mature candidates
+        run: bash .github/scripts/dependabot-enable-delayed-automerge.sh

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,9 +3,6 @@ name: Dependency Review
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'package.json'
-      - 'pnpm-lock.yaml'
 
 permissions:
   contents: read
@@ -17,6 +14,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Review dependency changes
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@
 ## Execution Requirements (Repository-Specific)
 
 - Always read layered `AGENTS.md` instructions first.
+- Prefer descriptive long-form CLI flags over short aliases whenever the CLI provides them.
 - Validation policy is path-based:
   - `pnpm format` runs for every change because it is fast and deterministic.
   - `pnpm check` is required when code, hooks, runtime configuration, schema, or lint-relevant files change.
@@ -51,8 +52,7 @@
 - Before creating any git commit that changes tracked files, run `pnpm format` first, even for docs-only or test-only work.
 - If required `check` or `build` fails, fix first, then rerun `pnpm format`.
 - `pnpm build` requires `PAYLOAD_SECRET` and network access to the Postgres Docker DB.
-- Keep `detect-secrets` in sync with the branch before push. If secret scanning updates `.secrets.baseline`, include that file in the same change set.
-- Treat `.secrets.baseline` drift as required maintenance so CI `Detect secrets` does not fail on baseline updates.
+- Keep `detect-secrets` and `.secrets.baseline` in sync with the branch before push; include baseline drift in the same change set so CI `Detect secrets` does not fail.
 - AI-slop enforcement mode is `pre-commit + pre-push + deep-quality-lane`; AI-slop itself remains intentionally non-blocking in the main PR CI workflow.
 - When changing instruction sources (`AGENTS.md`, `**/AGENTS.md`, `**/AGENTS.override.md`, `docs/frontend/mobile-ai-playbook.md`), run `pnpm ai:slop-check` locally.
 - For UI changes, always save Playwright screenshots in an ignored Playwright artifacts folder, review the change via those screenshots and runtime logs, and fix it immediately if the result is not correct or not good enough.
@@ -92,13 +92,15 @@
 
 ## Pull Request Metadata Rules
 
-- Title format: `<type>(optional-scope)?: short summary`; use only the types/scopes accepted by `.github/workflows/pr-gates.yml`; summary starts lowercase, imperative, and <= 72 chars.
-- Use `.github/pull_request_template.md` and start with a bilingual `Management summary`: one non-technical German paragraph followed by the same non-technical English paragraph, release-note quality, focused on visible product, operator, or business value.
-- Keep implementation detail in `## What changed`; include architectural or module-level context, link files only when useful for review, and do not paste code snippets into the PR body.
-- In `## Validation`, check every relevant item and explain every unchecked, skipped, or not-applicable item directly in the section.
-- In `## Development`, use `Closes` for every linked Issue, one line per Issue. Use `Closes #123` for same-repository Issues and `Closes findmydoc-platform/management#123` for trusted cross-repository Issues.
-- Do not require a standalone `Screenshots:` section by default; record UI evidence in the `UI/mobile QA` validation item unless a reviewer or workflow explicitly needs separate screenshots.
-- Build PR descriptions in a temporary markdown file or heredoc, pass them with `gh pr create --body-file` or `gh pr edit --body-file`, never inline multiline bodies through shell quoting, and verify the rendered body with `gh pr view --json body`.
+- Title format: `<type>(optional-scope)?: short summary`
+- Use only the types and scopes accepted by `.github/workflows/pr-gates.yml`; keep the title valid for `amannn/action-semantic-pull-request@v5`.
+- Summary starts lowercase, imperative, and <= 72 chars.
+- Start descriptions with a short user-impact sentence, then `## What changed` and `## Validation` sections.
+- For UI changes, include a `Screenshots:` section with affected states.
+- Keep language concise and concrete.
+- Build PR descriptions in a temporary markdown file or heredoc, then pass them with `gh pr create --body-file` or `gh pr edit --body-file`.
+- Never pass multiline PR bodies inline through shell quoting, and never rely on literal `\n` sequences to create paragraph breaks.
+- Verify the rendered PR body with `gh pr view --json body` before sharing the link.
 
 ## Issue Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,15 +92,13 @@
 
 ## Pull Request Metadata Rules
 
-- Title format: `<type>(optional-scope)?: short summary`
-- Use only the types and scopes accepted by `.github/workflows/pr-gates.yml`; keep the title valid for `amannn/action-semantic-pull-request@v5`.
-- Summary starts lowercase, imperative, and <= 72 chars.
-- Start descriptions with a short user-impact sentence, then `## What changed` and `## Validation` sections.
-- For UI changes, include a `Screenshots:` section with affected states.
-- Keep language concise and concrete.
-- Build PR descriptions in a temporary markdown file or heredoc, then pass them with `gh pr create --body-file` or `gh pr edit --body-file`.
-- Never pass multiline PR bodies inline through shell quoting, and never rely on literal `\n` sequences to create paragraph breaks.
-- Verify the rendered PR body with `gh pr view --json body` before sharing the link.
+- Title format: `<type>(optional-scope)?: short summary`; use only the types/scopes accepted by `.github/workflows/pr-gates.yml`; summary starts lowercase, imperative, and <= 72 chars.
+- Use `.github/pull_request_template.md` and start with a bilingual `Management summary`: one non-technical German paragraph followed by the same non-technical English paragraph, release-note quality, focused on visible product, operator, or business value.
+- Keep implementation detail in `## What changed`; include architectural or module-level context, link files only when useful for review, and do not paste code snippets into the PR body.
+- In `## Validation`, check every relevant item and explain every unchecked, skipped, or not-applicable item directly in the section.
+- In `## Development`, use `Closes` for every linked Issue, one line per Issue. Use `Closes #123` for same-repository Issues and `Closes findmydoc-platform/management#123` for trusted cross-repository Issues.
+- Do not require a standalone `Screenshots:` section by default; record UI evidence in the `UI/mobile QA` validation item unless a reviewer or workflow explicitly needs separate screenshots.
+- Build PR descriptions in a temporary markdown file or heredoc, pass them with `gh pr create --body-file` or `gh pr edit --body-file`, never inline multiline bodies through shell quoting, and verify the rendered body with `gh pr view --json body`.
 
 ## Issue Workflow
 


### PR DESCRIPTION
Dependency update automation now waits before merging safe Dependabot PRs while keeping major upgrades manual.

## What changed

- add explicit Dependabot schedules and release cooldowns for npm, Docker, and GitHub Actions updates
- mark only patch and minor Dependabot PRs as delayed auto-merge candidates
- activate auto-merge from a scheduled job only after the configured 48-hour minimum age
- keep major updates as manual PRs by excluding them from the auto-merge candidate path
- run Dependency Review on every PR so it can be required by the branch ruleset
- document the preference for descriptive long-form CLI flags in the root Codex instructions

## Validation

- `pnpm format`
- `pnpm check`
- `pnpm ai:slop-check`
- `bash -n .github/scripts/dependabot-enable-delayed-automerge.sh`
- `uvx zizmor --config zizmor.yml .github/workflows/dependabot-auto-merge.yml .github/workflows/dependency-review.yml`
- `git diff --check`
- GitHub ruleset verified with `Dependency Review` in required status checks

## Development

Closes #1195
