### PR TITLE
fix(clinics): allow legacy clinic updates

### DIFF
--- a/src/collections/Clinics.ts
+++ b/src/collections/Clinics.ts
@@ -22,18 +22,15 @@ const hasCompleteInternalPrimaryContact = (value: unknown): boolean => {
   })
 }
 
-const validateInternalPrimaryContactBeforeValidate: CollectionBeforeValidateHook<Clinic> = ({
-  data,
-  operation,
-  originalDoc,
-}) => {
+const validateInternalPrimaryContactBeforeValidate: CollectionBeforeValidateHook<Clinic> = ({ data, operation }) => {
   if (!data) return data
 
-  const contact =
-    data.internalPrimaryContact ?? (operation === 'update' ? originalDoc?.internalPrimaryContact : undefined)
+  const incomingContact = data.internalPrimaryContact
 
-  if (!hasCompleteInternalPrimaryContact(contact)) {
-    throw new Error(INTERNAL_PRIMARY_CONTACT_REQUIRED_MESSAGE)
+  if (operation === 'create' || incomingContact !== undefined) {
+    if (!hasCompleteInternalPrimaryContact(incomingContact)) {
+      throw new Error(INTERNAL_PRIMARY_CONTACT_REQUIRED_MESSAGE)
+    }
   }
 
   return data

--- a/tests/unit/collections/clinics.verification-field.test.ts
+++ b/tests/unit/collections/clinics.verification-field.test.ts
@@ -124,5 +124,14 @@ describe('Clinics collection verification field', () => {
         },
       }),
     ).resolves.toEqual({ name: 'Updated clinic' })
+    await expect(
+      runHook({
+        data: {
+          name: 'Legacy clinic update',
+        },
+        operation: 'update',
+        originalDoc: {},
+      }),
+    ).resolves.toEqual({ name: 'Legacy clinic update' })
   })
 })


### PR DESCRIPTION
## Management summary

### Deutsch
Bestehende Klinikprofile bleiben nach dem neuen Kontaktfeld weiter bearbeitbar, ohne dass neue oder gezielt geänderte Kontaktdaten die Pflichtprüfung umgehen.

### English
Existing clinic profiles remain editable after the new contact field rollout, while new records and explicit contact edits still go through the required validation.

## What changed

The clinic validation now enforces `internalPrimaryContact` only when a clinic is created or when that field is explicitly edited. Legacy clinic records that still lack the new contact data can save unrelated updates again. I also added a unit test that covers the legacy update path.

## Validation

- [x] `pnpm format`
- [x] `pnpm check`
- [x] `pnpm build`
- [x] Focused tests: `pnpm exec vitest run tests/unit/collections/clinics.verification-field.test.ts`
- [ ] UI/mobile QA: not applicable; no UI change.
- [ ] Security/privacy review: not needed; no auth, secret, or trust-boundary change.
- [ ] Migration/schema check: not needed; no migration or schema files changed.
- [ ] Documentation/instructions check: not needed; no instruction surfaces changed.

## Risk and rollout

Low risk. The change only relaxes validation for legacy clinic records missing the new contact data; create flows and explicit contact edits remain enforced.

## Development

Closes #1259
