### PR TITLE
fix: polish FAQ accordion affordance

### DIFF
--- a/src/components/atoms/accordion.tsx
+++ b/src/components/atoms/accordion.tsx
@@ -15,22 +15,29 @@ export const AccordionItem = React.forwardRef<
 
 AccordionItem.displayName = 'AccordionItem'
 
+export type AccordionTriggerProps = React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger> & {
+  iconClassName?: string
+}
+
 export const AccordionTrigger = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+  AccordionTriggerProps
+>(({ className, iconClassName, children, ...props }, ref) => (
   <AccordionPrimitive.Header className="flex">
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        'flex flex-1 items-center justify-between py-4 text-left font-medium ring-offset-background transition-all hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden',
+        'group flex flex-1 items-center justify-between py-4 text-left font-medium ring-offset-background transition-all hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden',
         className,
       )}
       {...props}
     >
       {children}
       <ChevronDown
-        className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 data-[state=open]:rotate-180"
+        className={cn(
+          'h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180',
+          iconClassName,
+        )}
         aria-hidden={true}
       />
     </AccordionPrimitive.Trigger>

--- a/src/components/organisms/FAQ/index.tsx
+++ b/src/components/organisms/FAQ/index.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/atoms/accordion'
 import { Heading } from '@/components/atoms/Heading'
 import { Container } from '@/components/molecules/Container'
