### PR TITLE
fix: allow legacy clinic updates without trust contact

### DIFF
--- a/src/collections/Clinics.ts
+++ b/src/collections/Clinics.ts
@@ -22,6 +22,21 @@ const hasCompleteInternalPrimaryContact = (value: unknown): boolean => {
   })
 }
 
+const shouldRequireInternalPrimaryContact = ({
+  existingValue,
+  hasIncomingValue,
+  operation,
+}: {
+  existingValue?: unknown
+  hasIncomingValue: boolean
+  operation?: 'create' | 'update'
+}): boolean => {
+  if (operation === 'create') return true
+  if (hasIncomingValue) return true
+
+  return hasCompleteInternalPrimaryContact(existingValue)
+}
+
 const validateInternalPrimaryContactBeforeValidate: CollectionBeforeValidateHook<Clinic> = ({
   data,
   operation,
@@ -29,8 +44,20 @@ const validateInternalPrimaryContactBeforeValidate: CollectionBeforeValidateHook
 }) => {
   if (!data) return data
 
-  const contact =
-    data.internalPrimaryContact ?? (operation === 'update' ? originalDoc?.internalPrimaryContact : undefined)
+  const hasIncomingInternalPrimaryContact = Object.prototype.hasOwnProperty.call(data, 'internalPrimaryContact')
+  const existingInternalPrimaryContact = operation === 'update' ? originalDoc?.internalPrimaryContact : undefined
+
+  if (
+    !shouldRequireInternalPrimaryContact({
+      existingValue: existingInternalPrimaryContact,
+      hasIncomingValue: hasIncomingInternalPrimaryContact,
+      operation,
+    })
+  ) {
+    return data
+  }
+
+  const contact = hasIncomingInternalPrimaryContact ? data.internalPrimaryContact : existingInternalPrimaryContact
 
   if (!hasCompleteInternalPrimaryContact(contact)) {
     throw new Error(INTERNAL_PRIMARY_CONTACT_REQUIRED_MESSAGE)
@@ -264,8 +291,21 @@ export const Clinics: CollectionConfig<'clinics'> = {
               name: 'internalPrimaryContact',
               label: 'Internal Primary Contact',
               type: 'group',
-              required: true,
-              validate: (value: unknown) => {
+              validate: (value: unknown, options) => {
+                const operation =
+                  options.operation === 'create' || options.operation === 'update' ? options.operation : undefined
+                const { previousValue } = options
+
+                if (
+                  !shouldRequireInternalPrimaryContact({
+                    existingValue: previousValue,
+                    hasIncomingValue: value !== undefined,
+                    operation,
+                  })
+                ) {
+                  return true
+                }
+
                 if (!hasCompleteInternalPrimaryContact(value)) {
                   return INTERNAL_PRIMARY_CONTACT_REQUIRED_MESSAGE
                 }

--- a/tests/unit/collections/clinics.verification-field.test.ts
+++ b/tests/unit/collections/clinics.verification-field.test.ts
@@ -10,7 +10,7 @@ type FieldNode = {
   defaultValue?: unknown
   options?: Array<{ label: string; value: string }>
   required?: boolean
-  validate?: (value: unknown) => true | string
+  validate?: (value: unknown, options?: { operation?: 'create' | 'update'; previousValue?: unknown }) => true | string
 }
 
 function findFieldByName(fields: FieldNode[] | undefined, name: string): FieldNode | null {
@@ -59,30 +59,36 @@ describe('Clinics collection verification field', () => {
 
     expect(contactField).toBeTruthy()
     expect(contactField?.type).toBe('group')
-    expect(contactField?.required).toBe(true)
 
     const validate = contactField?.validate
     expect(validate).toBeTypeOf('function')
     if (!validate) throw new Error('Expected internal primary contact validation')
 
-    expect(validate(null)).toBe('Internal primary contact is required.')
-    expect(validate({})).toBe('Internal primary contact is required.')
+    expect(validate(null, {})).toBe('Internal primary contact is required.')
+    expect(validate({}, {})).toBe('Internal primary contact is required.')
     expect(
-      validate({
-        firstName: 'Aylin',
-        lastName: 'Korkmaz',
-        email: ' ',
-        role: 'Clinic Management',
-      }),
+      validate(
+        {
+          firstName: 'Aylin',
+          lastName: 'Korkmaz',
+          email: ' ',
+          role: 'Clinic Management',
+        },
+        {},
+      ),
     ).toBe('Internal primary contact is required.')
     expect(
-      validate({
-        firstName: 'Aylin',
-        lastName: 'Korkmaz',
-        email: 'aylin.korkmaz@example.com',
-        role: 'Clinic Management',
-      }),
+      validate(
+        {
+          firstName: 'Aylin',
+          lastName: 'Korkmaz',
+          email: 'aylin.korkmaz@example.com',
+          role: 'Clinic Management',
+        },
+        {},
+      ),
     ).toBe(true)
+    expect(validate(undefined, { operation: 'update', previousValue: undefined })).toBe(true)
   })
 
   it('rejects clinic writes without a complete internal primary contact before validation', async () => {
@@ -124,5 +130,25 @@ describe('Clinics collection verification field', () => {
         },
       }),
     ).resolves.toEqual({ name: 'Updated clinic' })
+    await expect(
+      runHook({
+        data: {
+          name: 'Legacy clinic update',
+        },
+        operation: 'update',
+        originalDoc: {},
+      }),
+    ).resolves.toEqual({ name: 'Legacy clinic update' })
+    await expect(
+      runHook({
+        data: {
+          internalPrimaryContact: null,
+        },
+        operation: 'update',
+        originalDoc: {
+          internalPrimaryContact: validContact,
+        },
+      }),
+    ).rejects.toThrow('Internal primary contact is required.')
   })
 })


### PR DESCRIPTION
## Management summary

### Deutsch

Bestehende Klinikprofile ohne bereits gepflegten internen Hauptkontakt lassen sich wieder normal aktualisieren. Das senkt Betriebsrisiken bei Bestandsdaten und verhindert, dass unverbundene Profiländerungen an einer neuen Trust-Pflicht scheitern.

### English

Existing clinic profiles that do not yet have an internal primary contact can be updated normally again. This reduces operational risk for legacy data and prevents unrelated profile edits from failing because of the new trust requirement.

## What changed

- Scoped the `internalPrimaryContact` requirement in [`/Users/razorspoint/.codex/worktrees/1c95/website/src/collections/Clinics.ts`](/Users/razorspoint/.codex/worktrees/1c95/website/src/collections/Clinics.ts) to the cases that actually need enforcement: new clinic creation, explicit trust-field writes, or records that already contain contact data.
- Preserved strict validation when trust contact data is supplied or edited, so platform trust workflows still reject incomplete contact objects.
- Added regression coverage in [`/Users/razorspoint/.codex/worktrees/1c95/website/tests/unit/collections/clinics.verification-field.test.ts`](/Users/razorspoint/.codex/worktrees/1c95/website/tests/unit/collections/clinics.verification-field.test.ts) for legacy-update pass-through and explicit clearing of an existing contact.

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed.
- [ ] `pnpm build`: not run; collection validation change only, and local build also depends on DB/env setup.
- [x] Focused tests: `pnpm vitest run tests/unit/collections/clinics.verification-field.test.ts` passed.
- [ ] UI/mobile QA: not applicable; no UI changes.
- [x] Security/privacy review: reviewed access/validation impact; fix only relaxes legacy no-contact updates and keeps explicit trust-field writes guarded.
- [x] Migration/schema check: inspected `src/migrations/20260604_204616_add_clinic_internal_primary_contact.ts`; migration adds nullable columns without a backfill, which is the legacy-data regression source.
- [ ] Documentation/instructions check: not applicable; no docs or instruction surfaces changed.

## Risk and rollout

Low risk. New clinics and explicit internal contact edits still require a complete trust contact. The behavioral change only affects legacy clinic records that predate the new field and were previously blocked on unrelated updates.

## Development

Closes #1259
