### PR TITLE
chore: separate UI screenshots from validation

### DIFF
--- a/.codex/skills/gh-ui-screenshots/SKILL.md
+++ b/.codex/skills/gh-ui-screenshots/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-ui-screenshots
-description: Attach existing UI screenshots to GitHub pull request descriptions after a UI, frontend, visual, responsive, or mobile pull request has been created or updated. Use when Codex is preparing or updating a PR that needs screenshot evidence in the existing `UI/mobile QA` validation item. This skill does not create PRs, commit, push, run checks, run tests, or capture screenshots; it only uploads already available images and patches the PR body.
+description: Attach existing UI screenshots to GitHub pull request descriptions after a UI, frontend, visual, responsive, or mobile pull request has been created or updated. Use when Codex is preparing or updating a PR that needs screenshot evidence in a dedicated `UI/UX` section while keeping the existing `UI/mobile QA` validation item as a text summary. This skill does not create PRs, commit, push, run checks, run tests, or capture screenshots; it only uploads already available images and patches the PR body.
 ---
 
 # GitHub UI Screenshots
@@ -14,6 +14,7 @@ Boundary:
 - PR body updates use GitHub's official REST pull request `body` update path.
 - Image attachment upload uses GitHub's web comment-box attachment flow. Treat it as best-effort and private-internal, not as a stable public API.
 - Stored Playwright browser state contains sensitive GitHub cookies; keep it in the skill cache and never print cookie values.
+- Screenshots belong in `## UI/UX`, grouped by viewport/state with third-level headings. The `## Validation` item `UI/mobile QA` remains a checked text summary only.
 
 Decision:
 
@@ -52,10 +53,11 @@ Options:
 The script updates only the PR body:
 
 - Sets `- [ ] UI/mobile QA:` to `[x]`.
-- Inserts or replaces a marker block directly below that line:
+- Inserts or replaces a marker block in `## UI/UX`, creating that section before `## Validation` when needed:
   `<!-- gh-ui-screenshots:start --> ... <!-- gh-ui-screenshots:end -->`.
+- Renders each uploaded image under a third-level heading using the screenshot label.
 - Uses GitHub user-attachment URLs for Markdown images.
-- Does not add a separate `## Screenshots` section.
+- Does not put image Markdown inside `## Validation` and does not add a separate `## Screenshots` section.
 
 ## Failure Rules
 

--- a/.codex/skills/gh-ui-screenshots/scripts/attach-ui-screenshots.mjs
+++ b/.codex/skills/gh-ui-screenshots/scripts/attach-ui-screenshots.mjs
@@ -18,6 +18,7 @@ const PROBE_FILE = path.join(CACHE_DIR, 'upload-token-probe.png')
 const PLAYWRIGHT_VERSION = '1.60.0'
 const MARKER_START = '<!-- gh-ui-screenshots:start -->'
 const MARKER_END = '<!-- gh-ui-screenshots:end -->'
