### PR TITLE
feat(ui): add clinic registration funnel foundation

### DIFF
--- a/src/components/molecules/StepIndicator/index.tsx
+++ b/src/components/molecules/StepIndicator/index.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react'
+
+import { cn } from '@/utilities/ui'
+
+export type StepIndicatorProps = {
+  ariaLabel?: string
+  className?: string
+  currentStep: number
+  statusLabel: string
+  stepLabel: string
+  totalSteps: number
+}
+
+export function StepIndicator({
+  ariaLabel,
+  className,
+  currentStep,
+  statusLabel,
+  stepLabel,
+  totalSteps,
+}: StepIndicatorProps) {
+  const safeTotalSteps = Math.max(totalSteps, 1)
+  const safeCurrentStep = Math.min(Math.max(currentStep, 1), safeTotalSteps)
+  const segments = Array.from({ length: safeTotalSteps }, (_, index) => index + 1)
+  const getSegmentState = (segment: number) => {
+    if (segment < safeCurrentStep) return 'completed'
+    if (segment === safeCurrentStep) return 'current'
+    return 'upcoming'
+  }
+
+  return (
+    <div className={cn('w-full min-w-0', className)}>
+      <div className="flex min-h-6 items-center justify-between gap-4 text-sm font-semibold text-secondary sm:text-base">
+        <span className="leading-6 whitespace-nowrap">{stepLabel}</span>
+        <span className="text-right text-xs leading-5 font-medium whitespace-nowrap text-card-foreground/75 sm:text-sm">
+          {statusLabel}
+        </span>
+      </div>
+      <div
+        aria-label={ariaLabel ?? `${stepLabel}, ${statusLabel}`}
+        aria-valuemax={safeTotalSteps}
+        aria-valuemin={1}
+        aria-valuenow={safeCurrentStep}
+        aria-valuetext={stepLabel}
+        className="mt-2 flex h-1.5 gap-0.5 overflow-hidden rounded-full"
+        role="progressbar"
+      >
+        {segments.map((segment) => (
+          <span
+            aria-hidden="true"
+            className={cn(
+              'h-full flex-1 bg-[#e8eefb]',
+              getSegmentState(segment) === 'completed' && 'bg-primary',
+              getSegmentState(segment) === 'current' && 'bg-primary/45',
+            )}
+            data-state={getSegmentState(segment)}
+            key={segment}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/ClinicRegistrationFunnel.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/ClinicRegistrationFunnel.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import * as React from 'react'
+
+import { usePublicFormValidation } from '@/components/molecules/PublicFormValidation/usePublicFormValidation'
+import { StepIndicator } from '@/components/molecules/StepIndicator'
+import { cn } from '@/utilities/ui'
+import {
+  defaultFormValues,
+  defaultReviewSummary,
+  defaultSelectedTreatmentCategoryIds,
+  defaultTreatmentCategories,
+  stepStatusLabels,
+  totalSteps,
+} from './constants'
+import { categoryIconMap } from './icons'
+import { ContactStep } from './steps/ContactStep'
+import { ClinicDetailsStep } from './steps/ClinicDetailsStep'
+import { ReviewConfirmationStep } from './steps/ReviewConfirmationStep'
+import { TreatmentCategoriesStep } from './steps/TreatmentCategoriesStep'
+import type {
+  ClinicRegistrationFormValues,
+  ClinicRegistrationFunnelProps,
+  ClinicRegistrationReviewSummary,
+  ClinicRegistrationStep,
+  ResolvedTreatmentCategory,
+  StepTransitionDirection,
+} from './types'
+import { validationMessages } from './validation'
+import { getStepTransitionClassName, StepContentFrame } from './components/StepContentFrame'
+import { StepContextPanel } from './components/StepContextPanel'
+import { SplitStepShell } from './components/SplitStepShell'
+
+export function ClinicRegistrationFunnel({
+  className,
+  initialSelectedTreatmentCategoryIds = defaultSelectedTreatmentCategoryIds,
+  initialStep = 1,
+  initialValues,
+  reviewSummary = defaultReviewSummary,
+  treatmentCategories = defaultTreatmentCategories,
+}: ClinicRegistrationFunnelProps) {
+  const [step, setStep] = React.useState<ClinicRegistrationStep>(initialStep)
+  const [stepTransitionDirection, setStepTransitionDirection] = React.useState<StepTransitionDirection>('none')
+  const [formValues, setFormValues] = React.useState<ClinicRegistrationFormValues>({
+    ...defaultFormValues,
+    ...initialValues,
+  })
+  const [selectedTreatmentCategories, setSelectedTreatmentCategories] = React.useState<string[]>(
+    initialSelectedTreatmentCategoryIds,
+  )
+  const [isHydrated, setIsHydrated] = React.useState(false)
+  const publicFormValidation = usePublicFormValidation({ messages: validationMessages })
+  const stepHeadingRef = React.useRef<HTMLHeadingElement>(null)
+  const didMountRef = React.useRef(false)
+
+  const resolvedTreatmentCategories = React.useMemo<ResolvedTreatmentCategory[]>(
+    () =>
+      treatmentCategories.map((category) => ({
+        ...category,
+        icon: categoryIconMap[category.iconKey],
+      })),
+    [treatmentCategories],
+  )
+
+  const selectedCategoryLabels = resolvedTreatmentCategories
+    .filter((category) => selectedTreatmentCategories.includes(category.id))
+    .map((category) => category.label)
+
+  const resolvedReviewSummary = React.useMemo<ClinicRegistrationReviewSummary>(
+    () => ({
+      ...reviewSummary,
+      clinicName: formValues.clinicName.trim() || reviewSummary.clinicName,
+      clinicWebsite: formValues.clinicWebsite.trim() || reviewSummary.clinicWebsite || reviewSummary.clinicAddress,
+      contactEmail: formValues.contactEmail.trim() || reviewSummary.contactEmail,
+      contactName: formValues.contactName.trim() || reviewSummary.contactName,
+      contactRole: formValues.contactRole || reviewSummary.contactRole,
+    }),
+    [formValues, reviewSummary],
+  )
+
+  const transitionClassName = getStepTransitionClassName(stepTransitionDirection)
+
+  const goToNextStep = () => {
+    publicFormValidation.clearAllFieldErrors()
+    setStepTransitionDirection('forward')
+    setStep((currentStep) => (currentStep === 4 ? 4 : ((currentStep + 1) as ClinicRegistrationStep)))
+  }
+
+  const goToPreviousStep = () => {
+    publicFormValidation.clearAllFieldErrors()
+    setStepTransitionDirection('backward')
+    setStep((currentStep) => (currentStep === 1 ? 1 : ((currentStep - 1) as ClinicRegistrationStep)))
+  }
+
+  const updateFormValue = (fieldName: keyof ClinicRegistrationFormValues, value: string) => {
+    setFormValues((currentValues) => ({
+      ...currentValues,
+      [fieldName]: value,
+    }))
+  }
+
+  const toggleTreatmentCategory = (categoryId: string) => {
+    publicFormValidation.clearFieldError('treatmentCategories')
+    setSelectedTreatmentCategories((currentSelection) =>
+      currentSelection.includes(categoryId)
+        ? currentSelection.filter((selectedId) => selectedId !== categoryId)
+        : [...currentSelection, categoryId],
+    )
+  }
+
+  React.useEffect(() => {
+    setIsHydrated(true)
+  }, [])
+
+  React.useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true
+      return
+    }
+
+    stepHeadingRef.current?.focus()
+  }, [step])
+
+  return (
+    <section
+      aria-label="Klinikregistrierung"
+      className={cn('w-full text-card-foreground', className)}
+      data-clinic-registration-funnel-ready={isHydrated ? 'true' : undefined}
+      lang="de"
+    >
+      <SplitStepShell
+        contextPanel={
+          <StepContextPanel
+            key={step}
+            reviewSummary={resolvedReviewSummary}
+            selectedCategoryLabels={selectedCategoryLabels}
+            step={step}
+            transitionClassName={transitionClassName}
+          />
+        }
+        progress={
+          <StepIndicator
+            ariaLabel={`Klinikregistrierung, Schritt ${step} von ${totalSteps}, ${stepStatusLabels[step]}`}
+            currentStep={step}
+            statusLabel={stepStatusLabels[step]}
+            stepLabel={`Schritt ${step} von ${totalSteps}`}
+            totalSteps={totalSteps}
+          />
+        }
+      >
+        <StepContentFrame className={transitionClassName} key={step}>
+          {step === 1 ? (
+            <ClinicDetailsStep
+              formValues={formValues}
+              headingRef={stepHeadingRef}
+              onNext={goToNextStep}
+              onValueChange={updateFormValue}
+              validation={publicFormValidation}
+            />
+          ) : null}
+          {step === 2 ? (
+            <TreatmentCategoriesStep
+              headingRef={stepHeadingRef}
+              onBack={goToPreviousStep}
+              onNext={goToNextStep}
+              onToggleCategory={toggleTreatmentCategory}
+              treatmentCategories={resolvedTreatmentCategories}
+              selectedCategories={selectedTreatmentCategories}
+              validation={publicFormValidation}
+            />
+          ) : null}
+          {step === 3 ? (
+            <ContactStep
+              formValues={formValues}
+              headingRef={stepHeadingRef}
+              onBack={goToPreviousStep}
+              onNext={goToNextStep}
+              onValueChange={updateFormValue}
+              validation={publicFormValidation}
+            />
+          ) : null}
+          {step === 4 ? <ReviewConfirmationStep headingRef={stepHeadingRef} /> : null}
+        </StepContentFrame>
+      </SplitStepShell>
+    </section>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/components/ContactNotice.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/ContactNotice.tsx
@@ -1,0 +1,10 @@
+export function ContactNotice({ id }: { id: string }) {
+  return (
+    <p
+      className="rounded-[8px] border border-primary/15 bg-primary/10 px-4 py-3 text-xs leading-5 break-words text-card-foreground/75"
+      id={id}
+    >
+      Wir nutzen Ihre Angaben, um Sie im berechtigten Interesse zur Klinikregistrierung zu kontaktieren.
+    </p>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/components/RegistrationField.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/RegistrationField.tsx
@@ -1,0 +1,66 @@
+import type * as React from 'react'
+
+import { Field, FieldError } from '@/components/atoms/field'
+import { Input } from '@/components/atoms/input'
+import { Label } from '@/components/atoms/label'
+import type { ClinicRegistrationFormValues, IconComponent, PublicFormValidationController } from '../types'
+
+export function RegistrationField({
+  descriptionId,
+  icon: Icon,
+  id,
+  label,
+  name,
+  onValueChange,
+  placeholder,
+  required,
+  type = 'text',
+  validation,
+  value,
+}: {
+  descriptionId?: string
+  icon?: IconComponent
+  id: string
+  label: string
+  name: keyof ClinicRegistrationFormValues
+  onValueChange: (value: string) => void
+  placeholder: string
+  required?: boolean
+  type?: React.HTMLInputTypeAttribute
+  validation: PublicFormValidationController
+  value: string
+}) {
+  const error = validation.getFieldError(name)
+  const errorId = validation.getFieldErrorId(name)
+
+  return (
+    <Field className="min-w-0 gap-2 text-left" data-invalid={error ? true : undefined}>
+      <Label className="mb-2 block text-left text-sm font-semibold text-[#172033]" htmlFor={id}>
+        {label}
+      </Label>
+      <div className="relative">
+        <Input
+          {...validation.getFieldProps(name, descriptionId)}
+          className="h-[60px] min-w-0 rounded-[8px] border-slate-300 bg-[#fbfcff] px-3 pr-10 text-base text-slate-500 sm:px-4 sm:pr-12 md:text-base"
+          id={id}
+          name={name}
+          onChange={(event) => {
+            validation.handleFieldChange(event)
+            onValueChange(event.currentTarget.value)
+          }}
+          placeholder={placeholder}
+          required={required}
+          type={type}
+          value={value}
+        />
+        {Icon ? (
+          <Icon
+            aria-hidden="true"
+            className="pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 text-slate-400 sm:right-4 sm:size-5"
+          />
+        ) : null}
+      </div>
+      <FieldError id={errorId}>{error}</FieldError>
+    </Field>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/components/ReviewSummary.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/ReviewSummary.tsx
@@ -1,0 +1,44 @@
+import { BriefcaseBusiness, Building2, UserRound } from 'lucide-react'
+
+import type { ClinicRegistrationReviewSummary } from '../types'
+import { SummaryGroup } from './SummaryGroup'
+
+export function ReviewSummary({
+  reviewSummary,
+  selectedCategoryLabels,
+}: {
+  reviewSummary: ClinicRegistrationReviewSummary
+  selectedCategoryLabels: string[]
+}) {
+  return (
+    <div className="mt-12 grid gap-10">
+      <SummaryGroup icon={Building2} label="Klinik-Details">
+        <strong className="block text-base font-medium [overflow-wrap:anywhere] break-words text-white">
+          {reviewSummary.clinicName}
+        </strong>
+        <span className="block text-xs leading-5 [overflow-wrap:anywhere] break-words text-white/70">
+          {reviewSummary.clinicWebsite ?? reviewSummary.clinicAddress}
+        </span>
+      </SummaryGroup>
+      <SummaryGroup icon={BriefcaseBusiness} label="Schwerpunkte">
+        <div className="mt-2 flex flex-wrap gap-2">
+          {(selectedCategoryLabels.length > 0 ? selectedCategoryLabels : ['Noch nicht ausgewählt']).map((label) => (
+            <span className="rounded-full bg-primary/30 px-2.5 py-0.5 text-xs break-words text-white" key={label}>
+              {label}
+            </span>
+          ))}
+        </div>
+      </SummaryGroup>
+      <SummaryGroup icon={UserRound} label="Kontaktperson">
+        <strong className="block text-base font-medium [overflow-wrap:anywhere] break-words text-white">
+          {reviewSummary.contactName}
+        </strong>
+        <span className="block text-xs leading-5 [overflow-wrap:anywhere] break-words text-white/70">
+          {reviewSummary.contactRole}
+          <br />
+          {reviewSummary.contactEmail}
+        </span>
+      </SummaryGroup>
+    </div>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/components/SplitStepShell.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/SplitStepShell.tsx
@@ -1,0 +1,30 @@
+import type * as React from 'react'
+
+import { cn } from '@/utilities/ui'
+
+export function SplitStepShell({
+  children,
+  className,
+  contextPanel,
+  progress,
+}: {
+  children: React.ReactNode
+  className?: string
+  contextPanel: React.ReactNode
+  progress: React.ReactNode
+}) {
+  return (
+    <div
+      className={cn(
+        'mx-auto grid w-full max-w-[1184px] min-w-0 overflow-hidden rounded-[8px] border border-slate-300 bg-card shadow-[0_18px_44px_rgba(7,0,76,0.12)] lg:min-h-[828px] lg:grid-cols-[493px_minmax(0,1fr)]',
+        className,
+      )}
+    >
+      <div className="flex min-h-0 min-w-0 flex-col bg-card px-6 py-7 sm:px-10 sm:py-10 md:min-h-[610px] lg:col-start-2 lg:row-start-1 lg:min-h-0 lg:px-12 lg:py-12">
+        {progress}
+        {children}
+      </div>
+      <div className="flex min-w-0 lg:col-start-1 lg:row-start-1 lg:min-h-full">{contextPanel}</div>
+    </div>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/components/StepActions.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/StepActions.tsx
@@ -1,0 +1,52 @@
+import { ArrowLeft, ArrowRight } from 'lucide-react'
+
+import { Button } from '@/components/atoms/button'
+
+export function StepActions({
+  onBack,
+  onNext,
+  primaryLabel,
+  primaryType = 'button',
+}: {
+  onBack?: () => void
+  onNext?: () => void
+  primaryLabel: string
+  primaryType?: 'button' | 'submit'
+}) {
+  if (!onBack) {
+    return (
+      <div className="mx-auto mt-auto w-full max-w-[490px] pt-6 sm:pt-10 lg:pt-12">
+        <Button
+          className="h-[56px] w-full rounded-[8px] text-base leading-none font-semibold shadow-[0_9px_20px_rgba(0,118,255,0.22)] sm:h-[60px] sm:text-[19px]"
+          onClick={primaryType === 'button' ? onNext : undefined}
+          type={primaryType}
+        >
+          {primaryLabel}
+          <ArrowRight aria-hidden="true" className="size-5" />
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto mt-auto grid w-full max-w-[490px] gap-4 pt-6 sm:grid-cols-2 sm:items-center sm:pt-10 lg:pt-12">
+      <Button
+        className="min-h-11 justify-self-start px-0 text-card-foreground/80"
+        onClick={onBack}
+        type="button"
+        variant="ghost"
+      >
+        <ArrowLeft aria-hidden="true" className="size-4" />
+        Zurück
+      </Button>
+      <Button
+        className="h-[56px] w-full min-w-0 rounded-[8px] text-base leading-none font-semibold whitespace-normal shadow-[0_9px_20px_rgba(0,118,255,0.22)] sm:h-[60px] sm:text-[19px]"
+        onClick={primaryType === 'button' ? onNext : undefined}
+        type={primaryType}
+      >
+        {primaryLabel}
+        <ArrowRight aria-hidden="true" className="size-5" />
+      </Button>
+    </div>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/components/StepContentFrame.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/StepContentFrame.tsx
@@ -1,0 +1,20 @@
+import type * as React from 'react'
+
+import { cn } from '@/utilities/ui'
+import type { StepTransitionDirection } from '../types'
+
+export function getStepTransitionClassName(direction: StepTransitionDirection) {
+  if (direction === 'forward') {
+    return 'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-right-2 motion-safe:duration-150 motion-reduce:animate-none motion-reduce:transform-none'
+  }
+
+  if (direction === 'backward') {
+    return 'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-left-2 motion-safe:duration-150 motion-reduce:animate-none motion-reduce:transform-none'
+  }
+
+  return ''
+}
+
+export function StepContentFrame({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('flex min-w-0 flex-1 flex-col', className)}>{children}</div>
+}

--- a/src/components/templates/ClinicRegistrationFunnel/components/StepContextPanel.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/StepContextPanel.tsx
@@ -1,0 +1,122 @@
+import { Mail, MapPin, Phone } from 'lucide-react'
+
+import { Heading } from '@/components/atoms/Heading'
+import { cn } from '@/utilities/ui'
+import type { ClinicRegistrationReviewSummary, ClinicRegistrationStep } from '../types'
+import { ReviewSummary } from './ReviewSummary'
+import { SupportRow } from './SupportRow'
+
+export function StepContextPanel({
+  className,
+  reviewSummary,
+  selectedCategoryLabels,
+  step,
+  transitionClassName,
+}: {
+  className?: string
+  reviewSummary: ClinicRegistrationReviewSummary
+  selectedCategoryLabels: string[]
+  step: ClinicRegistrationStep
+  transitionClassName?: string
+}) {
+  if (step === 4) {
+    return (
+      <aside
+        className={cn(
+          'flex min-h-[300px] w-full min-w-0 flex-col bg-secondary px-7 py-8 text-secondary-foreground sm:px-10 sm:py-11 lg:min-h-full lg:px-12 lg:py-12',
+          transitionClassName,
+          className,
+        )}
+      >
+        <Heading
+          align="left"
+          as="h2"
+          className="text-[22px] leading-tight break-words text-white sm:text-[26px]"
+          size="h4"
+        >
+          Überprüfung
+        </Heading>
+        <p className="mt-4 max-w-[330px] text-[17px] leading-relaxed text-white/85">
+          Zusammenfassung Ihrer Angaben vor dem Abschluss.
+        </p>
+        <ReviewSummary reviewSummary={reviewSummary} selectedCategoryLabels={selectedCategoryLabels} />
+      </aside>
+    )
+  }
+
+  if (step === 3) {
+    return (
+      <aside
+        className={cn(
+          'flex min-h-[320px] w-full min-w-0 flex-col justify-center bg-secondary px-7 py-8 text-secondary-foreground sm:px-10 sm:py-11 lg:min-h-full lg:px-12 lg:py-12',
+          transitionClassName,
+          className,
+        )}
+      >
+        <Heading
+          align="left"
+          as="h2"
+          className="text-[22px] leading-tight break-words text-white sm:text-[26px]"
+          size="h4"
+        >
+          Kontaktinformationen
+        </Heading>
+        <p className="mt-4 max-w-[360px] text-base leading-relaxed text-white/85">
+          Wir melden uns bei der richtigen Kontaktperson, sobald die Registrierung geprüft wurde.
+        </p>
+        <div className="mt-10 grid gap-7 border-t border-white/15 pt-8 lg:mt-auto">
+          <SupportRow icon={Phone} label="Telefon" value="+49 (0) 30 1234 5678" />
+          <SupportRow icon={Mail} label="E-Mail" value="support@findmydoc.de" />
+          <SupportRow icon={MapPin} label="Zentrale" value="Friedrichstraße 100 10117 Berlin, Deutschland" />
+        </div>
+      </aside>
+    )
+  }
+
+  if (step === 2) {
+    return (
+      <aside
+        className={cn(
+          'flex min-h-[300px] w-full min-w-0 flex-col justify-center bg-secondary px-7 py-8 text-secondary-foreground sm:px-10 sm:py-11 lg:min-h-full lg:px-12 lg:py-12',
+          transitionClassName,
+          className,
+        )}
+      >
+        <Heading
+          align="left"
+          as="h2"
+          className="text-[22px] leading-tight break-words text-white sm:text-[26px]"
+          size="h4"
+        >
+          Schwerpunkte der Klinik
+        </Heading>
+        <p className="mt-4 max-w-[360px] text-base leading-relaxed text-white/90">
+          Wählen Sie die Behandlungskategorien, mit denen internationale Patientinnen und Patienten Ihre Klinik finden
+          sollen.
+        </p>
+      </aside>
+    )
+  }
+
+  return (
+    <aside
+      className={cn(
+        'flex min-h-[310px] w-full min-w-0 flex-col justify-center bg-secondary px-7 py-8 text-secondary-foreground sm:px-10 sm:py-11 lg:min-h-full lg:px-12 lg:py-12',
+        transitionClassName,
+        className,
+      )}
+    >
+      <Heading
+        align="left"
+        as="h2"
+        className="max-w-[385px] text-[22px] leading-tight break-words text-white sm:text-[26px]"
+        size="h4"
+      >
+        Klinik international sichtbar machen
+      </Heading>
+      <p className="mt-7 max-w-[388px] text-lg leading-relaxed text-white/90">
+        Registrieren Sie Ihre Klinik für die Prüfung und den Aufbau Ihrer Präsenz auf findmydoc.
+      </p>
+    </aside>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/components/StepForm.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/StepForm.tsx
@@ -1,0 +1,32 @@
+import type * as React from 'react'
+
+import type { PublicFormValidationController } from '../types'
+
+export function StepForm({
+  ariaLabelledBy,
+  children,
+  onSubmit,
+  validation,
+}: {
+  ariaLabelledBy: string
+  children: React.ReactNode
+  onSubmit: (form: HTMLFormElement) => void
+  validation: PublicFormValidationController
+}) {
+  return (
+    <form
+      aria-labelledby={ariaLabelledBy}
+      className="flex min-w-0 flex-1 flex-col"
+      onSubmit={(event) => {
+        event.preventDefault()
+        if (!validation.validateForm(event.currentTarget)) return
+
+        onSubmit(event.currentTarget)
+      }}
+      onInvalid={validation.handleInvalid}
+      noValidate
+    >
+      {children}
+    </form>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/components/SummaryGroup.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/SummaryGroup.tsx
@@ -1,0 +1,23 @@
+import type * as React from 'react'
+
+import type { IconComponent } from '../types'
+
+export function SummaryGroup({
+  children,
+  icon: Icon,
+  label,
+}: {
+  children: React.ReactNode
+  icon: IconComponent
+  label: string
+}) {
+  return (
+    <div className="grid min-w-0 grid-cols-[20px_minmax(0,1fr)] items-start gap-3">
+      <Icon aria-hidden="true" className="mt-[3px] size-4 text-primary" />
+      <div className="min-w-0">
+        <span className="block text-[13px] leading-5 font-bold tracking-[0.04em] text-primary uppercase">{label}</span>
+        <div className="mt-2">{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/components/SupportRow.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/SupportRow.tsx
@@ -1,0 +1,17 @@
+import type { IconComponent } from '../types'
+
+export function SupportRow({ icon: Icon, label, value }: { icon: IconComponent; label?: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[28px_minmax(0,1fr)] items-start gap-3 text-white">
+      <Icon aria-hidden="true" className="mt-0.5 size-4 text-primary" />
+      <div className="min-w-0">
+        {label ? (
+          <span className="block text-[13px] leading-4 font-medium tracking-[0.08em] text-white/55 uppercase">
+            {label}
+          </span>
+        ) : null}
+        <span className="block text-[15px] leading-5 font-normal break-words text-white/85">{value}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/components/TreatmentCategoryOptionCard.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/TreatmentCategoryOptionCard.tsx
@@ -1,0 +1,36 @@
+import { Check } from 'lucide-react'
+
+import { cn } from '@/utilities/ui'
+import type { ResolvedTreatmentCategory } from '../types'
+
+export function TreatmentCategoryOptionCard({
+  category,
+  isSelected,
+  onToggle,
+}: {
+  category: ResolvedTreatmentCategory
+  isSelected: boolean
+  onToggle: (categoryId: string) => void
+}) {
+  const Icon = category.icon
+
+  return (
+    <button
+      aria-pressed={isSelected}
+      className={cn(
+        'relative flex h-[100px] min-w-0 flex-col items-center justify-center gap-2 rounded-[8px] border border-slate-300 bg-card px-2 text-sm font-semibold text-[#172033] transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-hidden',
+        isSelected && 'border-primary bg-primary/5',
+      )}
+      onClick={() => onToggle(category.id)}
+      type="button"
+    >
+      {isSelected ? (
+        <span className="absolute top-2 right-2 grid size-5 place-items-center rounded-full bg-primary text-primary-foreground">
+          <Check aria-hidden="true" className="size-3.5" />
+        </span>
+      ) : null}
+      <Icon aria-hidden="true" className="size-8 text-primary" />
+      <span className="max-w-full text-center leading-4 break-words">{category.label}</span>
+    </button>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/constants.ts
+++ b/src/components/templates/ClinicRegistrationFunnel/constants.ts
@@ -1,0 +1,50 @@
+import type {
+  ClinicRegistrationFormValues,
+  ClinicRegistrationReviewSummary,
+  ClinicRegistrationStep,
+  ClinicRegistrationTreatmentCategory,
+} from './types'
+
+export const totalSteps = 4
+
+export const defaultTreatmentCategories: ClinicRegistrationTreatmentCategory[] = [
+  { id: 'dental', label: 'Dental', iconKey: 'dental' },
+  { id: 'eye-care', label: 'Eye Care', iconKey: 'eye-care' },
+  { id: 'hair-restoration', label: 'Hair Restoration', iconKey: 'hair-restoration' },
+  { id: 'dermatology', label: 'Dermatology', iconKey: 'dermatology' },
+  { id: 'plastic-surgery', label: 'Plastic Surgery', iconKey: 'plastic-surgery' },
+]
+
+export const stepStatusLabels: Record<ClinicRegistrationStep, string> = {
+  1: 'Initialisierung',
+  2: '50% abgeschlossen',
+  3: '75% abgeschlossen',
+  4: 'Anfrage übermittelt',
+}
+
+export const defaultSelectedTreatmentCategoryIds = ['dental']
+
+export const defaultReviewSummary: ClinicRegistrationReviewSummary = {
+  clinicAddress: 'Hauptstraße 124, 10115 Berlin',
+  clinicWebsite: 'https://marien-hospital.de',
+  clinicName: 'St. Marien Hospital',
+  contactEmail: 'm.musterfrau@marien-hospital.de',
+  contactName: 'Dr. Martina Musterfrau',
+  contactRole: 'Leitende Oberärztin',
+}
+
+export const defaultFormValues: ClinicRegistrationFormValues = {
+  clinicName: '',
+  clinicWebsite: '',
+  contactEmail: '',
+  contactName: '',
+  contactRole: '',
+}
+
+export const contactRoleOptions = [
+  { label: 'Ärztliche Leitung', value: 'Ärztliche Leitung' },
+  { label: 'Klinikmanagement', value: 'Klinikmanagement' },
+  { label: 'International Office', value: 'International Office' },
+]
+
+export const formContentClassName = 'mx-auto mt-8 w-full max-w-[490px] min-w-0 text-left sm:mt-10 lg:mt-13'

--- a/src/components/templates/ClinicRegistrationFunnel/icons.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/icons.tsx
@@ -1,0 +1,48 @@
+import { Eye, Sparkles } from 'lucide-react'
+
+import type { ClinicRegistrationCategoryIconKey, IconComponent } from './types'
+
+function ToothIcon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" {...props}>
+      <path
+        d="M7.3 3.4c1.1 0 2.1.5 3 1.1.9.6 1.5.6 2.4 0 .9-.6 1.9-1.1 3-1.1 2.4 0 4 1.9 4 4.4 0 1.8-.7 3.6-1.4 5.1-.7 1.7-1.1 3.4-1.4 5.1-.2 1.2-.9 2.6-2.1 2.6-1.1 0-1.4-1.4-1.7-2.9-.3-1.3-.6-2.7-1.1-2.7s-.8 1.4-1.1 2.7c-.3 1.5-.6 2.9-1.7 2.9-1.2 0-1.9-1.4-2.1-2.6-.3-1.7-.7-3.4-1.4-5.1-.7-1.5-1.4-3.3-1.4-5.1 0-2.5 1.6-4.4 4-4.4Z"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function HairRestorationIcon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" {...props}>
+      <path d="M6 14.4c.3-4.8 2.7-7.2 6-7.2s5.7 2.4 6 7.2" strokeLinecap="round" />
+      <path d="M8.3 13.1c.8-1.8 2-2.8 3.7-2.8s2.9 1 3.7 2.8" strokeLinecap="round" />
+      <path d="M5.2 15.7c1.5 2.5 3.8 3.8 6.8 3.8s5.3-1.3 6.8-3.8" strokeLinecap="round" />
+      <path d="M8.4 5.2c.5 1 .6 1.9.3 2.9" strokeLinecap="round" />
+      <path d="M12 4.5c.4 1.1.4 2.1 0 3.2" strokeLinecap="round" />
+      <path d="M15.6 5.2c-.5 1-.6 1.9-.3 2.9" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function PlasticSurgeryIcon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" {...props}>
+      <path d="M8.6 4.5c.9 1.2 2 1.8 3.4 1.8s2.5-.6 3.4-1.8" strokeLinecap="round" />
+      <path d="M7 8.6c1.3 1.2 3 1.8 5 1.8s3.7-.6 5-1.8" strokeLinecap="round" />
+      <path d="M8.1 19.5c1.2-1.4 1.8-3.3 1.8-5.8" strokeLinecap="round" />
+      <path d="M15.9 19.5c-1.2-1.4-1.8-3.3-1.8-5.8" strokeLinecap="round" />
+      <path d="M5.5 12.2c1.5.9 3.7 1.4 6.5 1.4s5-.5 6.5-1.4" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+export const categoryIconMap: Record<ClinicRegistrationCategoryIconKey, IconComponent> = {
+  dental: ToothIcon,
+  dermatology: Sparkles,
+  'eye-care': Eye,
+  'hair-restoration': HairRestorationIcon,
+  'plastic-surgery': PlasticSurgeryIcon,
+}

--- a/src/components/templates/ClinicRegistrationFunnel/index.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/index.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+export { ClinicRegistrationFunnel } from './ClinicRegistrationFunnel'
+export type {
+  ClinicRegistrationCategoryIconKey,
+  ClinicRegistrationFormValues,
+  ClinicRegistrationFunnelProps,
+  ClinicRegistrationReviewSummary,
+  ClinicRegistrationTreatmentCategory,
+} from './types'

--- a/src/components/templates/ClinicRegistrationFunnel/steps/ClinicDetailsStep.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/steps/ClinicDetailsStep.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react'
+import { Building2, CircleHelp, Globe2 } from 'lucide-react'
+
+import { Heading } from '@/components/atoms/Heading'
+import { formContentClassName } from '../constants'
+import type { ClinicRegistrationFormValues, PublicFormValidationController } from '../types'
+import { RegistrationField } from '../components/RegistrationField'
+import { StepActions } from '../components/StepActions'
+import { StepForm } from '../components/StepForm'
+
+export function ClinicDetailsStep({
+  formValues,
+  headingRef,
+  onNext,
+  onValueChange,
+  validation,
+}: {
+  formValues: ClinicRegistrationFormValues
+  headingRef: React.Ref<HTMLHeadingElement>
+  onNext: () => void
+  onValueChange: (fieldName: keyof ClinicRegistrationFormValues, value: string) => void
+  validation: PublicFormValidationController
+}) {
+  const idBase = React.useId()
+  const headingId = `${idBase}-details-heading`
+  const descriptionId = `${idBase}-details-notice`
+
+  return (
+    <StepForm ariaLabelledBy={headingId} onSubmit={onNext} validation={validation}>
+      <div className={formContentClassName}>
+        <Heading
+          align="left"
+          as="h2"
+          className="text-[32px] leading-tight text-[#172033]"
+          id={headingId}
+          ref={headingRef}
+          size="h3"
+          tabIndex={-1}
+        >
+          Klinik registrieren
+        </Heading>
+        <p className="mt-3 text-base text-card-foreground/70">Starten Sie Ihre internationale Präsenz.</p>
+
+        <div className="mt-8 grid gap-5 sm:mt-10 sm:gap-6 lg:mt-12">
+          <RegistrationField
+            descriptionId={descriptionId}
+            id={`${idBase}-clinic-name`}
+            icon={Building2}
+            label="Klinikname"
+            name="clinicName"
+            onValueChange={(value) => onValueChange('clinicName', value)}
+            placeholder="z.B. Charité"
+            required
+            validation={validation}
+            value={formValues.clinicName}
+          />
+          <RegistrationField
+            descriptionId={descriptionId}
+            id={`${idBase}-clinic-website`}
+            icon={Globe2}
+            label="Website"
+            name="clinicWebsite"
+            onValueChange={(value) => onValueChange('clinicWebsite', value)}
+            placeholder="https://klinik.de"
+            required
+            type="url"
+            validation={validation}
+            value={formValues.clinicWebsite}
+          />
+          <div
+            className="grid grid-cols-[20px_minmax(0,1fr)] gap-3 rounded-[8px] border border-primary/15 bg-primary/10 px-4 py-4 text-xs leading-4 text-card-foreground/80"
+            id={descriptionId}
+          >
+            <CircleHelp aria-hidden="true" className="mt-0.5 size-4 text-primary" />
+            <p>Diese Informationen werden zur ersten Validierung Ihres Standortes verwendet.</p>
+          </div>
+        </div>
+      </div>
+      <StepActions primaryLabel="Weiter" primaryType="submit" />
+    </StepForm>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/steps/ContactStep.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/steps/ContactStep.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react'
+import { ChevronDown } from 'lucide-react'
+
+import { Field, FieldError } from '@/components/atoms/field'
+import { Heading } from '@/components/atoms/Heading'
+import { Label } from '@/components/atoms/label'
+import { contactRoleOptions, formContentClassName } from '../constants'
+import type { ClinicRegistrationFormValues, PublicFormValidationController } from '../types'
+import { ContactNotice } from '../components/ContactNotice'
+import { RegistrationField } from '../components/RegistrationField'
+import { StepActions } from '../components/StepActions'
+import { StepForm } from '../components/StepForm'
+
+export function ContactStep({
+  formValues,
+  headingRef,
+  onBack,
+  onNext,
+  onValueChange,
+  validation,
+}: {
+  formValues: ClinicRegistrationFormValues
+  headingRef: React.Ref<HTMLHeadingElement>
+  onBack: () => void
+  onNext: () => void
+  onValueChange: (fieldName: keyof ClinicRegistrationFormValues, value: string) => void
+  validation: PublicFormValidationController
+}) {
+  const idBase = React.useId()
+  const headingId = `${idBase}-contact-heading`
+  const noticeId = `${idBase}-contact-notice`
+  const positionId = `${idBase}-position`
+  const positionError = validation.getFieldError('contactRole')
+  const positionErrorId = validation.getFieldErrorId('contactRole')
+
+  return (
+    <StepForm ariaLabelledBy={headingId} onSubmit={onNext} validation={validation}>
+      <div className={formContentClassName}>
+        <Heading
+          align="left"
+          as="h2"
+          className="text-[32px] leading-tight text-[#172033]"
+          id={headingId}
+          ref={headingRef}
+          size="h3"
+          tabIndex={-1}
+        >
+          Ihr Kontakt
+        </Heading>
+        <p className="mt-3 text-base text-card-foreground/70">Wer ist unsere Kontaktperson für die Koordination?</p>
+
+        <div className="mt-8 grid gap-5 sm:mt-10 sm:gap-6 lg:mt-12">
+          <RegistrationField
+            descriptionId={noticeId}
+            id={`${idBase}-contact-name`}
+            label="Vollständiger Name"
+            name="contactName"
+            onValueChange={(value) => onValueChange('contactName', value)}
+            placeholder="z.B. Dr. Muster"
+            required
+            validation={validation}
+            value={formValues.contactName}
+          />
+          <RegistrationField
+            descriptionId={noticeId}
+            id={`${idBase}-contact-email`}
+            label="E-Mail Adresse"
+            name="contactEmail"
+            onValueChange={(value) => onValueChange('contactEmail', value)}
+            placeholder="kontakt@klinik.de"
+            required
+            type="email"
+            validation={validation}
+            value={formValues.contactEmail}
+          />
+          <Field className="min-w-0 gap-2 text-left" data-invalid={positionError ? true : undefined}>
+            <Label className="mb-2 block text-left text-sm font-semibold text-[#172033]" htmlFor={positionId}>
+              Position / Funktion
+            </Label>
+            <div className="relative">
+              <select
+                {...validation.getFieldProps('contactRole', noticeId)}
+                className="h-[60px] w-full min-w-0 appearance-none rounded-[8px] border border-slate-300 bg-[#fbfcff] px-3 pr-10 text-left text-base text-slate-500 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-hidden aria-invalid:border-destructive/70 aria-invalid:focus-visible:ring-destructive/20 sm:px-4 sm:pr-12 md:text-base"
+                id={positionId}
+                name="contactRole"
+                onChange={(event) => {
+                  validation.handleFieldChange(event)
+                  onValueChange('contactRole', event.currentTarget.value)
+                }}
+                required
+                value={formValues.contactRole}
+              >
+                <option disabled value="">
+                  Bitte auswählen
+                </option>
+                {contactRoleOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown
+                aria-hidden="true"
+                className="pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 text-slate-500 sm:right-4 sm:size-5"
+              />
+            </div>
+            <FieldError id={positionErrorId}>{positionError}</FieldError>
+          </Field>
+          <ContactNotice id={noticeId} />
+        </div>
+      </div>
+      <StepActions onBack={onBack} primaryLabel="Anfrage senden" primaryType="submit" />
+    </StepForm>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/steps/ReviewConfirmationStep.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/steps/ReviewConfirmationStep.tsx
@@ -1,0 +1,27 @@
+import type * as React from 'react'
+import { ShieldCheck } from 'lucide-react'
+
+import { Heading } from '@/components/atoms/Heading'
+
+export function ReviewConfirmationStep({ headingRef }: { headingRef: React.Ref<HTMLHeadingElement> }) {
+  return (
+    <div className="mx-auto flex w-full max-w-[490px] flex-1 flex-col items-center justify-center py-12 text-center">
+      <div className="grid size-[88px] place-items-center rounded-full bg-accent text-secondary">
+        <ShieldCheck aria-hidden="true" className="size-10" />
+      </div>
+      <Heading
+        align="center"
+        as="h2"
+        className="mt-5 text-[34px] leading-tight text-[#172033]"
+        ref={headingRef}
+        size="h3"
+        tabIndex={-1}
+      >
+        Anfrage übermittelt
+      </Heading>
+      <p className="mt-4 max-w-[430px] text-lg leading-relaxed text-card-foreground/70">
+        Ihre Anfrage wurde übermittelt. Wir kontaktieren Sie, sobald die Prüfung abgeschlossen ist.
+      </p>
+    </div>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/steps/TreatmentCategoriesStep.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/steps/TreatmentCategoriesStep.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react'
+
+import { Field, FieldError } from '@/components/atoms/field'
+import { Heading } from '@/components/atoms/Heading'
+import { formContentClassName } from '../constants'
+import type { PublicFormValidationController, ResolvedTreatmentCategory } from '../types'
+import { treatmentCategoriesRequiredMessage } from '../validation'
+import { StepActions } from '../components/StepActions'
+import { StepForm } from '../components/StepForm'
+import { TreatmentCategoryOptionCard } from '../components/TreatmentCategoryOptionCard'
+
+export function TreatmentCategoriesStep({
+  headingRef,
+  onBack,
+  onNext,
+  onToggleCategory,
+  selectedCategories,
+  treatmentCategories,
+  validation,
+}: {
+  headingRef: React.Ref<HTMLHeadingElement>
+  onBack: () => void
+  onNext: () => void
+  onToggleCategory: (categoryId: string) => void
+  selectedCategories: string[]
+  treatmentCategories: ResolvedTreatmentCategory[]
+  validation: PublicFormValidationController
+}) {
+  const idBase = React.useId()
+  const headingId = `${idBase}-treatment-categories-heading`
+  const descriptionId = `${idBase}-treatment-categories-description`
+  const error = validation.getFieldError('treatmentCategories')
+  const errorId = validation.getFieldErrorId('treatmentCategories')
+  const groupRef = React.useRef<HTMLFieldSetElement>(null)
+
+  return (
+    <StepForm
+      ariaLabelledBy={headingId}
+      onSubmit={() => {
+        if (selectedCategories.length === 0) {
+          validation.setCustomFieldError('treatmentCategories', treatmentCategoriesRequiredMessage)
+          groupRef.current?.focus()
+          return
+        }
+
+        onNext()
+      }}
+      validation={validation}
+    >
+      <div className={formContentClassName}>
+        <Heading
+          align="left"
+          as="h2"
+          className="text-[32px] leading-tight text-[#172033]"
+          id={headingId}
+          ref={headingRef}
+          size="h3"
+          tabIndex={-1}
+        >
+          Schwerpunkte wählen
+        </Heading>
+        <p className="mt-3 max-w-[590px] text-base leading-relaxed text-card-foreground/70" id={descriptionId}>
+          Wählen Sie Ihre Hauptkategorien für die Kliniksuche. Dies hilft uns, die passenden Ergebnisse für Sie zu
+          priorisieren.
+        </p>
+
+        <Field className="mt-8 min-w-0 gap-3 sm:mt-10 lg:mt-12" data-invalid={error ? true : undefined}>
+          <fieldset
+            aria-describedby={[descriptionId, error ? errorId : undefined].filter(Boolean).join(' ')}
+            aria-invalid={error ? true : undefined}
+            className="min-w-0 border-0 p-0 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-hidden"
+            data-field-name="treatmentCategories"
+            ref={groupRef}
+            tabIndex={-1}
+          >
+            <legend className="sr-only">Behandlungskategorien auswählen</legend>
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+              {treatmentCategories.map((category) => (
+                <TreatmentCategoryOptionCard
+                  category={category}
+                  isSelected={selectedCategories.includes(category.id)}
+                  key={category.id}
+                  onToggle={onToggleCategory}
+                />
+              ))}
+            </div>
+          </fieldset>
+          <FieldError id={errorId}>{error}</FieldError>
+        </Field>
+      </div>
+      <StepActions onBack={onBack} primaryLabel="Weiter" primaryType="submit" />
+    </StepForm>
+  )
+}

--- a/src/components/templates/ClinicRegistrationFunnel/types.ts
+++ b/src/components/templates/ClinicRegistrationFunnel/types.ts
@@ -1,0 +1,51 @@
+import type * as React from 'react'
+
+import type { usePublicFormValidation } from '@/components/molecules/PublicFormValidation/usePublicFormValidation'
+
+export type ClinicRegistrationStep = 1 | 2 | 3 | 4
+export type StepTransitionDirection = 'backward' | 'forward' | 'none'
+export type IconComponent = React.ElementType<React.SVGProps<SVGSVGElement>>
+export type PublicFormValidationController = ReturnType<typeof usePublicFormValidation>
+
+export type ClinicRegistrationFunnelProps = {
+  className?: string
+  initialSelectedTreatmentCategoryIds?: string[]
+  initialStep?: ClinicRegistrationStep
+  initialValues?: Partial<ClinicRegistrationFormValues>
+  reviewSummary?: ClinicRegistrationReviewSummary
+  treatmentCategories?: ClinicRegistrationTreatmentCategory[]
+}
+
+export type ClinicRegistrationFormValues = {
+  clinicName: string
+  clinicWebsite: string
+  contactEmail: string
+  contactName: string
+  contactRole: string
+}
+
+export type ClinicRegistrationReviewSummary = {
+  clinicAddress: string
+  clinicWebsite?: string
+  clinicName: string
+  contactEmail: string
+  contactName: string
+  contactRole: string
+}
+
+export type ClinicRegistrationCategoryIconKey =
+  | 'dental'
+  | 'dermatology'
+  | 'eye-care'
+  | 'hair-restoration'
+  | 'plastic-surgery'
+
+export type ClinicRegistrationTreatmentCategory = {
+  iconKey: ClinicRegistrationCategoryIconKey
+  id: string
+  label: string
+}
+
+export type ResolvedTreatmentCategory = ClinicRegistrationTreatmentCategory & {
+  icon: IconComponent
+}

--- a/src/components/templates/ClinicRegistrationFunnel/validation.ts
+++ b/src/components/templates/ClinicRegistrationFunnel/validation.ts
@@ -1,0 +1,21 @@
+export const validationMessages = {
+  clinicName: {
+    valueMissing: 'Bitte geben Sie den Kliniknamen ein.',
+  },
+  clinicWebsite: {
+    typeMismatch: 'Bitte geben Sie eine gültige Website-URL ein.',
+    valueMissing: 'Bitte geben Sie die Website ein.',
+  },
+  contactEmail: {
+    typeMismatch: 'Bitte geben Sie eine gültige E-Mail-Adresse ein.',
+    valueMissing: 'Bitte geben Sie die E-Mail-Adresse ein.',
+  },
+  contactName: {
+    valueMissing: 'Bitte geben Sie den vollständigen Namen ein.',
+  },
+  contactRole: {
+    valueMissing: 'Bitte wählen Sie eine Position aus.',
+  },
+}
+
+export const treatmentCategoriesRequiredMessage = 'Bitte wählen Sie mindestens einen Schwerpunkt aus.'

--- a/src/stories/molecules/StepIndicator.stories.tsx
+++ b/src/stories/molecules/StepIndicator.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, within } from 'storybook/test'
+
+import { StepIndicator } from '@/components/molecules/StepIndicator'
+
+const meta = {
+  title: 'Shared/Molecules/StepIndicator',
+  component: StepIndicator,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs', 'domain:shared', 'layer:molecule', 'status:experimental'],
+  args: {
+    currentStep: 2,
+    statusLabel: '50% abgeschlossen',
+    stepLabel: 'Schritt 2 von 4',
+    totalSteps: 4,
+  },
+} satisfies Meta<typeof StepIndicator>
+
+export default meta
+
+type Story = StoryObj<typeof StepIndicator>
+
+export const Default: Story = {
+  render: (args) => (
+    <div className="w-[min(480px,calc(100vw-32px))]">
+      <StepIndicator {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const progress = canvas.getByRole('progressbar', { name: /schritt 2 von 4/i })
+
+    await expect(progress).toHaveAttribute('aria-valuenow', '2')
+    await expect(progress).toHaveAttribute('aria-valuemax', '4')
+    await expect(progress).toHaveAttribute('aria-valuetext', 'Schritt 2 von 4')
+    expect([...progress.querySelectorAll('[data-state]')].map((segment) => segment.getAttribute('data-state'))).toEqual(
+      ['completed', 'current', 'upcoming', 'upcoming'],
+    )
+  },
+}
+
+export const Submitted: Story = {
+  args: {
+    ariaLabel: 'Klinikregistrierung, Schritt 4 von 4, Anfrage übermittelt',
+    currentStep: 4,
+    statusLabel: 'Anfrage übermittelt',
+    stepLabel: 'Schritt 4 von 4',
+    totalSteps: 4,
+  },
+  render: Default.render,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const progress = canvas.getByRole('progressbar', {
+      name: 'Klinikregistrierung, Schritt 4 von 4, Anfrage übermittelt',
+    })
+
+    await expect(progress).toHaveAttribute('aria-valuetext', 'Schritt 4 von 4')
+    expect([...progress.querySelectorAll('[data-state]')].map((segment) => segment.getAttribute('data-state'))).toEqual(
+      ['completed', 'completed', 'completed', 'current'],
+    )
+  },
+}

--- a/src/stories/templates/ClinicRegistrationFunnel.stories.tsx
+++ b/src/stories/templates/ClinicRegistrationFunnel.stories.tsx
@@ -1,0 +1,231 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
+
+import { ClinicRegistrationFunnel } from '@/components/templates/ClinicRegistrationFunnel'
+import type { ClinicRegistrationFunnelProps } from '@/components/templates/ClinicRegistrationFunnel'
+import { withViewportStory } from '../utils/viewportMatrix'
+
+const getStoryRemountKey = (args: ClinicRegistrationFunnelProps) =>
+  JSON.stringify({
+    initialSelectedTreatmentCategoryIds: args.initialSelectedTreatmentCategoryIds,
+    initialStep: args.initialStep,
+    initialValues: args.initialValues,
+    reviewSummary: args.reviewSummary,
+    treatmentCategories: args.treatmentCategories,
+  })
+
+const meta = {
+  title: 'Domain/ClinicRegistration/Templates/Clinic Registration Funnel',
+  component: ClinicRegistrationFunnel,
+  decorators: [
+    (Story) => (
+      <div className="w-full bg-muted px-4 py-8 text-card-foreground sm:px-6 lg:px-10">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: (args) => <ClinicRegistrationFunnel key={getStoryRemountKey(args)} {...args} />,
+  tags: ['autodocs', 'domain:clinic-registration', 'layer:template', 'status:experimental', 'used-in:shared'],
+} satisfies Meta<typeof ClinicRegistrationFunnel>
+
+export default meta
+
+type Story = StoryObj<typeof ClinicRegistrationFunnel>
+
+const storyReviewSummary = {
+  clinicAddress: 'Hauptstraße 124, 10115 Berlin',
+  clinicWebsite: 'https://marien-hospital.de',
+  clinicName: 'St. Marien Hospital',
+  contactEmail: 'm.musterfrau@marien-hospital.de',
+  contactName: 'Dr. Martina Musterfrau',
+  contactRole: 'Leitende Oberärztin',
+}
+
+const longStoryReviewSummary = {
+  clinicAddress: 'Sehrlangeklinikhauptadresseohneleerzeichen-Station-Internationalisierung-124-126, 10115 Berlin',
+  clinicWebsite: 'https://sehrlange-klinik-domain-berlin.example/internationale-klinikregistrierung',
+  clinicName: 'Klinikzentrum fuer internationale rekonstruktive Spezialbehandlungen und Langzeitversorgung Berlin',
+  contactEmail: 'martina.musterfrau.verantwortliche.klinikregistrierung@sehrlange-klinik-domain-berlin.example',
+  contactName: 'Dr. Martina Elisabeth Musterfrau-Schwerpunktkoordination',
+  contactRole: 'Leitende Oberaerztin und Verantwortliche fuer internationale Klinikregistrierung',
+}
+
+const defaultStoryArgs = {
+  initialSelectedTreatmentCategoryIds: ['dental'],
+  reviewSummary: storyReviewSummary,
+}
+
+export const Step1ClinicDetails: Story = {
+  args: {
+    ...defaultStoryArgs,
+    initialStep: 1,
+  },
+}
+
+export const Step2TreatmentCategories: Story = {
+  args: {
+    ...defaultStoryArgs,
+    initialStep: 2,
+  },
+}
+
+export const Step3Contact: Story = {
+  args: {
+    ...defaultStoryArgs,
+    initialStep: 3,
+  },
+}
+
+export const Step1ValidationErrors: Story = {
+  args: {
+    ...defaultStoryArgs,
+    initialStep: 1,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await userEvent.click(canvas.getByRole('button', { name: /^weiter$/i }))
+
+    await expect(canvas.getByText('Bitte geben Sie den Kliniknamen ein.')).toBeInTheDocument()
+    await expect(canvas.getByText('Bitte geben Sie die Website ein.')).toBeInTheDocument()
+    await expect(canvas.getByLabelText('Klinikname')).toHaveAttribute('aria-invalid', 'true')
+    await expect(canvas.getByLabelText('Klinikname')).toHaveFocus()
+  },
+}
+
+export const Step2ValidationErrors: Story = {
+  args: {
+    ...defaultStoryArgs,
+    initialSelectedTreatmentCategoryIds: [],
+    initialStep: 2,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await userEvent.click(canvas.getByRole('button', { name: /^weiter$/i }))
+
+    await expect(canvas.getByText('Bitte wählen Sie mindestens einen Schwerpunkt aus.')).toBeInTheDocument()
+    await expect(canvas.getByRole('group', { name: /behandlungskategorien auswählen/i })).toHaveFocus()
+  },
+}
+
+export const Step3ValidationErrors: Story = {
+  args: {
+    ...defaultStoryArgs,
+    initialStep: 3,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await userEvent.click(canvas.getByRole('button', { name: /^anfrage senden$/i }))
+
+    await expect(canvas.getByText('Bitte geben Sie den vollständigen Namen ein.')).toBeInTheDocument()
+    await expect(canvas.getByText('Bitte geben Sie die E-Mail-Adresse ein.')).toBeInTheDocument()
+    await expect(canvas.getByText('Bitte wählen Sie eine Position aus.')).toBeInTheDocument()
+    await expect(canvas.getByLabelText('Vollständiger Name')).toHaveFocus()
+  },
+}
+
+export const Step4ReviewConfirmation: Story = {
+  args: {
+    ...defaultStoryArgs,
+    initialSelectedTreatmentCategoryIds: ['dental', 'hair-restoration'],
+    initialStep: 4,
+  },
+}
+
+export const Step4LongReviewSummary: Story = {
+  args: {
+    ...defaultStoryArgs,
+    initialSelectedTreatmentCategoryIds: ['dental', 'hair-restoration', 'plastic-surgery'],
+    initialStep: 4,
+    reviewSummary: longStoryReviewSummary,
+  },
+}
+
+export const InteractiveFunnel: Story = {
+  args: {
+    ...defaultStoryArgs,
+    initialStep: 1,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByRole('heading', { name: /klinik registrieren/i })).toBeInTheDocument()
+    await expect(canvas.getByText(/klinik international sichtbar machen/i)).toBeInTheDocument()
+    await expect(canvas.queryByText(/international patients/i)).not.toBeInTheDocument()
+    await userEvent.type(canvas.getByLabelText('Klinikname'), 'Aurora Klinik Berlin')
+    await userEvent.type(canvas.getByLabelText('Website'), 'https://aurora-klinik.example')
+    await userEvent.click(canvas.getByRole('button', { name: /^weiter$/i }))
+
+    const treatmentCategoriesHeading = await canvas.findByRole('heading', { name: /schwerpunkte wählen/i })
+    await expect(treatmentCategoriesHeading).toBeInTheDocument()
+    await waitFor(() => expect(treatmentCategoriesHeading).toHaveFocus())
+    await expect(canvas.getByText(/schwerpunkte der klinik/i)).toBeInTheDocument()
+    const treatmentCategoryGroup = canvas.getByRole('group', { name: /behandlungskategorien auswählen/i })
+    await expect(treatmentCategoryGroup).toBeInTheDocument()
+    await expect(treatmentCategoryGroup).toHaveAccessibleDescription(/hauptkategorien für die kliniksuche/i)
+    for (const categoryLabel of ['Dental', 'Eye Care', 'Hair Restoration', 'Dermatology', 'Plastic Surgery']) {
+      await expect(canvas.getByRole('button', { name: categoryLabel })).toBeInTheDocument()
+    }
+    await expect(canvas.queryByRole('button', { name: 'Body' })).not.toBeInTheDocument()
+    await expect(canvas.queryByRole('button', { name: 'Kardio' })).not.toBeInTheDocument()
+    await expect(canvas.queryByRole('button', { name: 'Allgemein' })).not.toBeInTheDocument()
+    await expect(canvas.queryByText(/profil/i)).not.toBeInTheDocument()
+    const hairCategoryButton = canvas.getByRole('button', { name: 'Hair Restoration' })
+    hairCategoryButton.focus()
+    await expect(hairCategoryButton).toHaveFocus()
+    await userEvent.keyboard('{Enter}')
+    await expect(hairCategoryButton).toHaveAttribute('aria-pressed', 'true')
+    await userEvent.click(canvas.getByRole('button', { name: /^weiter$/i }))
+
+    const contactHeading = await canvas.findByRole('heading', { name: /ihr kontakt/i })
+    await expect(contactHeading).toBeInTheDocument()
+    await waitFor(() => expect(contactHeading).toHaveFocus())
+    await expect(canvas.getByText(/berechtigten interesse zur klinikregistrierung/i)).toBeInTheDocument()
+    await userEvent.type(canvas.getByLabelText('Vollständiger Name'), 'Dr. Ada Lovelace')
+    await userEvent.type(canvas.getByLabelText('E-Mail Adresse'), 'ada.lovelace@aurora-klinik.example')
+    await userEvent.selectOptions(canvas.getByLabelText('Position / Funktion'), 'Klinikmanagement')
+    await userEvent.click(canvas.getByRole('button', { name: /^anfrage senden$/i }))
+
+    const confirmationHeading = await canvas.findByRole('heading', { name: /anfrage übermittelt/i })
+    await expect(confirmationHeading).toBeInTheDocument()
+    await waitFor(() => expect(confirmationHeading).toHaveFocus())
+    await expect(canvas.getByText(/wir kontaktieren sie, sobald die prüfung abgeschlossen ist/i)).toBeInTheDocument()
+    await expect(canvas.getByText('Aurora Klinik Berlin')).toBeInTheDocument()
+    await expect(canvas.getByText('https://aurora-klinik.example')).toBeInTheDocument()
+    await expect(canvas.getByText('Dr. Ada Lovelace')).toBeInTheDocument()
+    await expect(canvas.getByText(/Klinikmanagement/)).toBeInTheDocument()
+    await expect(canvas.getByText(/ada.lovelace@aurora-klinik.example/)).toBeInTheDocument()
+    await expect(canvas.getByText('Dental')).toBeInTheDocument()
+    await expect(canvas.getByText('Hair Restoration')).toBeInTheDocument()
+    await expect(canvas.queryByText(/dashboard/i)).not.toBeInTheDocument()
+    await expect(canvas.queryByText(/profil vervollständigen/i)).not.toBeInTheDocument()
+    await expect(canvas.queryByText(/consent/i)).not.toBeInTheDocument()
+  },
+}
+
+export const Responsive320: Story = withViewportStory(Step1ClinicDetails, 'public320', 'Responsive / 320')
+export const Responsive375: Story = withViewportStory(Step1ClinicDetails, 'public375', 'Responsive / 375')
+export const Responsive640: Story = withViewportStory(Step1ClinicDetails, 'public640', 'Responsive / 640')
+export const Responsive768: Story = withViewportStory(Step1ClinicDetails, 'public768', 'Responsive / 768')
+export const Responsive1024: Story = withViewportStory(Step1ClinicDetails, 'public1024', 'Responsive / 1024')
+export const Responsive1280: Story = withViewportStory(Step1ClinicDetails, 'public1280', 'Responsive / 1280')
+export const Responsive375Short: Story = withViewportStory(
+  Step1ClinicDetails,
+  'public375Short',
+  'Responsive / 375 short',
+)
+export const Step3ValidationErrors375Short: Story = withViewportStory(
+  Step3ValidationErrors,
+  'public375Short',
+  'Error State / Step 3 / 375 short',
+)
+export const Step4LongReviewSummary320Short: Story = withViewportStory(
+  Step4LongReviewSummary,
+  'public320Short',
+  'Edge Case / Step 4 Long Review / 320 short',
+)


### PR DESCRIPTION
## Management summary

### Deutsch

Diese Änderung legt die UI-Grundlage für die neue Klinikregistrierung an, ohne die bestehende Registrierungsseite live zu verändern. Das Team kann den mehrstufigen Ablauf, die Validierung und die responsive Darstellung im Storybook prüfen und weiter iterieren, bevor die Route ausgetauscht wird.

### English

This change adds the UI foundation for the new clinic registration experience without changing the live registration page. The team can review and iterate on the multi-step flow, validation, and responsive behavior in Storybook before the route is replaced.

## What changed

- Added a reusable `StepIndicator` molecule with segmented progress states and Storybook coverage.
- Added the `ClinicRegistrationFunnel` template with internal split-shell, step components, category cards, local state, local validation, error states, and review/confirmation UI.
- Added Storybook coverage for the four funnel steps, interactive behavior, validation states, short-height states, long-review edge case, and viewport stories.
- Kept `/register/clinic`, public E2E route coverage, API submission, Payload schema, and landing page integration unchanged for the stacked route PR.
- Related management context: findmydoc-platform/management#287.

## UI/UX

<!-- gh-ui-screenshots:start -->
### Step 2 desktop

![Step 2 desktop](https://github.com/user-attachments/assets/0a751a5d-99b6-4eb5-a997-36e3e7a9c791)

### Step 3 mobile error state

![Step 3 mobile error state](https://github.com/user-attachments/assets/4c364104-4e9c-4bf3-b789-c7cf64c2347e)

### Step 4 review desktop

![Step 4 review desktop](https://github.com/user-attachments/assets/7fe4fdb6-500a-4066-807f-83ab56033574)

### Step 1 short-height mobile

![Step 1 short-height mobile](https://github.com/user-attachments/assets/10308af0-b709-44cc-8620-b609756334f1)
<!-- gh-ui-screenshots:end -->

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed.
- [ ] `pnpm build`: not run for this foundation PR because no route/runtime entry point is changed; `pnpm build-storybook` was run instead.
- [x] Focused tests: `pnpm stories:governance:check`, `pnpm vitest --project storybook --run src/stories/templates/ClinicRegistrationFunnel.stories.tsx src/stories/molecules/StepIndicator.stories.tsx` (`20` tests), and `pnpm build-storybook` passed.
- [x] UI/mobile QA: Storybook screenshots captured for Step 2 desktop, Step 3 mobile error state, Step 4 review, and Step 1 short-height mobile; screenshots are documented in `## UI/UX`. Playwright checked no horizontal overflow. Short-height CTA was rechecked at `320x700` with the primary CTA inside the initial viewport (`buttonBottom=697`, `clientHeight=700`).
- [x] Security/privacy review: no network submission, API, authentication, secrets, Payload access, or persistence behavior is introduced.
- [x] Migration/schema check: no Payload schema, collection, migration, or seed data changes.
- [x] Documentation/instructions check: Storybook docs are covered by the new stories; no operator documentation changes are required for a non-live foundation PR.

## Risk and rollout

This PR is not live-route affecting. The main risk is visual or accessibility debt inside the Storybook-only funnel foundation before it is used by `/register/clinic`; reviewer rechecks found no remaining issue at `>=5/10`. Known lower-severity follow-ups are semantic preference for checkbox-style category selection and a single aggregate form-error announcement. The route replacement is intentionally isolated into the next stacked PR. Rollback is a normal revert of this foundation branch.

## Development

Closes #1205
