### PR TITLE
feat(frontend): place clinic registration funnel on partner page

### DIFF
--- a/src/app/(frontend)/_components/ClinicRegistrationLandingSection.tsx
+++ b/src/app/(frontend)/_components/ClinicRegistrationLandingSection.tsx
@@ -1,49 +1,29 @@
 import { ClinicRegistrationFunnel } from '@/components/templates/ClinicRegistrationFunnel'
 import { Container } from '@/components/molecules/Container'
-import { SectionHeading } from '@/components/molecules/SectionHeading'
 import { cn } from '@/utilities/ui'
 
 type ClinicRegistrationLandingSectionProps = {
+  ariaLabel?: string
   className?: string
-  description?: string
-  headingAs?: 'h1' | 'h2' | 'h3'
   id?: string
-  title?: string
 }
 
-const defaultTitle = 'Klinikregistrierung'
-const defaultDescription =
-  'Tragen Sie Ihre Klinik in wenigen Schritten ein. Wir prüfen die Angaben und melden uns, sobald die Registrierung eingeordnet ist.'
-
 export function ClinicRegistrationLandingSection({
+  ariaLabel = 'Klinikregistrierung',
   className,
-  description = defaultDescription,
-  headingAs = 'h2',
   id = 'clinic-registration',
-  title = defaultTitle,
 }: ClinicRegistrationLandingSectionProps) {
-  const titleId = `${id}-heading`
-
   return (
     <section
-      aria-labelledby={titleId}
+      aria-label={ariaLabel}
       className={cn(
-        'scroll-mt-[calc(var(--site-header-height)+1rem)] bg-site-canvas py-16 sm:py-20 md:py-24',
+        'scroll-mt-[calc(var(--site-header-height)+1rem)] bg-site-canvas py-12 sm:py-16 md:py-20',
         className,
       )}
       id={id}
     >
       <Container>
-        <div className="mx-auto flex w-full max-w-[1184px] flex-col gap-8 sm:gap-10">
-          <SectionHeading
-            align="center"
-            description={description}
-            descriptionClassName="max-w-3xl"
-            headingAs={headingAs}
-            size="section"
-            title={title}
-            titleId={titleId}
-          />
+        <div className="mx-auto w-full max-w-[1184px]">
           <ClinicRegistrationFunnel />
         </div>
       </Container>

--- a/src/app/(frontend)/_components/ClinicRegistrationLandingSection.tsx
+++ b/src/app/(frontend)/_components/ClinicRegistrationLandingSection.tsx
@@ -1,0 +1,52 @@
+import { ClinicRegistrationFunnel } from '@/components/templates/ClinicRegistrationFunnel'
+import { Container } from '@/components/molecules/Container'
+import { SectionHeading } from '@/components/molecules/SectionHeading'
+import { cn } from '@/utilities/ui'
+
+type ClinicRegistrationLandingSectionProps = {
+  className?: string
+  description?: string
+  headingAs?: 'h1' | 'h2' | 'h3'
+  id?: string
+  title?: string
+}
+
+const defaultTitle = 'Klinikregistrierung'
+const defaultDescription =
+  'Tragen Sie Ihre Klinik in wenigen Schritten ein. Wir prüfen die Angaben und melden uns, sobald die Registrierung eingeordnet ist.'
+
+export function ClinicRegistrationLandingSection({
+  className,
+  description = defaultDescription,
+  headingAs = 'h2',
+  id = 'clinic-registration',
+  title = defaultTitle,
+}: ClinicRegistrationLandingSectionProps) {
+  const titleId = `${id}-heading`
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className={cn(
+        'scroll-mt-[calc(var(--site-header-height)+1rem)] bg-site-canvas py-16 sm:py-20 md:py-24',
+        className,
+      )}
+      id={id}
+    >
+      <Container>
+        <div className="mx-auto flex w-full max-w-[1184px] flex-col gap-8 sm:gap-10">
+          <SectionHeading
+            align="center"
+            description={description}
+            descriptionClassName="max-w-3xl"
+            headingAs={headingAs}
+            size="section"
+            title={title}
+            titleId={titleId}
+          />
+          <ClinicRegistrationFunnel />
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -9,7 +9,6 @@ import { PublicContactSection } from '@/components/organisms/Contact'
 import { BlogCardCollection } from '@/components/organisms/Blog/BlogCardCollection'
 import { FAQSection } from '@/components/organisms/FAQ'
 import { ScrollReveal } from '@/components/molecules/ScrollReveal'
-import { ClinicRegistrationLandingSection } from './_components/ClinicRegistrationLandingSection'
 import { normalizePost } from '@/utilities/blog/normalizePost'
 import { getLandingMedicalSpecialtyCategories } from '@/utilities/landing/medicalSpecialtyCategories'
 import { getHomeLandingContent } from '@/utilities/landing/landingPageContent'
@@ -166,10 +165,6 @@ export default async function Home({
 
       <ScrollReveal>
         <PublicContactSection title={landingContent.contact.title} description={landingContent.contact.description} />
-      </ScrollReveal>
-
-      <ScrollReveal>
-        <ClinicRegistrationLandingSection className="border-t border-site-divider/60" />
       </ScrollReveal>
     </main>
   )

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -9,6 +9,7 @@ import { PublicContactSection } from '@/components/organisms/Contact'
 import { BlogCardCollection } from '@/components/organisms/Blog/BlogCardCollection'
 import { FAQSection } from '@/components/organisms/FAQ'
 import { ScrollReveal } from '@/components/molecules/ScrollReveal'
+import { ClinicRegistrationLandingSection } from './_components/ClinicRegistrationLandingSection'
 import { normalizePost } from '@/utilities/blog/normalizePost'
 import { getLandingMedicalSpecialtyCategories } from '@/utilities/landing/medicalSpecialtyCategories'
 import { getHomeLandingContent } from '@/utilities/landing/landingPageContent'
@@ -165,6 +166,10 @@ export default async function Home({
 
       <ScrollReveal>
         <PublicContactSection title={landingContent.contact.title} description={landingContent.contact.description} />
+      </ScrollReveal>
+
+      <ScrollReveal>
+        <ClinicRegistrationLandingSection className="border-t border-site-divider/60" />
       </ScrollReveal>
     </main>
   )

--- a/src/app/(frontend)/partners/clinics/page.tsx
+++ b/src/app/(frontend)/partners/clinics/page.tsx
@@ -10,12 +10,12 @@ import {
   LandingTeam,
   LandingTestimonials,
 } from '@/components/organisms/Landing'
-import { PublicContactSection } from '@/components/organisms/Contact'
 import { BlogCardCollection } from '@/components/organisms/Blog/BlogCardCollection'
 import { LandingHero } from '@/components/organisms/Heroes/LandingHero'
 import { CallToAction } from '@/components/organisms/CallToAction'
 import { FAQSection } from '@/components/organisms/FAQ'
 import { ScrollReveal } from '@/components/molecules/ScrollReveal'
+import { ClinicRegistrationLandingSection } from '../../_components/ClinicRegistrationLandingSection'
 import { normalizePost } from '@/utilities/blog/normalizePost'
 import { findLatestPosts } from '@/utilities/content/serverData'
 import { createSiteMetadata } from '@/utilities/generateMeta'
@@ -78,7 +78,7 @@ export default async function ClinicLandingPage() {
             }
             links={[
               {
-                href: landingContent.cta.buttonLink,
+                href: '#contact',
                 label: landingContent.cta.buttonText,
                 appearance: 'default',
                 size: 'lg',
@@ -127,11 +127,7 @@ export default async function ClinicLandingPage() {
         </ScrollReveal>
       ) : null}
       <ScrollReveal>
-        <PublicContactSection
-          title={landingContent.contact.title}
-          description={landingContent.contact.description}
-          formContext="clinic_partner_landing"
-        />
+        <ClinicRegistrationLandingSection className="border-t border-site-divider/60" id="contact" />
       </ScrollReveal>
     </main>
   )


### PR DESCRIPTION
## Management summary

### Deutsch

Die Partnerseite führt interessierte Kliniken jetzt direkt in den passenden Registrierungsprozess statt in das generische Kontaktformular. Die Homepage bleibt patientenorientiert und behält ihren bestehenden Kontaktbereich.

### English

The partner page now guides interested clinics directly into the appropriate registration flow instead of the generic contact form. The homepage remains patient-oriented and keeps its existing contact section.

## What changed

- Adds a route-local `ClinicRegistrationLandingSection` wrapper that places the existing `ClinicRegistrationFunnel` inside the landing-page container rhythm without an additional visible section heading or description.
- Replaces the clinic partner landing page contact section with the clinic registration section.
- Points the partner page CTA to the embedded registration section via `#contact`.
- Keeps the homepage and standalone `/register/clinic` route unchanged.
- Context: findmydoc-platform/management#287.

## UI/UX

<!-- gh-ui-screenshots:start -->
### Partner Page Desktop

![Partner Page Desktop](https://github.com/user-attachments/assets/cdebfd17-2276-4413-a70f-cfdf95dab387)

### Partner Page Mobile

![Partner Page Mobile](https://github.com/user-attachments/assets/4d2718d2-4cb5-45fa-93dd-e4e964f20e70)
<!-- gh-ui-screenshots:end -->

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed.
- [x] `pnpm build`: passed with `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret}`.
- [x] Focused tests: `pnpm playwright test tests/e2e/public/auth.registration.public-smoke.spec.ts --grep "clinic registration"` passed before the scope correction; custom Playwright smoke passed after the correction for `/partners/clinics` CTA scroll, hidden wrapper heading/description, homepage absence of the funnel, and mobile/desktop overflow checks.
- [x] UI/mobile QA: Playwright screenshots captured for the partner landing page at 1280 desktop and 375 mobile; no horizontal overflow or console errors observed.
- [x] Security/privacy review: no API, auth, persistence, cookie, or permission changes; the embedded form still uses local fake-success only.
- [ ] Migration/schema check: not applicable; no Payload collection, field, or migration changes.
- [ ] Documentation/instructions check: not applicable; no operator docs or instruction sources changed.

## Risk and rollout

Risk is limited to partner landing-page layout and CTA behavior. The homepage remains unchanged after scope correction. Rollback is a normal revert of this PR.

## Development

Closes #1213
