### PR TITLE
chore(fields): clarify clinic field copy

### DIFF
--- a/src/collections/ClinicApplications.ts
+++ b/src/collections/ClinicApplications.ts
@@ -107,7 +107,7 @@ export const ClinicApplications: CollectionConfig = {
       hasMany: true,
       required: true,
       admin: {
-        description: 'Top-level medical specialty categories selected in the registration funnel',
+        description: 'Main specialties selected during registration',
       },
       filterOptions: () => ({
         parentSpecialty: {
@@ -148,9 +148,9 @@ export const ClinicApplications: CollectionConfig = {
     {
       name: 'linkedRecords',
       type: 'group',
-      label: 'Created clinic records',
+      label: 'Created records',
       admin: {
-        description: 'Clinic, user, and staff records created from this application',
+        description: 'Clinic, user, and staff records created after approval',
         condition: (data) => data?.status !== 'submitted',
       },
       fields: [
@@ -163,7 +163,7 @@ export const ClinicApplications: CollectionConfig = {
     {
       name: 'sourceMeta',
       type: 'group',
-      admin: { description: 'IP address and browser info', readOnly: true, position: 'sidebar' },
+      admin: { description: 'Request IP address and browser details', readOnly: true, position: 'sidebar' },
       fields: [
         { name: 'ip', type: 'text' },
         { name: 'userAgent', type: 'text' },

--- a/src/collections/PatientClinicInquiries.ts
+++ b/src/collections/PatientClinicInquiries.ts
@@ -225,7 +225,7 @@ export const PatientClinicInquiries: CollectionConfig = {
       type: 'relationship',
       relationTo: 'basicUsers',
       admin: {
-        description: 'Platform user responsible for follow-up',
+        description: 'Platform user handling this request',
       },
       filterOptions: () => ({
         userType: { equals: 'platform' },

--- a/src/collections/common/mediaCollection.ts
+++ b/src/collections/common/mediaCollection.ts
@@ -71,7 +71,7 @@ export function buildMediaCaptionField(options?: { name?: string; label?: string
     type: 'richText',
     required: false,
     admin: {
-      description: options?.description ?? 'Optional caption shown with the media',
+      description: options?.description ?? 'Optional caption for the media',
     },
   }
 }
@@ -123,7 +123,7 @@ export function buildMediaStoragePathField(options?: { label?: string; descripti
     type: 'text',
     required: true,
     admin: {
-      description: options?.description ?? 'Stored file path',
+      description: options?.description ?? 'File path',
       readOnly: true,
       hidden: true,
     },
@@ -138,7 +138,7 @@ export function buildMediaPrefixField(options?: { label?: string; description?: 
     admin: {
       hidden: true,
       readOnly: true,
-      description: options?.description ?? 'Storage prefix',
+      description: options?.description ?? 'Storage folder',
     },
     access: {
       read: () => true,


### PR DESCRIPTION
## Management summary

### Deutsch

Wir haben die unklaren Feldtexte in den Clinic-Collections auf kurze, verständliche Sprache reduziert. Die betroffenen Felder sind jetzt für neue Klinik-Teams leichter zu erfassen, ohne interne oder technische Begriffe lesen zu müssen.

### English

We reduced unclear field copy in the clinic collections to short, plain language. The affected fields are now easier for new clinic teams to understand without internal or technical wording.

## What changed

- Simplified a small set of labels and descriptions in `src/collections/ClinicApplications.ts`, `src/collections/common/mediaCollection.ts`, and `src/collections/PatientClinicInquiries.ts`.
- Kept the changes local and conservative; no field structure, access rules, hooks, or validation changed.

## Validation

- [x] `pnpm format`
- [x] `pnpm check`
- [ ] `pnpm build`: not needed for copy-only changes.
- [ ] Focused tests: not needed; no behavior changed.
- [ ] UI/mobile QA: not applicable; no UI code changed.
- [ ] Security/privacy review: not needed; no trust boundary changed.
- [ ] Migration/schema check: not needed; no schema changed.
- [ ] Documentation/instructions check: not needed; no instruction files changed.

## Risk and rollout

Low risk. This only updates admin-facing copy. No rollout or migration steps are required.

## Development

Closes #1249
