### PR TITLE
fix: render preview clinic media

### DIFF
--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1117,7 +1117,7 @@ export interface Country {
   createdAt: string;
 }
 /**
- * Doctors and their specialty expertise
+ * Doctors and their specialties
  *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "doctorspecialties".
@@ -1374,7 +1374,7 @@ export interface DoctorMedia {
   };
 }
 /**
- * Links doctors to treatments and their expertise
+ * Doctors and their treatments
  *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "doctortreatments".
@@ -2197,7 +2197,7 @@ export interface ClinicApplication {
    */
   reviewNotes?: string | null;
   /**
-   * Records created from this application
+   * Clinic, user, and staff records created from this application
    */
   linkedRecords?: {
     clinic?: (number | null) | Clinic;
@@ -2206,14 +2206,14 @@ export interface ClinicApplication {
     processedAt?: string | null;
   };
   /**
-   * IP address and browser details
+   * IP address and browser info
    */
   sourceMeta?: {
     ip?: string | null;
     userAgent?: string | null;
   };
   /**
-   * Privacy notice shown during submission
+   * Privacy notice text
    */
   privacyNotice?: {
     acknowledgedAt?: string | null;

--- a/src/utilities/listingComparison/serverData/presentation.ts
+++ b/src/utilities/listingComparison/serverData/presentation.ts
@@ -1,6 +1,7 @@
 import type { VerificationBadgeVariant } from '@/components/atoms/verification-badge'
 import type { ListingCardData } from '@/components/organisms/Listing'
 import type { Clinic } from '@/payload-types'
+import { resolveMediaImage } from '@/utilities/media/resolveMediaImage'
 import { resolveMediaDescriptorFromLoadedRelation } from '@/utilities/media/relationMedia'
 import { slugify } from '@/utilities/slugify'
 import { splitUrlQuery } from '@/utilities/urlParts'
@@ -36,21 +37,37 @@ function mapLocationHref(coordinates: unknown): string | undefined {
   return `https://www.google.com/maps?q=${encodeURIComponent(`${lat},${lng}`)}`
 }
 
-function resolveAvailableMediaSrc(
+function resolveAvailableMediaCandidate(
   url: string | null | undefined,
   availableClinicMediaFiles: ReadonlySet<string> | undefined,
-): string {
-  if (!url) return PLACEHOLDER_MEDIA.src
+): string | null {
+  if (!url) return null
   if (!url.startsWith(CLINIC_MEDIA_API_PREFIX)) return url
 
   const { path: rawFileName } = splitUrlQuery(url.slice(CLINIC_MEDIA_API_PREFIX.length))
   const fileName = decodeURIComponent(rawFileName).replace(/^\/+/, '')
 
-  if (!fileName || !availableClinicMediaFiles?.has(fileName)) {
-    return PLACEHOLDER_MEDIA.src
+  if (!fileName) {
+    return null
+  }
+
+  if (availableClinicMediaFiles && !availableClinicMediaFiles.has(fileName)) {
+    return null
   }
 
   return url
+}
+
+function resolveAvailableMediaSrc(
+  urls: Array<string | null | undefined>,
+  availableClinicMediaFiles: ReadonlySet<string> | undefined,
+): string {
+  for (const url of urls) {
+    const resolved = resolveAvailableMediaCandidate(url, availableClinicMediaFiles)
+    if (resolved) return resolved
+  }
+
+  return PLACEHOLDER_MEDIA.src
 }
 
 export function buildClinicPresentationMeta(
@@ -121,12 +138,24 @@ export function mapListingCardResults(
   return pageRows.map(({ clinic, location, locationHref, priceFrom }) => {
     const ratingValue = typeof clinic.averageRating === 'number' ? clinic.averageRating : 0
     const ratingCount = reviewCounts.get(clinic.id) ?? 0
+    const fallbackMediaAlt = `${clinic.name} image`
+    const resolvedImage =
+      typeof clinic.thumbnail === 'object' && clinic.thumbnail !== null
+        ? resolveMediaImage(clinic.thumbnail, {
+            fallbackAlt: fallbackMediaAlt,
+            usage: 'listingCard',
+          })
+        : undefined
     const resolvedMedia = resolveMediaDescriptorFromLoadedRelation(clinic.thumbnail, 'clinicMedia')
-    const mediaSrc = resolveAvailableMediaSrc(resolvedMedia?.url, options.availableClinicMediaFiles)
+    const mediaSrc = resolveAvailableMediaSrc(
+      [resolvedImage?.src, resolvedMedia?.url],
+      options.availableClinicMediaFiles,
+    )
+    const mediaAltCandidate = resolvedImage?.alt ?? resolvedMedia?.alt
     const mediaAlt =
-      typeof resolvedMedia?.alt === 'string' && resolvedMedia.alt.trim().length > 0
-        ? resolvedMedia.alt
-        : `${clinic.name} image`
+      typeof mediaAltCandidate === 'string' && mediaAltCandidate.trim().length > 0
+        ? mediaAltCandidate
+        : fallbackMediaAlt
     const tags =
       clinic.tags?.flatMap((tag) => {
         if (typeof tag === 'object' && tag !== null && 'name' in tag && typeof tag.name === 'string') {

--- a/src/utilities/listingComparison/serverData/repositories.ts
+++ b/src/utilities/listingComparison/serverData/repositories.ts
@@ -16,7 +16,7 @@ type ListingComparisonCatalogSnapshot = {
   treatmentDocs: Treatment[]
   specialtyDocs: MedicalSpecialty[]
   approvedClinics: Clinic[]
-  availableClinicMediaFiles: ReadonlySet<string>
+  availableClinicMediaFiles?: ReadonlySet<string>
 }
 
 type PagedDocs<T> = {
@@ -154,13 +154,13 @@ export async function findAllApprovedClinics(payload: Payload): Promise<Clinic[]
   })
 }
 
-async function findAvailableClinicMediaFiles(): Promise<ReadonlySet<string>> {
+async function findAvailableClinicMediaFiles(): Promise<ReadonlySet<string> | undefined> {
   try {
     const entries = await fs.readdir(CLINIC_MEDIA_STATIC_DIR, { withFileTypes: true })
     return new Set(entries.filter((entry) => entry.isFile()).map((entry) => entry.name))
   } catch (error) {
     if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
-      return new Set()
+      return undefined
     }
 
     throw error

--- a/tests/unit/utilities/listingComparisonPresentation.test.ts
+++ b/tests/unit/utilities/listingComparisonPresentation.test.ts
@@ -65,6 +65,78 @@ describe('mapListingCardResults media resolution', () => {
     expect(result[0]?.media.alt).toBe('Bravo image')
   })
 
+  it('prefers an available listing-card image size over the original upload URL', () => {
+    const clinic = buildClinic({
+      id: 20,
+      name: 'Bravo Sized Clinic',
+      thumbnail: {
+        id: 120,
+        url: '/api/clinicMedia/file/20-aabbccdde0-bravo-sized-clinic.webp',
+        filename: '20-aabbccdde0-bravo-sized-clinic.webp',
+        alt: 'Bravo sized image',
+        sizes: {
+          medium: {
+            url: '/api/clinicMedia/file/bravo-sized-clinic-900x600.webp',
+            width: 900,
+            height: 600,
+          },
+        },
+      },
+    })
+
+    const result = mapListingCardResults([buildRow(clinic)], new Map(), {
+      availableClinicMediaFiles: new Set(['bravo-sized-clinic-900x600.webp']),
+    })
+
+    expect(result[0]?.media.src).toBe('/api/clinicMedia/file/bravo-sized-clinic-900x600.webp')
+    expect(result[0]?.media.alt).toBe('Bravo sized image')
+  })
+
+  it('falls back from a missing listing-card image size to an available original upload URL', () => {
+    const clinic = buildClinic({
+      id: 23,
+      name: 'Bravo Original Clinic',
+      thumbnail: {
+        id: 123,
+        url: '/api/clinicMedia/file/23-aabbccdde0-bravo-original-clinic.webp',
+        filename: '23-aabbccdde0-bravo-original-clinic.webp',
+        alt: 'Bravo original image',
+        sizes: {
+          medium: {
+            url: '/api/clinicMedia/file/bravo-original-clinic-900x600.webp',
+            width: 900,
+            height: 600,
+          },
+        },
+      },
+    })
+
+    const result = mapListingCardResults([buildRow(clinic)], new Map(), {
+      availableClinicMediaFiles: new Set(['23-aabbccdde0-bravo-original-clinic.webp']),
+    })
+
+    expect(result[0]?.media.src).toBe('/api/clinicMedia/file/23-aabbccdde0-bravo-original-clinic.webp')
+    expect(result[0]?.media.alt).toBe('Bravo original image')
+  })
+
+  it('uses a filename-derived upload URL when no local availability set exists', () => {
+    const clinic = buildClinic({
+      id: 21,
+      name: 'Bravo Preview Clinic',
+      thumbnail: {
+        id: 121,
+        url: null,
+        filename: 'preview-file.jpg',
+        alt: 'Bravo preview image',
+      },
+    })
+
+    const result = mapListingCardResults([buildRow(clinic)], new Map())
+
+    expect(result[0]?.media.src).toBe('/api/clinicMedia/file/preview-file.jpg')
+    expect(result[0]?.media.alt).toBe('Bravo preview image')
+  })
+
   it('falls back to the placeholder when a filename-derived upload is unavailable', () => {
     const clinic = buildClinic({
       id: 22,


### PR DESCRIPTION
## Management summary

### Deutsch

Die Preview-Clinic-Liste zeigt wieder echte Klinikbilder statt Platzhalter, wenn Demo-Medien vorhanden sind. Dadurch wirkt die Vergleichsansicht vollständiger und vertrauenswürdiger, besonders bei Review- und Demo-Umgebungen.

### English

The preview clinic list now shows real clinic images instead of placeholders when demo media exists. This makes the comparison view feel more complete and trustworthy, especially in review and demo environments.

## What changed

- Changed listing-card media resolution to prefer Payload-generated listing-size image URLs before falling back to the original upload URL.
- Stopped treating a missing local `src/public/clinic-media` directory as proof that preview media is unavailable.
- Added fallback coverage for missing listing-size files, preview-like missing local availability sets, and unavailable media.
- Kept generated Payload type comments in sync with the current collection metadata.

## UI/UX

<!-- gh-ui-screenshots:start -->
### Listing Comparison Mobile

![Listing Comparison Mobile](https://github.com/user-attachments/assets/1b30660b-3b2b-4904-aade-443926d4c921)

### Listing Comparison Desktop

![Listing Comparison Desktop](https://github.com/user-attachments/assets/338d3322-3d99-44dd-8692-879fa6527457)
<!-- gh-ui-screenshots:end -->
## Validation

- [x] `pnpm format`: Passed.
- [x] `pnpm check`: Passed.
- [x] `pnpm build`: Passed. The build logged the existing local `NEXT_PUBLIC_SUPABASE_URL is not defined` warning during static generation, but exited successfully.
- [x] Focused tests: `pnpm tests tests/unit/utilities/listingComparisonPresentation.test.ts` passed with 8 tests.
- [x] UI/mobile QA: Playwright checked `/listing-comparison` at 390x844 and 1440x1200. Confirmed 0 placeholder images, no horizontal overflow, cookie banner dismissed, and clinic images loaded in the captured route.
- [x] Security/privacy review: `detect-secrets-hook --baseline .secrets.baseline` passed. Mobile UI and web vitals reviewers found no findings at or above 5/10; the 4/10 fallback edge case from mobile review was addressed.
- [ ] Migration/schema check: Not applicable; no schema or migration changes.
- [ ] Documentation/instructions check: Not applicable; no documentation or instruction files changed.

## Risk and rollout

Low risk. The change is limited to listing comparison media source selection and keeps the existing placeholder fallback when neither a generated size nor the original upload can be used.

## Development

Closes #1244
