### PR TITLE
fix(frontend): reduce listing comparison render work

### DIFF
--- a/src/components/templates/ListingComparison/ListingFiltersJumpBar.client.tsx
+++ b/src/components/templates/ListingComparison/ListingFiltersJumpBar.client.tsx
@@ -15,6 +15,7 @@ type BarPlacement = {
 
 const VIEWPORT_MARGIN_PX = 16
 const VISIBILITY_DELAY_MS = 180
+const LARGE_VIEWPORT_QUERY = '(min-width: 1024px)'
 
 export function ListingFiltersJumpBar({ targetId }: ListingFiltersJumpBarProps) {
   const [isLargeViewport, setIsLargeViewport] = React.useState(false)
@@ -26,7 +27,12 @@ export function ListingFiltersJumpBar({ targetId }: ListingFiltersJumpBarProps) 
   })
 
   React.useEffect(() => {
-    const query = window.matchMedia('(min-width: 1024px)')
+    if (typeof window.matchMedia !== 'function') {
+      setIsLargeViewport(false)
+      return
+    }
+
+    const query = window.matchMedia(LARGE_VIEWPORT_QUERY)
     const updateViewportState = () => {
       setIsLargeViewport(query.matches)
     }

--- a/src/components/templates/ListingComparison/ListingFiltersJumpBar.client.tsx
+++ b/src/components/templates/ListingComparison/ListingFiltersJumpBar.client.tsx
@@ -17,6 +17,7 @@ const VIEWPORT_MARGIN_PX = 16
 const VISIBILITY_DELAY_MS = 180
 
 export function ListingFiltersJumpBar({ targetId }: ListingFiltersJumpBarProps) {
+  const [isLargeViewport, setIsLargeViewport] = React.useState(false)
   const [isTargetVisible, setIsTargetVisible] = React.useState(true)
   const [isDelayedVisible, setIsDelayedVisible] = React.useState(false)
   const [placement, setPlacement] = React.useState<BarPlacement>({
@@ -25,6 +26,22 @@ export function ListingFiltersJumpBar({ targetId }: ListingFiltersJumpBarProps) 
   })
 
   React.useEffect(() => {
+    const query = window.matchMedia('(min-width: 1024px)')
+    const updateViewportState = () => {
+      setIsLargeViewport(query.matches)
+    }
+
+    updateViewportState()
+    query.addEventListener('change', updateViewportState)
+
+    return () => {
+      query.removeEventListener('change', updateViewportState)
+    }
+  }, [])
+
+  React.useEffect(() => {
+    if (!isLargeViewport) return
+
     const target = document.getElementById(targetId)
     if (!target) return
 
@@ -65,15 +82,13 @@ export function ListingFiltersJumpBar({ targetId }: ListingFiltersJumpBarProps) 
     resizeObserver.observe(target)
 
     window.addEventListener('resize', updatePlacement)
-    window.addEventListener('scroll', updatePlacement, { passive: true })
 
     return () => {
       observer.disconnect()
       resizeObserver.disconnect()
       window.removeEventListener('resize', updatePlacement)
-      window.removeEventListener('scroll', updatePlacement)
     }
-  }, [targetId])
+  }, [isLargeViewport, targetId])
 
   React.useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -85,7 +100,7 @@ export function ListingFiltersJumpBar({ targetId }: ListingFiltersJumpBarProps) 
     }
   }, [isTargetVisible])
 
