### PR TITLE
fix(ci): use gh app filter for dependabot

### DIFF
--- a/.github/scripts/dependabot-enable-delayed-automerge.sh
+++ b/.github/scripts/dependabot-enable-delayed-automerge.sh
@@ -16,7 +16,7 @@ gh label create "$label" \
 
 prs_json="$(
   gh pr list \
-    --author "app/dependabot" \
+    --app "dependabot" \
     --base "main" \
     --state "open" \
     --label "$label" \


### PR DESCRIPTION
## Management summary

### Deutsch

Der geplante Dependabot-Automerge läuft jetzt wieder zuverlässig für passende Dependency-Updates. Dadurch werden freigegebene Paketaktualisierungen nicht mehr wegen eines falschen Filters übersehen und können nach der vorgesehenen Wartezeit automatisch zusammengeführt werden.

### English

The scheduled Dependabot auto-merge now works reliably for eligible dependency updates. Approved package updates are no longer missed because of a wrong filter and can be merged automatically after the intended delay.

## What changed

- Fixed the Dependabot candidate sweep to use the GitHub App filter supported by `gh pr list`.
- The delayed auto-merge job now matches Dependabot PRs consistently before enabling auto-merge.

## Validation

- [x] `pnpm format`
- [x] `pnpm check`
- [ ] `pnpm build`: Not run; CI/workflow-only change.
- [ ] Focused tests: Not needed for this one-line workflow fix.
- [ ] UI/mobile QA: Not applicable.
- [ ] Security/privacy review: Not applicable.
- [ ] Migration/schema check: Not applicable.
- [ ] Documentation/instructions check: Not needed.

## Risk and rollout

Low risk. The change only adjusts the GitHub CLI filter used by the delayed auto-merge script.

## Development

Closes #1200
