### PR TITLE
fix(frontend): improve listing comparison accessibility

### DIFF
--- a/src/app/(frontend)/listing-comparison/ListingComparisonFilters.client.tsx
+++ b/src/app/(frontend)/listing-comparison/ListingComparisonFilters.client.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 
 import { Input } from '@/components/atoms/input'
+import { Label } from '@/components/atoms/label'
 import { CheckboxWithLabel } from '@/components/molecules/CheckboxWithLabel'
 import { ListingFilters } from '@/components/organisms/Listing'
 import type { RatingFilterValue } from '@/components/molecules/RatingFilter'
@@ -63,6 +64,14 @@ type CollapsibleFilterSectionProps = {
   isOpen: boolean
   onToggle: () => void
   children: React.ReactNode
+}
+
+type RadioOptionWithLabelProps = {
+  name: string
+  label: string
+  checked: boolean
+  disabled?: boolean
+  onSelect: () => void
 }
 
 function deduplicateSelections(values: string[]): string[] {
@@ -201,6 +210,46 @@ const CollapsibleFilterSection: React.FC<CollapsibleFilterSectionProps> = ({
   )
 }
 
+function RadioOptionWithLabel({ name, label, checked, disabled, onSelect }: RadioOptionWithLabelProps) {
+  const radioId = React.useId()
+
+  return (
+    <label
+      htmlFor={radioId}
+      className={cn(
+        'flex min-h-11 cursor-pointer items-start gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-muted/40',
+        disabled && 'cursor-not-allowed opacity-60 hover:bg-transparent',
+      )}
+    >
+      <input
+        id={radioId}
+        type="radio"
+        name={name}
+        checked={checked}
+        disabled={disabled}
+        className="peer sr-only"
+        onChange={(event) => {
+          if (event.currentTarget.checked) {
+            onSelect()
+          }
+        }}
+      />
+      <span
+        aria-hidden="true"
+        className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-primary ring-offset-background transition-colors peer-checked:bg-primary peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-offset-2"
+      >
+        <span
+          className={cn(
+            'h-2 w-2 rounded-full bg-primary-foreground transition-opacity',
+            checked ? 'opacity-100' : 'opacity-0',
+          )}
+        />
+      </span>
+      <span className="min-w-0 flex-1 pt-0.5 text-sm leading-5 font-normal break-words">{label}</span>
+    </label>
+  )
+}
+
 export function ListingComparisonFilters({
   cityOptions = [],
   specialtyOptions = [],
@@ -246,6 +295,9 @@ export function ListingComparisonFilters({
   const [treatmentSearch, setTreatmentSearch] = React.useState('')
   const [priceRange, setPriceRange] = React.useState<[number, number]>(initialPriceRange)
   const [rating, setRating] = React.useState<RatingFilterValue>(initialValues?.rating ?? null)
+  const medicalSpecialtyGroupName = React.useId()
+  const subspecialtyGroupName = React.useId()
+  const treatmentSearchId = React.useId()
 
   const normalizedCityOptions = React.useMemo(
     () => cityOptions.map((option) => normalizeCheckboxOption(option)),
@@ -555,30 +607,24 @@ export function ListingComparisonFilters({
             isOpen={openSections.medicalSpecialty}
             onToggle={() => toggleOpenSection('medicalSpecialty')}
           >
-            <div className="space-y-2">
-              <CheckboxWithLabel
+            <div className="space-y-2" role="radiogroup" aria-label="Medical Specialty">
+              <RadioOptionWithLabel
+                name={medicalSpecialtyGroupName}
                 label="All specialties"
                 checked={specialty === null}
-                onCheckedChange={(checked) => {
-                  if (!checked) return
+                onSelect={() => {
                   handleSpecialtyChange(null)
                 }}
               />
 
               {parentSpecialtyOptions.map((option) => (
-                <CheckboxWithLabel
+                <RadioOptionWithLabel
                   key={option.value}
+                  name={medicalSpecialtyGroupName}
                   label={option.label}
                   checked={selectedParentSpecialty === option.value}
-                  onCheckedChange={(checked) => {
-                    if (checked) {
-                      handleSpecialtyChange(option.value)
-                      return
-                    }
-
-                    if (selectedParentSpecialty === option.value) {
-                      handleSpecialtyChange(null)
-                    }
+                  onSelect={() => {
+                    handleSpecialtyChange(option.value)
                   }}
                 />
               ))}
@@ -595,30 +641,24 @@ export function ListingComparisonFilters({
             isOpen={openSections.subspecialty}
             onToggle={() => toggleOpenSection('subspecialty')}
           >
-            <div className="space-y-2">
-              <CheckboxWithLabel
+            <div className="space-y-2" role="radiogroup" aria-label="Subspecialty">
+              <RadioOptionWithLabel
+                name={subspecialtyGroupName}
                 label="All subspecialties"
                 checked={selectedChildSpecialty === null}
-                onCheckedChange={(checked) => {
-                  if (!checked) return
+                onSelect={() => {
                   handleSpecialtyChange(selectedParentSpecialty)
                 }}
               />
 
               {visibleChildSpecialtyOptions.map((option) => (
-                <CheckboxWithLabel
+                <RadioOptionWithLabel
                   key={option.value}
+                  name={subspecialtyGroupName}
                   label={option.label}
                   checked={selectedChildSpecialty === option.value}
-                  onCheckedChange={(checked) => {
-                    if (checked) {
-                      handleSpecialtyChange(option.value)
-                      return
-                    }
-
-                    if (selectedChildSpecialty === option.value) {
-                      handleSpecialtyChange(selectedParentSpecialty)
-                    }
+                  onSelect={() => {
+                    handleSpecialtyChange(option.value)
                   }}
                 />
               ))}
@@ -640,7 +680,11 @@ export function ListingComparisonFilters({
         >
           <div className="space-y-3">
             <div className="flex items-center gap-2">
+              <Label htmlFor={treatmentSearchId} className="sr-only">
+                Search treatments
+              </Label>
               <Input
+                id={treatmentSearchId}
                 type="text"
                 value={treatmentSearch}
                 placeholder="Search treatments"

--- a/src/app/(frontend)/listing-comparison/ListingComparisonPage.client.tsx
+++ b/src/app/(frontend)/listing-comparison/ListingComparisonPage.client.tsx
@@ -193,6 +193,9 @@ export function ListingComparisonPageClient({
             isPatient={favorites.isPatient}
             loginHref={loginHref}
             variant="icon"
+            savedAriaLabel={`Remove ${data.name} from saved clinics`}
+            unsavedAriaLabel={`Save ${data.name} to saved clinics`}
+            pendingAriaLabel={`Updating saved status for ${data.name}`}
           />
         )
       }}

--- a/src/components/atoms/slider.tsx
+++ b/src/components/atoms/slider.tsx
@@ -10,10 +10,12 @@ export type SliderProps = Omit<
 > & {
   value: number[]
   onValueChange: (value: number[]) => void
+  thumbLabels?: string[]
+  getThumbValueText?: (value: number, index: number) => string
 }
 
 export const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, SliderProps>(
-  ({ className, value, onValueChange, ...props }, ref) => {
+  ({ className, value, onValueChange, thumbLabels, getThumbValueText, ...props }, ref) => {
     const resolvedValues = React.useMemo(() => (value.length ? value : [0]), [value])
     const activeThumbIndexRef = React.useRef<number | null>(null)
 
@@ -58,6 +60,10 @@ export const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.R
           <SliderPrimitive.Thumb
             // Radix uses index-based keys internally; mirroring that here is fine.
             key={index}
+            aria-label={thumbLabels?.[index]}
+            aria-valuetext={
+              getThumbValueText ? getThumbValueText(resolvedValues[index] ?? resolvedValues[0] ?? 0, index) : undefined
+            }
             onPointerDown={() => {
               activeThumbIndexRef.current = index
             }}

--- a/src/components/molecules/RatingFilter/index.tsx
+++ b/src/components/molecules/RatingFilter/index.tsx
@@ -43,6 +43,7 @@ export function RatingFilter({ label = 'Minimum rating', defaultValue = null, va
             type="button"
             size="xs"
             variant={option.value === current ? 'filter' : 'outline'}
+            aria-pressed={option.value === current}
             className="rounded-lg px-4"
             onClick={() => handleSelect(option.value)}
           >

--- a/src/components/organisms/Listing/ListingCard.tsx
+++ b/src/components/organisms/Listing/ListingCard.tsx
@@ -44,8 +44,8 @@ export type ListingCardData = {
     label: string
   }
   actions: {
-    details: { href: string; label: string }
-    compare?: { href: string; label: string }
+    details: { href: string; label: string; ariaLabel?: string }
+    compare?: { href: string; label: string; ariaLabel?: string }
   }
 }
 
@@ -114,11 +114,15 @@ export function ListingCard({
 
         <div className={cn('flex shrink-0 flex-col gap-3 md:w-36 md:items-end', cornerAction ? 'md:pt-14' : 'md:pt-1')}>
           <Button asChild className="h-12 w-full text-sm font-semibold">
-            <a href={data.actions.details.href}>{data.actions.details.label}</a>
+            <a href={data.actions.details.href} aria-label={data.actions.details.ariaLabel}>
+              {data.actions.details.label}
+            </a>
           </Button>
           {data.actions.compare ? (
             <Button asChild variant="secondary" className="h-12 w-full text-sm font-semibold text-foreground">
-              <a href={data.actions.compare.href}>{data.actions.compare.label}</a>
+              <a href={data.actions.compare.href} aria-label={data.actions.compare.ariaLabel}>
+                {data.actions.compare.label}
+              </a>
             </Button>
           ) : null}
         </div>

--- a/src/components/organisms/Listing/ListingFilters.tsx
+++ b/src/components/organisms/Listing/ListingFilters.tsx
@@ -202,6 +202,8 @@ const Price = ({ className, min, max, step }: { className?: string; min?: number
             )
           }
         }}
+        thumbLabels={['Minimum price', 'Maximum price']}
+        getThumbValueText={(value) => `${value.toLocaleString('en-US')} euros`}
       />
       <div className="flex items-center justify-between text-sm font-medium text-muted-foreground">
         <span>{displayedRange[0].toLocaleString('en-US')}€</span>

--- a/src/components/templates/ListingComparison/Component.tsx
+++ b/src/components/templates/ListingComparison/Component.tsx
@@ -39,7 +39,7 @@ export function ListingComparison({
 
   const defaultHeader = sortControl ? (
     <div className="flex flex-wrap items-center justify-between gap-4">
-      <p className="text-sm text-muted-foreground">
+      <p className="text-sm text-muted-foreground" role="status" aria-live="polite" aria-atomic="true">
         Showing <span className="font-semibold text-foreground">{visibleCount}</span> of{' '}
         <span className="font-semibold text-foreground">{totalCount}</span> {resultsLabel}
       </p>

--- a/src/features/favorites/FavoriteClinicButton.tsx
+++ b/src/features/favorites/FavoriteClinicButton.tsx
@@ -30,6 +30,8 @@ export type FavoriteClinicButtonProps = {
   unsavedLabel?: string
   pendingLabel?: string
   buttonAriaLabel?: string
+  savedAriaLabel?: string
+  unsavedAriaLabel?: string
   pendingAriaLabel?: string
   showIcon?: boolean
   className?: string
@@ -148,6 +150,8 @@ export function FavoriteClinicButton({
   unsavedLabel = 'Save',
   pendingLabel = 'Saving...',
   buttonAriaLabel,
+  savedAriaLabel,
+  unsavedAriaLabel,
   pendingAriaLabel,
   showIcon = true,
   className,
@@ -162,7 +166,11 @@ export function FavoriteClinicButton({
   const isIconVariant = variant === 'icon'
   const shouldShowIcon = isIconVariant || showIcon
   const content = isIconVariant ? <span className="sr-only">{label}</span> : label
-  const accessibleLabel = isPending ? (pendingAriaLabel ?? buttonAriaLabel) : buttonAriaLabel
+  const accessibleLabel = isPending
+    ? (pendingAriaLabel ?? buttonAriaLabel)
+    : isFavorite
+      ? (savedAriaLabel ?? buttonAriaLabel)
+      : (unsavedAriaLabel ?? buttonAriaLabel)
   const buttonVariant = isIconVariant
     ? 'secondary'
     : variant === 'list'
@@ -229,7 +237,7 @@ export function FavoriteClinicButton({
           className,
         )}
       >
-        <Link href={loginHref} aria-label={buttonAriaLabel}>
+        <Link href={loginHref} aria-label={unsavedAriaLabel ?? buttonAriaLabel}>
           {shouldShowIcon ? <Heart className="size-4" aria-hidden={true} /> : null}
           {isIconVariant ? <span className="sr-only">{unsavedLabel}</span> : unsavedLabel}
         </Link>

--- a/src/utilities/listingComparison/serverData/presentation.ts
+++ b/src/utilities/listingComparison/serverData/presentation.ts
@@ -161,6 +161,7 @@ export function mapListingCardResults(pageRows: ClinicRow[], reviewCounts: Map<n
         details: {
           href: `/clinics/${encodeURIComponent(slug)}`,
           label: 'Details',
+          ariaLabel: `View details for ${clinic.name}`,
         },
       },
     }

--- a/src/utilities/listingComparison/serverData/presentation.ts
+++ b/src/utilities/listingComparison/serverData/presentation.ts
@@ -162,10 +162,6 @@ export function mapListingCardResults(pageRows: ClinicRow[], reviewCounts: Map<n
           href: `/clinics/${encodeURIComponent(slug)}`,
           label: 'Details',
         },
-        compare: {
-          href: '#',
-          label: 'Compare',
-        },
       },
     }
   })

--- a/tests/unit/components/listingCard.test.tsx
+++ b/tests/unit/components/listingCard.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { ListingCard, type ListingCardData } from '@/components/organisms/Listing'
+
+const baseCard: ListingCardData = {
+  id: 'listing-card-test',
+  name: 'Accessible Clinic',
+  location: 'Berlin, Mitte',
+  media: {
+    src: '/images/placeholder-576-968.svg',
+    alt: 'Accessible Clinic image',
+  },
+  verification: {
+    variant: 'gold',
+  },
+  rating: {
+    value: 4.8,
+    count: 12,
+  },
+  tags: ['Orthopedics'],
+  actions: {
+    details: {
+      href: '/clinics/accessible-clinic',
+      label: 'Details',
+      ariaLabel: 'View details for Accessible Clinic',
+    },
+    compare: {
+      href: '#compare',
+      label: 'Compare',
+      ariaLabel: 'Compare Accessible Clinic',
+    },
+  },
+}
+
+describe('ListingCard', () => {
+  it('uses clinic-specific accessible names for repeated card actions', () => {
+    render(<ListingCard data={baseCard} />)
+
+    expect(screen.getByRole('link', { name: 'View details for Accessible Clinic' })).toHaveAttribute(
+      'href',
+      '/clinics/accessible-clinic',
+    )
+    expect(screen.getByRole('link', { name: 'Compare Accessible Clinic' })).toHaveAttribute('href', '#compare')
+  })
+})

--- a/tests/unit/components/listingComparisonFilters.test.tsx
+++ b/tests/unit/components/listingComparisonFilters.test.tsx
@@ -124,7 +124,7 @@ describe('ListingComparisonFilters', () => {
 
     expect(screen.queryByRole('checkbox', { name: 'Dental implant' })).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Dental' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'Dental' }))
 
     fireEvent.click(screen.getByRole('checkbox', { name: 'Dental implant' }))
 
@@ -166,7 +166,7 @@ describe('ListingComparisonFilters', () => {
       />,
     )
 
-    fireEvent.change(screen.getByPlaceholderText('Search treatments'), { target: { value: 'dental' } })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search treatments' }), { target: { value: 'dental' } })
 
     expect(screen.getByRole('checkbox', { name: 'Dental implant' })).toBeInTheDocument()
     expect(screen.queryByRole('checkbox', { name: 'Rhinoplasty' })).not.toBeInTheDocument()
@@ -197,7 +197,7 @@ describe('ListingComparisonFilters', () => {
       />,
     )
 
-    fireEvent.change(screen.getByPlaceholderText('Search treatments'), { target: { value: 'bleph' } })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search treatments' }), { target: { value: 'bleph' } })
 
     expect(screen.getByRole('checkbox', { name: 'Rhinoplasty' })).toBeInTheDocument()
     expect(screen.getByRole('checkbox', { name: 'Blepharoplasty' })).toBeInTheDocument()

--- a/tests/unit/components/listingFilters.test.tsx
+++ b/tests/unit/components/listingFilters.test.tsx
@@ -1,11 +1,31 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom'
 import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { ListingFilters } from '@/components/organisms/Listing/ListingFilters'
 
 describe('ListingFilters', () => {
+  beforeAll(() => {
+    class ResizeObserverMock {
+      observe() {
+        return undefined
+      }
+      unobserve() {
+        return undefined
+      }
+      disconnect() {
+        return undefined
+      }
+    }
+
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+  })
+
+  afterAll(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('emits the current price range when an uncontrolled rating selection changes', () => {
     const onValueChange = vi.fn()
 
@@ -21,6 +41,7 @@ describe('ListingFilters', () => {
       priceRange: [1000, 4000],
       rating: 4,
     })
+    expect(screen.getByRole('button', { name: '4+ ★' })).toHaveAttribute('aria-pressed', 'true')
   })
 
   it('keeps controlled values intact when emitting rating changes', () => {
@@ -38,5 +59,16 @@ describe('ListingFilters', () => {
       priceRange: [2000, 8000],
       rating: null,
     })
+  })
+
+  it('labels both price slider thumbs', () => {
+    render(
+      <ListingFilters.Root defaultPriceRange={[1000, 4000]}>
+        <ListingFilters.Price />
+      </ListingFilters.Root>,
+    )
+
+    expect(screen.getByRole('slider', { name: 'Minimum price' })).toHaveAttribute('aria-valuetext', '1,000 euros')
+    expect(screen.getByRole('slider', { name: 'Maximum price' })).toHaveAttribute('aria-valuetext', '4,000 euros')
   })
 })

--- a/tests/unit/features/favorites/FavoriteClinicButton.test.tsx
+++ b/tests/unit/features/favorites/FavoriteClinicButton.test.tsx
@@ -46,6 +46,31 @@ describe('FavoriteClinicButton', () => {
     )
   })
 
+  it('uses state-specific accessible names when provided', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ id: 55 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <FavoriteClinicButton
+        clinicId={12}
+        isPatient={true}
+        loginHref="/login/patient?next=%2Flisting-comparison"
+        variant="icon"
+        savedAriaLabel="Remove Alpha Clinic from saved clinics"
+        unsavedAriaLabel="Save Alpha Clinic to saved clinics"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Alpha Clinic to saved clinics' }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Remove Alpha Clinic from saved clinics' })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      ),
+    )
+  })
+
   it('creates a favorite and reflects the saved state', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ id: 55 }))
     vi.stubGlobal('fetch', fetchMock)


### PR DESCRIPTION
Improve keyboard and screen-reader clarity on the clinic comparison page.

## What changed

- Add accessible price slider thumb names and value text.
- Label treatment search and expose rating selection state.
- Use radio semantics for single-select specialty filters.
- Announce result count changes and give saved-clinic icon actions clinic-specific names.
- Give repeated listing card action links clinic-specific accessible names.
- Remove the placeholder `Compare` link from server-backed listing cards until compare behavior is source-backed.

## UI/UX

<!-- gh-ui-screenshots:start -->
### Listing Comparison Accessibility

![Listing Comparison Accessibility](https://github.com/user-attachments/assets/c24f6400-c7f2-4dc9-b6c4-6b1f14291f03)
<!-- gh-ui-screenshots:end -->

## Validation

- [x] UI/mobile QA: Screenshots are documented in `## UI/UX`.
- [x] `rtk pnpm format`
- [x] `rtk pnpm exec vitest tests/unit/components/listingCard.test.tsx tests/unit/components/listingFilters.test.tsx tests/unit/components/listingComparisonFilters.test.tsx tests/unit/features/favorites/FavoriteClinicButton.test.tsx tests/unit/utilities/listingComparisonPresentation.test.ts`
- [x] `rtk pnpm check`
- [x] `rtk bash -lc 'PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build'`
- [x] Playwright route check for `/listing-comparison`; console showed only local env/dev noise after restarting with `PAYLOAD_SECRET`.
- [x] Accessibility reviewer re-run after follow-up: no findings at `5/10` or higher.

Screenshots:
- `output/playwright/listing-comparison-a11y-fixed.png`

## Development

Closes #1215
