### PR TITLE
chore(collections): clarify clinic copy

### DIFF
--- a/src/collections/ClinicApplications.ts
+++ b/src/collections/ClinicApplications.ts
@@ -176,9 +176,9 @@ export const ClinicApplications: CollectionConfig = {
     {
       name: 'linkedRecords',
       type: 'group',
-      label: 'Created records',
+      label: 'Created clinic records',
       admin: {
-        description: 'Records created from this application',
+        description: 'Clinic, user, and staff records created from this application',
         condition: (data) => data?.status !== 'submitted',
       },
       fields: [
@@ -191,7 +191,7 @@ export const ClinicApplications: CollectionConfig = {
     {
       name: 'sourceMeta',
       type: 'group',
-      admin: { description: 'IP address and browser details', readOnly: true, position: 'sidebar' },
+      admin: { description: 'IP address and browser info', readOnly: true, position: 'sidebar' },
       fields: [
         { name: 'ip', type: 'text' },
         { name: 'userAgent', type: 'text' },
@@ -200,7 +200,7 @@ export const ClinicApplications: CollectionConfig = {
     {
       name: 'privacyNotice',
       type: 'group',
-      admin: { description: 'Privacy notice shown during submission', readOnly: true, position: 'sidebar' },
+      admin: { description: 'Privacy notice text', readOnly: true, position: 'sidebar' },
       fields: [
         { name: 'acknowledgedAt', type: 'date', admin: { readOnly: true } },
         { name: 'url', type: 'text', admin: { readOnly: true } },

--- a/src/collections/DoctorSpecialties.ts
+++ b/src/collections/DoctorSpecialties.ts
@@ -16,7 +16,7 @@ export const DoctorSpecialties: CollectionConfig = {
   },
   admin: {
     group: 'Medical Network',
-    description: 'Doctors and their specialty expertise',
+    description: 'Doctors and their specialties',
     useAsTitle: 'id',
     defaultColumns: ['doctor', 'medicalSpecialty', 'specializationLevel'],
   },

--- a/src/collections/DoctorTreatments.ts
+++ b/src/collections/DoctorTreatments.ts
@@ -15,7 +15,7 @@ export const DoctorTreatments: CollectionConfig = {
   },
   admin: {
     group: 'Medical Network',
-    description: 'Links doctors to treatments and their expertise',
+    description: 'Doctors and their treatments',
     useAsTitle: 'id',
     defaultColumns: ['doctor', 'treatment', 'specializationLevel'],
   },


### PR DESCRIPTION
## Management summary

### Deutsch

Wir haben die Bezeichnungen und Beschreibungen in einigen Klinik-Collections vereinfacht, damit sie für neue Klinik-Teams schneller verständlich sind. Die Oberfläche bleibt gleich; nur die Formulierungen sind klarer und weniger intern.

### English

We simplified labels and descriptions in a few clinic collections so they are easier for new clinic teams to understand at a glance. The UI stays the same; only the wording is clearer and less internal.

## What changed

- Tightened a small set of collection field labels and descriptions in src/collections/**.
- Kept the edits local and conservative: no schema, validation, access, or hook changes.
- Focused on copy that was internal, overly technical, or likely confusing to a first-time clinic user.

## Validation

- [x] pnpm format: ran successfully after the copy edits.
- [ ] pnpm check: not run; copy-only changes did not affect runtime or lint-relevant code.
- [ ] pnpm build: not run; no build-relevant sources changed.
- [ ] Focused tests: not run; no behavior changed.
- [ ] UI/mobile QA: not applicable; no UI code changed.
- [ ] Security/privacy review: not needed; no access or data-flow changes.
- [ ] Migration/schema check: not needed; no schema changes.
- [ ] Documentation/instructions check: not needed; no instruction files changed.

## Risk and rollout

None known. This is copy-only and can be rolled back by reverting the three collection files.

## Development

Closes #1225
