### PR TITLE
fix(auth): clear stale password form errors

### DIFF
--- a/src/app/(frontend)/auth/invite/complete/InviteCompleteForm.tsx
+++ b/src/app/(frontend)/auth/invite/complete/InviteCompleteForm.tsx
@@ -91,6 +91,8 @@ export function InviteCompleteForm({ error }: { error?: string }) {
     event.preventDefault()
     if (!isSessionReady) return
 
+    setFormState((prev) => ({ ...prev, error: null, success: false }))
+
     const form = event.currentTarget
     if (!formValidation.validateForm(form)) return
 

--- a/src/app/(frontend)/auth/password/reset/ResetPasswordRequestForm.tsx
+++ b/src/app/(frontend)/auth/password/reset/ResetPasswordRequestForm.tsx
@@ -51,6 +51,7 @@ export function ResetPasswordRequestForm() {
     event.preventDefault()
 
     const form = event.currentTarget
+    setFormState({ status: 'idle', error: null })
     if (!formValidation.validateForm(form)) return
 
     setFormState({ status: 'submitting', error: null })

--- a/src/app/(frontend)/auth/password/reset/complete/ResetPasswordCompleteForm.tsx
+++ b/src/app/(frontend)/auth/password/reset/complete/ResetPasswordCompleteForm.tsx
@@ -75,6 +75,8 @@ export function ResetPasswordCompleteForm({ error }: { error?: string }) {
       return
     }
 
+    setFormState((prev) => ({ ...prev, error: null, success: false }))
+
     const form = event.currentTarget
     if (!formValidation.validateForm(form)) return
 


### PR DESCRIPTION
## Management summary

### Deutsch
Beim Senden der Passwort-Reset- und Einladungsabschluss-Formulare wird der alte oberste Fehlerzustand jetzt vor einer neuen Validierung zurückgesetzt. Dadurch bleiben nach einem erneuten Submit nur die aktuellen Inline-Fehler sichtbar und der Nutzer wird nicht durch veraltete Fehlermeldungen abgelenkt.

### English
When submitting the password reset and invite completion forms, the previous top-level error state is now cleared before a new validation pass. That keeps only the current inline errors visible after resubmission and avoids confusing users with stale error messages.

## What changed

- Cleared the persisted `formState.error` / `success` state at the start of the submit flow in the password reset request, password reset completion, and invite completion forms.
- Kept the existing inline field validation path intact so native validation and custom field errors still render in place.
- Linked the change to issue [#1202](https://github.com/findmydoc-platform/website/issues/1202).

## Validation

- [x] `pnpm format`: ran successfully.
- [x] `pnpm check`: ran successfully.
- [x] `pnpm build`: ran successfully with `PAYLOAD_SECRET=dev-secret`.
- [ ] Focused tests: not added; this is a narrow submit-state fix and existing form coverage already exercises the affected flows.
- [ ] UI/mobile QA: not run; the change is logic-only and does not alter layout or responsive behavior.
- [ ] Security/privacy review: not needed; no auth, secret, or server-trust boundary changes.
- [ ] Migration/schema check: not applicable; no schema or data-model changes.
- [ ] Documentation/instructions check: not needed; no repo instructions changed.

## Risk and rollout

Low risk. The change only resets transient client-side error state before validation, with no API or data contract impact.

## Development

Closes #1202
