### PR TITLE
fix: align demo doctor specialties

### DIFF
--- a/src/endpoints/seed/data/demo/doctorSpecialties.json
+++ b/src/endpoints/seed/data/demo/doctorSpecialties.json
@@ -20,7 +20,7 @@
   {
     "stableId": "seed-doctor-specialty-04",
     "doctorStableId": "seed-doctor-kaan-sahin",
-    "medicalSpecialtyStableId": "10000000-0000-0000-0000-000000000402",
+    "medicalSpecialtyStableId": "10000000-0000-0000-0000-000000000201",
     "specializationLevel": "specialist"
   },
   {
@@ -38,7 +38,7 @@
   {
     "stableId": "seed-doctor-specialty-07",
     "doctorStableId": "seed-doctor-zeynep-gunes",
-    "medicalSpecialtyStableId": "10000000-0000-0000-0000-000000000402",
+    "medicalSpecialtyStableId": "10000000-0000-0000-0000-000000000201",
     "specializationLevel": "expert"
   },
   {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1117,7 +1117,7 @@ export interface Country {
   createdAt: string;
 }
 /**
- * Doctors and their specialty expertise
+ * Doctors and their specialties
  *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "doctorspecialties".
@@ -1374,7 +1374,7 @@ export interface DoctorMedia {
   };
 }
 /**
- * Links doctors to treatments and their expertise
+ * Doctors and their treatments
  *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "doctortreatments".
@@ -2197,7 +2197,7 @@ export interface ClinicApplication {
    */
   reviewNotes?: string | null;
   /**
-   * Records created from this application
+   * Clinic, user, and staff records created from this application
    */
   linkedRecords?: {
     clinic?: (number | null) | Clinic;
@@ -2206,14 +2206,14 @@ export interface ClinicApplication {
     processedAt?: string | null;
   };
   /**
-   * IP address and browser details
+   * IP address and browser info
    */
   sourceMeta?: {
     ip?: string | null;
     userAgent?: string | null;
   };
   /**
-   * Privacy notice shown during submission
+   * Privacy notice text
    */
   privacyNotice?: {
     acknowledgedAt?: string | null;

--- a/tests/unit/endpoints/seed/medicalSpecialtyPermittierung.test.ts
+++ b/tests/unit/endpoints/seed/medicalSpecialtyPermittierung.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import medicalSpecialties from '@/endpoints/seed/data/baseline/medicalSpecialties.json'
 import treatments from '@/endpoints/seed/data/baseline/treatments.json'
+import doctorSpecialties from '@/endpoints/seed/data/demo/doctorSpecialties.json'
 import { medicalSpecialtyIconOptions } from '@/utilities/medicalSpecialties/iconKeys'
 
 type MedicalSpecialtySeed = {
@@ -12,6 +13,11 @@ type MedicalSpecialtySeed = {
 }
 
 type TreatmentSeed = {
+  stableId: string
+  medicalSpecialtyStableId: string
+}
+
+type DoctorSpecialtySeed = {
   stableId: string
   medicalSpecialtyStableId: string
 }
@@ -34,6 +40,7 @@ function normalizeName(value: string): string {
 describe('medical specialty seed permittierung', () => {
   const specialties = medicalSpecialties as MedicalSpecialtySeed[]
   const treatmentSeeds = treatments as TreatmentSeed[]
+  const doctorSpecialtySeeds = doctorSpecialties as DoctorSpecialtySeed[]
   const specialtiesByStableId = new Map(specialties.map((entry) => [entry.stableId, entry]))
   const validIconKeys = new Set<string>(medicalSpecialtyIconOptions.map((option) => option.value))
 
@@ -62,6 +69,20 @@ describe('medical specialty seed permittierung', () => {
       expect(
         specialty?.parentSpecialtyStableId,
         `Treatment ${treatment.stableId} must point to an L2 specialty, but got ${treatment.medicalSpecialtyStableId}`,
+      ).toBeTruthy()
+    })
+  })
+
+  it('maps every demo doctor specialty to an existing specialty stableId', () => {
+    doctorSpecialtySeeds.forEach((doctorSpecialty) => {
+      const specialty = specialtiesByStableId.get(doctorSpecialty.medicalSpecialtyStableId)
+      expect(
+        specialtiesByStableId.has(doctorSpecialty.medicalSpecialtyStableId),
+        `Unknown specialty ${doctorSpecialty.medicalSpecialtyStableId} for doctor specialty ${doctorSpecialty.stableId}`,
+      ).toBe(true)
+      expect(
+        specialty?.parentSpecialtyStableId,
+        `Doctor specialty ${doctorSpecialty.stableId} must point to an L2 specialty, but got ${doctorSpecialty.medicalSpecialtyStableId}`,
       ).toBeTruthy()
     })
   })


### PR DESCRIPTION
## Management summary

### Deutsch

Die Demo-Daten laufen sauberer durch, weil zwei fehlerhafte Arzt-Spezialisierungen wieder einer vorhandenen medizinischen Fachrichtung zugeordnet sind. Dadurch verschwinden irreführende Seed-Warnungen und die Demo bleibt für Betreiber und Reviewer konsistenter.

### English

The demo data now runs more cleanly because two invalid doctor specialty links point to an existing medical specialty again. This removes misleading seed warnings and keeps the demo more consistent for operators and reviewers.

## What changed

- Pointed the two affected demo doctor-specialty records to the existing level-two `Lens Surgery` specialty because their demo treatments are ICL and cataract surgery.
- Added seed coverage that asserts every demo doctor specialty references an existing level-two medical specialty.
- Kept generated Payload type comments in sync with the current collection metadata.

## Validation

- [x] `pnpm format`: Passed.
- [x] `pnpm check`: Passed.
- [ ] `pnpm build`: Not run; this PR only changes demo seed data, a focused seed test, and generated type comments.
- [x] Focused tests: `pnpm tests tests/unit/endpoints/seed/medicalSpecialtyPermittierung.test.ts` passed.
- [ ] UI/mobile QA: Not applicable; no UI, route, or rendered image behavior changed.
- [x] Security/privacy review: `detect-secrets-hook --baseline .secrets.baseline` passed.
- [ ] Migration/schema check: Not applicable; no schema or migration changes.
- [ ] Documentation/instructions check: Not applicable; no documentation or instruction files changed.

## Risk and rollout

Low risk. This only corrects demo seed references and can be rolled back by reverting the commit.

## Development

Closes #1243
