### PR TITLE
fix(frontend): align clinic registration funnel copy

### DIFF
--- a/src/app/(frontend)/_components/ClinicRegistrationLandingSection.tsx
+++ b/src/app/(frontend)/_components/ClinicRegistrationLandingSection.tsx
@@ -1,5 +1,6 @@
 import { ClinicRegistrationFunnel } from '@/components/templates/ClinicRegistrationFunnel'
 import { Container } from '@/components/molecules/Container'
+import { SectionHeading } from '@/components/molecules/SectionHeading'
 import { cn } from '@/utilities/ui'
 
 type ClinicRegistrationLandingSectionProps = {
@@ -9,7 +10,7 @@ type ClinicRegistrationLandingSectionProps = {
 }
 
 export function ClinicRegistrationLandingSection({
-  ariaLabel = 'Klinikregistrierung',
+  ariaLabel = 'Start partner inquiry',
   className,
   id = 'clinic-registration',
 }: ClinicRegistrationLandingSectionProps) {
@@ -24,7 +25,16 @@ export function ClinicRegistrationLandingSection({
     >
       <Container>
         <div className="mx-auto w-full max-w-[1184px]">
-          <ClinicRegistrationFunnel />
+          <div className="mb-12 sm:mb-14 md:mb-16">
+            <SectionHeading
+              title="Ready for verified visibility?"
+              description="Share the key details. We review your request personally and follow up with the next steps."
+              size="section"
+              align="center"
+              titleClassName="font-semibold"
+            />
+          </div>
+          <ClinicRegistrationFunnel variant="landing" />
         </div>
       </Container>
     </section>

--- a/src/components/templates/ClinicRegistrationFunnel/ClinicRegistrationFunnel.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/ClinicRegistrationFunnel.tsx
@@ -38,6 +38,7 @@ export function ClinicRegistrationFunnel({
   initialValues,
   reviewSummary = defaultReviewSummary,
   treatmentCategories = defaultTreatmentCategories,
+  variant = 'default',
 }: ClinicRegistrationFunnelProps) {
   const [step, setStep] = React.useState<ClinicRegistrationStep>(initialStep)
   const [stepTransitionDirection, setStepTransitionDirection] = React.useState<StepTransitionDirection>('none')
@@ -49,7 +50,10 @@ export function ClinicRegistrationFunnel({
     initialSelectedTreatmentCategoryIds,
   )
   const [isHydrated, setIsHydrated] = React.useState(false)
-  const publicFormValidation = usePublicFormValidation({ messages: validationMessages })
+  const visibleStepStatusLabels = stepStatusLabels
+  const publicFormValidation = usePublicFormValidation({
+    messages: validationMessages,
+  })
   const stepHeadingRef = React.useRef<HTMLHeadingElement>(null)
   const didMountRef = React.useRef(false)
 
@@ -123,10 +127,11 @@ export function ClinicRegistrationFunnel({
 
   return (
     <section
-      aria-label="Klinikregistrierung"
+      aria-label="Clinic registration"
       className={cn('w-full text-card-foreground', className)}
       data-clinic-registration-funnel-ready={isHydrated ? 'true' : undefined}
-      lang="de"
+      data-variant={variant}
+      lang="en"
     >
       <SplitStepShell
         contextPanel={
@@ -136,17 +141,24 @@ export function ClinicRegistrationFunnel({
             selectedCategoryLabels={selectedCategoryLabels}
             step={step}
             transitionClassName={transitionClassName}
+            variant={variant}
           />
         }
         progress={
           <StepIndicator
-            ariaLabel={`Klinikregistrierung, Schritt ${step} von ${totalSteps}, ${stepStatusLabels[step]}`}
+            ariaLabel={`Clinic registration, Step ${step} of ${totalSteps}, ${visibleStepStatusLabels[step]}`}
+            className={
+              variant === 'landing'
+                ? '[&_[data-state=completed]]:bg-[#0d6b59] [&_[data-state=current]]:bg-accent [&_[data-state=upcoming]]:bg-slate-200 [&>div:first-child]:text-[#0d6b59] [&>div:first-child_span:last-child]:text-[#37665d]'
+                : undefined
+            }
             currentStep={step}
-            statusLabel={stepStatusLabels[step]}
-            stepLabel={`Schritt ${step} von ${totalSteps}`}
+            statusLabel={visibleStepStatusLabels[step]}
+            stepLabel={`Step ${step} of ${totalSteps}`}
             totalSteps={totalSteps}
           />
         }
+        variant={variant}
       >
         <StepContentFrame className={transitionClassName} key={step}>
           {step === 1 ? (
@@ -156,6 +168,7 @@ export function ClinicRegistrationFunnel({
               onNext={goToNextStep}
               onValueChange={updateFormValue}
               validation={publicFormValidation}
+              variant={variant}
             />
           ) : null}
           {step === 2 ? (
@@ -167,6 +180,7 @@ export function ClinicRegistrationFunnel({
               treatmentCategories={resolvedTreatmentCategories}
               selectedCategories={selectedTreatmentCategories}
               validation={publicFormValidation}
+              variant={variant}
             />
           ) : null}
           {step === 3 ? (
@@ -177,9 +191,10 @@ export function ClinicRegistrationFunnel({
               onNext={goToNextStep}
               onValueChange={updateFormValue}
               validation={publicFormValidation}
+              variant={variant}
             />
           ) : null}
-          {step === 4 ? <ReviewConfirmationStep headingRef={stepHeadingRef} /> : null}
+          {step === 4 ? <ReviewConfirmationStep headingRef={stepHeadingRef} variant={variant} /> : null}
         </StepContentFrame>
       </SplitStepShell>
     </section>

--- a/src/components/templates/ClinicRegistrationFunnel/components/ContactNotice.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/ContactNotice.tsx
@@ -1,10 +1,20 @@
-export function ContactNotice({ id }: { id: string }) {
+import { cn } from '@/utilities/ui'
+import type { ClinicRegistrationFunnelVariant } from '../types'
+
+export function ContactNotice({ id, variant = 'default' }: { id: string; variant?: ClinicRegistrationFunnelVariant }) {
+  const isLanding = variant === 'landing'
+
   return (
     <p
-      className="rounded-[8px] border border-primary/15 bg-primary/10 px-4 py-3 text-xs leading-5 break-words text-card-foreground/75"
+      className={cn(
+        'border px-4 py-3 text-xs leading-5 break-words',
+        isLanding
+          ? 'rounded-2xl border-accent/30 bg-accent/15 text-[#064c3f]'
+          : 'rounded-[8px] border-primary/15 bg-primary/10 text-card-foreground/75',
+      )}
       id={id}
     >
-      Wir nutzen Ihre Angaben, um Sie im berechtigten Interesse zur Klinikregistrierung zu kontaktieren.
+      We use your details to contact you about this clinic registration based on legitimate interest.
     </p>
   )
 }

--- a/src/components/templates/ClinicRegistrationFunnel/components/RegistrationField.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/RegistrationField.tsx
@@ -3,7 +3,13 @@ import type * as React from 'react'
 import { Field, FieldError } from '@/components/atoms/field'
 import { Input } from '@/components/atoms/input'
 import { Label } from '@/components/atoms/label'
-import type { ClinicRegistrationFormValues, IconComponent, PublicFormValidationController } from '../types'
+import { cn } from '@/utilities/ui'
+import type {
+  ClinicRegistrationFormValues,
+  ClinicRegistrationFunnelVariant,
+  IconComponent,
+  PublicFormValidationController,
+} from '../types'
 
 export function RegistrationField({
   descriptionId,
@@ -17,6 +23,7 @@ export function RegistrationField({
   type = 'text',
   validation,
   value,
+  variant = 'default',
 }: {
   descriptionId?: string
   icon?: IconComponent
@@ -29,19 +36,29 @@ export function RegistrationField({
   type?: React.HTMLInputTypeAttribute
   validation: PublicFormValidationController
   value: string
+  variant?: ClinicRegistrationFunnelVariant
 }) {
   const error = validation.getFieldError(name)
   const errorId = validation.getFieldErrorId(name)
+  const isLanding = variant === 'landing'
 
   return (
     <Field className="min-w-0 gap-2 text-left" data-invalid={error ? true : undefined}>
-      <Label className="mb-2 block text-left text-sm font-semibold text-[#172033]" htmlFor={id}>
+      <Label
+        className={cn('mb-2 block text-left text-sm font-semibold', isLanding ? 'text-foreground' : 'text-[#172033]')}
+        htmlFor={id}
+      >
         {label}
       </Label>
       <div className="relative">
         <Input
           {...validation.getFieldProps(name, descriptionId)}
-          className="h-[60px] min-w-0 rounded-[8px] border-slate-300 bg-[#fbfcff] px-3 pr-10 text-base text-slate-500 sm:px-4 sm:pr-12 md:text-base"
+          className={cn(
+            'h-[60px] min-w-0 px-3 pr-10 text-base text-slate-500 sm:px-4 sm:pr-12 md:text-base',
+            isLanding
+              ? 'rounded-2xl border-slate-200 bg-white/95 focus-visible:border-[#0d6b59] focus-visible:ring-2 focus-visible:ring-[#0d6b59]/70'
+              : 'rounded-[8px] border-slate-300 bg-[#fbfcff]',
+          )}
           id={id}
           name={name}
           onChange={(event) => {
@@ -56,7 +73,10 @@ export function RegistrationField({
         {Icon ? (
           <Icon
             aria-hidden="true"
-            className="pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 text-slate-400 sm:right-4 sm:size-5"
+            className={cn(
+              'pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 sm:right-4 sm:size-5',
+              isLanding ? 'text-[#0d6b59]/55' : 'text-slate-400',
+            )}
           />
         ) : null}
       </div>

--- a/src/components/templates/ClinicRegistrationFunnel/components/ReviewSummary.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/ReviewSummary.tsx
@@ -1,39 +1,60 @@
 import { BriefcaseBusiness, Building2, UserRound } from 'lucide-react'
 
-import type { ClinicRegistrationReviewSummary } from '../types'
+import { cn } from '@/utilities/ui'
+import type { ClinicRegistrationFunnelVariant, ClinicRegistrationReviewSummary } from '../types'
 import { SummaryGroup } from './SummaryGroup'
 
 export function ReviewSummary({
   reviewSummary,
   selectedCategoryLabels,
+  variant = 'default',
 }: {
   reviewSummary: ClinicRegistrationReviewSummary
   selectedCategoryLabels: string[]
+  variant?: ClinicRegistrationFunnelVariant
 }) {
+  const isLanding = variant === 'landing'
+
   return (
-    <div className="mt-12 grid gap-10">
-      <SummaryGroup icon={Building2} label="Klinik-Details">
-        <strong className="block text-base font-medium [overflow-wrap:anywhere] break-words text-white">
+    <div className={cn('grid', isLanding ? 'mt-10 gap-8' : 'mt-12 gap-10')}>
+      <SummaryGroup icon={Building2} label="Clinic details" variant={variant}>
+        <strong className={cn('block text-base font-medium [overflow-wrap:anywhere] break-words text-white')}>
           {reviewSummary.clinicName}
         </strong>
-        <span className="block text-xs leading-5 [overflow-wrap:anywhere] break-words text-white/70">
+        <span
+          className={cn(
+            'block text-xs leading-5 [overflow-wrap:anywhere] break-words',
+            isLanding ? 'text-white/72' : 'text-white/70',
+          )}
+        >
           {reviewSummary.clinicWebsite ?? reviewSummary.clinicAddress}
         </span>
       </SummaryGroup>
-      <SummaryGroup icon={BriefcaseBusiness} label="Schwerpunkte">
+      <SummaryGroup icon={BriefcaseBusiness} label="Departments" variant={variant}>
         <div className="mt-2 flex flex-wrap gap-2">
-          {(selectedCategoryLabels.length > 0 ? selectedCategoryLabels : ['Noch nicht ausgewählt']).map((label) => (
-            <span className="rounded-full bg-primary/30 px-2.5 py-0.5 text-xs break-words text-white" key={label}>
+          {(selectedCategoryLabels.length > 0 ? selectedCategoryLabels : ['Not selected yet']).map((label) => (
+            <span
+              className={cn(
+                'rounded-full px-2.5 py-0.5 text-xs break-words',
+                isLanding ? 'border border-accent/25 bg-accent/15 text-accent' : 'bg-primary/30 text-white',
+              )}
+              key={label}
+            >
               {label}
             </span>
           ))}
         </div>
       </SummaryGroup>
-      <SummaryGroup icon={UserRound} label="Kontaktperson">
-        <strong className="block text-base font-medium [overflow-wrap:anywhere] break-words text-white">
+      <SummaryGroup icon={UserRound} label="Contact person" variant={variant}>
+        <strong className={cn('block text-base font-medium [overflow-wrap:anywhere] break-words text-white')}>
           {reviewSummary.contactName}
         </strong>
-        <span className="block text-xs leading-5 [overflow-wrap:anywhere] break-words text-white/70">
+        <span
+          className={cn(
+            'block text-xs leading-5 [overflow-wrap:anywhere] break-words',
+            isLanding ? 'text-white/72' : 'text-white/70',
+          )}
+        >
           {reviewSummary.contactRole}
           <br />
           {reviewSummary.contactEmail}

--- a/src/components/templates/ClinicRegistrationFunnel/components/SplitStepShell.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/SplitStepShell.tsx
@@ -1,30 +1,57 @@
 import type * as React from 'react'
 
 import { cn } from '@/utilities/ui'
+import type { ClinicRegistrationFunnelVariant } from '../types'
 
 export function SplitStepShell({
   children,
   className,
   contextPanel,
   progress,
+  variant = 'default',
 }: {
   children: React.ReactNode
   className?: string
   contextPanel: React.ReactNode
   progress: React.ReactNode
+  variant?: ClinicRegistrationFunnelVariant
 }) {
+  const isLanding = variant === 'landing'
+  const contentColumn = (
+    <div
+      className={cn(
+        'flex min-h-0 min-w-0 flex-col lg:col-start-2 lg:row-start-1 lg:min-h-0',
+        isLanding
+          ? 'bg-white/95 px-5 py-7 sm:px-8 sm:py-9 md:min-h-[560px] lg:px-10 lg:py-10'
+          : 'bg-card px-6 py-7 sm:px-10 sm:py-10 md:min-h-[610px] lg:px-12 lg:py-12',
+      )}
+    >
+      {progress}
+      {children}
+    </div>
+  )
+  const contextColumn = <div className="flex min-w-0 lg:col-start-1 lg:row-start-1 lg:min-h-full">{contextPanel}</div>
+
   return (
     <div
       className={cn(
-        'mx-auto grid w-full max-w-[1184px] min-w-0 overflow-hidden rounded-[8px] border border-slate-300 bg-card shadow-[0_18px_44px_rgba(7,0,76,0.12)] lg:min-h-[828px] lg:grid-cols-[493px_minmax(0,1fr)]',
+        isLanding
+          ? 'mx-auto grid w-full max-w-[1184px] min-w-0 overflow-hidden rounded-[30px] border border-slate-200/80 bg-white/95 shadow-[0_30px_90px_-58px_rgba(15,23,42,0.35)] sm:rounded-[32px] lg:min-h-[720px] lg:grid-cols-[420px_minmax(0,1fr)]'
+          : 'mx-auto grid w-full max-w-[1184px] min-w-0 overflow-hidden rounded-[8px] border border-slate-300 bg-card shadow-[0_18px_44px_rgba(7,0,76,0.12)] lg:min-h-[828px] lg:grid-cols-[493px_minmax(0,1fr)]',
         className,
       )}
     >
-      <div className="flex min-h-0 min-w-0 flex-col bg-card px-6 py-7 sm:px-10 sm:py-10 md:min-h-[610px] lg:col-start-2 lg:row-start-1 lg:min-h-0 lg:px-12 lg:py-12">
-        {progress}
-        {children}
-      </div>
-      <div className="flex min-w-0 lg:col-start-1 lg:row-start-1 lg:min-h-full">{contextPanel}</div>
+      {isLanding ? (
+        <>
+          {contextColumn}
+          {contentColumn}
+        </>
+      ) : (
+        <>
+          {contentColumn}
+          {contextColumn}
+        </>
+      )}
     </div>
   )
 }

--- a/src/components/templates/ClinicRegistrationFunnel/components/StepActions.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/StepActions.tsx
@@ -1,26 +1,34 @@
 import { ArrowLeft, ArrowRight } from 'lucide-react'
 
 import { Button } from '@/components/atoms/button'
+import { cn } from '@/utilities/ui'
+import type { ClinicRegistrationFunnelVariant } from '../types'
 
 export function StepActions({
   onBack,
   onNext,
   primaryLabel,
   primaryType = 'button',
+  variant = 'default',
 }: {
   onBack?: () => void
   onNext?: () => void
   primaryLabel: string
   primaryType?: 'button' | 'submit'
+  variant?: ClinicRegistrationFunnelVariant
 }) {
+  const isLanding = variant === 'landing'
+  const primaryClassName = cn(
+    'h-[56px] w-full text-base leading-none font-semibold sm:h-[60px] sm:text-[19px]',
+    isLanding
+      ? 'rounded-full bg-accent text-[#063d34] shadow-[0_16px_34px_-22px_rgba(66,226,183,0.9)] hover:bg-[#35d4aa] sm:text-base'
+      : 'rounded-[8px] shadow-[0_9px_20px_rgba(0,118,255,0.22)]',
+  )
+
   if (!onBack) {
     return (
       <div className="mx-auto mt-auto w-full max-w-[490px] pt-6 sm:pt-10 lg:pt-12">
-        <Button
-          className="h-[56px] w-full rounded-[8px] text-base leading-none font-semibold shadow-[0_9px_20px_rgba(0,118,255,0.22)] sm:h-[60px] sm:text-[19px]"
-          onClick={primaryType === 'button' ? onNext : undefined}
-          type={primaryType}
-        >
+        <Button className={primaryClassName} onClick={primaryType === 'button' ? onNext : undefined} type={primaryType}>
           {primaryLabel}
           <ArrowRight aria-hidden="true" className="size-5" />
         </Button>
@@ -31,16 +39,19 @@ export function StepActions({
   return (
     <div className="mx-auto mt-auto grid w-full max-w-[490px] gap-4 pt-6 sm:grid-cols-2 sm:items-center sm:pt-10 lg:pt-12">
       <Button
-        className="min-h-11 justify-self-start px-0 text-card-foreground/80"
+        className={cn(
+          'min-h-11 justify-self-start text-card-foreground/80',
+          isLanding ? 'rounded-full px-4 text-[#0d6b59] hover:bg-accent/25 hover:text-[#095747]' : 'px-0',
+        )}
         onClick={onBack}
         type="button"
         variant="ghost"
       >
         <ArrowLeft aria-hidden="true" className="size-4" />
-        Zurück
+        Back
       </Button>
       <Button
-        className="h-[56px] w-full min-w-0 rounded-[8px] text-base leading-none font-semibold whitespace-normal shadow-[0_9px_20px_rgba(0,118,255,0.22)] sm:h-[60px] sm:text-[19px]"
+        className={cn(primaryClassName, 'min-w-0 whitespace-normal')}
         onClick={primaryType === 'button' ? onNext : undefined}
         type={primaryType}
       >

--- a/src/components/templates/ClinicRegistrationFunnel/components/StepContextPanel.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/StepContextPanel.tsx
@@ -2,7 +2,7 @@ import { Mail, MapPin, Phone } from 'lucide-react'
 
 import { Heading } from '@/components/atoms/Heading'
 import { cn } from '@/utilities/ui'
-import type { ClinicRegistrationReviewSummary, ClinicRegistrationStep } from '../types'
+import type { ClinicRegistrationFunnelVariant, ClinicRegistrationReviewSummary, ClinicRegistrationStep } from '../types'
 import { ReviewSummary } from './ReviewSummary'
 import { SupportRow } from './SupportRow'
 
@@ -12,34 +12,51 @@ export function StepContextPanel({
   selectedCategoryLabels,
   step,
   transitionClassName,
+  variant = 'default',
 }: {
   className?: string
   reviewSummary: ClinicRegistrationReviewSummary
   selectedCategoryLabels: string[]
   step: ClinicRegistrationStep
   transitionClassName?: string
+  variant?: ClinicRegistrationFunnelVariant
 }) {
+  const isLanding = variant === 'landing'
+  const panelClassName = isLanding
+    ? 'bg-[#076b5d] px-6 py-8 text-white sm:px-8 sm:py-9 lg:min-h-full lg:px-9 lg:py-10'
+    : 'bg-secondary px-7 py-8 text-secondary-foreground sm:px-10 sm:py-11 lg:min-h-full lg:px-12 lg:py-12'
+  const headingClassName = isLanding
+    ? 'text-[21px] leading-tight break-words text-white sm:text-[24px]'
+    : 'text-[22px] leading-tight break-words text-white sm:text-[26px]'
+  const paragraphClassName = isLanding ? 'text-base leading-7 text-white/80' : 'text-base leading-relaxed text-white/85'
+
   if (step === 4) {
     return (
       <aside
         className={cn(
-          'flex min-h-[300px] w-full min-w-0 flex-col bg-secondary px-7 py-8 text-secondary-foreground sm:px-10 sm:py-11 lg:min-h-full lg:px-12 lg:py-12',
+          'flex min-h-[300px] w-full min-w-0 flex-col',
+          panelClassName,
+          isLanding && 'lg:min-h-full',
           transitionClassName,
           className,
         )}
       >
-        <Heading
-          align="left"
-          as="h2"
-          className="text-[22px] leading-tight break-words text-white sm:text-[26px]"
-          size="h4"
-        >
-          Überprüfung
+        <Heading align="left" as="h2" className={headingClassName} size="h4">
+          Review
         </Heading>
-        <p className="mt-4 max-w-[330px] text-[17px] leading-relaxed text-white/85">
-          Zusammenfassung Ihrer Angaben vor dem Abschluss.
+        <p
+          className={cn(
+            'mt-4 max-w-[330px]',
+            isLanding ? paragraphClassName : 'text-[17px] leading-relaxed text-white/85',
+          )}
+        >
+          Summary of your details before submission.
         </p>
-        <ReviewSummary reviewSummary={reviewSummary} selectedCategoryLabels={selectedCategoryLabels} />
+        <ReviewSummary
+          reviewSummary={reviewSummary}
+          selectedCategoryLabels={selectedCategoryLabels}
+          variant={variant}
+        />
       </aside>
     )
   }
@@ -48,26 +65,34 @@ export function StepContextPanel({
     return (
       <aside
         className={cn(
-          'flex min-h-[320px] w-full min-w-0 flex-col justify-center bg-secondary px-7 py-8 text-secondary-foreground sm:px-10 sm:py-11 lg:min-h-full lg:px-12 lg:py-12',
+          'flex min-h-[320px] w-full min-w-0 flex-col justify-center',
+          panelClassName,
           transitionClassName,
           className,
         )}
       >
-        <Heading
-          align="left"
-          as="h2"
-          className="text-[22px] leading-tight break-words text-white sm:text-[26px]"
-          size="h4"
-        >
-          Kontaktinformationen
+        <Heading align="left" as="h2" className={headingClassName} size="h4">
+          Contact information
         </Heading>
-        <p className="mt-4 max-w-[360px] text-base leading-relaxed text-white/85">
-          Wir melden uns bei der richtigen Kontaktperson, sobald die Registrierung geprüft wurde.
-        </p>
-        <div className="mt-10 grid gap-7 border-t border-white/15 pt-8 lg:mt-auto">
-          <SupportRow icon={Phone} label="Telefon" value="+49 (0) 30 1234 5678" />
-          <SupportRow icon={Mail} label="E-Mail" value="support@findmydoc.de" />
-          <SupportRow icon={MapPin} label="Zentrale" value="Friedrichstraße 100 10117 Berlin, Deutschland" />
+        {isLanding ? null : (
+          <p className={cn('mt-4 max-w-[360px]', paragraphClassName)}>
+            We will contact the right person once the registration has been reviewed.
+          </p>
+        )}
+        <div
+          className={cn(
+            'grid border-t',
+            isLanding ? 'mt-8 gap-6 border-white/20 pt-7 lg:mt-auto' : 'mt-10 gap-7 border-white/15 pt-8 lg:mt-auto',
+          )}
+        >
+          <SupportRow icon={Phone} label="Phone" value="+49 (0) 30 1234 5678" variant={variant} />
+          <SupportRow icon={Mail} label="Email" value="support@findmydoc.de" variant={variant} />
+          <SupportRow
+            icon={MapPin}
+            label="Headquarters"
+            value="Friedrichstrasse 100, 10117 Berlin, Germany"
+            variant={variant}
+          />
         </div>
       </aside>
     )
@@ -77,22 +102,22 @@ export function StepContextPanel({
     return (
       <aside
         className={cn(
-          'flex min-h-[300px] w-full min-w-0 flex-col justify-center bg-secondary px-7 py-8 text-secondary-foreground sm:px-10 sm:py-11 lg:min-h-full lg:px-12 lg:py-12',
+          'flex min-h-[300px] w-full min-w-0 flex-col justify-center',
+          panelClassName,
           transitionClassName,
           className,
         )}
       >
-        <Heading
-          align="left"
-          as="h2"
-          className="text-[22px] leading-tight break-words text-white sm:text-[26px]"
-          size="h4"
-        >
-          Schwerpunkte der Klinik
+        <Heading align="left" as="h2" className={headingClassName} size="h4">
+          Welcome to the network.
         </Heading>
-        <p className="mt-4 max-w-[360px] text-base leading-relaxed text-white/90">
-          Wählen Sie die Behandlungskategorien, mit denen internationale Patientinnen und Patienten Ihre Klinik finden
-          sollen.
+        <p
+          className={cn(
+            'mt-4 max-w-[360px]',
+            isLanding ? 'text-base leading-7 text-white/80' : 'text-base leading-relaxed text-white/90',
+          )}
+        >
+          Complete your profile so international patients can find you more easily.
         </p>
       </aside>
     )
@@ -101,21 +126,22 @@ export function StepContextPanel({
   return (
     <aside
       className={cn(
-        'flex min-h-[310px] w-full min-w-0 flex-col justify-center bg-secondary px-7 py-8 text-secondary-foreground sm:px-10 sm:py-11 lg:min-h-full lg:px-12 lg:py-12',
+        'flex min-h-[310px] w-full min-w-0 flex-col justify-center',
+        panelClassName,
         transitionClassName,
         className,
       )}
     >
-      <Heading
-        align="left"
-        as="h2"
-        className="max-w-[385px] text-[22px] leading-tight break-words text-white sm:text-[26px]"
-        size="h4"
-      >
-        Klinik international sichtbar machen
+      <Heading align="left" as="h2" className={cn('max-w-[385px]', headingClassName)} size="h4">
+        Interested in gaining international patients and increasing your clinic's global reach?
       </Heading>
-      <p className="mt-7 max-w-[388px] text-lg leading-relaxed text-white/90">
-        Registrieren Sie Ihre Klinik für die Prüfung und den Aufbau Ihrer Präsenz auf findmydoc.
+      <p
+        className={cn(
+          'max-w-[388px]',
+          isLanding ? 'mt-5 text-base leading-7 text-white/80' : 'mt-7 text-lg leading-relaxed text-white/90',
+        )}
+      >
+        Contact us to explore how your clinic can benefit from our international comparison platform.
       </p>
     </aside>
   )

--- a/src/components/templates/ClinicRegistrationFunnel/components/SummaryGroup.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/SummaryGroup.tsx
@@ -1,21 +1,33 @@
 import type * as React from 'react'
 
-import type { IconComponent } from '../types'
+import { cn } from '@/utilities/ui'
+import type { ClinicRegistrationFunnelVariant, IconComponent } from '../types'
 
 export function SummaryGroup({
   children,
   icon: Icon,
   label,
+  variant = 'default',
 }: {
   children: React.ReactNode
   icon: IconComponent
   label: string
+  variant?: ClinicRegistrationFunnelVariant
 }) {
+  const isLanding = variant === 'landing'
+
   return (
     <div className="grid min-w-0 grid-cols-[20px_minmax(0,1fr)] items-start gap-3">
-      <Icon aria-hidden="true" className="mt-[3px] size-4 text-primary" />
+      <Icon aria-hidden="true" className={cn('mt-[3px] size-4', isLanding ? 'text-accent' : 'text-primary')} />
       <div className="min-w-0">
-        <span className="block text-[13px] leading-5 font-bold tracking-[0.04em] text-primary uppercase">{label}</span>
+        <span
+          className={cn(
+            'block text-[13px] leading-5 font-bold tracking-[0.04em] uppercase',
+            isLanding ? 'text-accent' : 'text-primary',
+          )}
+        >
+          {label}
+        </span>
         <div className="mt-2">{children}</div>
       </div>
     </div>

--- a/src/components/templates/ClinicRegistrationFunnel/components/SupportRow.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/SupportRow.tsx
@@ -1,16 +1,34 @@
-import type { IconComponent } from '../types'
+import { cn } from '@/utilities/ui'
+import type { ClinicRegistrationFunnelVariant, IconComponent } from '../types'
 
-export function SupportRow({ icon: Icon, label, value }: { icon: IconComponent; label?: string; value: string }) {
+export function SupportRow({
+  icon: Icon,
+  label,
+  value,
+  variant = 'default',
+}: {
+  icon: IconComponent
+  label?: string
+  value: string
+  variant?: ClinicRegistrationFunnelVariant
+}) {
+  const isLanding = variant === 'landing'
+
   return (
     <div className="grid grid-cols-[28px_minmax(0,1fr)] items-start gap-3 text-white">
-      <Icon aria-hidden="true" className="mt-0.5 size-4 text-primary" />
+      <Icon aria-hidden="true" className={cn('mt-0.5 size-4', isLanding ? 'text-accent' : 'text-primary')} />
       <div className="min-w-0">
         {label ? (
-          <span className="block text-[13px] leading-4 font-medium tracking-[0.08em] text-white/55 uppercase">
+          <span
+            className={cn(
+              'block text-[13px] leading-4 font-medium tracking-[0.08em] uppercase',
+              isLanding ? 'text-accent/75' : 'text-white/55',
+            )}
+          >
             {label}
           </span>
         ) : null}
-        <span className="block text-[15px] leading-5 font-normal break-words text-white/85">{value}</span>
+        <span className={cn('block text-[15px] leading-5 font-normal break-words text-white/85')}>{value}</span>
       </div>
     </div>
   )

--- a/src/components/templates/ClinicRegistrationFunnel/components/TreatmentCategoryOptionCard.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/components/TreatmentCategoryOptionCard.tsx
@@ -1,35 +1,49 @@
 import { Check } from 'lucide-react'
 
 import { cn } from '@/utilities/ui'
-import type { ResolvedTreatmentCategory } from '../types'
+import type { ClinicRegistrationFunnelVariant, ResolvedTreatmentCategory } from '../types'
 
 export function TreatmentCategoryOptionCard({
   category,
   isSelected,
   onToggle,
+  variant = 'default',
 }: {
   category: ResolvedTreatmentCategory
   isSelected: boolean
   onToggle: (categoryId: string) => void
+  variant?: ClinicRegistrationFunnelVariant
 }) {
   const Icon = category.icon
+  const isLanding = variant === 'landing'
 
   return (
     <button
       aria-pressed={isSelected}
       className={cn(
-        'relative flex h-[100px] min-w-0 flex-col items-center justify-center gap-2 rounded-[8px] border border-slate-300 bg-card px-2 text-sm font-semibold text-[#172033] transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-hidden',
-        isSelected && 'border-primary bg-primary/5',
+        'relative flex h-[100px] min-w-0 flex-col items-center justify-center gap-2 border px-2 text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden',
+        isLanding
+          ? 'rounded-2xl border-slate-200 bg-white/95 text-foreground shadow-sm focus-visible:ring-[#0d6b59]/70'
+          : 'rounded-[8px] border-slate-300 bg-card text-[#172033] focus-visible:ring-primary',
+        isSelected &&
+          (isLanding
+            ? 'border-[#0d6b59] bg-accent/20 shadow-[0_16px_36px_-28px_rgba(13,107,89,0.55)]'
+            : 'border-primary bg-primary/5'),
       )}
       onClick={() => onToggle(category.id)}
       type="button"
     >
       {isSelected ? (
-        <span className="absolute top-2 right-2 grid size-5 place-items-center rounded-full bg-primary text-primary-foreground">
+        <span
+          className={cn(
+            'absolute top-2 right-2 grid size-5 place-items-center rounded-full',
+            isLanding ? 'bg-[#0d6b59] text-white' : 'bg-primary text-primary-foreground',
+          )}
+        >
           <Check aria-hidden="true" className="size-3.5" />
         </span>
       ) : null}
-      <Icon aria-hidden="true" className="size-8 text-primary" />
+      <Icon aria-hidden="true" className={cn('size-8', isLanding ? 'text-[#0d6b59]' : 'text-primary')} />
       <span className="max-w-full text-center leading-4 break-words">{category.label}</span>
     </button>
   )

--- a/src/components/templates/ClinicRegistrationFunnel/constants.ts
+++ b/src/components/templates/ClinicRegistrationFunnel/constants.ts
@@ -16,21 +16,21 @@ export const defaultTreatmentCategories: ClinicRegistrationTreatmentCategory[] =
 ]
 
 export const stepStatusLabels: Record<ClinicRegistrationStep, string> = {
-  1: 'Initialisierung',
-  2: '50% abgeschlossen',
-  3: '75% abgeschlossen',
-  4: 'Anfrage übermittelt',
+  1: 'Initialization',
+  2: '50% completed',
+  3: '75% completed',
+  4: 'Request submitted',
 }
 
 export const defaultSelectedTreatmentCategoryIds = ['dental']
 
 export const defaultReviewSummary: ClinicRegistrationReviewSummary = {
-  clinicAddress: 'Hauptstraße 124, 10115 Berlin',
-  clinicWebsite: 'https://marien-hospital.de',
+  clinicAddress: 'Main Street 124, 10115 Berlin',
+  clinicWebsite: 'https://marien-hospital.example',
   clinicName: 'St. Marien Hospital',
-  contactEmail: 'm.musterfrau@marien-hospital.de',
+  contactEmail: 'm.musterfrau@marien-hospital.example',
   contactName: 'Dr. Martina Musterfrau',
-  contactRole: 'Leitende Oberärztin',
+  contactRole: 'Medical Director',
 }
 
 export const defaultFormValues: ClinicRegistrationFormValues = {
@@ -42,8 +42,8 @@ export const defaultFormValues: ClinicRegistrationFormValues = {
 }
 
 export const contactRoleOptions = [
-  { label: 'Ärztliche Leitung', value: 'Ärztliche Leitung' },
-  { label: 'Klinikmanagement', value: 'Klinikmanagement' },
+  { label: 'Medical Director', value: 'Medical Director' },
+  { label: 'Clinic Management', value: 'Clinic Management' },
   { label: 'International Office', value: 'International Office' },
 ]
 

--- a/src/components/templates/ClinicRegistrationFunnel/index.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/index.tsx
@@ -5,6 +5,7 @@ export type {
   ClinicRegistrationCategoryIconKey,
   ClinicRegistrationFormValues,
   ClinicRegistrationFunnelProps,
+  ClinicRegistrationFunnelVariant,
   ClinicRegistrationReviewSummary,
   ClinicRegistrationTreatmentCategory,
 } from './types'

--- a/src/components/templates/ClinicRegistrationFunnel/steps/ClinicDetailsStep.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/steps/ClinicDetailsStep.tsx
@@ -2,8 +2,13 @@ import * as React from 'react'
 import { Building2, CircleHelp, Globe2 } from 'lucide-react'
 
 import { Heading } from '@/components/atoms/Heading'
+import { cn } from '@/utilities/ui'
 import { formContentClassName } from '../constants'
-import type { ClinicRegistrationFormValues, PublicFormValidationController } from '../types'
+import type {
+  ClinicRegistrationFormValues,
+  ClinicRegistrationFunnelVariant,
+  PublicFormValidationController,
+} from '../types'
 import { RegistrationField } from '../components/RegistrationField'
 import { StepActions } from '../components/StepActions'
 import { StepForm } from '../components/StepForm'
@@ -14,45 +19,51 @@ export function ClinicDetailsStep({
   onNext,
   onValueChange,
   validation,
+  variant = 'default',
 }: {
   formValues: ClinicRegistrationFormValues
   headingRef: React.Ref<HTMLHeadingElement>
   onNext: () => void
   onValueChange: (fieldName: keyof ClinicRegistrationFormValues, value: string) => void
   validation: PublicFormValidationController
+  variant?: ClinicRegistrationFunnelVariant
 }) {
   const idBase = React.useId()
   const headingId = `${idBase}-details-heading`
   const descriptionId = `${idBase}-details-notice`
+  const isLanding = variant === 'landing'
 
   return (
     <StepForm ariaLabelledBy={headingId} onSubmit={onNext} validation={validation}>
-      <div className={formContentClassName}>
+      <div className={cn(formContentClassName, isLanding && 'mt-7 sm:mt-8 lg:mt-9')}>
         <Heading
           align="left"
           as="h2"
-          className="text-[32px] leading-tight text-[#172033]"
+          className={cn('text-[32px] leading-tight', isLanding ? 'text-foreground' : 'text-[#172033]')}
           id={headingId}
           ref={headingRef}
           size="h3"
           tabIndex={-1}
         >
-          Klinik registrieren
+          Register your clinic
         </Heading>
-        <p className="mt-3 text-base text-card-foreground/70">Starten Sie Ihre internationale Präsenz.</p>
+        <p className={cn('mt-3 text-base', isLanding ? 'leading-7 text-slate-700' : 'text-card-foreground/70')}>
+          Start your international presence.
+        </p>
 
         <div className="mt-8 grid gap-5 sm:mt-10 sm:gap-6 lg:mt-12">
           <RegistrationField
             descriptionId={descriptionId}
             id={`${idBase}-clinic-name`}
             icon={Building2}
-            label="Klinikname"
+            label="Clinic name"
             name="clinicName"
             onValueChange={(value) => onValueChange('clinicName', value)}
-            placeholder="z.B. Charité"
+            placeholder="e.g. Charité University Medicine"
             required
             validation={validation}
             value={formValues.clinicName}
+            variant={variant}
           />
           <RegistrationField
             descriptionId={descriptionId}
@@ -61,22 +72,31 @@ export function ClinicDetailsStep({
             label="Website"
             name="clinicWebsite"
             onValueChange={(value) => onValueChange('clinicWebsite', value)}
-            placeholder="https://klinik.de"
+            placeholder="https://www.your-clinic.com"
             required
             type="url"
             validation={validation}
             value={formValues.clinicWebsite}
+            variant={variant}
           />
           <div
-            className="grid grid-cols-[20px_minmax(0,1fr)] gap-3 rounded-[8px] border border-primary/15 bg-primary/10 px-4 py-4 text-xs leading-4 text-card-foreground/80"
+            className={cn(
+              'grid grid-cols-[20px_minmax(0,1fr)] gap-3 border px-4 py-4 text-xs leading-4',
+              isLanding
+                ? 'rounded-2xl border-accent/30 bg-accent/15 text-[#064c3f]'
+                : 'rounded-[8px] border-primary/15 bg-primary/10 text-card-foreground/80',
+            )}
             id={descriptionId}
           >
-            <CircleHelp aria-hidden="true" className="mt-0.5 size-4 text-primary" />
-            <p>Diese Informationen werden zur ersten Validierung Ihres Standortes verwendet.</p>
+            <CircleHelp
+              aria-hidden="true"
+              className={cn('mt-0.5 size-4', isLanding ? 'text-[#0d6b59]' : 'text-primary')}
+            />
+            <p>This information is used for the initial validation of your location.</p>
           </div>
         </div>
       </div>
-      <StepActions primaryLabel="Weiter" primaryType="submit" />
+      <StepActions primaryLabel="Continue" primaryType="submit" variant={variant} />
     </StepForm>
   )
 }

--- a/src/components/templates/ClinicRegistrationFunnel/steps/ContactStep.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/steps/ContactStep.tsx
@@ -4,8 +4,13 @@ import { ChevronDown } from 'lucide-react'
 import { Field, FieldError } from '@/components/atoms/field'
 import { Heading } from '@/components/atoms/Heading'
 import { Label } from '@/components/atoms/label'
+import { cn } from '@/utilities/ui'
 import { contactRoleOptions, formContentClassName } from '../constants'
-import type { ClinicRegistrationFormValues, PublicFormValidationController } from '../types'
+import type {
+  ClinicRegistrationFormValues,
+  ClinicRegistrationFunnelVariant,
+  PublicFormValidationController,
+} from '../types'
 import { ContactNotice } from '../components/ContactNotice'
 import { RegistrationField } from '../components/RegistrationField'
 import { StepActions } from '../components/StepActions'
@@ -18,6 +23,7 @@ export function ContactStep({
   onNext,
   onValueChange,
   validation,
+  variant = 'default',
 }: {
   formValues: ClinicRegistrationFormValues
   headingRef: React.Ref<HTMLHeadingElement>
@@ -25,6 +31,7 @@ export function ContactStep({
   onNext: () => void
   onValueChange: (fieldName: keyof ClinicRegistrationFormValues, value: string) => void
   validation: PublicFormValidationController
+  variant?: ClinicRegistrationFunnelVariant
 }) {
   const idBase = React.useId()
   const headingId = `${idBase}-contact-heading`
@@ -32,55 +39,71 @@ export function ContactStep({
   const positionId = `${idBase}-position`
   const positionError = validation.getFieldError('contactRole')
   const positionErrorId = validation.getFieldErrorId('contactRole')
+  const isLanding = variant === 'landing'
 
   return (
     <StepForm ariaLabelledBy={headingId} onSubmit={onNext} validation={validation}>
-      <div className={formContentClassName}>
+      <div className={cn(formContentClassName, isLanding && 'mt-7 sm:mt-8 lg:mt-9')}>
         <Heading
           align="left"
           as="h2"
-          className="text-[32px] leading-tight text-[#172033]"
+          className={cn('text-[32px] leading-tight', isLanding ? 'text-foreground' : 'text-[#172033]')}
           id={headingId}
           ref={headingRef}
           size="h3"
           tabIndex={-1}
         >
-          Ihr Kontakt
+          Your contact
         </Heading>
-        <p className="mt-3 text-base text-card-foreground/70">Wer ist unsere Kontaktperson für die Koordination?</p>
+        <p className={cn('mt-3 text-base', isLanding ? 'leading-7 text-slate-700' : 'text-card-foreground/70')}>
+          Who should we contact for follow-up questions?
+        </p>
 
         <div className="mt-8 grid gap-5 sm:mt-10 sm:gap-6 lg:mt-12">
           <RegistrationField
             descriptionId={noticeId}
             id={`${idBase}-contact-name`}
-            label="Vollständiger Name"
+            label="Full name"
             name="contactName"
             onValueChange={(value) => onValueChange('contactName', value)}
-            placeholder="z.B. Dr. Muster"
+            placeholder="e.g. Dr. Max Sample"
             required
             validation={validation}
             value={formValues.contactName}
+            variant={variant}
           />
           <RegistrationField
             descriptionId={noticeId}
             id={`${idBase}-contact-email`}
-            label="E-Mail Adresse"
+            label="Email address"
             name="contactEmail"
             onValueChange={(value) => onValueChange('contactEmail', value)}
-            placeholder="kontakt@klinik.de"
+            placeholder="name@example-clinic.com"
             required
             type="email"
             validation={validation}
             value={formValues.contactEmail}
+            variant={variant}
           />
           <Field className="min-w-0 gap-2 text-left" data-invalid={positionError ? true : undefined}>
-            <Label className="mb-2 block text-left text-sm font-semibold text-[#172033]" htmlFor={positionId}>
-              Position / Funktion
+            <Label
+              className={cn(
+                'mb-2 block text-left text-sm font-semibold',
+                isLanding ? 'text-foreground' : 'text-[#172033]',
+              )}
+              htmlFor={positionId}
+            >
+              Position / role
             </Label>
             <div className="relative">
               <select
                 {...validation.getFieldProps('contactRole', noticeId)}
-                className="h-[60px] w-full min-w-0 appearance-none rounded-[8px] border border-slate-300 bg-[#fbfcff] px-3 pr-10 text-left text-base text-slate-500 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-hidden aria-invalid:border-destructive/70 aria-invalid:focus-visible:ring-destructive/20 sm:px-4 sm:pr-12 md:text-base"
+                className={cn(
+                  'h-[60px] w-full min-w-0 appearance-none border px-3 pr-10 text-left text-base text-slate-500 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden aria-invalid:border-destructive/70 aria-invalid:focus-visible:ring-destructive/20 sm:px-4 sm:pr-12 md:text-base',
+                  isLanding
+                    ? 'rounded-2xl border-slate-200 bg-white/95 focus-visible:border-[#0d6b59] focus-visible:ring-[#0d6b59]/70'
+                    : 'rounded-[8px] border-slate-300 bg-[#fbfcff] focus-visible:ring-primary',
+                )}
                 id={positionId}
                 name="contactRole"
                 onChange={(event) => {
@@ -91,7 +114,7 @@ export function ContactStep({
                 value={formValues.contactRole}
               >
                 <option disabled value="">
-                  Bitte auswählen
+                  Please select
                 </option>
                 {contactRoleOptions.map((option) => (
                   <option key={option.value} value={option.value}>
@@ -101,15 +124,18 @@ export function ContactStep({
               </select>
               <ChevronDown
                 aria-hidden="true"
-                className="pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 text-slate-500 sm:right-4 sm:size-5"
+                className={cn(
+                  'pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 sm:right-4 sm:size-5',
+                  isLanding ? 'text-[#0d6b59]/60' : 'text-slate-500',
+                )}
               />
             </div>
             <FieldError id={positionErrorId}>{positionError}</FieldError>
           </Field>
-          <ContactNotice id={noticeId} />
+          <ContactNotice id={noticeId} variant={variant} />
         </div>
       </div>
-      <StepActions onBack={onBack} primaryLabel="Anfrage senden" primaryType="submit" />
+      <StepActions onBack={onBack} primaryLabel="Submit request" primaryType="submit" variant={variant} />
     </StepForm>
   )
 }

--- a/src/components/templates/ClinicRegistrationFunnel/steps/ReviewConfirmationStep.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/steps/ReviewConfirmationStep.tsx
@@ -2,25 +2,45 @@ import type * as React from 'react'
 import { ShieldCheck } from 'lucide-react'
 
 import { Heading } from '@/components/atoms/Heading'
+import { cn } from '@/utilities/ui'
+import type { ClinicRegistrationFunnelVariant } from '../types'
 
-export function ReviewConfirmationStep({ headingRef }: { headingRef: React.Ref<HTMLHeadingElement> }) {
+export function ReviewConfirmationStep({
+  headingRef,
+  variant = 'default',
+}: {
+  headingRef: React.Ref<HTMLHeadingElement>
+  variant?: ClinicRegistrationFunnelVariant
+}) {
+  const isLanding = variant === 'landing'
+
   return (
-    <div className="mx-auto flex w-full max-w-[490px] flex-1 flex-col items-center justify-center py-12 text-center">
-      <div className="grid size-[88px] place-items-center rounded-full bg-accent text-secondary">
+    <div
+      className={cn(
+        'mx-auto flex w-full max-w-[490px] flex-1 flex-col items-center justify-center py-12 text-center',
+        isLanding && 'py-10',
+      )}
+    >
+      <div
+        className={cn(
+          'grid place-items-center rounded-full bg-accent',
+          isLanding ? 'size-20 text-[#0d6b59]' : 'size-[88px] text-secondary',
+        )}
+      >
         <ShieldCheck aria-hidden="true" className="size-10" />
       </div>
       <Heading
         align="center"
         as="h2"
-        className="mt-5 text-[34px] leading-tight text-[#172033]"
+        className={cn('mt-5 text-[34px] leading-tight', isLanding ? 'text-foreground' : 'text-[#172033]')}
         ref={headingRef}
         size="h3"
         tabIndex={-1}
       >
-        Anfrage übermittelt
+        Request submitted
       </Heading>
       <p className="mt-4 max-w-[430px] text-lg leading-relaxed text-card-foreground/70">
-        Ihre Anfrage wurde übermittelt. Wir kontaktieren Sie, sobald die Prüfung abgeschlossen ist.
+        Your request has been submitted. We will contact you once the review is complete.
       </p>
     </div>
   )

--- a/src/components/templates/ClinicRegistrationFunnel/steps/TreatmentCategoriesStep.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/steps/TreatmentCategoriesStep.tsx
@@ -2,8 +2,13 @@ import * as React from 'react'
 
 import { Field, FieldError } from '@/components/atoms/field'
 import { Heading } from '@/components/atoms/Heading'
+import { cn } from '@/utilities/ui'
 import { formContentClassName } from '../constants'
-import type { PublicFormValidationController, ResolvedTreatmentCategory } from '../types'
+import type {
+  ClinicRegistrationFunnelVariant,
+  PublicFormValidationController,
+  ResolvedTreatmentCategory,
+} from '../types'
 import { treatmentCategoriesRequiredMessage } from '../validation'
 import { StepActions } from '../components/StepActions'
 import { StepForm } from '../components/StepForm'
@@ -17,6 +22,7 @@ export function TreatmentCategoriesStep({
   selectedCategories,
   treatmentCategories,
   validation,
+  variant = 'default',
 }: {
   headingRef: React.Ref<HTMLHeadingElement>
   onBack: () => void
@@ -25,6 +31,7 @@ export function TreatmentCategoriesStep({
   selectedCategories: string[]
   treatmentCategories: ResolvedTreatmentCategory[]
   validation: PublicFormValidationController
+  variant?: ClinicRegistrationFunnelVariant
 }) {
   const idBase = React.useId()
   const headingId = `${idBase}-treatment-categories-heading`
@@ -32,6 +39,7 @@ export function TreatmentCategoriesStep({
   const error = validation.getFieldError('treatmentCategories')
   const errorId = validation.getFieldErrorId('treatmentCategories')
   const groupRef = React.useRef<HTMLFieldSetElement>(null)
+  const isLanding = variant === 'landing'
 
   return (
     <StepForm
@@ -47,33 +55,41 @@ export function TreatmentCategoriesStep({
       }}
       validation={validation}
     >
-      <div className={formContentClassName}>
+      <div className={cn(formContentClassName, isLanding && 'mt-7 sm:mt-8 lg:mt-9')}>
         <Heading
           align="left"
           as="h2"
-          className="text-[32px] leading-tight text-[#172033]"
+          className={cn('text-[32px] leading-tight', isLanding ? 'text-foreground' : 'text-[#172033]')}
           id={headingId}
           ref={headingRef}
           size="h3"
           tabIndex={-1}
         >
-          Schwerpunkte wählen
+          Choose focus areas
         </Heading>
-        <p className="mt-3 max-w-[590px] text-base leading-relaxed text-card-foreground/70" id={descriptionId}>
-          Wählen Sie Ihre Hauptkategorien für die Kliniksuche. Dies hilft uns, die passenden Ergebnisse für Sie zu
-          priorisieren.
+        <p
+          className={cn(
+            'mt-3 max-w-[590px] text-base leading-relaxed',
+            isLanding ? 'text-slate-700' : 'text-card-foreground/70',
+          )}
+          id={descriptionId}
+        >
+          Choose the main categories for clinic search. This helps us prioritize the right results for you.
         </p>
 
         <Field className="mt-8 min-w-0 gap-3 sm:mt-10 lg:mt-12" data-invalid={error ? true : undefined}>
           <fieldset
             aria-describedby={[descriptionId, error ? errorId : undefined].filter(Boolean).join(' ')}
             aria-invalid={error ? true : undefined}
-            className="min-w-0 border-0 p-0 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-hidden"
+            className={cn(
+              'min-w-0 border-0 p-0 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden',
+              isLanding ? 'focus-visible:ring-[#0d6b59]/70' : 'focus-visible:ring-primary',
+            )}
             data-field-name="treatmentCategories"
             ref={groupRef}
             tabIndex={-1}
           >
-            <legend className="sr-only">Behandlungskategorien auswählen</legend>
+            <legend className="sr-only">Select treatment categories</legend>
             <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
               {treatmentCategories.map((category) => (
                 <TreatmentCategoryOptionCard
@@ -81,6 +97,7 @@ export function TreatmentCategoriesStep({
                   isSelected={selectedCategories.includes(category.id)}
                   key={category.id}
                   onToggle={onToggleCategory}
+                  variant={variant}
                 />
               ))}
             </div>
@@ -88,7 +105,7 @@ export function TreatmentCategoriesStep({
           <FieldError id={errorId}>{error}</FieldError>
         </Field>
       </div>
-      <StepActions onBack={onBack} primaryLabel="Weiter" primaryType="submit" />
+      <StepActions onBack={onBack} primaryLabel="Continue" primaryType="submit" variant={variant} />
     </StepForm>
   )
 }

--- a/src/components/templates/ClinicRegistrationFunnel/types.ts
+++ b/src/components/templates/ClinicRegistrationFunnel/types.ts
@@ -3,6 +3,7 @@ import type * as React from 'react'
 import type { usePublicFormValidation } from '@/components/molecules/PublicFormValidation/usePublicFormValidation'
 
 export type ClinicRegistrationStep = 1 | 2 | 3 | 4
+export type ClinicRegistrationFunnelVariant = 'default' | 'landing'
 export type StepTransitionDirection = 'backward' | 'forward' | 'none'
 export type IconComponent = React.ElementType<React.SVGProps<SVGSVGElement>>
 export type PublicFormValidationController = ReturnType<typeof usePublicFormValidation>
@@ -14,6 +15,7 @@ export type ClinicRegistrationFunnelProps = {
   initialValues?: Partial<ClinicRegistrationFormValues>
   reviewSummary?: ClinicRegistrationReviewSummary
   treatmentCategories?: ClinicRegistrationTreatmentCategory[]
+  variant?: ClinicRegistrationFunnelVariant
 }
 
 export type ClinicRegistrationFormValues = {

--- a/src/components/templates/ClinicRegistrationFunnel/validation.ts
+++ b/src/components/templates/ClinicRegistrationFunnel/validation.ts
@@ -1,21 +1,21 @@
 export const validationMessages = {
   clinicName: {
-    valueMissing: 'Bitte geben Sie den Kliniknamen ein.',
+    valueMissing: 'Please enter the clinic name.',
   },
   clinicWebsite: {
-    typeMismatch: 'Bitte geben Sie eine gültige Website-URL ein.',
-    valueMissing: 'Bitte geben Sie die Website ein.',
+    typeMismatch: 'Please enter a valid website URL.',
+    valueMissing: 'Please enter the website.',
   },
   contactEmail: {
-    typeMismatch: 'Bitte geben Sie eine gültige E-Mail-Adresse ein.',
-    valueMissing: 'Bitte geben Sie die E-Mail-Adresse ein.',
+    typeMismatch: 'Please enter a valid email address.',
+    valueMissing: 'Please enter the email address.',
   },
   contactName: {
-    valueMissing: 'Bitte geben Sie den vollständigen Namen ein.',
+    valueMissing: 'Please enter the full name.',
   },
   contactRole: {
-    valueMissing: 'Bitte wählen Sie eine Position aus.',
+    valueMissing: 'Please select a position.',
   },
 }
 
-export const treatmentCategoriesRequiredMessage = 'Bitte wählen Sie mindestens einen Schwerpunkt aus.'
+export const treatmentCategoriesRequiredMessage = 'Please select at least one focus area.'

--- a/src/stories/templates/ClinicRegistrationFunnel.stories.tsx
+++ b/src/stories/templates/ClinicRegistrationFunnel.stories.tsx
@@ -3,6 +3,7 @@ import { expect, userEvent, waitFor, within } from 'storybook/test'
 
 import { ClinicRegistrationFunnel } from '@/components/templates/ClinicRegistrationFunnel'
 import type { ClinicRegistrationFunnelProps } from '@/components/templates/ClinicRegistrationFunnel'
+import { cn } from '@/utilities/ui'
 import { withViewportStory } from '../utils/viewportMatrix'
 
 const getStoryRemountKey = (args: ClinicRegistrationFunnelProps) =>
@@ -12,14 +13,20 @@ const getStoryRemountKey = (args: ClinicRegistrationFunnelProps) =>
     initialValues: args.initialValues,
     reviewSummary: args.reviewSummary,
     treatmentCategories: args.treatmentCategories,
+    variant: args.variant,
   })
 
 const meta = {
   title: 'Domain/ClinicRegistration/Templates/Clinic Registration Funnel',
   component: ClinicRegistrationFunnel,
   decorators: [
-    (Story) => (
-      <div className="w-full bg-muted px-4 py-8 text-card-foreground sm:px-6 lg:px-10">
+    (Story, context) => (
+      <div
+        className={cn(
+          'w-full px-4 py-8 text-card-foreground sm:px-6 lg:px-10',
+          context.args.variant === 'landing' ? 'bg-site-canvas' : 'bg-muted',
+        )}
+      >
         <Story />
       </div>
     ),
@@ -36,27 +43,42 @@ export default meta
 type Story = StoryObj<typeof ClinicRegistrationFunnel>
 
 const storyReviewSummary = {
-  clinicAddress: 'Hauptstraße 124, 10115 Berlin',
-  clinicWebsite: 'https://marien-hospital.de',
+  clinicAddress: 'Main Street 124, 10115 Berlin',
+  clinicWebsite: 'https://marien-hospital.example',
   clinicName: 'St. Marien Hospital',
-  contactEmail: 'm.musterfrau@marien-hospital.de',
+  contactEmail: 'm.musterfrau@marien-hospital.example',
   contactName: 'Dr. Martina Musterfrau',
-  contactRole: 'Leitende Oberärztin',
+  contactRole: 'Medical Director',
+}
+
+const landingStoryReviewSummary = {
+  clinicAddress: 'Main Street 124, 10115 Berlin',
+  clinicWebsite: 'https://marien-hospital.example',
+  clinicName: 'St. Marien Hospital',
+  contactEmail: 'm.musterfrau@marien-hospital.example',
+  contactName: 'Dr. Martina Musterfrau',
+  contactRole: 'Medical Director',
 }
 
 const longStoryReviewSummary = {
-  clinicAddress: 'Sehrlangeklinikhauptadresseohneleerzeichen-Station-Internationalisierung-124-126, 10115 Berlin',
-  clinicWebsite: 'https://sehrlange-klinik-domain-berlin.example/internationale-klinikregistrierung',
-  clinicName: 'Klinikzentrum fuer internationale rekonstruktive Spezialbehandlungen und Langzeitversorgung Berlin',
-  contactEmail: 'martina.musterfrau.verantwortliche.klinikregistrierung@sehrlange-klinik-domain-berlin.example',
-  contactName: 'Dr. Martina Elisabeth Musterfrau-Schwerpunktkoordination',
-  contactRole: 'Leitende Oberaerztin und Verantwortliche fuer internationale Klinikregistrierung',
+  clinicAddress: 'Verylongclinicmainaddresswithoutspaces-Internationalization-Station-124-126, 10115 Berlin',
+  clinicWebsite: 'https://very-long-clinic-domain-berlin.example/international-clinic-registration',
+  clinicName: 'Clinic Center for International Reconstructive Specialist Treatments and Long-Term Care Berlin',
+  contactEmail: 'martina.musterfrau.clinic-registration-owner@very-long-clinic-domain-berlin.example',
+  contactName: 'Dr. Martina Elisabeth Musterfrau-Specialty Coordination',
+  contactRole: 'Medical Director and Responsible Owner for International Clinic Registration',
 }
 
 const defaultStoryArgs = {
   initialSelectedTreatmentCategoryIds: ['dental'],
   reviewSummary: storyReviewSummary,
 }
+
+const landingStoryArgs = {
+  ...defaultStoryArgs,
+  reviewSummary: landingStoryReviewSummary,
+  variant: 'landing',
+} satisfies ClinicRegistrationFunnelProps
 
 export const Step1ClinicDetails: Story = {
   args: {
@@ -87,12 +109,12 @@ export const Step1ValidationErrors: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    await userEvent.click(canvas.getByRole('button', { name: /^weiter$/i }))
+    await userEvent.click(canvas.getByRole('button', { name: /^continue$/i }))
 
-    await expect(canvas.getByText('Bitte geben Sie den Kliniknamen ein.')).toBeInTheDocument()
-    await expect(canvas.getByText('Bitte geben Sie die Website ein.')).toBeInTheDocument()
-    await expect(canvas.getByLabelText('Klinikname')).toHaveAttribute('aria-invalid', 'true')
-    await expect(canvas.getByLabelText('Klinikname')).toHaveFocus()
+    await expect(canvas.getByText('Please enter the clinic name.')).toBeInTheDocument()
+    await expect(canvas.getByText('Please enter the website.')).toBeInTheDocument()
+    await expect(canvas.getByLabelText('Clinic name')).toHaveAttribute('aria-invalid', 'true')
+    await expect(canvas.getByLabelText('Clinic name')).toHaveFocus()
   },
 }
 
@@ -105,10 +127,10 @@ export const Step2ValidationErrors: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    await userEvent.click(canvas.getByRole('button', { name: /^weiter$/i }))
+    await userEvent.click(canvas.getByRole('button', { name: /^continue$/i }))
 
-    await expect(canvas.getByText('Bitte wählen Sie mindestens einen Schwerpunkt aus.')).toBeInTheDocument()
-    await expect(canvas.getByRole('group', { name: /behandlungskategorien auswählen/i })).toHaveFocus()
+    await expect(canvas.getByText('Please select at least one focus area.')).toBeInTheDocument()
+    await expect(canvas.getByRole('group', { name: /select treatment categories/i })).toHaveFocus()
   },
 }
 
@@ -120,12 +142,12 @@ export const Step3ValidationErrors: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    await userEvent.click(canvas.getByRole('button', { name: /^anfrage senden$/i }))
+    await userEvent.click(canvas.getByRole('button', { name: /^submit request$/i }))
 
-    await expect(canvas.getByText('Bitte geben Sie den vollständigen Namen ein.')).toBeInTheDocument()
-    await expect(canvas.getByText('Bitte geben Sie die E-Mail-Adresse ein.')).toBeInTheDocument()
-    await expect(canvas.getByText('Bitte wählen Sie eine Position aus.')).toBeInTheDocument()
-    await expect(canvas.getByLabelText('Vollständiger Name')).toHaveFocus()
+    await expect(canvas.getByText('Please enter the full name.')).toBeInTheDocument()
+    await expect(canvas.getByText('Please enter the email address.')).toBeInTheDocument()
+    await expect(canvas.getByText('Please select a position.')).toBeInTheDocument()
+    await expect(canvas.getByLabelText('Full name')).toHaveFocus()
   },
 }
 
@@ -146,6 +168,45 @@ export const Step4LongReviewSummary: Story = {
   },
 }
 
+export const LandingStep1ClinicDetails: Story = {
+  args: {
+    ...landingStoryArgs,
+    initialStep: 1,
+  },
+}
+
+export const LandingStep2FocusCategories: Story = {
+  args: {
+    ...landingStoryArgs,
+    initialStep: 2,
+  },
+}
+
+export const LandingStep3ContactError: Story = {
+  args: {
+    ...landingStoryArgs,
+    initialStep: 3,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await userEvent.click(canvas.getByRole('button', { name: /^submit request$/i }))
+
+    await expect(canvas.getByText('Please enter the full name.')).toBeInTheDocument()
+    await expect(canvas.getByText('Please enter the email address.')).toBeInTheDocument()
+    await expect(canvas.getByText('Please select a position.')).toBeInTheDocument()
+    await expect(canvas.getByLabelText('Full name')).toHaveFocus()
+  },
+}
+
+export const LandingStep4ReviewConfirmation: Story = {
+  args: {
+    ...landingStoryArgs,
+    initialSelectedTreatmentCategoryIds: ['dental', 'hair-restoration'],
+    initialStep: 4,
+  },
+}
+
 export const InteractiveFunnel: Story = {
   args: {
     ...defaultStoryArgs,
@@ -154,56 +215,54 @@ export const InteractiveFunnel: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    await expect(canvas.getByRole('heading', { name: /klinik registrieren/i })).toBeInTheDocument()
-    await expect(canvas.getByText(/klinik international sichtbar machen/i)).toBeInTheDocument()
-    await expect(canvas.queryByText(/international patients/i)).not.toBeInTheDocument()
-    await userEvent.type(canvas.getByLabelText('Klinikname'), 'Aurora Klinik Berlin')
-    await userEvent.type(canvas.getByLabelText('Website'), 'https://aurora-klinik.example')
-    await userEvent.click(canvas.getByRole('button', { name: /^weiter$/i }))
+    await expect(canvas.getByRole('heading', { name: /register your clinic/i })).toBeInTheDocument()
+    await expect(canvas.getByText(/international patients/i)).toBeInTheDocument()
+    await userEvent.type(canvas.getByLabelText('Clinic name'), 'Aurora Clinic Berlin')
+    await userEvent.type(canvas.getByLabelText('Website'), 'https://aurora-clinic.example')
+    await userEvent.click(canvas.getByRole('button', { name: /^continue$/i }))
 
-    const treatmentCategoriesHeading = await canvas.findByRole('heading', { name: /schwerpunkte wählen/i })
+    const treatmentCategoriesHeading = await canvas.findByRole('heading', { name: /choose focus areas/i })
     await expect(treatmentCategoriesHeading).toBeInTheDocument()
     await waitFor(() => expect(treatmentCategoriesHeading).toHaveFocus())
-    await expect(canvas.getByText(/schwerpunkte der klinik/i)).toBeInTheDocument()
-    const treatmentCategoryGroup = canvas.getByRole('group', { name: /behandlungskategorien auswählen/i })
+    await expect(canvas.getByText(/welcome to the network/i)).toBeInTheDocument()
+    const treatmentCategoryGroup = canvas.getByRole('group', { name: /select treatment categories/i })
     await expect(treatmentCategoryGroup).toBeInTheDocument()
-    await expect(treatmentCategoryGroup).toHaveAccessibleDescription(/hauptkategorien für die kliniksuche/i)
+    await expect(treatmentCategoryGroup).toHaveAccessibleDescription(/main categories for clinic search/i)
     for (const categoryLabel of ['Dental', 'Eye Care', 'Hair Restoration', 'Dermatology', 'Plastic Surgery']) {
       await expect(canvas.getByRole('button', { name: categoryLabel })).toBeInTheDocument()
     }
     await expect(canvas.queryByRole('button', { name: 'Body' })).not.toBeInTheDocument()
     await expect(canvas.queryByRole('button', { name: 'Kardio' })).not.toBeInTheDocument()
     await expect(canvas.queryByRole('button', { name: 'Allgemein' })).not.toBeInTheDocument()
-    await expect(canvas.queryByText(/profil/i)).not.toBeInTheDocument()
     const hairCategoryButton = canvas.getByRole('button', { name: 'Hair Restoration' })
     hairCategoryButton.focus()
     await expect(hairCategoryButton).toHaveFocus()
     await userEvent.keyboard('{Enter}')
     await expect(hairCategoryButton).toHaveAttribute('aria-pressed', 'true')
-    await userEvent.click(canvas.getByRole('button', { name: /^weiter$/i }))
+    await userEvent.click(canvas.getByRole('button', { name: /^continue$/i }))
 
-    const contactHeading = await canvas.findByRole('heading', { name: /ihr kontakt/i })
+    const contactHeading = await canvas.findByRole('heading', { name: /your contact/i })
     await expect(contactHeading).toBeInTheDocument()
     await waitFor(() => expect(contactHeading).toHaveFocus())
-    await expect(canvas.getByText(/berechtigten interesse zur klinikregistrierung/i)).toBeInTheDocument()
-    await userEvent.type(canvas.getByLabelText('Vollständiger Name'), 'Dr. Ada Lovelace')
-    await userEvent.type(canvas.getByLabelText('E-Mail Adresse'), 'ada.lovelace@aurora-klinik.example')
-    await userEvent.selectOptions(canvas.getByLabelText('Position / Funktion'), 'Klinikmanagement')
-    await userEvent.click(canvas.getByRole('button', { name: /^anfrage senden$/i }))
+    await expect(canvas.getByText(/legitimate interest/i)).toBeInTheDocument()
+    await userEvent.type(canvas.getByLabelText('Full name'), 'Dr. Ada Lovelace')
+    await userEvent.type(canvas.getByLabelText('Email address'), 'ada.lovelace@aurora-clinic.example')
+    await userEvent.selectOptions(canvas.getByLabelText('Position / role'), 'Clinic Management')
+    await userEvent.click(canvas.getByRole('button', { name: /^submit request$/i }))
 
-    const confirmationHeading = await canvas.findByRole('heading', { name: /anfrage übermittelt/i })
+    const confirmationHeading = await canvas.findByRole('heading', { name: /request submitted/i })
     await expect(confirmationHeading).toBeInTheDocument()
     await waitFor(() => expect(confirmationHeading).toHaveFocus())
-    await expect(canvas.getByText(/wir kontaktieren sie, sobald die prüfung abgeschlossen ist/i)).toBeInTheDocument()
-    await expect(canvas.getByText('Aurora Klinik Berlin')).toBeInTheDocument()
-    await expect(canvas.getByText('https://aurora-klinik.example')).toBeInTheDocument()
+    await expect(canvas.getByText(/we will contact you once the review is complete/i)).toBeInTheDocument()
+    await expect(canvas.getByText('Aurora Clinic Berlin')).toBeInTheDocument()
+    await expect(canvas.getByText('https://aurora-clinic.example')).toBeInTheDocument()
     await expect(canvas.getByText('Dr. Ada Lovelace')).toBeInTheDocument()
-    await expect(canvas.getByText(/Klinikmanagement/)).toBeInTheDocument()
-    await expect(canvas.getByText(/ada.lovelace@aurora-klinik.example/)).toBeInTheDocument()
+    await expect(canvas.getByText(/Clinic Management/)).toBeInTheDocument()
+    await expect(canvas.getByText(/ada.lovelace@aurora-clinic.example/)).toBeInTheDocument()
     await expect(canvas.getByText('Dental')).toBeInTheDocument()
     await expect(canvas.getByText('Hair Restoration')).toBeInTheDocument()
     await expect(canvas.queryByText(/dashboard/i)).not.toBeInTheDocument()
-    await expect(canvas.queryByText(/profil vervollständigen/i)).not.toBeInTheDocument()
+    await expect(canvas.queryByText(/complete your profile/i)).not.toBeInTheDocument()
     await expect(canvas.queryByText(/consent/i)).not.toBeInTheDocument()
   },
 }
@@ -228,4 +287,45 @@ export const Step4LongReviewSummary320Short: Story = withViewportStory(
   Step4LongReviewSummary,
   'public320Short',
   'Edge Case / Step 4 Long Review / 320 short',
+)
+
+export const LandingResponsive320: Story = withViewportStory(
+  LandingStep1ClinicDetails,
+  'public320',
+  'Landing Responsive / 320',
+)
+export const LandingResponsive375: Story = withViewportStory(
+  LandingStep1ClinicDetails,
+  'public375',
+  'Landing Responsive / 375',
+)
+export const LandingResponsive640: Story = withViewportStory(
+  LandingStep1ClinicDetails,
+  'public640',
+  'Landing Responsive / 640',
+)
+export const LandingResponsive768: Story = withViewportStory(
+  LandingStep1ClinicDetails,
+  'public768',
+  'Landing Responsive / 768',
+)
+export const LandingResponsive1024: Story = withViewportStory(
+  LandingStep1ClinicDetails,
+  'public1024',
+  'Landing Responsive / 1024',
+)
+export const LandingResponsive1280: Story = withViewportStory(
+  LandingStep1ClinicDetails,
+  'public1280',
+  'Landing Responsive / 1280',
+)
+export const LandingResponsive375Short: Story = withViewportStory(
+  LandingStep1ClinicDetails,
+  'public375Short',
+  'Landing Responsive / 375 short',
+)
+export const LandingStep3ContactError375Short: Story = withViewportStory(
+  LandingStep3ContactError,
+  'public375Short',
+  'Landing Error State / Step 3 / 375 short',
 )

--- a/tests/e2e/public/auth.registration.public-smoke.spec.ts
+++ b/tests/e2e/public/auth.registration.public-smoke.spec.ts
@@ -36,21 +36,21 @@ async function stubSupabaseSignup(page: Page, handler: (route: Route) => Promise
 
 async function fillClinicRegistrationFunnel(page: Page) {
   await expect(page.locator('[data-clinic-registration-funnel-ready="true"]')).toBeVisible()
-  await page.getByLabel('Klinikname').fill('Aurora Clinic')
+  await page.getByLabel('Clinic name').fill('Aurora Clinic')
   await page.getByLabel('Website').fill('https://aurora-clinic.example')
-  await page.getByRole('button', { name: 'Weiter' }).click()
+  await page.getByRole('button', { name: 'Continue' }).click()
 
-  await expect(page.getByRole('heading', { name: 'Schwerpunkte wählen' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Choose focus areas' })).toBeVisible()
   const hairRestorationCategory = page.getByRole('button', { name: 'Hair Restoration' })
   if ((await hairRestorationCategory.getAttribute('aria-pressed')) !== 'true') {
     await hairRestorationCategory.click()
   }
-  await page.getByRole('button', { name: 'Weiter' }).click()
+  await page.getByRole('button', { name: 'Continue' }).click()
 
-  await expect(page.getByRole('heading', { name: 'Ihr Kontakt' })).toBeVisible()
-  await page.getByLabel('Vollständiger Name').fill('Ada Lovelace')
-  await page.getByLabel('E-Mail Adresse').fill('clinic@example.com')
-  await page.getByLabel('Position / Funktion').selectOption({ label: 'Klinikmanagement' })
+  await expect(page.getByRole('heading', { name: 'Your contact' })).toBeVisible()
+  await page.getByLabel('Full name').fill('Ada Lovelace')
+  await page.getByLabel('Email address').fill('clinic@example.com')
+  await page.getByLabel('Position / role').selectOption({ label: 'Clinic Management' })
 }
 
 async function fillPatientRegistrationForm(page: Page, passwords: { password: string; confirmPassword?: string }) {
@@ -72,10 +72,10 @@ test('clinic registration shows success feedback after a successful submit @smok
 
   await page.goto('/register/clinic', { waitUntil: 'domcontentloaded' })
   await fillClinicRegistrationFunnel(page)
-  await page.getByRole('button', { name: 'Anfrage senden' }).click()
+  await page.getByRole('button', { name: 'Submit request' }).click()
 
-  await expect(page.getByRole('heading', { name: 'Anfrage übermittelt' })).toBeVisible()
-  await expect(page.getByText('Ihre Anfrage wurde übermittelt.')).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Request submitted' })).toBeVisible()
+  await expect(page.getByText('Your request has been submitted.')).toBeVisible()
   await expect(page.getByText('Aurora Clinic')).toBeVisible()
   await expect(page.getByText('clinic@example.com')).toBeVisible()
   await expect(page.getByText('Hair Restoration')).toBeVisible()
@@ -89,27 +89,27 @@ test('clinic registration surfaces inline validation errors before fake submit @
 
   await page.goto('/register/clinic', { waitUntil: 'domcontentloaded' })
   await expect(page.locator('[data-clinic-registration-funnel-ready="true"]')).toBeVisible()
-  await page.getByRole('button', { name: 'Weiter' }).click()
+  await page.getByRole('button', { name: 'Continue' }).click()
 
-  await expect(page.getByText('Bitte geben Sie den Kliniknamen ein.')).toBeVisible()
-  await expect(page.getByText('Bitte geben Sie die Website ein.')).toBeVisible()
-  await expect(page.getByLabel('Klinikname')).toBeFocused()
+  await expect(page.getByText('Please enter the clinic name.')).toBeVisible()
+  await expect(page.getByText('Please enter the website.')).toBeVisible()
+  await expect(page.getByLabel('Clinic name')).toBeFocused()
 
-  await page.getByLabel('Klinikname').fill('Aurora Clinic')
+  await page.getByLabel('Clinic name').fill('Aurora Clinic')
   await page.getByLabel('Website').fill('https://aurora-clinic.example')
-  await page.getByRole('button', { name: 'Weiter' }).click()
+  await page.getByRole('button', { name: 'Continue' }).click()
 
   await page.getByRole('button', { name: 'Dental' }).click()
-  await page.getByRole('button', { name: 'Weiter' }).click()
-  await expect(page.getByText('Bitte wählen Sie mindestens einen Schwerpunkt aus.')).toBeVisible()
+  await page.getByRole('button', { name: 'Continue' }).click()
+  await expect(page.getByText('Please select at least one focus area.')).toBeVisible()
 
   await page.getByRole('button', { name: 'Dental' }).click()
-  await page.getByRole('button', { name: 'Weiter' }).click()
-  await page.getByRole('button', { name: 'Anfrage senden' }).click()
+  await page.getByRole('button', { name: 'Continue' }).click()
+  await page.getByRole('button', { name: 'Submit request' }).click()
 
-  await expect(page.getByText('Bitte geben Sie den vollständigen Namen ein.')).toBeVisible()
-  await expect(page.getByText('Bitte geben Sie die E-Mail-Adresse ein.')).toBeVisible()
-  await expect(page.getByText('Bitte wählen Sie eine Position aus.')).toBeVisible()
+  await expect(page.getByText('Please enter the full name.')).toBeVisible()
+  await expect(page.getByText('Please enter the email address.')).toBeVisible()
+  await expect(page.getByText('Please select a position.')).toBeVisible()
   await expect(page).toHaveURL(/\/register\/clinic(?:\?.*)?$/)
   await expectNoBrowserIssues(issues)
 })

--- a/tests/e2e/public/listing-comparison.public-smoke.spec.ts
+++ b/tests/e2e/public/listing-comparison.public-smoke.spec.ts
@@ -29,7 +29,7 @@ test('listing filters preserve the selected specialty when rating changes @smoke
   const medicalSpecialtyToggle = page.getByRole('button', { name: /^Medical Specialty/ })
   await medicalSpecialtyToggle.click()
   await expect(medicalSpecialtyToggle).toHaveAttribute('aria-expanded', 'true')
-  await page.getByRole('checkbox', { name: 'Dental', exact: true }).click()
+  await page.getByRole('radiogroup', { name: 'Medical Specialty' }).getByText('Dental', { exact: true }).click()
   await waitForSearchParam(page, 'specialty', '1')
 
   const fourStarButton = page.getByRole('button', { name: '4+ ★' })


### PR DESCRIPTION
## Management summary

### Deutsch

Die Klinikregistrierung spricht Kliniken jetzt konsistent auf Englisch an, egal ob sie über die Partner-Landingpage oder die eigene Registrierungsseite einsteigen. Die Landingpage bleibt optisch auf den Partner-Kontext abgestimmt, während der eigentliche Registrierungsfluss dieselbe vertrauensbildende Botschaft, dieselben Schritte und dieselben Fehlerhinweise verwendet.

### English

The clinic registration now addresses clinics consistently in English, whether they enter from the partner landing page or the dedicated registration page. The landing page remains visually adapted to the partner context, while the registration flow itself uses the same trust-building message, steps, and validation feedback.

## What changed

- Aligns the `ClinicRegistrationFunnel` copy, labels, validation messages, review labels, panel text, and default sample data to English.
- Keeps the default register variant and landing variant visually distinct through styling only, while sharing the same funnel copy and validation behavior.
- Updates the partner landing section heading/subline to a less repetitive conversion-oriented message.
- Updates Storybook stories and public clinic registration smoke tests to assert the English funnel copy and inline validation states.

Context: findmydoc-platform/management#287

## UI/UX

<!-- gh-ui-screenshots:start -->
### Partner Landing Desktop

![Partner Landing Desktop](https://github.com/user-attachments/assets/c4f791b1-1f6c-433e-aed5-db05c44babcb)

### Register Desktop

![Register Desktop](https://github.com/user-attachments/assets/df5daf1c-c92f-4fd9-914a-2ebac906d644)

### Register Mobile

![Register Mobile](https://github.com/user-attachments/assets/b51bc749-7169-406f-b77a-5c5d316e04e8)

### Landing Mobile Error State

![Landing Mobile Error State](https://github.com/user-attachments/assets/af2b81aa-daac-4782-a4ec-40e4577d50a0)
<!-- gh-ui-screenshots:end -->
## Validation

- [x] `pnpm format`: passed after the final rebase.
- [x] `pnpm check`: passed after the final rebase.
- [x] `pnpm build`: passed with `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret}`; local environment warns that Node `v26.0.0` is outside the repo engine range `>=24 <25`.
- [x] Focused tests: `pnpm stories:governance:check`, `pnpm vitest --project storybook --run src/stories/templates/ClinicRegistrationFunnel.stories.tsx src/stories/molecules/StepIndicator.stories.tsx`, `pnpm build-storybook`, and `pnpm playwright test tests/e2e/public/auth.registration.public-smoke.spec.ts --grep "clinic registration"` passed. The first E2E attempt was blocked by an already running local dev server; it passed after stopping that server.
- [x] UI/mobile QA: Playwright screenshots checked `/partners/clinics` and `/register/clinic` at desktop and mobile widths, including mobile validation/error states; checked captures reported `0px` horizontal overflow.
- [x] Security/privacy review: no new API, auth, persistence, secrets, or server trust boundary changes; existing fake local submission behavior remains unchanged.
- [x] Migration/schema check: not applicable; no Payload schema, migration, or data-model files changed.
- [x] Documentation/instructions check: not applicable; no operator docs or instruction sources changed.

## Risk and rollout

Low risk. This changes UI copy, visual variant styling, Storybook coverage, and public E2E expectations only. There is no data migration, no API submission change, and no production deployment by itself.

## Development

Closes #1219
