### PR TITLE
fix(forms): split clinic registration contact name

### DIFF
--- a/src/app/api/auth/register/clinic/route.ts
+++ b/src/app/api/auth/register/clinic/route.ts
@@ -119,9 +119,14 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Invalid clinicWebsite' }, { status: 400 })
     }
 
-    const contactName = readString(body.contactName)
-    if (contactName.length === 0) {
-      return NextResponse.json({ error: 'Contact name is required' }, { status: 400 })
+    const contactFirstName = readString(body.contactFirstName)
+    if (contactFirstName.length === 0) {
+      return NextResponse.json({ error: 'Contact first name is required' }, { status: 400 })
+    }
+
+    const contactLastName = readString(body.contactLastName)
+    if (contactLastName.length === 0) {
+      return NextResponse.json({ error: 'Contact last name is required' }, { status: 400 })
     }
 
     const contactEmail = readString(body.contactEmail).toLowerCase()
@@ -196,8 +201,8 @@ export async function POST(req: NextRequest) {
       data: {
         clinicName,
         clinicWebsite,
-        contactFirstName: null,
-        contactLastName: contactName,
+        contactFirstName,
+        contactLastName,
         contactEmail,
         contactRole,
         medicalSpecialties: medicalSpecialtyIds,

--- a/src/auth/utilities/clinicRegistrationSubmission.ts
+++ b/src/auth/utilities/clinicRegistrationSubmission.ts
@@ -2,7 +2,8 @@ type ClinicRegistrationFormData = {
   clinicName: string
   clinicWebsite: string
   contactEmail: string
-  contactName: string
+  contactFirstName: string
+  contactLastName: string
   contactRole: string
   medicalSpecialties: string[]
 }

--- a/src/components/templates/ClinicRegistrationFunnel/ClinicRegistrationFunnel.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/ClinicRegistrationFunnel.tsx
@@ -50,9 +50,14 @@ const serverFieldErrorMap: Record<
     message: validationMessages.clinicWebsite.typeMismatch,
     step: 1,
   },
-  'Contact name is required': {
-    fieldName: 'contactName',
-    message: validationMessages.contactName.valueMissing,
+  'Contact first name is required': {
+    fieldName: 'contactFirstName',
+    message: validationMessages.contactFirstName.valueMissing,
+    step: 3,
+  },
+  'Contact last name is required': {
+    fieldName: 'contactLastName',
+    message: validationMessages.contactLastName.valueMissing,
     step: 3,
   },
   'Invalid contactEmail': {
@@ -120,17 +125,21 @@ export function ClinicRegistrationFunnel({
     .filter((category) => selectedTreatmentCategories.includes(category.id))
     .map((category) => category.label)
 
-  const resolvedReviewSummary = React.useMemo<ClinicRegistrationReviewSummary>(
-    () => ({
+  const resolvedReviewSummary = React.useMemo<ClinicRegistrationReviewSummary>(() => {
+    const contactName = [formValues.contactFirstName, formValues.contactLastName]
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .join(' ')
+
+    return {
       ...reviewSummary,
       clinicName: formValues.clinicName.trim() || reviewSummary.clinicName,
       clinicWebsite: formValues.clinicWebsite.trim() || reviewSummary.clinicWebsite || reviewSummary.clinicAddress,
       contactEmail: formValues.contactEmail.trim() || reviewSummary.contactEmail,
-      contactName: formValues.contactName.trim() || reviewSummary.contactName,
+      contactName: contactName || reviewSummary.contactName,
       contactRole: formValues.contactRole || reviewSummary.contactRole,
-    }),
-    [formValues, reviewSummary],
-  )
+    }
+  }, [formValues, reviewSummary])
 
   const transitionClassName = getStepTransitionClassName(stepTransitionDirection)
 

--- a/src/components/templates/ClinicRegistrationFunnel/constants.ts
+++ b/src/components/templates/ClinicRegistrationFunnel/constants.ts
@@ -37,7 +37,8 @@ export const defaultFormValues: ClinicRegistrationFormValues = {
   clinicName: '',
   clinicWebsite: '',
   contactEmail: '',
-  contactName: '',
+  contactFirstName: '',
+  contactLastName: '',
   contactRole: '',
 }
 

--- a/src/components/templates/ClinicRegistrationFunnel/steps/ContactStep.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/steps/ContactStep.tsx
@@ -65,18 +65,32 @@ export function ContactStep({
         </p>
 
         <div className="mt-8 grid gap-5 sm:mt-10 sm:gap-6 lg:mt-12">
-          <RegistrationField
-            descriptionId={noticeId}
-            id={`${idBase}-contact-name`}
-            label="Full name"
-            name="contactName"
-            onValueChange={(value) => onValueChange('contactName', value)}
-            placeholder="e.g. Dr. Max Sample"
-            required
-            validation={validation}
-            value={formValues.contactName}
-            variant={variant}
-          />
+          <div className="grid min-w-0 gap-5 sm:grid-cols-2 sm:gap-4">
+            <RegistrationField
+              descriptionId={noticeId}
+              id={`${idBase}-contact-first-name`}
+              label="First name"
+              name="contactFirstName"
+              onValueChange={(value) => onValueChange('contactFirstName', value)}
+              placeholder="e.g. Ada"
+              required
+              validation={validation}
+              value={formValues.contactFirstName}
+              variant={variant}
+            />
+            <RegistrationField
+              descriptionId={noticeId}
+              id={`${idBase}-contact-last-name`}
+              label="Last name"
+              name="contactLastName"
+              onValueChange={(value) => onValueChange('contactLastName', value)}
+              placeholder="e.g. Lovelace"
+              required
+              validation={validation}
+              value={formValues.contactLastName}
+              variant={variant}
+            />
+          </div>
           <RegistrationField
             descriptionId={noticeId}
             id={`${idBase}-contact-email`}

--- a/src/components/templates/ClinicRegistrationFunnel/types.ts
+++ b/src/components/templates/ClinicRegistrationFunnel/types.ts
@@ -24,7 +24,8 @@ export type ClinicRegistrationFormValues = {
   clinicName: string
   clinicWebsite: string
   contactEmail: string
-  contactName: string
+  contactFirstName: string
+  contactLastName: string
   contactRole: string
 }
 

--- a/src/components/templates/ClinicRegistrationFunnel/validation.ts
+++ b/src/components/templates/ClinicRegistrationFunnel/validation.ts
@@ -10,8 +10,11 @@ export const validationMessages = {
     typeMismatch: 'Please enter a valid email address.',
     valueMissing: 'Please enter the email address.',
   },
-  contactName: {
-    valueMissing: 'Please enter the full name.',
+  contactFirstName: {
+    valueMissing: 'Please enter the first name.',
+  },
+  contactLastName: {
+    valueMissing: 'Please enter the last name.',
   },
   contactRole: {
     valueMissing: 'Please select a position.',

--- a/src/stories/templates/ClinicRegistrationFunnel.stories.tsx
+++ b/src/stories/templates/ClinicRegistrationFunnel.stories.tsx
@@ -145,10 +145,11 @@ export const Step3ValidationErrors: Story = {
 
     await userEvent.click(canvas.getByRole('button', { name: /^submit request$/i }))
 
-    await expect(canvas.getByText('Please enter the full name.')).toBeInTheDocument()
+    await expect(canvas.getByText('Please enter the first name.')).toBeInTheDocument()
+    await expect(canvas.getByText('Please enter the last name.')).toBeInTheDocument()
     await expect(canvas.getByText('Please enter the email address.')).toBeInTheDocument()
     await expect(canvas.getByText('Please select a position.')).toBeInTheDocument()
-    await expect(canvas.getByLabelText('Full name')).toHaveFocus()
+    await expect(canvas.getByLabelText('First name')).toHaveFocus()
   },
 }
 
@@ -160,7 +161,8 @@ export const Step3ServerError: Story = {
       clinicName: 'Aurora Clinic Berlin',
       clinicWebsite: 'https://aurora-clinic.example',
       contactEmail: 'ada.lovelace@aurora-clinic.example',
-      contactName: 'Dr. Ada Lovelace',
+      contactFirstName: 'Ada',
+      contactLastName: 'Lovelace',
       contactRole: 'Clinic Management',
     },
     onSubmit: async () => {
@@ -218,10 +220,11 @@ export const LandingStep3ContactError: Story = {
 
     await userEvent.click(canvas.getByRole('button', { name: /^submit request$/i }))
 
-    await expect(canvas.getByText('Please enter the full name.')).toBeInTheDocument()
+    await expect(canvas.getByText('Please enter the first name.')).toBeInTheDocument()
+    await expect(canvas.getByText('Please enter the last name.')).toBeInTheDocument()
     await expect(canvas.getByText('Please enter the email address.')).toBeInTheDocument()
     await expect(canvas.getByText('Please select a position.')).toBeInTheDocument()
-    await expect(canvas.getByLabelText('Full name')).toHaveFocus()
+    await expect(canvas.getByLabelText('First name')).toHaveFocus()
   },
 }
 
@@ -271,7 +274,8 @@ export const InteractiveFunnel: Story = {
     await expect(contactHeading).toBeInTheDocument()
     await waitFor(() => expect(contactHeading).toHaveFocus())
     await expect(canvas.getByText(/legitimate interest/i)).toBeInTheDocument()
-    await userEvent.type(canvas.getByLabelText('Full name'), 'Dr. Ada Lovelace')
+    await userEvent.type(canvas.getByLabelText('First name'), 'Ada')
+    await userEvent.type(canvas.getByLabelText('Last name'), 'Lovelace')
     await userEvent.type(canvas.getByLabelText('Email address'), 'ada.lovelace@aurora-clinic.example')
     await userEvent.selectOptions(canvas.getByLabelText('Position / role'), 'Clinic Management')
     await userEvent.click(canvas.getByRole('button', { name: /^submit request$/i }))
@@ -282,7 +286,7 @@ export const InteractiveFunnel: Story = {
     await expect(canvas.getByText(/we will contact you once the review is complete/i)).toBeInTheDocument()
     await expect(canvas.getByText('Aurora Clinic Berlin')).toBeInTheDocument()
     await expect(canvas.getByText('https://aurora-clinic.example')).toBeInTheDocument()
-    await expect(canvas.getByText('Dr. Ada Lovelace')).toBeInTheDocument()
+    await expect(canvas.getByText('Ada Lovelace')).toBeInTheDocument()
     await expect(canvas.getByText(/Clinic Management/)).toBeInTheDocument()
     await expect(canvas.getByText(/ada.lovelace@aurora-clinic.example/)).toBeInTheDocument()
     await expect(canvas.getByText('Dental')).toBeInTheDocument()

--- a/tests/e2e/public/auth.registration.public-smoke.spec.ts
+++ b/tests/e2e/public/auth.registration.public-smoke.spec.ts
@@ -48,7 +48,8 @@ async function fillClinicRegistrationFunnel(page: Page) {
   await page.getByRole('button', { name: 'Continue' }).click()
 
   await expect(page.getByRole('heading', { name: 'Your contact' })).toBeVisible()
-  await page.getByLabel('Full name').fill('Ada Lovelace')
+  await page.getByLabel('First name').fill('Ada')
+  await page.getByLabel('Last name').fill('Lovelace')
   await page.getByLabel('Email address').fill('clinic@example.com')
   await page.getByLabel('Position / role').selectOption({ label: 'Clinic Management' })
 }
@@ -87,7 +88,8 @@ test('clinic registration shows success feedback after a successful submit @smok
   expect(submittedClinicApplication).toMatchObject({
     clinicName: 'Aurora Clinic',
     clinicWebsite: 'https://aurora-clinic.example',
-    contactName: 'Ada Lovelace',
+    contactFirstName: 'Ada',
+    contactLastName: 'Lovelace',
     contactEmail: 'clinic@example.com',
     contactRole: 'Clinic Management',
   })
@@ -119,7 +121,8 @@ test('clinic registration surfaces inline validation errors before submit @smoke
   await page.getByRole('button', { name: 'Continue' }).click()
   await page.getByRole('button', { name: 'Submit request' }).click()
 
-  await expect(page.getByText('Please enter the full name.')).toBeVisible()
+  await expect(page.getByText('Please enter the first name.')).toBeVisible()
+  await expect(page.getByText('Please enter the last name.')).toBeVisible()
   await expect(page.getByText('Please enter the email address.')).toBeVisible()
   await expect(page.getByText('Please select a position.')).toBeVisible()
   await expect(page).toHaveURL(/\/register\/clinic(?:\?.*)?$/)

--- a/tests/unit/api/registerClinic.route.test.ts
+++ b/tests/unit/api/registerClinic.route.test.ts
@@ -71,7 +71,8 @@ import { NextRequest } from 'next/server'
 const validSubmission = {
   clinicName: 'New Clinic',
   clinicWebsite: 'new-clinic.example',
-  contactName: 'Dr. Ada Lovelace',
+  contactFirstName: 'Ada',
+  contactLastName: 'Lovelace',
   contactEmail: 'clinic@example.com',
   contactRole: 'Clinic Management',
   medicalSpecialties: ['1', '3'],
@@ -108,8 +109,8 @@ describe('POST /api/auth/register/clinic', () => {
         data: expect.objectContaining({
           clinicName: 'New Clinic',
           clinicWebsite: 'https://new-clinic.example/',
-          contactFirstName: null,
-          contactLastName: 'Dr. Ada Lovelace',
+          contactFirstName: 'Ada',
+          contactLastName: 'Lovelace',
           contactEmail: 'clinic@example.com',
           contactRole: 'Clinic Management',
           medicalSpecialties: [1, 3],
@@ -207,6 +208,34 @@ describe('POST /api/auth/register/clinic', () => {
 
     expect(res.status).toBe(400)
     expect(json.error).toBe('Invalid contactEmail')
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  test('rejects missing contactFirstName values', async () => {
+    const res = await POST(
+      makeRequest({
+        ...validSubmission,
+        contactFirstName: '',
+      }),
+    )
+    const json = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(json.error).toBe('Contact first name is required')
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  test('rejects missing contactLastName values', async () => {
+    const res = await POST(
+      makeRequest({
+        ...validSubmission,
+        contactLastName: '',
+      }),
+    )
+    const json = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(json.error).toBe('Contact last name is required')
     expect(createMock).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Management summary

### Deutsch

Die Klinikregistrierung erfasst die Kontaktperson jetzt sauber mit getrenntem Vor- und Nachnamen. Dadurch landen die Angaben konsistent im Prüfprozess und das Team muss vollständige Namen nicht mehr aus einem Nachnamen-Feld heraus interpretieren.

### English

Clinic registration now captures the contact person with separate first and last name fields. This keeps the submitted details consistent for review and removes the need for the team to interpret a full name from a last-name field.

## What changed

- Split the clinic registration funnel contact step into `First name` and `Last name` fields.
- Updated local validation, server error mapping, review display, and API submission payloads to use `contactFirstName` and `contactLastName`.
- Updated the clinic registration API tests, public smoke tests, and Funnel Storybook tests for the split fields.
- Context: `findmydoc-platform/management#287`.

## UI/UX

<!-- gh-ui-screenshots:start -->
### Step 3 Contact Mobile

![Step 3 Contact Mobile](https://github.com/user-attachments/assets/e2bae16b-c149-4de4-a849-dab23d0b97cf)

### Step 3 Validation Mobile

![Step 3 Validation Mobile](https://github.com/user-attachments/assets/0803f7fb-9d4c-49e4-95b3-63a71f8d6b48)

### Step 3 Contact Desktop

![Step 3 Contact Desktop](https://github.com/user-attachments/assets/e8583d2d-d385-45b8-8d43-b3e82f41f2e2)
<!-- gh-ui-screenshots:end -->
## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed.
- [x] `pnpm build`: passed with local Postgres running and `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret}`; local Supabase URL warning was logged but did not fail the build.
- [x] Focused tests: `pnpm stories:governance:check`, `pnpm vitest --project storybook --run src/stories/templates/ClinicRegistrationFunnel.stories.tsx`, `pnpm vitest --run tests/unit/api/registerClinic.route.test.ts`, `pnpm playwright test tests/e2e/public/auth.registration.public-smoke.spec.ts --grep "clinic registration"`, `pnpm build-storybook`.
- [x] UI/mobile QA: checked Storybook Step 3 contact and error states at 375px and 1280px; split fields stack on mobile, align on desktop, and error text remains in flow without clipping the CTA.
- [x] Security/privacy review: payload shape only; no auth, permission, secret, or data-retention policy changes.
- [x] Migration/schema check: no schema or migration changes.
- [x] Documentation/instructions check: no documentation or instruction changes.

## Risk and rollout

Low. This changes the clinic registration submission shape for a field that already exists in the clinic application model. The public route remains the same, and rollback is the branch revert.

## Development

Closes #1230
