### PR TITLE
test: cover public journey persistence

### DIFF
--- a/scripts/public-e2e-clinic-fixture.ts
+++ b/scripts/public-e2e-clinic-fixture.ts
@@ -53,6 +53,16 @@ function parseArgs(argv: string[]) {
   }
 }
 
+function extractRelationId(value: unknown): number | string | null {
+  if (typeof value === 'number' || typeof value === 'string') return value
+
+  if (value && typeof value === 'object' && 'id' in value) {
+    return extractRelationId((value as { id?: unknown }).id)
+  }
+
+  return null
+}
+
 async function ensureCountryId(prefix: string) {
   const countries = await payload.find({
     collection: 'countries',
@@ -154,14 +164,27 @@ async function readInquiry(prefix: string, email: string) {
     depth: 0,
   })
 
+  const allClinicInquiries = await payload.find({
+    collection: 'patientClinicInquiries',
+    where: { clinic: { in: clinicIds } },
+    limit: 100,
+    overrideAccess: true,
+    depth: 0,
+  })
+
   const inquiry = inquiries.docs[0]
   process.stdout.write(
     `${JSON.stringify({
       found: Boolean(inquiry),
       id: inquiry?.id,
+      clinic: extractRelationId(inquiry?.clinic),
+      doctor: extractRelationId(inquiry?.doctor),
+      treatment: extractRelationId(inquiry?.treatment),
       status: inquiry?.status,
       email: inquiry?.email,
+      createdAt: inquiry?.createdAt,
       count: inquiries.docs.length,
+      totalClinicCount: allClinicInquiries.docs.length,
     })}\n`,
   )
 }

--- a/scripts/public-e2e-clinic-registration-fixture.ts
+++ b/scripts/public-e2e-clinic-registration-fixture.ts
@@ -1,0 +1,159 @@
+import payload from 'payload'
+
+import config from '../src/payload.config'
+
+type Command = 'cleanup' | 'read-application'
+
+function parseArgs(argv: string[]) {
+  const [command, ...rest] = argv
+
+  if (command !== 'cleanup' && command !== 'read-application') {
+    throw new Error('Expected command to be "cleanup" or "read-application".')
+  }
+
+  let prefix = ''
+  let email = ''
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index]
+
+    if (arg === '--prefix') {
+      prefix = rest[index + 1] ?? ''
+      index += 1
+      continue
+    }
+
+    if (arg?.startsWith('--prefix=')) {
+      prefix = arg.slice('--prefix='.length)
+      continue
+    }
+
+    if (arg === '--email') {
+      email = rest[index + 1] ?? ''
+      index += 1
+      continue
+    }
+
+    if (arg?.startsWith('--email=')) {
+      email = arg.slice('--email='.length)
+      continue
+    }
+
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+
+  if (!prefix) {
+    throw new Error('Missing required --prefix argument.')
+  }
+
+  return {
+    command: command as Command,
+    email,
+    prefix,
+  }
+}
+
+function extractRelationId(value: unknown): number | string | null {
+  if (typeof value === 'number' || typeof value === 'string') return value
+
+  if (value && typeof value === 'object' && 'id' in value) {
+    return extractRelationId((value as { id?: unknown }).id)
+  }
+
+  return null
+}
+
+async function findApplicationsByPrefix(prefix: string) {
+  return payload.find({
+    collection: 'clinicApplications',
+    where: { clinicName: { like: `${prefix}%` } },
+    sort: '-createdAt',
+    limit: 100,
+    overrideAccess: true,
+    depth: 0,
+  })
+}
+
+async function cleanupApplications(prefix: string) {
+  const applications = await findApplicationsByPrefix(prefix)
+
+  for (const application of applications.docs) {
+    await payload.delete({ collection: 'clinicApplications', id: application.id, overrideAccess: true })
+  }
+}
+
+async function readApplication(prefix: string, email: string) {
+  if (!email) {
+    throw new Error('Missing required --email argument for read-application.')
+  }
+
+  const applications = await payload.find({
+    collection: 'clinicApplications',
+    where: {
+      and: [{ clinicName: { like: `${prefix}%` } }, { contactEmail: { equals: email.toLowerCase() } }],
+    },
+    sort: '-createdAt',
+    limit: 100,
+    overrideAccess: true,
+    depth: 0,
+  })
+
+  const application = applications.docs[0]
+  const applicationRecord = application as Record<string, unknown> | undefined
+  const privacyNotice =
+    applicationRecord?.privacyNotice && typeof applicationRecord.privacyNotice === 'object'
+      ? (applicationRecord.privacyNotice as Record<string, unknown>)
+      : undefined
+  const medicalSpecialties = Array.isArray(applicationRecord?.medicalSpecialties)
+    ? applicationRecord.medicalSpecialties.map(extractRelationId).filter((id) => id !== null)
+    : []
+
+  process.stdout.write(
+    `${JSON.stringify({
+      found: Boolean(application),
+      id: application?.id,
+      clinicName: application?.clinicName,
+      clinicWebsite: application?.clinicWebsite,
+      contactFirstName: application?.contactFirstName,
+      contactLastName: application?.contactLastName,
+      contactEmail: application?.contactEmail,
+      contactRole: application?.contactRole,
+      medicalSpecialties,
+      status: application?.status,
+      createdAt: application?.createdAt,
+      privacyNotice: {
+        acknowledgedAt: privacyNotice?.acknowledgedAt,
+        url: privacyNotice?.url,
+      },
+      hasAdditionalNotes: Boolean(
+        applicationRecord && Object.prototype.hasOwnProperty.call(applicationRecord, 'additionalNotes'),
+      ),
+      count: applications.docs.length,
+    })}\n`,
+  )
+}
+
+async function main() {
+  const { command, email, prefix } = parseArgs(process.argv.slice(2))
+
+  await payload.init({ config })
+
+  if (command === 'read-application') {
+    await readApplication(prefix, email)
+    return
+  }
+
+  await cleanupApplications(prefix)
+}
+
+void (async () => {
+  try {
+    await main()
+    await payload.destroy().catch(() => undefined)
+    process.exit(0)
+  } catch (error) {
+    console.error(error)
+    await payload.destroy().catch(() => undefined)
+    process.exit(1)
+  }
+})()