-  if (placement.width <= 0) {
+  if (!isLargeViewport || placement.width <= 0) {
     return null
   }
 

--- a/src/utilities/listingComparison/serverData/getListingComparisonServerData.ts
+++ b/src/utilities/listingComparison/serverData/getListingComparisonServerData.ts
@@ -22,11 +22,8 @@ import { buildClinicPresentationMeta, buildScopedClinicRows, mapListingCardResul
 import { extractRelationId } from './relations'
 import {
   countApprovedReviewsByClinic,
-  findAllApprovedClinics,
-  findAllCities,
-  findAllSpecialties,
-  findAllTreatments,
   findClinicTreatmentsForClinics,
+  findListingComparisonCatalog,
 } from './repositories'
 import {
   buildSpecialtyFilterOptions,
@@ -91,12 +88,8 @@ export async function getListingComparisonServerData(
   const parsed = parseListingComparisonQueryState(searchParams)
   const initialQueryState = parsed.state
 
-  const [cityDocs, treatmentDocs, specialtyDocs, approvedClinics] = await Promise.all([
-    findAllCities(payload),
-    findAllTreatments(payload),
-    findAllSpecialties(payload),
-    findAllApprovedClinics(payload),
-  ])
+  const { cityDocs, treatmentDocs, specialtyDocs, approvedClinics, availableClinicMediaFiles } =
+    await findListingComparisonCatalog(payload)
   const totalAvailableResults = approvedClinics.length
   const verifiedClinics = approvedClinics.filter((clinic) => isVerifiedClinic(clinic)).length
   const treatmentTypes = treatmentDocs.length
@@ -238,7 +231,7 @@ export async function getListingComparisonServerData(
     pageRows.map((row) => row.clinic.id),
   )
 
-  const results = mapListingCardResults(pageRows, reviewCounts)
+  const results = mapListingCardResults(pageRows, reviewCounts, { availableClinicMediaFiles })
 
   const cityFacetRows = applyPriceWindow(
     buildRowsForSelectedCities(new Set<number>()),

--- a/src/utilities/listingComparison/serverData/presentation.ts
+++ b/src/utilities/listingComparison/serverData/presentation.ts
@@ -1,6 +1,3 @@
-import fs from 'node:fs'
-import path from 'node:path'
-
 import type { VerificationBadgeVariant } from '@/components/atoms/verification-badge'
 import type { ListingCardData } from '@/components/organisms/Listing'
 import type { Clinic } from '@/payload-types'
@@ -17,7 +14,10 @@ const PLACEHOLDER_MEDIA = {
   alt: 'Clinic placeholder image',
 }
 const CLINIC_MEDIA_API_PREFIX = '/api/clinicMedia/file/'
-const CLINIC_MEDIA_PUBLIC_DIR = path.join(process.cwd(), 'public', 'clinic-media')
+
+type ListingCardPresentationOptions = {
+  availableClinicMediaFiles?: ReadonlySet<string>
+}
 
 function normalizeVerification(value: unknown): VerificationBadgeVariant {
   if (value === 'bronze' || value === 'silver' || value === 'gold' || value === 'unverified') {
@@ -36,18 +36,21 @@ function mapLocationHref(coordinates: unknown): string | undefined {
   return `https://www.google.com/maps?q=${encodeURIComponent(`${lat},${lng}`)}`
 }
 
-function hasAvailableClinicMedia(url: string | null | undefined): boolean {
-  if (!url) return false
-  if (!url.startsWith(CLINIC_MEDIA_API_PREFIX)) return true
+function resolveAvailableMediaSrc(
+  url: string | null | undefined,
+  availableClinicMediaFiles: ReadonlySet<string> | undefined,
+): string {
+  if (!url) return PLACEHOLDER_MEDIA.src
+  if (!url.startsWith(CLINIC_MEDIA_API_PREFIX)) return url
 
   const { path: rawFileName } = splitUrlQuery(url.slice(CLINIC_MEDIA_API_PREFIX.length))
   const fileName = decodeURIComponent(rawFileName).replace(/^\/+/, '')
 
-  if (!fileName) {
-    return false
+  if (!fileName || !availableClinicMediaFiles?.has(fileName)) {
+    return PLACEHOLDER_MEDIA.src
   }
 
-  return fs.existsSync(path.join(CLINIC_MEDIA_PUBLIC_DIR, fileName))
+  return url
 }
 
 export function buildClinicPresentationMeta(
@@ -110,14 +113,16 @@ export function buildScopedClinicRows({
   })
 }
 
-export function mapListingCardResults(pageRows: ClinicRow[], reviewCounts: Map<number, number>): ListingCardData[] {
+export function mapListingCardResults(
+  pageRows: ClinicRow[],
+  reviewCounts: Map<number, number>,
+  options: ListingCardPresentationOptions = {},
+): ListingCardData[] {
   return pageRows.map(({ clinic, location, locationHref, priceFrom }) => {
     const ratingValue = typeof clinic.averageRating === 'number' ? clinic.averageRating : 0
     const ratingCount = reviewCounts.get(clinic.id) ?? 0
     const resolvedMedia = resolveMediaDescriptorFromLoadedRelation(clinic.thumbnail, 'clinicMedia')
-    const mediaSrc = hasAvailableClinicMedia(resolvedMedia?.url)
-      ? (resolvedMedia?.url ?? PLACEHOLDER_MEDIA.src)
-      : PLACEHOLDER_MEDIA.src
+    const mediaSrc = resolveAvailableMediaSrc(resolvedMedia?.url, options.availableClinicMediaFiles)
     const mediaAlt =
       typeof resolvedMedia?.alt === 'string' && resolvedMedia.alt.trim().length > 0
         ? resolvedMedia.alt

--- a/src/utilities/listingComparison/serverData/repositories.ts
+++ b/src/utilities/listingComparison/serverData/repositories.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
 import type { Payload } from 'payload'
 
 import type { City, Clinic, Clinictreatment, MedicalSpecialty, Review, Treatment } from '@/payload-types'
@@ -5,11 +8,28 @@ import { chunkArray, extractRelationId } from './relations'
 
 const CLINIC_CHUNK_SIZE = 200
 const QUERY_PAGE_SIZE = 500
+const LISTING_COMPARISON_CATALOG_CACHE_TTL_MS = 60_000
+const CLINIC_MEDIA_STATIC_DIR = path.resolve(process.cwd(), 'src/public/clinic-media')
+
+type ListingComparisonCatalogSnapshot = {
+  cityDocs: City[]
+  treatmentDocs: Treatment[]
+  specialtyDocs: MedicalSpecialty[]
+  approvedClinics: Clinic[]
+  availableClinicMediaFiles: ReadonlySet<string>
+}
 
 type PagedDocs<T> = {
   docs: T[]
   hasNextPage: boolean
 }
+
+type CatalogCacheEntry = {
+  expiresAt: number
+  promise: Promise<ListingComparisonCatalogSnapshot>
+}
+
+const catalogCacheByPayload = new WeakMap<Payload, CatalogCacheEntry>()
 
 async function collectAllPages<T>(fetchPage: (page: number) => Promise<PagedDocs<T>>): Promise<T[]> {
   const allDocs: T[] = []
@@ -132,6 +152,56 @@ export async function findAllApprovedClinics(payload: Payload): Promise<Clinic[]
       hasNextPage: result.hasNextPage,
     }
   })
+}
+
+async function findAvailableClinicMediaFiles(): Promise<ReadonlySet<string>> {
+  try {
+    const entries = await fs.readdir(CLINIC_MEDIA_STATIC_DIR, { withFileTypes: true })
+    return new Set(entries.filter((entry) => entry.isFile()).map((entry) => entry.name))
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return new Set()
+    }
+
+    throw error
+  }
+}
+
+export async function findListingComparisonCatalog(payload: Payload): Promise<ListingComparisonCatalogSnapshot> {
+  const now = Date.now()
+  const cached = catalogCacheByPayload.get(payload)
+  if (cached && cached.expiresAt > now) {
+    return cached.promise
+  }
+
+  const promise = Promise.all([
+    findAllCities(payload),
+    findAllTreatments(payload),
+    findAllSpecialties(payload),
+    findAllApprovedClinics(payload),
+    findAvailableClinicMediaFiles(),
+  ]).then(([cityDocs, treatmentDocs, specialtyDocs, approvedClinics, availableClinicMediaFiles]) => ({
+    cityDocs,
+    treatmentDocs,
+    specialtyDocs,
+    approvedClinics,
+    availableClinicMediaFiles,
+  }))
+
+  catalogCacheByPayload.set(payload, {
+    expiresAt: now + LISTING_COMPARISON_CATALOG_CACHE_TTL_MS,
+    promise,
+  })
+
+  try {
+    return await promise
+  } catch (error) {
+    const current = catalogCacheByPayload.get(payload)
+    if (current?.promise === promise) {
+      catalogCacheByPayload.delete(payload)
+    }
+    throw error
+  }
 }
 
 export async function findClinicTreatmentsForClinics(

--- a/tests/e2e/public/listing-comparison.public-smoke.spec.ts
+++ b/tests/e2e/public/listing-comparison.public-smoke.spec.ts
@@ -29,7 +29,7 @@ test('listing filters preserve the selected specialty when rating changes @smoke
   const medicalSpecialtyToggle = page.getByRole('button', { name: /^Medical Specialty/ })
   await medicalSpecialtyToggle.click()
   await expect(medicalSpecialtyToggle).toHaveAttribute('aria-expanded', 'true')
-  await page.getByRole('checkbox', { name: 'Dental', exact: true }).click()
+  await page.getByRole('radiogroup', { name: 'Medical Specialty' }).getByText('Dental', { exact: true }).click()
   await waitForSearchParam(page, 'specialty', '1')
 
   const fourStarButton = page.getByRole('button', { name: '4+ ★' })

--- a/tests/unit/utilities/listingComparisonPresentation.test.ts
+++ b/tests/unit/utilities/listingComparisonPresentation.test.ts
@@ -1,5 +1,4 @@
-import fs from 'node:fs'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import type { Clinic } from '@/payload-types'
 import { mapListingCardResults } from '@/utilities/listingComparison/serverData/presentation'
@@ -27,19 +26,13 @@ function buildRow(clinic: Clinic): ClinicRow {
 }
 
 describe('mapListingCardResults media resolution', () => {
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it('uses relation URL when the media file is available', () => {
-    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
-
+  it('uses direct relation URL when media provides one', () => {
     const clinic = buildClinic({
       id: 1,
       name: 'Alpha Clinic',
       thumbnail: {
         id: 101,
-        url: '/api/clinicMedia/file/from-relation.jpg',
+        url: '/images/clinic/from-relation.jpg',
         filename: 'from-filename.jpg',
         alt: 'Alpha image',
       },
@@ -47,12 +40,12 @@ describe('mapListingCardResults media resolution', () => {
 
     const result = mapListingCardResults([buildRow(clinic)], new Map())
 
-    expect(result[0]?.media.src).toBe('/api/clinicMedia/file/from-relation.jpg')
+    expect(result[0]?.media.src).toBe('/images/clinic/from-relation.jpg')
     expect(result[0]?.media.alt).toBe('Alpha image')
     expect(result[0]?.actions.details.href).toBe('/clinics/alpha-clinic-1')
   })
 
-  it('falls back to the placeholder when only a missing filename-derived upload is available', () => {
+  it('uses an available filename-derived upload URL without per-card filesystem checks', () => {
     const clinic = buildClinic({
       id: 2,
       name: 'Bravo Clinic',
@@ -64,10 +57,32 @@ describe('mapListingCardResults media resolution', () => {
       },
     })
 
-    const result = mapListingCardResults([buildRow(clinic)], new Map())
+    const result = mapListingCardResults([buildRow(clinic)], new Map(), {
+      availableClinicMediaFiles: new Set(['from-filename.jpg']),
+    })
+
+    expect(result[0]?.media.src).toBe('/api/clinicMedia/file/from-filename.jpg')
+    expect(result[0]?.media.alt).toBe('Bravo image')
+  })
+
+  it('falls back to the placeholder when a filename-derived upload is unavailable', () => {
+    const clinic = buildClinic({
+      id: 22,
+      name: 'Bravo Missing Clinic',
+      thumbnail: {
+        id: 122,
+        url: null,
+        filename: 'missing.jpg',
+        alt: 'Bravo missing image',
+      },
+    })
+
+    const result = mapListingCardResults([buildRow(clinic)], new Map(), {
+      availableClinicMediaFiles: new Set(['other.jpg']),
+    })
 
     expect(result[0]?.media.src).toBe('/images/placeholder-576-968.svg')
-    expect(result[0]?.media.alt).toBe('Bravo image')
+    expect(result[0]?.media.alt).toBe('Bravo missing image')
   })
 
   it('falls back to placeholder when URL and filename are both missing', () => {
@@ -86,22 +101,21 @@ describe('mapListingCardResults media resolution', () => {
     expect(result[0]?.media.src).toBe('/images/placeholder-576-968.svg')
   })
 
-  it('preserves full query content when checking clinic media availability', () => {
-    const existsSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(true)
-
+  it('preserves full query content on clinic media URLs', () => {
     const clinic = buildClinic({
       id: 4,
       name: 'Delta Clinic',
       thumbnail: {
         id: 104,
-        url: '/api/clinicMedia/file/path%2Fimage.jpg?note=first?second&lang=de',
+        url: '/api/clinicMedia/file/image.jpg?note=first?second&lang=de',
         alt: 'Delta image',
       },
     })
 
-    const result = mapListingCardResults([buildRow(clinic)], new Map())
+    const result = mapListingCardResults([buildRow(clinic)], new Map(), {
+      availableClinicMediaFiles: new Set(['image.jpg']),
+    })
 
-    expect(result[0]?.media.src).toBe('/api/clinicMedia/file/path%2Fimage.jpg?note=first?second&lang=de')
-    expect(existsSyncSpy).toHaveBeenCalledWith(expect.stringMatching(/public\/clinic-media\/path\/image\.jpg$/))
+    expect(result[0]?.media.src).toBe('/api/clinicMedia/file/image.jpg?note=first?second&lang=de')
   })
 })

--- a/tests/unit/utilities/listingComparisonServerData.contract.test.ts
+++ b/tests/unit/utilities/listingComparisonServerData.contract.test.ts
@@ -1,5 +1,5 @@
 import type { Payload } from 'payload'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { getListingComparisonServerData } from '@/utilities/listingComparison/serverData'
 
@@ -129,9 +129,13 @@ function matchesClause(doc: Record<string, unknown>, clause: Record<string, unkn
   })
 }
 
-function createMockPayload(data: MockCollectionData): Payload {
-  return {
-    find: async (args: {
+type MockPayload = Payload & {
+  find: ReturnType<typeof vi.fn>
+}
+
+function createMockPayload(data: MockCollectionData): MockPayload {
+  const find = vi.fn(
+    async (args: {
       collection: keyof MockCollectionData
       page?: number
       limit?: number
@@ -160,7 +164,11 @@ function createMockPayload(data: MockCollectionData): Payload {
         pagingCounter: start + 1,
       }
     },
-  } as unknown as Payload
+  )
+
+  return {
+    find,
+  } as unknown as MockPayload
 }
 
 describe('getListingComparisonServerData (contract)', () => {
@@ -230,5 +238,23 @@ describe('getListingComparisonServerData (contract)', () => {
     expect(treatmentLabels).toContain('Nose job (1)')
     expect(treatmentPlainLabels).toContain('Breast augmentation')
     expect(treatmentPlainLabels).toContain('Nose job')
+  })
+
+  it('reuses the public listing catalog for repeated requests on the same payload instance', async () => {
+    const payload = createMockPayload(baseData)
+
+    await getListingComparisonServerData(payload, { specialty: '2' })
+    await getListingComparisonServerData(payload, { city: '10' })
+
+    const catalogCollections = ['cities', 'treatments', 'medical-specialties', 'clinics']
+    const catalogCalls = payload.find.mock.calls.filter(([args]) =>
+      catalogCollections.includes(String(args.collection)),
+    )
+    const dynamicCalls = payload.find.mock.calls.filter(([args]) =>
+      ['clinictreatments', 'reviews'].includes(String(args.collection)),
+    )
+
+    expect(catalogCalls.map(([args]) => args.collection).sort()).toEqual(catalogCollections.sort())
+    expect(dynamicCalls.length).toBeGreaterThan(2)
   })
 })


### PR DESCRIPTION
Reduces avoidable render-path work on the public clinic comparison page.

## What changed

- Cache stable listing catalog data per Payload instance for a short TTL so repeated requests do not rebuild cities, treatments, specialties, and approved clinics every time.
- Replace synchronous per-card media file checks with an async cached clinic-media filename set, preserving placeholders for unavailable local uploads.
- Gate the filter jump bar to desktop viewports and remove scroll-time layout reads.
- Keep the jump bar media-query effect safe in jsdom and align the public listing smoke test with the accessible specialty radiogroup.

## UI/UX

<!-- gh-ui-screenshots:start -->
### Mobile

![Mobile](https://github.com/user-attachments/assets/302bf3ab-bad2-48fa-ac5d-1da6c4077c84)

### Desktop Jumpbar

![Desktop Jumpbar](https://github.com/user-attachments/assets/2d3cfd08-1bb6-476f-9da2-2f98dbb0fb5a)
<!-- gh-ui-screenshots:end -->

## Validation

- [x] `rtk pnpm format`
- [x] `rtk pnpm check`
- [x] `rtk pnpm vitest --project unit --run --coverage`
- [x] `rtk pnpm exec vitest tests/unit/utilities/listingComparisonServerData.contract.test.ts tests/unit/utilities/listingComparisonPresentation.test.ts tests/unit/components/listingComparisonTemplate.test.tsx`
- [x] `rtk pnpm exec playwright test tests/e2e/public/listing-comparison.public-smoke.spec.ts --config=playwright.config.ts --project=public-smoke -g "listing filters preserve the selected specialty"`
- [x] `rtk pnpm tests:e2e:smoke:public`
- [x] `rtk bash -lc 'PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build'`
- [x] UI/mobile QA: checked `390x844` and `1280x900`; no horizontal overflow; mobile renders without the jump bar; desktop jump bar appears after scrolling past filters.
- [x] Runtime log check: route loads with existing local env warnings only; no missing clinic media file requests after the cached placeholder fallback.

Screenshots:
- Mobile: `output/playwright/listing-comparison-performance-mobile.png`
- Desktop jump bar: `output/playwright/listing-comparison-performance-desktop-jumpbar.png`

## Development

Closes #1217
