### PR TITLE
fix: link landing ctas to contact

### DIFF
--- a/src/app/(frontend)/partners/clinics/page.tsx
+++ b/src/app/(frontend)/partners/clinics/page.tsx
@@ -37,6 +37,7 @@ export default async function ClinicLandingPage() {
   ])
 
   const normalizedPosts = posts.map((post) => normalizePost(post))
+  const partnerContactHref = '#contact'
 
   return (
     <main className="flex min-h-screen flex-col">
@@ -80,7 +81,7 @@ export default async function ClinicLandingPage() {
             }
             links={[
               {
-                href: '#contact',
+                href: partnerContactHref,
                 label: landingContent.cta.buttonText,
                 appearance: 'default',
                 size: 'lg',
@@ -95,6 +96,7 @@ export default async function ClinicLandingPage() {
           team={landingContent.team}
           title={landingContent.teamIntro.title}
           description={landingContent.teamIntro.description}
+          ctaHref={partnerContactHref}
         />
       </ScrollReveal>
       <ScrollReveal>
@@ -110,6 +112,7 @@ export default async function ClinicLandingPage() {
           title={landingContent.pricing.title}
           description={landingContent.pricing.description}
           modelItems={landingContent.pricingModel}
+          ctaHref={partnerContactHref}
         />
       </ScrollReveal>
       <ScrollReveal>

--- a/src/components/AGENTS.md
+++ b/src/components/AGENTS.md
@@ -21,6 +21,7 @@
 - Keep molecules router-agnostic; pass navigation callbacks as props.
 - Design component APIs so mobile state is explicit and testable; avoid hidden responsive behavior that cannot be previewed or asserted in isolation.
 - Do not introduce hover-only interactions for essential actions or navigation.
+- Render standard CTAs and button-like actions through `Button` or `UiLink`: use `UiLink` for navigation with `href` and `Button` for actions, submits, and disabled fallbacks. Raw `<button>` is only for specialized controls such as tabs, carousel dots, menu triggers, or headless composite controls, and must have `type="button"`, accessible semantics, and a real interaction.
 - Avoid component layouts that depend on horizontal scrolling unless the component is explicitly a scrollable pattern and provides clear touch affordances.
 - Keep touch targets, spacing, and text wrapping resilient at narrow widths before layering larger-screen enhancements.
 

--- a/src/components/organisms/Landing/LandingPricing.tsx
+++ b/src/components/organisms/Landing/LandingPricing.tsx
@@ -4,6 +4,7 @@ import { Check, Layers3, TrendingUp } from 'lucide-react'
 import { Heading } from '@/components/atoms/Heading'
 import { Button } from '@/components/atoms/button'
 import { Container } from '@/components/molecules/Container'
+import { UiLink } from '@/components/molecules/Link'
 import { SectionHeading } from '@/components/molecules/SectionHeading'
 import { cn } from '@/utilities/ui'
 
@@ -28,11 +29,22 @@ type LandingPricingProps = {
   title: string
   description: string
   modelItems?: LandingPricingModelItem[]
+  ctaHref?: string
 }
 
 const modelIcons = [Layers3, TrendingUp, Check] as const
+const primaryPlanCtaClassName =
+  'w-full rounded-full border-secondary/40 bg-white/80 text-secondary hover:bg-secondary hover:text-white'
+const compactPlanCtaClassName =
+  'w-full rounded-full border-secondary/40 text-secondary hover:bg-secondary hover:text-white lg:w-auto'
 
-export const LandingPricing: React.FC<LandingPricingProps> = ({ plans, title, description, modelItems = [] }) => {
+export const LandingPricing: React.FC<LandingPricingProps> = ({
+  plans,
+  title,
+  description,
+  modelItems = [],
+  ctaHref,
+}) => {
   const primaryPlans = plans.filter((plan) => plan.layout !== 'compact')
   const compactPlans = plans.filter((plan) => plan.layout === 'compact')
 
@@ -98,13 +110,19 @@ export const LandingPricing: React.FC<LandingPricingProps> = ({ plans, title, de
                 <div className="mb-8" />
               )}
 
-              <Button
-                variant="outline"
-                size="lg"
-                className="w-full rounded-full border-secondary/40 bg-white/80 text-secondary hover:bg-secondary hover:text-white"
-              >
-                {plan.buttonText}
-              </Button>
+              {ctaHref ? (
+                <UiLink
+                  href={ctaHref}
+                  label={plan.buttonText}
+                  appearance="outline"
+                  size="lg"
+                  className={primaryPlanCtaClassName}
+                />
+              ) : (
+                <Button type="button" variant="outline" size="lg" className={primaryPlanCtaClassName} disabled>
+                  {plan.buttonText}
+                </Button>
+              )}
             </article>
           ))}
         </div>
@@ -143,13 +161,19 @@ export const LandingPricing: React.FC<LandingPricingProps> = ({ plans, title, de
                 ) : null}
               </div>
 
-              <Button
-                variant="outline"
-                size="lg"
-                className="w-full rounded-full border-secondary/40 text-secondary hover:bg-secondary hover:text-white lg:w-auto"
-              >
-                {plan.buttonText}
-              </Button>
+              {ctaHref ? (
+                <UiLink
+                  href={ctaHref}
+                  label={plan.buttonText}
+                  appearance="outline"
+                  size="lg"
+                  className={compactPlanCtaClassName}
+                />
+              ) : (
+                <Button type="button" variant="outline" size="lg" className={compactPlanCtaClassName} disabled>
+                  {plan.buttonText}
+                </Button>
+              )}
             </div>
           </article>
         ))}

--- a/src/components/organisms/Landing/LandingTeam.tsx
+++ b/src/components/organisms/Landing/LandingTeam.tsx
@@ -3,9 +3,11 @@ import Image from 'next/image'
 import { FaGithub, FaLinkedin } from 'react-icons/fa'
 import { SiInstagram, SiMeta, SiX } from 'react-icons/si'
 
+import { Button } from '@/components/atoms/button'
 import { Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext } from '@/components/atoms/carousel'
 import { Heading } from '@/components/atoms/Heading'
 import { Container } from '@/components/molecules/Container'
+import { UiLink } from '@/components/molecules/Link'
 import type { SocialPlatform } from '@/components/molecules/SocialLink'
 import { SectionHeading } from '@/components/molecules/SectionHeading'
 import { cn } from '@/utilities/ui'
@@ -23,9 +25,19 @@ type LandingTeamProps = {
   team: LandingTeamMember[]
   title: string
   description: string
+  ctaHref?: string
+  ctaLabel?: string
 }
 
-export const LandingTeam: React.FC<LandingTeamProps> = ({ team, title, description }) => {
+const teamCtaClassName = 'rounded-lg border-secondary/30 text-secondary hover:bg-secondary hover:text-white'
+
+export const LandingTeam: React.FC<LandingTeamProps> = ({
+  team,
+  title,
+  description,
+  ctaHref,
+  ctaLabel = 'Learn More',
+}) => {
   return (
     <section className="bg-site-canvas py-20">
       <Container>
@@ -97,9 +109,13 @@ export const LandingTeam: React.FC<LandingTeamProps> = ({ team, title, descripti
         </Carousel>
 
         <div className="mt-12 text-center">
-          <button className="cursor-pointer rounded-lg border border-secondary/30 px-8 py-3 text-secondary transition-colors hover:bg-secondary hover:text-white">
-            Learn More
-          </button>
+          {ctaHref ? (
+            <UiLink href={ctaHref} label={ctaLabel} appearance="outline" size="lg" className={teamCtaClassName} />
+          ) : (
+            <Button type="button" variant="outline" size="lg" className={teamCtaClassName} disabled>
+              {ctaLabel}
+            </Button>
+          )}
         </div>
       </Container>
     </section>

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -792,7 +792,7 @@ export interface PlatformContentMedia {
    */
   alt: string;
   /**
-   * Optional caption shown with the media
+   * Optional caption for the media
    */
   caption?: {
     root: {
@@ -814,11 +814,11 @@ export interface PlatformContentMedia {
    */
   createdBy?: (number | null) | BasicUser;
   /**
-   * Stored file path
+   * File path
    */
   storagePath: string;
   /**
-   * Storage prefix
+   * Storage folder
    */
   prefix?: string | null;
   updatedAt: string;
@@ -960,11 +960,11 @@ export interface UserProfileMedia {
         value: number | Patient;
       } | null);
   /**
-   * Stored file path
+   * File path
    */
   storagePath: string;
   /**
-   * Storage prefix
+   * Storage folder
    */
   prefix?: string | null;
   updatedAt: string;
@@ -1265,7 +1265,7 @@ export interface DoctorMedia {
    */
   alt: string;
   /**
-   * Optional caption shown with the media
+   * Optional caption for the media
    */
   caption?: {
     root: {
@@ -1295,11 +1295,11 @@ export interface DoctorMedia {
    */
   createdBy?: (number | null) | BasicUser;
   /**
-   * Stored file path
+   * File path
    */
   storagePath: string;
   /**
-   * Storage prefix
+   * Storage folder
    */
   prefix?: string | null;
   updatedAt: string;
@@ -1415,7 +1415,7 @@ export interface ClinicMedia {
    */
   alt: string;
   /**
-   * Optional caption shown with the media
+   * Optional caption for the media
    */
   caption?: {
     root: {
@@ -1441,11 +1441,11 @@ export interface ClinicMedia {
    */
   createdBy?: (number | null) | BasicUser;
   /**
-   * Stored file path
+   * File path
    */
   storagePath: string;
   /**
-   * Storage prefix
+   * Storage folder
    */
   prefix?: string | null;
   updatedAt: string;
@@ -1624,11 +1624,11 @@ export interface ClinicGalleryMedia {
   createdBy?: (number | null) | BasicUser;
   storageKey: string;
   /**
-   * Stored file path
+   * File path
    */
   storagePath: string;
   /**
-   * Storage prefix
+   * Storage folder
    */
   prefix?: string | null;
   updatedAt: string;
@@ -2185,7 +2185,7 @@ export interface ClinicApplication {
    */
   clinicWebsite: string;
   /**
-   * Top-level medical specialty categories selected in the registration funnel
+   * Main specialties selected during registration
    */
   medicalSpecialties: (number | MedicalSpecialty)[];
   /**
@@ -2197,7 +2197,7 @@ export interface ClinicApplication {
    */
   reviewNotes?: string | null;
   /**
-   * Clinic, user, and staff records created from this application
+   * Clinic, user, and staff records created after approval
    */
   linkedRecords?: {
     clinic?: (number | null) | Clinic;
@@ -2206,7 +2206,7 @@ export interface ClinicApplication {
     processedAt?: string | null;
   };
   /**
-   * IP address and browser info
+   * Request IP address and browser details
    */
   sourceMeta?: {
     ip?: string | null;
@@ -2279,7 +2279,7 @@ export interface PatientClinicInquiry {
    */
   status: 'submitted' | 'in_review' | 'contacted' | 'closed' | 'spam';
   /**
-   * Platform user responsible for follow-up
+   * Platform user handling this request
    */
   assignedTo?: (number | null) | BasicUser;
   updatedAt: string;

--- a/src/stories/organisms/Landing/LandingPricing.stories.tsx
+++ b/src/stories/organisms/Landing/LandingPricing.stories.tsx
@@ -18,6 +18,7 @@ const meta = {
     description:
       'Three monthly tiers for different growth stages, plus performance-based commission on successful cases.',
     modelItems: clinicPricingModelItems,
+    ctaHref: '#contact',
   },
 } satisfies Meta<typeof LandingPricing>
 

--- a/src/stories/organisms/Landing/LandingTeam.stories.tsx
+++ b/src/stories/organisms/Landing/LandingTeam.stories.tsx
@@ -31,6 +31,7 @@ const meta = {
     title: 'Our Team',
     description:
       'We are a multidisciplinary team with backgrounds in healthcare, international patient management, medical marketing, and platform technology.',
+    ctaHref: '#contact',
   },
 } satisfies Meta<typeof LandingTeam>
 

--- a/src/stories/templates/Landing.stories.tsx
+++ b/src/stories/templates/Landing.stories.tsx
@@ -111,6 +111,7 @@ export const FullPage: StoryObj = {
         team={clinicTeamData}
         title="Our Team"
         description="We are a multidisciplinary team with backgrounds in healthcare, international patient management, medical marketing, and platform technology."
+        ctaHref="#contact"
       />
       <LandingTestimonials
         testimonials={clinicTestimonialsData}
@@ -122,6 +123,7 @@ export const FullPage: StoryObj = {
         title="Pricing"
         description="Flexible pricing and partnership options to suit clinics of any size."
         modelItems={clinicPricingModelItems}
+        ctaHref="#contact"
       />
       <BlogCardCollection
         posts={clinicBlogData.map((p) => ({
@@ -231,6 +233,7 @@ export const Team: StoryObj<typeof LandingTeam> = {
       team={clinicTeamData}
       title="Our Team"
       description="We are a multidisciplinary team with backgrounds in healthcare, international patient management, medical marketing, and platform technology."
+      ctaHref="#contact"
     />
   ),
 }
@@ -252,6 +255,7 @@ export const Pricing: StoryObj<typeof LandingPricing> = {
       title="Pricing"
       description="Flexible pricing and partnership options to suit clinics of any size."
       modelItems={clinicPricingModelItems}
+      ctaHref="#contact"
     />
   ),
 }


### PR DESCRIPTION
## Management summary

### Deutsch

Die Partner-Clinic-Landingpage führt sichtbare Handlungsaufforderungen jetzt verlässlich zur Kontakt- und Registrierungssektion. Dadurch wirken Team- und Pricing-Bereiche nicht mehr wie Sackgassen, und interessierte Kliniken können aus jedem relevanten Abschnitt direkt den nächsten Schritt starten.

### English

The partner clinic landing page now reliably routes visible calls to action to the contact and registration section. This removes dead-end interactions in the team and pricing areas and lets interested clinics continue directly from each relevant section.

## What changed

- Converted the team `Learn More` CTA and pricing plan CTAs from inert controls into existing `UiLink`-based navigation to the partner contact section.
- Added disabled `Button` fallbacks for component usage without a CTA target, so button-like UI does not become a clickable dead end.
- Added the component guidance that standard CTAs should use `UiLink` for navigation and `Button` for actions/submits/disabled fallbacks, while raw `<button>` stays reserved for specialized controls.
- Updated landing Storybook fixtures to include the contact CTA target.
- Included Payload typegen description drift generated by `pnpm check`.

## UI/UX

<!-- gh-ui-screenshots:start -->
### Team CTA Mobile

![Team CTA Mobile](https://github.com/user-attachments/assets/012436e6-5cd9-4436-9873-889c4638ff83)

### Pricing CTA Desktop

![Pricing CTA Desktop](https://github.com/user-attachments/assets/65b9359d-3dd1-4755-9bfd-febeda4aa2d0)

### Contact Jump Mobile

![Contact Jump Mobile](https://github.com/user-attachments/assets/42161a6e-9d0d-4f32-8c2f-d49096f8d313)
<!-- gh-ui-screenshots:end -->
## Validation

- [x] `pnpm format`: passed after implementation and again after typegen/build validation.
- [x] `pnpm check`: passed.
- [x] `pnpm build`: passed with `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret}`; local environment shows the existing Node engine warning because Node `v26.0.0` is outside the repo range `>=24 <25`.
- [x] Focused tests: In-app Browser verified `Learn More` and `Choose Premium` click through to `/partners/clinics#contact`.
- [x] UI/mobile QA: checked `/partners/clinics` at `320`, `375`, `640`, `768`, `1024`, and `1280`; no horizontal overflow, no matching dead CTA buttons, and all partner CTAs render as `href="#contact"` links.
- [x] Security/privacy review: no auth, data access, secrets, or submission behavior changed; local detect-secrets hook completed without findings.
- [x] Migration/schema check: no schema or migration changes; `src/payload-types.ts` was regenerated by typegen only.
- [x] Documentation/instructions check: `src/components/AGENTS.md` updated and `pnpm ai:slop-check` passed.

## Risk and rollout

Risk is low. The change only routes existing visible CTAs to the already-rendered contact section and preserves non-link component fallback behavior as disabled central buttons. Rollback is the single commit if the CTA destination needs to change later.

## Development

Closes #1256