--- a/tests/e2e/public/auth.registration.public-smoke.spec.ts
+++ b/tests/e2e/public/auth.registration.public-smoke.spec.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from 'node:child_process'
+
 import { expect, test, type Page, type Route } from '@playwright/test'
 
 import { createBrowserIssueCollector, expectNoBrowserIssues } from '../helpers/browserIssues'
@@ -20,6 +22,50 @@ async function fulfillJson(route: Route, status: number, body: unknown, headers?
   })
 }
 
+function runClinicRegistrationFixtureCommand(args: string[]) {
+  return execFileSync('pnpm', ['dlx', 'tsx', 'scripts/public-e2e-clinic-registration-fixture.ts', ...args], {
+    cwd: process.cwd(),
+    env: process.env,
+    encoding: 'utf8',
+  })
+}
+
+type ClinicApplicationLookup = {
+  found: boolean
+  clinicName?: string
+  clinicWebsite?: string
+  contactFirstName?: string
+  contactLastName?: string
+  contactEmail?: string
+  contactRole?: string
+  medicalSpecialties: Array<number | string>
+  status?: string
+  createdAt?: string
+  privacyNotice?: {
+    acknowledgedAt?: string
+    url?: string
+  }
+  hasAdditionalNotes: boolean
+  count: number
+}
+
+function readClinicApplication(prefix: string, email: string): ClinicApplicationLookup {
+  const output = runClinicRegistrationFixtureCommand(['read-application', '--prefix', prefix, '--email', email])
+  const lines = output.trim().split('\n').filter(Boolean)
+  const lastLine = lines.at(-1)
+
+  if (!lastLine) {
+    throw new Error('Clinic application lookup did not return output.')
+  }
+
+  return JSON.parse(lastLine) as ClinicApplicationLookup
+}
+
+function expectValidIsoDate(value: string | undefined) {
+  expect(value).toEqual(expect.any(String))
+  expect(Number.isNaN(Date.parse(value ?? ''))).toBe(false)
+}
+
 async function stubSupabaseSignup(page: Page, handler: (route: Route) => Promise<void>) {
   await page.route('**/auth/v1/signup**', async (route) => {
     if (route.request().method() === 'OPTIONS') {
@@ -33,6 +79,15 @@ async function stubSupabaseSignup(page: Page, handler: (route: Route) => Promise
     await handler(route)
   })
 }
+
+const clinicRegistrationPrefixes = new Set<string>()
+
+test.afterEach(() => {
+  for (const prefix of [...clinicRegistrationPrefixes]) {
+    runClinicRegistrationFixtureCommand(['cleanup', '--prefix', prefix])
+    clinicRegistrationPrefixes.delete(prefix)
+  }
+})
 
 async function fillClinicRegistrationFunnel(page: Page) {
   await expect(page.locator('[data-clinic-registration-funnel-ready="true"]')).toBeVisible()
@@ -95,6 +150,61 @@ test('clinic registration shows success feedback after a successful submit @smok
   })
   expect(submittedClinicApplication.medicalSpecialties).toEqual(expect.arrayContaining([expect.any(String)]))
   await expect(page).toHaveURL(/\/register\/clinic(?:\?.*)?$/)
+  await expectNoBrowserIssues(issues)
+})
+
+test('clinic registration persists a real application after funnel submit @smoke', async ({ page }) => {
+  const issues = createBrowserIssueCollector(page)
+  const prefix = `e2e-clinic-registration-${Date.now()}`
+  const clinicName = `${prefix} Clinic`
+  const clinicWebsite = `https://${prefix}.example.com`
+  const contactEmail = `${prefix}@example.com`
+
+  clinicRegistrationPrefixes.add(prefix)
+
+  await page.goto('/register/clinic', { waitUntil: 'domcontentloaded' })
+  await expect(page.locator('[data-clinic-registration-funnel-ready="true"]')).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Register your clinic' })).toBeVisible()
+
+  await page.getByLabel('Clinic name').fill(clinicName)
+  await page.getByLabel('Website').fill(clinicWebsite)
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page.getByRole('heading', { name: 'Choose focus areas' })).toBeVisible()
+  const dentalCategory = page.getByRole('button', { name: 'Dental' })
+  if ((await dentalCategory.getAttribute('aria-pressed')) !== 'true') {
+    await dentalCategory.click()
+  }
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page.getByRole('heading', { name: 'Your contact' })).toBeVisible()
+  await page.getByLabel('First name').fill('Ada')
+  await page.getByLabel('Last name').fill('Lovelace')
+  await page.getByLabel('Email address').fill(contactEmail)
+  await page.getByLabel('Position / role').selectOption({ label: 'Clinic Management' })
+  await page.getByRole('button', { name: 'Submit request' }).click()
+
+  await expect(page.getByRole('heading', { name: 'Request submitted' })).toBeVisible()
+  await expect(page.getByText(clinicName)).toBeVisible()
+  await expect(page.getByText(contactEmail)).toBeVisible()
+
+  const application = readClinicApplication(prefix, contactEmail)
+  expect(application).toMatchObject({
+    found: true,
+    clinicName,
+    clinicWebsite: new URL(clinicWebsite).toString(),
+    contactFirstName: 'Ada',
+    contactLastName: 'Lovelace',
+    contactEmail,
+    contactRole: 'Clinic Management',
+    status: 'submitted',
+    count: 1,
+    hasAdditionalNotes: false,
+  })
+  expect(application.medicalSpecialties.length).toBeGreaterThan(0)
+  expectValidIsoDate(application.createdAt)
+  expectValidIsoDate(application.privacyNotice?.acknowledgedAt)
+  expect(application.privacyNotice?.url).toBe('/privacy-policy')
   await expectNoBrowserIssues(issues)
 })
 