+import { SectionHeading } from '@/components/molecules/SectionHeading'
 import { cn } from '@/utilities/ui'
 
 export type FAQItem = {
@@ -25,27 +26,50 @@ export const FAQSection: React.FC<FAQSectionProps> = ({ title, description, item
   const titleId = React.useId()
 
   return (
-    <section className={cn('py-16 md:py-20', className)} aria-labelledby={titleId}>
+    <section className={cn('bg-white py-14 sm:py-16 md:py-20', className)} aria-labelledby={titleId}>
       <Container>
-        <header className="mx-auto flex max-w-4xl flex-col items-center gap-4 text-center">
-          <Heading id={titleId} as="h2" align="center" className="text-size-56 text-foreground">
-            {title}
-          </Heading>
-          {description ? <p className="text-big text-muted-foreground">{description}</p> : null}
-        </header>
+        {description ? (
+          <SectionHeading
+            title={title}
+            description={description}
+            titleId={titleId}
+            size="section"
+            align="center"
+            className="mx-auto max-w-3xl"
+          />
+        ) : (
+          <header className="mx-auto max-w-3xl text-center">
+            <Heading
+              id={titleId}
+              as="h2"
+              align="center"
+              className="text-3xl font-bold tracking-tight sm:text-4xl md:text-5xl"
+            >
+              {title}
+            </Heading>
+          </header>
+        )}
 
-        <div className="mt-10 w-full">
-          <Accordion type="single" collapsible defaultValue={defaultOpenItemId} className="flex flex-col gap-4">
+        <div className="mx-auto mt-8 w-full max-w-5xl sm:mt-10">
+          <Accordion
+            type="single"
+            collapsible
+            defaultValue={defaultOpenItemId}
+            className="flex flex-col gap-3 sm:gap-4"
+          >
             {items.map((item) => (
               <AccordionItem
                 key={item.id}
                 value={item.id}
-                className="overflow-hidden rounded-3xl border-0 bg-card shadow-elevated-strong"
+                className="scroll-mb-24 overflow-hidden rounded-2xl border border-accent/60 bg-accent shadow-[0_22px_64px_-48px_rgba(7,0,76,0.5)] transition-colors focus-within:border-primary/70"
               >
-                <AccordionTrigger className="bg-accent px-6 py-6 text-2xl font-bold text-black hover:no-underline md:px-10">
+                <AccordionTrigger
+                  iconClassName="h-5 w-5 text-accent-foreground"
+                  className="min-h-14 cursor-pointer gap-4 bg-accent px-5 py-4 text-base leading-6 font-semibold text-accent-foreground transition-colors hover:bg-accent/90 hover:no-underline focus-visible:ring-ring data-[state=open]:bg-accent sm:min-h-16 sm:px-6 sm:py-5 sm:text-lg md:px-7"
+                >
                   {item.question}
                 </AccordionTrigger>
-                <AccordionContent className="px-6 text-left text-lg leading-8 text-foreground md:px-10 md:text-xl">
+                <AccordionContent className="border-t border-accent-foreground/10 bg-white px-5 pt-4 pb-5 text-left text-sm leading-7 text-foreground/80 sm:px-6 sm:text-base md:px-7">
                   {item.answer}
                 </AccordionContent>
               </AccordionItem>

--- a/src/stories/organisms/FAQSection.stories.tsx
+++ b/src/stories/organisms/FAQSection.stories.tsx
@@ -2,7 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, userEvent, within } from 'storybook/test'
 
 import { FAQSection } from '@/components/organisms/FAQ'
-import { homepageFaqSection } from '@/stories/fixtures/listings'
+import { clinicPartnersFaqSection, homepageFaqSection } from '@/stories/fixtures/listings'
+import { withViewportStory } from '@/stories/utils/viewportMatrix'
 
 const meta: Meta<typeof FAQSection> = {
   title: 'Shared/Organisms/FAQSection',
@@ -34,18 +35,62 @@ export const Default: Story = {
     const canvas = within(canvasElement)
 
     // Default: first answer visible
-    await expect(
-      canvas.getByText(
-        'By combining global visibility, patient guidance, and quality-focused clinic presentation in one trusted comparison environment.',
-      ),
-    ).toBeInTheDocument()
+    const firstAnswer = canvas.getByText(
+      'By combining global visibility, patient guidance, and quality-focused clinic presentation in one trusted comparison environment.',
+    )
+    await expect(firstAnswer).toBeInTheDocument()
 
+    const q1 = canvas.getByRole('button', {
+      name: 'How does this platform help clinics gain international patients?',
+    })
     const q2 = canvas.getByRole('button', { name: 'Are the patient inquiries exclusive?' })
     await userEvent.click(q2)
 
-    // After selecting another question: new answer visible
+    // After selecting another question: trigger state and answer content update
+    await expect(q1).toHaveAttribute('aria-expanded', 'false')
+    await expect(q2).toHaveAttribute('aria-expanded', 'true')
     await expect(
       canvas.getByText('Inquiries are handled according to your clinic profile settings and availability.'),
     ).toBeInTheDocument()
   },
 }
+
+export const ClinicPartners: Story = {
+  args: {
+    title: clinicPartnersFaqSection.title,
+    description: clinicPartnersFaqSection.description,
+    defaultOpenItemId: clinicPartnersFaqSection.defaultOpenItemId,
+    items: clinicPartnersFaqSection.items,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const q1 = canvas.getByRole('button', {
+      name: 'How does this platform help clinics gain international patients?',
+    })
+    const q2 = canvas.getByRole('button', { name: 'Are the patient inquiries exclusive?' })
+
+    await expect(q1).toHaveAttribute('aria-expanded', 'true')
+    await userEvent.click(q2)
+
+    await expect(q1).toHaveAttribute('aria-expanded', 'false')
+    await expect(q2).toHaveAttribute('aria-expanded', 'true')
+    await expect(
+      canvas.getByText('Patients contact clinics directly. There are no resold or recycled leads.'),
+    ).toBeInTheDocument()
+  },
+}
+
+export const Mobile320: Story = withViewportStory(Default, 'public320', 'FAQSection / 320')
+export const Mobile375: Story = withViewportStory(Default, 'public375', 'FAQSection / 375')
+export const Mobile640: Story = withViewportStory(Default, 'public640', 'FAQSection / 640')
+export const Tablet768: Story = withViewportStory(Default, 'public768', 'FAQSection / 768')
+export const Desktop1024: Story = withViewportStory(Default, 'public1024', 'FAQSection / 1024')
+export const Desktop1280: Story = withViewportStory(Default, 'public1280', 'FAQSection / 1280')
+
+export const ClinicPartners320: Story = withViewportStory(ClinicPartners, 'public320', 'Clinic partners FAQ / 320')
+export const ClinicPartners375: Story = withViewportStory(ClinicPartners, 'public375', 'Clinic partners FAQ / 375')
+export const ClinicPartners640: Story = withViewportStory(ClinicPartners, 'public640', 'Clinic partners FAQ / 640')
+export const ClinicPartners768: Story = withViewportStory(ClinicPartners, 'public768', 'Clinic partners FAQ / 768')
+export const ClinicPartners1024: Story = withViewportStory(ClinicPartners, 'public1024', 'Clinic partners FAQ / 1024')
+export const ClinicPartners1280: Story = withViewportStory(ClinicPartners, 'public1280', 'Clinic partners FAQ / 1280')

--- a/tests/unit/components/FAQSection.test.tsx
+++ b/tests/unit/components/FAQSection.test.tsx
@@ -20,6 +20,38 @@ describe('FAQSection', () => {
     expect(screen.getByText('Common questions.')).toBeInTheDocument()
   })
 
+  it('renders compact pointer-enabled accordion triggers', () => {
+    render(
+      <FAQSection
+        title="FAQ"
+        description="Common questions."
+        defaultOpenItemId="q1"
+        items={[{ id: 'q1', question: 'Question 1?', answer: 'Answer 1.' }]}
+      />,
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Question 1?' })
+    const icon = trigger.querySelector('svg')
+    if (!icon) throw new Error('Expected FAQ trigger icon')
+
+    expect(trigger).toHaveClass('cursor-pointer')
+    expect(trigger).toHaveClass('bg-accent')
+    expect(trigger).toHaveClass('text-accent-foreground')
+    expect(trigger).toHaveClass('text-base')
+    expect(trigger).toHaveClass('sm:text-lg')
+    expect(trigger).not.toHaveClass('md:text-xl')
+    expect(trigger).toHaveClass('focus-visible:ring-ring')
+    expect(trigger).not.toHaveClass('before:bg-secondary')
+    expect(trigger).not.toHaveClass('data-[state=open]:before:bg-secondary')
+    expect(icon).toHaveClass('text-accent-foreground')
+    expect(icon).toHaveClass('group-data-[state=open]:rotate-180')
+    expect(screen.getByText('Answer 1.')).toHaveClass('text-foreground/80')
+    expect(screen.getByText('Answer 1.')).toHaveClass('bg-white')
+    expect(screen.getByText('Answer 1.')).toHaveClass('text-sm')
+    expect(screen.getByText('Answer 1.')).toHaveClass('sm:text-base')
+    expect(trigger.parentElement?.parentElement).toHaveClass('scroll-mb-24')
+  })
+
   it('supports default open item and switching between items', () => {
     render(
       <FAQSection
@@ -38,12 +70,17 @@ describe('FAQSection', () => {
       expect(answer2Initial).not.toBeVisible()
     }
 
-    fireEvent.click(screen.getByRole('button', { name: 'Question 2?' }))
+    const question1 = screen.getByRole('button', { name: 'Question 1?' })
+    const question2 = screen.getByRole('button', { name: 'Question 2?' })
+
+    fireEvent.click(question2)
 
     const answer1After = screen.queryByText('Answer 1.')
     if (answer1After) {
       expect(answer1After).not.toBeVisible()
     }
     expect(screen.getByText('Answer 2.')).toBeVisible()
+    expect(question1).toHaveAttribute('aria-expanded', 'false')
+    expect(question2).toHaveAttribute('aria-expanded', 'true')
   })
 })


### PR DESCRIPTION
## Management summary

### Deutsch

Die FAQ auf den öffentlichen Einstiegsseiten ist kompakter, klarer bedienbar und besser lesbar. Fragen wirken jetzt eindeutig klickbar, der Pfeil ist auf dem grünen Hintergrund kontraststärker, und geöffnete Antworten bleiben neutral auf weißem Hintergrund ohne zusätzliche visuelle Leiste.

### English

The FAQ on the public entry pages is more compact, easier to interact with, and more readable. Questions now clearly behave like clickable controls, the chevron has stronger contrast on the green background, and expanded answers stay neutral on a white background without an extra visual bar.

## What changed

- Tightened FAQ section spacing and capped question/answer text sizes for mobile and desktop.
- Added pointer affordance, hover/focus/open-state polish, and readable FAQ chevron coloring.
- Added optional accordion icon styling so FAQ-specific icon color does not change other accordions.
- Expanded FAQ unit coverage and Storybook viewport/play coverage for homepage and clinic partners fixtures.

## UI/UX

### Homepage mobile

Screenshot captured locally: `/Users/razorspoint/repos/website/output/playwright/faq-qa-production/faq-no-mint-home-375.png`

### Additional QA evidence

Screenshots captured locally for homepage and clinic partners FAQ at mobile and desktop widths under `/Users/razorspoint/repos/website/output/playwright/faq-qa-production/`.

## Validation

- [x] `pnpm format`: `rtk pnpm format`
- [x] `pnpm check`: `rtk pnpm check`
- [x] `pnpm build`: `rtk env PAYLOAD_SECRET=dev-secret pnpm build`
- [x] Focused tests: `rtk pnpm vitest --project unit tests/unit/components/FAQSection.test.tsx --run`; `rtk pnpm vitest --project storybook src/stories/organisms/FAQSection.stories.tsx --run`
- [x] UI/mobile QA: Playwright checked `/` and `/partners/clinics`; no horizontal overflow, no text clipping, pointer cursor present, keyboard toggle works, answer background is white.
- [x] Security/privacy review: not applicable; frontend-only visual and interaction change.
- [x] Migration/schema check: not applicable; no schema or migration changes.
- [x] Documentation/instructions check: not applicable; no docs or instruction changes.

## Risk and rollout

None known. The change is limited to shared FAQ presentation and AccordionTrigger icon styling.

## Development

Closes #1221