+const UI_UX_SECTION_HEADING = '## UI/UX'
 const IMAGE_EXTENSIONS = new Set(['.gif', '.jpg', '.jpeg', '.png', '.svg', '.webp'])
 const REQUIRED_WEB_SESSION_COOKIES = ['user_session', '_gh_sess']
 const CONTENT_TYPES = new Map([
@@ -631,32 +632,52 @@ const markerPattern = () =>
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 const renderMarkerBlock = (uploads) => {
-  const lines = [
-    `  ${MARKER_START}`,
-    ...uploads.map((upload) => `  - ${upload.label}: ${upload.markdown}`),
-    `  ${MARKER_END}`,
-  ]
+  const lines = [MARKER_START]
+  uploads.forEach((upload, index) => {
+    if (index > 0) lines.push('')
+    lines.push(`### ${upload.label}`, '', upload.markdown)
+  })
+  lines.push(MARKER_END)
   return lines.join('\n')
+}
+
+const patchUiMobileQaLine = (body) => {
+  const uiLinePattern = /^(\s*-\s*\[)( |x|X)(\]\s*UI\/mobile QA:\s*)(.*)$/m
+  const match = body.match(uiLinePattern)
+  if (match) {
+    const existingText = match[4]?.trim()
+    const line = `${match[1]}x${match[3]}${existingText || 'Screenshots are documented in `## UI/UX`.'}`
+    return body.replace(uiLinePattern, line)
+  }
+
+  const validationPattern = /(## Validation\s*\n)/i
+  const inserted = '- [x] UI/mobile QA: Screenshots are documented in `## UI/UX`.\n'
+  if (validationPattern.test(body)) {
+    return body.replace(validationPattern, `$1\n${inserted}`)
+  }
+
+  return `${body.trimEnd()}\n\n## Validation\n\n${inserted}`
+}
+
+const patchUiUxSection = (body, block) => {
+  const uiUxHeadingPattern = /^## UI\/UX\s*$/im
+  if (uiUxHeadingPattern.test(body)) {
+    return body.replace(uiUxHeadingPattern, `${UI_UX_SECTION_HEADING}\n\n${block}`)
+  }
+
+  const validationHeadingPattern = /^## Validation\s*$/im
+  if (validationHeadingPattern.test(body)) {
+    return body.replace(validationHeadingPattern, `${UI_UX_SECTION_HEADING}\n\n${block}\n\n## Validation`)
+  }
+
+  return `${body.trimEnd()}\n\n${UI_UX_SECTION_HEADING}\n\n${block}`
 }
 
 const patchPrBody = (body, uploads) => {
   const block = renderMarkerBlock(uploads)
-  const cleaned = (body || '').replace(markerPattern(), '\n')
-  const uiLinePattern = /^(\s*-\s*\[)( |x|X)(\]\s*UI\/mobile QA:\s*)(.*)$/m
-  const match = cleaned.match(uiLinePattern)
-  if (match) {
-    const existingText = match[4]?.trim()
-    const line = `${match[1]}x${match[3]}${existingText || 'Screenshots attached below.'}`
-    return cleaned.replace(uiLinePattern, `${line}\n${block}`)
-  }
-
-  const validationPattern = /(## Validation\s*\n)/i
-  const inserted = `- [x] UI/mobile QA: Screenshots attached below.\n${block}\n`
-  if (validationPattern.test(cleaned)) {
-    return cleaned.replace(validationPattern, `$1\n${inserted}`)
-  }
-
-  return `${cleaned.trimEnd()}\n\n## Validation\n\n${inserted}`
+  const cleaned = (body || '').replace(markerPattern(), '\n').replace(/\n{3,}/g, '\n\n')
+  const validationPatched = patchUiMobileQaLine(cleaned)
+  return patchUiUxSection(validationPatched, block).replace(/^(## [^\n]+)\n(?!\n)/gm, '$1\n\n')
 }
 
 const updatePrBody = async (token, pr, uploads) => {

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,10 @@
 
 -
 
+## UI/UX
+
+<!-- Optional. Include only for UI, frontend, visual, responsive, or mobile changes. Add screenshots here, grouped by state and viewport with short third-level headings such as `### Homepage mobile` or `### Error state desktop`. Do not put screenshots inside `## Validation`; keep the `UI/mobile QA` validation item as a text summary and reference this section. Remove this section for non-UI changes. -->
+
 ## Validation
 
 <!-- Check every relevant item. If an item was not run or is not applicable, leave it unchecked and explain why after the colon. -->


### PR DESCRIPTION
## Management summary

### Deutsch

UI-Änderungen in Pull Requests sind leichter zu prüfen, weil Screenshots künftig in einem eigenen UI/UX-Bereich stehen und die Validierungsliste wieder kompakt bleibt. Reviewer sehen visuelle Nachweise nach Zustand und Viewport gruppiert, ohne dass Test- und QA-Zusammenfassungen unübersichtlich werden.

### English

UI changes in pull requests are easier to review because screenshots now live in a dedicated UI/UX section while the validation checklist stays compact. Reviewers can scan visual evidence grouped by state and viewport without mixing it into test and QA summaries.

## What changed

- Adds optional `## UI/UX` guidance to the pull request template for UI, frontend, visual, responsive, and mobile changes.
- Updates the `gh-ui-screenshots` skill documentation so screenshot evidence belongs in `## UI/UX`, while `UI/mobile QA` remains a text-only validation summary.
- Updates the screenshot attachment script to create or update `## UI/UX` before `## Validation`, render uploaded images under `###` headings, remove older marker blocks, and keep `UI/mobile QA` checked without embedding image Markdown there.

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed.
- [ ] `pnpm build`: not run; this changes PR template and local screenshot tooling only, not runtime app output.
- [x] Focused tests: local `patchPrBody` regression script passed for moving an existing validation marker block into `## UI/UX` and keeping screenshots out of `## Validation`.
- [ ] UI/mobile QA: not applicable; no product UI changed.
- [x] Security/privacy review: no auth, permissions, token acquisition, screenshot capture, or upload target changes; no secrets in diff.
- [ ] Migration/schema check: not applicable; no Payload schema, collection, or migration changes.
- [x] Documentation/instructions check: PR template guidance and `gh-ui-screenshots` skill instructions updated.

## Risk and rollout

Low risk. This affects future PR body formatting and screenshot placement only. Existing PRs with `gh-ui-screenshots` markers are handled idempotently by replacing the marker block in its new location. Rollback is a normal revert of this workflow commit.

## Development

Closes #1209