--- a/tests/e2e/public/clinic-detail.public-smoke.spec.ts
+++ b/tests/e2e/public/clinic-detail.public-smoke.spec.ts
@@ -13,6 +13,35 @@ function runFixtureCommand(args: string[]) {
   })
 }
 
+type InquiryLookup = {
+  found: boolean
+  clinic?: number | string | null
+  doctor?: number | string | null
+  treatment?: number | string | null
+  status?: string
+  email?: string
+  createdAt?: string
+  count: number
+  totalClinicCount: number
+}
+
+function readInquiry(prefix: string, email: string): InquiryLookup {
+  const output = runFixtureCommand(['read-inquiry', '--prefix', prefix, '--email', email])
+  const lines = output.trim().split('\n').filter(Boolean)
+  const lastLine = lines.at(-1)
+
+  if (!lastLine) {
+    throw new Error('Inquiry lookup did not return output.')
+  }
+
+  return JSON.parse(lastLine) as InquiryLookup
+}
+
+function expectValidIsoDate(value: string | undefined) {
+  expect(value).toEqual(expect.any(String))
+  expect(Number.isNaN(Date.parse(value ?? ''))).toBe(false)
+}
+
 test.describe('clinic detail map dialog', () => {
   test.describe.configure({ mode: 'serial' })
 
@@ -140,6 +169,7 @@ test.describe('clinic detail map dialog', () => {
       ],
     })
     const email = `${slugPrefix}-contact@example.com`
+    const secondEmail = `${slugPrefix}-contact-second@example.com`
 
     await context.clearCookies()
     await setCookieConsent(context, { functional: true })
@@ -147,7 +177,8 @@ test.describe('clinic detail map dialog', () => {
     await page.goto(`/clinics/${clinicSlug}`, { waitUntil: 'domcontentloaded' })
     await page.waitForLoadState('networkidle')
 
-    await page.locator('select[name="doctor"]').selectOption({ index: 1 })
+    const [selectedDoctorId] = await page.locator('select[name="doctor"]').selectOption({ index: 1 })
+    expect(selectedDoctorId).toBeTruthy()
     await page.getByLabel('Full Name').fill(`${slugPrefix} Patient`)
     await page.getByLabel('Phone Number').fill('+49 30 123456')
     await page.getByLabel('Email').fill(email)
@@ -161,20 +192,45 @@ test.describe('clinic detail map dialog', () => {
     await expect(page.getByRole('status')).toHaveText('Your clinic request has been sent successfully.')
     await expect(page.getByRole('button', { name: 'Request sent' })).toBeDisabled()
 
-    const output = runFixtureCommand(['read-inquiry', '--prefix', slugPrefix, '--email', email])
-    const lines = output.trim().split('\n').filter(Boolean)
-    const lastLine = lines.at(-1)
-
-    if (!lastLine) {
-      throw new Error('Inquiry lookup did not return output.')
-    }
-
-    expect(JSON.parse(lastLine)).toMatchObject({
+    const firstInquiry = readInquiry(slugPrefix, email)
+    expect(firstInquiry).toMatchObject({
       found: true,
       status: 'submitted',
       email,
       count: 1,
+      totalClinicCount: 1,
     })
+    expect(firstInquiry.clinic).toBeTruthy()
+    expect(String(firstInquiry.doctor)).toBe(selectedDoctorId)
+    expect(firstInquiry.treatment).toBeNull()
+    expectValidIsoDate(firstInquiry.createdAt)
+
+    await page.locator('form[aria-label="Clinic appointment request"]').evaluate((form: HTMLFormElement) => {
+      form.requestSubmit()
+    })
+
+    await expect.poll(() => readInquiry(slugPrefix, email).count).toBe(1)
+    expect(readInquiry(slugPrefix, email).totalClinicCount).toBe(1)
+
+    await page.getByLabel('Email').fill(secondEmail)
+    await expect(page.getByRole('button', { name: 'Submit Contact Request' })).toBeEnabled()
+    await page.getByRole('button', { name: 'Submit Contact Request' }).click()
+
+    await expect(page.getByRole('status')).toHaveText('Your clinic request has been sent successfully.')
+    await expect(page.getByRole('button', { name: 'Request sent' })).toBeDisabled()
+
+    const secondInquiry = readInquiry(slugPrefix, secondEmail)
+    expect(secondInquiry).toMatchObject({
+      found: true,
+      status: 'submitted',
+      email: secondEmail,
+      count: 1,
+      totalClinicCount: 2,
+    })
+    expect(secondInquiry.clinic).toBe(firstInquiry.clinic)
+    expect(String(secondInquiry.doctor)).toBe(selectedDoctorId)
+    expect(secondInquiry.treatment).toBeNull()
+    expectValidIsoDate(secondInquiry.createdAt)
 
     await expectNoBrowserIssues(issues)
   })


### PR DESCRIPTION
## Management summary

### Deutsch

Die öffentlichen Kontakt- und Registrierungswege von findmydoc werden zuverlässiger abgesichert: Anfragen von Patientinnen und Patienten sowie Klinikregistrierungen werden künftig genauer darauf geprüft, dass sie korrekt gespeichert werden und keine unbeabsichtigten Doppelübermittlungen entstehen.

### English

findmydoc's public contact and registration journeys are better protected: patient inquiries and clinic registrations are now checked more precisely to make sure they are stored correctly and do not create unintended duplicate submissions.

## What changed

- Refined the public Playwright tracking issues for the current remaining scope: #1177, #1178, and #1182.
- Expanded the clinic detail contact-form smoke journey to verify persisted clinic, doctor, timestamp, per-email count, total clinic inquiry count, duplicate-submit lock behavior, and a second intended inquiry after changing the email.
- Added a clinic-registration E2E fixture helper for reading and cleaning up `clinicApplications` records by deterministic test prefix.
- Added a database-backed clinic registration Playwright journey that submits the real `/register/clinic` funnel and verifies normalized website, contact data, selected specialties, status, timestamps, privacy notice metadata, and absence of removed public-form fields.

## Validation

- [x] `pnpm format`: passed
- [x] `pnpm check`: passed
- [ ] `pnpm build`: not run; this change is limited to Playwright specs and test fixture scripts, with no runtime production output changes.
- [ ] Focused tests: attempted `pnpm exec playwright test tests/e2e/public/clinic-detail.public-smoke.spec.ts tests/e2e/public/auth.registration.public-smoke.spec.ts --config=playwright.config.ts --project public-smoke --grep 'submits the clinic contact form|clinic registration persists'`, but local Docker was unavailable: `failed to connect to the docker API at unix:///Users/razorspoint/.docker/run/docker.sock`.
- [x] UI/mobile QA: not applicable; no UI implementation changed.
- [x] Security/privacy review: `detect-secrets-hook --baseline .secrets.baseline scripts/public-e2e-clinic-fixture.ts scripts/public-e2e-clinic-registration-fixture.ts tests/e2e/public/auth.registration.public-smoke.spec.ts tests/e2e/public/clinic-detail.public-smoke.spec.ts` passed.
- [x] Migration/schema check: not applicable; no schema or migration changes.
- [x] Documentation/instructions check: no repository docs or instruction files changed; GitHub issues #1177, #1178, and #1182 were updated directly.

## Risk and rollout

The main risk is E2E flakiness from the new database-backed public smoke assertions. The tests use deterministic prefixes and cleanup helpers so records remain scoped to each run. No product runtime behavior, schema, or migration changes are included.

## Development

Closes #1177
Closes #1178
Closes #1182
