### PR TITLE
docs: add design system source of truth

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,647 @@
+---
+version: alpha
+name: findmydoc
+description: Design system source of truth for the findmydoc international patient clinic discovery platform.
+colors:
+  background: '#FFFFFF'
+  foreground: '#333333'
+  primary: '#006DE5'
+  primary-hover: '#004EA5'
+  primary-foreground: '#FFFFFF'
+  secondary: '#07004C'
+  secondary-foreground: '#FFFFFF'
+  muted: '#F8F9FA'
+  muted-foreground: '#999999'
+  accent: '#42E2B7'
+  accent-foreground: '#07004C'
+  card: '#FFFFFF'
+  card-foreground: '#333333'
+  popover: '#FFFFFF'
+  popover-foreground: '#333333'
+  border: '#E2E8F0'
+  input: '#E2E8F0'
+  ring: '#006DE5'
+  site-canvas: '{colors.muted}'
+  site-chrome: '{colors.muted}'
+  site-section: '{colors.muted}'
+  site-divider: '{colors.border}'
+  destructive: '#B91C1C'
+  destructive-foreground: '#FFFFFF'
+  accent-2: '#E0E0E0'
+  accent-2-foreground: '#08004D'
+  success: '#9ACDDF'
+  warning: '#FBDDB7'
+  error: '#FFC3B8'
+  backdrop: '#000000'
+  verification-bronze: '#8B5E34'
+  verification-bronze-foreground: '#FFFFFF'
+  verification-silver: '#C4C4C4'
+  verification-silver-foreground: '#111827'
+  verification-gold: '#EFBF04'
+  verification-gold-foreground: '#111827'
+  chart-1: '#91C5FF'
+  chart-2: '#3A81F6'
+  chart-3: '#2563EF'
+  chart-4: '#1A4EDA'
+  chart-5: '#1F3FAD'
+  sidebar: '#FAFAFA'
+  sidebar-foreground: '#171717'
+  sidebar-primary: '#262626'
+  sidebar-primary-foreground: '#FAFAFA'
+  sidebar-accent: '#F5F5F5'
+  sidebar-accent-foreground: '#262626'
+  sidebar-border: '#E5E5E5'
+  sidebar-ring: '#A3A3A3'
+typography:
+  h1:
+    fontFamily: 'DM Sans, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif'
+    fontSize: 3.125rem
+    fontWeight: 700
+    lineHeight: 58.335px
+    letterSpacing: 0px
+  h2:
+    fontFamily: 'DM Sans, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif'
+    fontSize: 2.333rem
+    fontWeight: 700
+    lineHeight: 42px
+    letterSpacing: 0px
+  h3:
+    fontFamily: 'DM Sans, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif'
+    fontSize: 1.75rem
+    fontWeight: 700
+    lineHeight: 33.6px
+    letterSpacing: 0px
+  h4:
+    fontFamily: 'DM Sans, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif'
+    fontSize: 1.333rem
+    fontWeight: 700
+    lineHeight: 28.438px
+    letterSpacing: 0px
+  h5-caps:
+    fontFamily: 'DM Sans, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif'
+    fontSize: 1rem
+    fontWeight: 400
+    lineHeight: 24px
+    letterSpacing: 5px
+  h6:
+    fontFamily: 'DM Sans, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif'
+    fontSize: 0.875rem
+    fontWeight: 400
+    lineHeight: 18.2px
+    letterSpacing: 0px
+  body-lg:
+    fontFamily: 'DM Sans, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif'
+    fontSize: 20px
+    fontWeight: 400
+    lineHeight: 32px
+    letterSpacing: 0px
+  body-md:
+    fontFamily: 'DM Sans, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif'
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 24px
+    letterSpacing: 0px
+  body-md-strong:
+    fontFamily: 'DM Sans, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif'
+    fontSize: 16px
+    fontWeight: 700
+    lineHeight: 24px
+    letterSpacing: 0px
+  label-sm:
+    fontFamily: 'DM Sans, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif'
+    fontSize: 12px
+    fontWeight: 700
+    lineHeight: 12px
+    letterSpacing: 0px
+  display-72:
+    fontFamily: 'DM Sans, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif'
+    fontSize: 4.5rem
+    fontWeight: 700
+    lineHeight: 82px
+    letterSpacing: 0px
+  display-56:
+    fontFamily: 'DM Sans, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif'
+    fontSize: 3.5rem
+    fontWeight: 700
+    lineHeight: 64px
+    letterSpacing: 0px
+  display-40:
+    fontFamily: 'DM Sans, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif'
+    fontSize: 2.5rem
+    fontWeight: 700
+    lineHeight: 48px
+    letterSpacing: 0px
+  display-32:
+    fontFamily: 'DM Sans, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif'
+    fontSize: 2rem
+    fontWeight: 700
+    lineHeight: 42px
+    letterSpacing: 0px
+  mono:
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace'
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 20px
+    letterSpacing: 0px
+rounded:
+  xs: 0.125rem
+  sm: 0.25rem
+  md: 0.5rem
+  lg: 0.75rem
+  xl: 1rem
+  xxl: 1.25rem
+  xxxl: 2rem
+  xxxxl: 2.5rem
+  full: 9999px
+spacing:
+  xxs: 0.125rem
+  xs: 0.25rem
+  sm: 0.5rem
+  md: 1rem
+  lg: 1.5rem
+  xl: 2rem
+  xxl: 3rem
+  xxxl: 4rem
+  xxxxl: 5rem
+  content-max: 1620px
+  content-wide: 34rem
+  legacy-136: 34rem
+  grid-gutter-mobile: 1.5rem
+  grid-gutter-desktop: 4rem
+  page-inset-mobile: 1.5rem
+  page-inset-sm: 2rem
+  page-inset-lg: 3rem
+  page-inset-xl: 5rem
+  page-inset-xxl: 8rem
+components:
+  page:
+    backgroundColor: '{colors.background}'
+    textColor: '{colors.foreground}'
+    typography: '{typography.body-md}'
+  site-canvas:
+    backgroundColor: '{colors.site-canvas}'
+    textColor: '{colors.foreground}'
+  site-chrome:
+    backgroundColor: '{colors.site-chrome}'
+    textColor: '{colors.foreground}'
+  site-section:
+    backgroundColor: '{colors.site-section}'
+    textColor: '{colors.foreground}'
+  landing-page:
+    backgroundColor: '{colors.site-canvas}'
+    textColor: '{colors.foreground}'
+    typography: '{typography.body-md}'
+  landing-hero:
+    backgroundColor: '{colors.site-canvas}'
+    textColor: '{colors.foreground}'
+    typography: '{typography.body-lg}'
+    rounded: '{rounded.xxxxl}'
+    padding: '{spacing.xxxl}'
+  landing-panel:
+    backgroundColor: '{colors.card}'
+    textColor: '{colors.card-foreground}'
+    typography: '{typography.body-md}'
+    rounded: '{rounded.xxxl}'
+    padding: '{spacing.xl}'
+  landing-image-card:
+    backgroundColor: '{colors.backdrop}'
+    textColor: '{colors.primary-foreground}'
+    typography: '{typography.body-md-strong}'
+    rounded: '{rounded.xxxl}'
+    padding: '{spacing.lg}'
+  landing-accent-band:
+    backgroundColor: '{colors.accent}'
+    textColor: '{colors.accent-foreground}'
+    typography: '{typography.body-md}'
+    rounded: '{rounded.md}'
+    padding: '{spacing.xxxl}'
+  content-page:
+    backgroundColor: '{colors.site-canvas}'
+    textColor: '{colors.foreground}'
+    typography: '{typography.body-md}'
+  content-hero:
+    backgroundColor: '{colors.secondary}'
+    textColor: '{colors.secondary-foreground}'
+    typography: '{typography.body-lg}'
+    padding: '{spacing.xxxl}'
+  content-card:
+    backgroundColor: '{colors.card}'
+    textColor: '{colors.card-foreground}'
+    typography: '{typography.body-md}'
+    rounded: '{rounded.lg}'
+    padding: '{spacing.lg}'
+  comparison-card:
+    backgroundColor: '{colors.card}'
+    textColor: '{colors.card-foreground}'
+    typography: '{typography.body-md}'
+    rounded: '{rounded.lg}'
+    padding: '{spacing.lg}'
+  detail-evidence-card:
+    backgroundColor: '{colors.card}'
+    textColor: '{colors.secondary}'
+    typography: '{typography.body-md}'
+    rounded: '{rounded.xxl}'
+    padding: '{spacing.lg}'
+  card:
+    backgroundColor: '{colors.card}'
+    textColor: '{colors.card-foreground}'
+    typography: '{typography.body-md}'
+    rounded: '{rounded.lg}'
+    padding: '{spacing.lg}'
+  popover:
+    backgroundColor: '{colors.popover}'
+    textColor: '{colors.popover-foreground}'
+    rounded: '{rounded.md}'
+    padding: '{spacing.sm}'
+  button-primary:
+    backgroundColor: '{colors.primary}'
+    textColor: '{colors.primary-foreground}'
+    typography: '{typography.body-md-strong}'
+    rounded: '{rounded.lg}'
+    height: 40px
+    padding: '{spacing.lg}'
+  button-primary-hover:
+    backgroundColor: '{colors.primary-hover}'
+    textColor: '{colors.primary-foreground}'
+  button-secondary:
+    backgroundColor: '{colors.card}'
+    textColor: '{colors.primary}'
+    typography: '{typography.body-md-strong}'
+    rounded: '{rounded.lg}'
+    height: 40px
+    padding: '{spacing.lg}'
+  button-accent:
+    backgroundColor: '{colors.accent}'
+    textColor: '{colors.accent-foreground}'
+    typography: '{typography.body-md-strong}'
+    rounded: '{rounded.lg}'
+    height: 40px
+    padding: '{spacing.lg}'
+  button-filter:
+    backgroundColor: '{colors.secondary}'
+    textColor: '{colors.secondary-foreground}'
+    typography: '{typography.body-md-strong}'
+    rounded: '{rounded.lg}'
+    height: 40px
+    padding: '{spacing.lg}'
+  button-destructive:
+    backgroundColor: '{colors.destructive}'
+    textColor: '{colors.destructive-foreground}'
+    typography: '{typography.body-md-strong}'
+    rounded: '{rounded.lg}'
+    height: 40px
+    padding: '{spacing.lg}'
+  button-outline:
+    backgroundColor: '{colors.background}'
+    textColor: '{colors.primary}'
+    typography: '{typography.body-md-strong}'
+    rounded: '{rounded.lg}'
+    height: 40px
+    padding: '{spacing.lg}'
+  button-ghost:
+    textColor: '{colors.secondary}'
+    typography: '{typography.body-md-strong}'
+    rounded: '{rounded.lg}'
+    height: 40px
+    padding: '{spacing.md}'
+  button-ghost-white:
+    textColor: '{colors.primary-foreground}'
+    typography: '{typography.body-md-strong}'
+    rounded: '{rounded.lg}'
+    height: 40px
+    padding: '{spacing.md}'
+  button-brand-outline-thick:
+    backgroundColor: '{colors.background}'
+    textColor: '{colors.primary}'
+    typography: '{typography.body-md-strong}'
+    rounded: '{rounded.lg}'
+    height: 40px
+    padding: '{spacing.lg}'
+  input:
+    backgroundColor: '{colors.background}'
+    textColor: '{colors.foreground}'
+    typography: '{typography.body-md}'
+    rounded: '{rounded.md}'
+    height: 40px
+    padding: '{spacing.md}'
+  input-border:
+    backgroundColor: '{colors.input}'
+  focus-ring:
+    backgroundColor: '{colors.ring}'
+  divider:
+    backgroundColor: '{colors.site-divider}'
+  link:
+    backgroundColor: '{colors.background}'
+    textColor: '{colors.primary}'
+  link-hover:
+    backgroundColor: '{colors.background}'
+    textColor: '{colors.primary-hover}'
+  accent-link-contextual:
+    textColor: '{colors.accent}'
+  metadata:
+    textColor: '{colors.muted-foreground}'
+  status-success:
+    backgroundColor: '{colors.success}'
+    textColor: '{colors.secondary}'
+  status-warning:
+    backgroundColor: '{colors.warning}'
+    textColor: '{colors.secondary}'
+  status-error:
+    backgroundColor: '{colors.error}'
+    textColor: '{colors.secondary}'
+  accent-2-surface:
+    backgroundColor: '{colors.accent-2}'
+    textColor: '{colors.accent-2-foreground}'
+  backdrop:
+    backgroundColor: '{colors.backdrop}'
+  verification-bronze:
+    backgroundColor: '{colors.verification-bronze}'
+    textColor: '{colors.verification-bronze-foreground}'
+  verification-silver:
+    backgroundColor: '{colors.verification-silver}'
+    textColor: '{colors.verification-silver-foreground}'
+  verification-gold:
+    backgroundColor: '{colors.verification-gold}'
+    textColor: '{colors.verification-gold-foreground}'
+  chart-series-1:
+    backgroundColor: '{colors.chart-1}'
+  chart-series-2:
+    backgroundColor: '{colors.chart-2}'
+  chart-series-3:
+    backgroundColor: '{colors.chart-3}'
+  chart-series-4:
+    backgroundColor: '{colors.chart-4}'
+  chart-series-5:
+    backgroundColor: '{colors.chart-5}'
+  admin-sidebar:
+    backgroundColor: '{colors.sidebar}'
+    textColor: '{colors.sidebar-foreground}'
+  admin-sidebar-primary:
+    backgroundColor: '{colors.sidebar-primary}'
+    textColor: '{colors.sidebar-primary-foreground}'
+  admin-sidebar-accent:
+    backgroundColor: '{colors.sidebar-accent}'
+    textColor: '{colors.sidebar-accent-foreground}'
+  admin-sidebar-border:
+    backgroundColor: '{colors.sidebar-border}'
+  admin-sidebar-ring:
+    backgroundColor: '{colors.sidebar-ring}'
+---
+
+# findmydoc Design System
+
+## Overview
+
+`DESIGN.md` is the canonical source of truth for findmydoc visual identity, design tokens, and reusable UI styling decisions. The YAML front matter is normative; the markdown prose explains how to apply it. Runtime CSS variables, Tailwind utilities, shadcn atom variants, Storybook examples, and visual QA notes must mirror this file instead of introducing independent design rules.
+
+findmydoc should feel clinical, precise, calm, and operationally useful. The interface helps international patients compare clinics and specialists without visual noise. Prioritize trust, scanability, direct action, and accessible contrast over decorative expression. Mobile is the primary design baseline; desktop can add density only after the narrow viewport hierarchy is stable.
+
+Trust and transparency are the product's core design obligations. Every important claim should feel inspectable: clinic identity, verification status, treatment scope, price ranges, location, response pathways, and patient-facing next steps must be presented with clear labels, visible provenance where available, and restrained emphasis. The UI should reduce uncertainty by showing what is known, what is missing, and what action follows next.
+
+findmydoc has two canonical visual modes. They share the same token system, typeface, and trust rules, but they use different density, radius, color balance, and page rhythm. Choose the mode before composing a page; do not average the two styles.
+
+## Design Modes
+
+| Mode                | Primary routes and surfaces                                                                                                                    | Character                                                       | Use when                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `landing-editorial` | `/`, `/partners/clinics`, landing feature bands, pricing, team, testimonials, blog teasers, contact/onboarding sections.                       | Open, calm, image-led, rounded, low-density, narrative.         | The user is learning what findmydoc is, why to trust it, or why to start.                   |
+| `content-evidence`  | `/listing-comparison`, `/clinics/[slug]`, filters, cards, comparison views, treatment and doctor evidence, contact forms inside clinic detail. | Compact, structured, evidence-led, operational, higher-density. | The user is comparing options, inspecting facts, filtering, or taking a concrete next step. |
+
+- **Mode selection:** Route templates and reusable sections must declare which mode they follow in implementation notes, stories, or component names. If a section mixes narrative and data, the local task decides the mode: narrative intro uses `landing-editorial`; comparable facts use `content-evidence`.
+- **Landing-editorial contract:** Use generous vertical rhythm, centered section headings, large image or media surfaces, soft overlays, `rounded-xxxl`/`rounded-xxxxl` panels, pill CTAs, and one primary idea per section. Density should feel intentionally sparse.
+- **Content-evidence contract:** Use compact cards, visible data labels, left-aligned scan paths where comparison matters, tighter gaps, smaller radii, and stronger evidence blocks. Density may increase when it helps compare clinics, prices, reviews, treatments, or doctors.
+- **Shared contract:** Both modes must keep trust cues visible, use DM Sans, keep focus and touch behavior accessible, and avoid decorative elements that do not clarify the user's decision.
+
+## Colors
+
+The palette is built from a clear medical blue, a deep navy anchor, a mint accent, white surfaces, and quiet gray page areas.
+
+- **Primary (#006DE5):** The main action and link color. Use it for the single strongest action in a local context, active states, focus rings, and critical navigation emphasis.
+- **Primary hover (#004EA5):** The canonical darker primary interaction state. Runtime CSS may derive this with `color-mix`, but generated tokens should use the hex value.
+- **Secondary (#07004C):** The deep brand anchor. Use it for high-confidence headings, dense filters, and trustworthy summary states.
+- **Accent (#42E2B7):** A mint signal for positive affordances and accent surfaces. Do not use it as ordinary text on white; default links use primary.
+- **Muted (#F8F9FA):** The public site canvas, chrome, and structural section background. This keeps clinical content open without pure-white page glare.
+- **Card and popover (#FFFFFF):** Use white for repeated cards, dialogs, floating panels, popovers, and form surfaces on muted backgrounds.
+- **Foreground (#333333):** Default body text. Keep long-form content on foreground or secondary, not muted foreground.
+- **Muted foreground (#999999):** Secondary metadata only. Do not use it for required form labels, prices, clinic names, or key comparison data.
+- **Border/input (#E2E8F0):** Subtle separation for cards, inputs, dividers, and low-emphasis panels.
+- **Destructive (#B91C1C):** Error and destructive action color only. This is intentionally darker than Tailwind red-500 so white text passes WCAG AA.
+- **Accent 2 (#E0E0E0):** Neutral secondary accent surface for legacy or low-emphasis UI states. Use it only when muted is too quiet and mint would imply action or success.
+- **Status surfaces:** Success, warning, and error are soft surfaces for inline status panels, validation summaries, and contextual chips. Pair them with secondary or foreground text; do not use them as the only status cue.
+- **Backdrop (#000000):** Scrim base for dialogs, drawers, overlays, and image-lightbox states. Runtime opacity controls intensity; the token stays black for predictable contrast.
+- **Verification colors:** Bronze, silver, and gold are reserved for `VerificationBadge` semantics. Do not repurpose them as decorative accents.
+- **Chart colors:** Use chart tokens only in data visualizations. Keep labels and legends in foreground or secondary for contrast.
+- **Sidebar colors:** Sidebar tokens are implementation support for admin/shadcn surfaces, not public brand colors.
+- **Landing-editorial color balance:** Let site-canvas, white, soft image overlays, and translucent panels dominate. Primary blue is mostly CTA/search/action, secondary anchors headlines, and accent may own one full band or highlight section when it carries a clear benefit message.
+- **Content-evidence color balance:** Use site-canvas plus white cards for most content, secondary for strong hero/evidence blocks, primary for prices/actions/focus, and accent only for trust/benefit bands. Do not make comparison or clinic-detail pages feel like a marketing landing page.
+- **Image overlays:** Landing heroes use image backdrops with a light site-canvas overlay when copy sits over photography. Content pages use images as evidence/media cards; do not wash out clinical evidence images unless text is placed on top.
+
+## Typography
+
+Use DM Sans as the brand typeface for all public UI. It is chosen for a neutral medical platform voice: human enough for patient decisions, precise enough for comparison workflows, and calm enough for high-stakes healthcare context. System sans fallbacks are acceptable only as runtime fallback, not as a separate design direction. Use the Heading atom for headings in implementation.
+
+- **H1-H4:** Bold, compact, centered by default in the base layer. Override alignment only when the layout needs scanning, comparison, or form completion.
+- **Landing-editorial type:** Prefer centered headings, larger display moments, short explanatory paragraphs, and generous line spacing. Landing copy should invite understanding, not enumerate every fact.
+- **Content-evidence type:** Prefer scan-friendly labels, compact headings, tabular or prominent numeric treatment for prices/ratings, and left alignment when comparing data. Long names must wrap cleanly instead of shrinking the whole layout.
+- **H5 caps:** Uppercase, wide-tracked section labeling. Use sparingly; it is a cue, not body copy.
+- **Body text:** Use 16px/24px for default copy and 20px/32px for prominent explanatory text.
+- **Labels:** Use 12px bold labels for compact controls and validation contexts. Keep form labels readable and avoid muted foreground when the label is required.
+- **Font philosophy:** Typography should create confidence through hierarchy, not personality. Avoid playful, editorial, luxury, or startup-style type treatments. When in doubt, make labels clearer, numbers easier to compare, and caveats easier to find.
+- **Display sizes:** 32px, 40px, 56px, and 72px are reserved for marketing, hero, or high-emphasis editorial compositions. Do not use display type inside compact cards, filters, tables, or sidebars.
+- **Letter spacing:** Default letter spacing is `0px`. The only wide-tracked default is `h5-caps`.
+- **Implementation mapping:** YAML typography is the brand scale and uses dimension line heights so CLI exports preserve `--leading-*` tokens. The `Heading` atom is the runtime API for responsive headings; raw browser heading styles are fallback only.
+
+## Layout
+
+Use a mobile-first vertical flow. Pages should start with the narrowest supported viewport, then widen into tablet and desktop layouts after content priority and primary actions are stable.
+
+- **Canvas:** Public route backgrounds use `site-canvas`. Shared header/footer chrome uses `site-chrome`. Structural page bands use `site-section`.
+- **Content width:** The maximum content width is `1620px`. Keep content centered within `container-content` unless a route intentionally uses full-width media or a tool surface.
+- **Grid system:** Use a 12-column grid for desktop and wide composed layouts. On mobile, collapse to a vertical flow or a 4-column local grid only when the content remains readable without horizontal scrolling.
+- **Grid gutters:** Use 24px gutters on mobile/local grids and 64px gutters for wide 12-column editorial or detail layouts. Route-specific dense tools may reduce gutters only when scanability improves.
+- **8-point system:** The base spacing rhythm is 8px. Use 16px, 24px, 32px, 48px, 64px, 80px, and 128px for durable layout spacing. Use 4px and 2px only for micro-alignment, icon gaps, fine borders, or compact control internals.
+- **Spacing:** Use the spacing scale from YAML first. Prefer `sm`, `md`, `lg`, and `xl` for controls and cards; reserve `xxl` and above for page-level separation.
+- **Page insets:** Container padding follows the 8-point system: 24px mobile, 32px small screens, 48px large screens, 80px extra-large screens, and 128px 2xl screens.
+- **Density:** Operational screens such as comparison, filters, registration, and admin-adjacent views should be compact but readable. Avoid oversized marketing composition in repeated workflows.
+- **Responsive order:** Preserve the primary action above secondary metadata on mobile. Do not require horizontal scrolling unless the pattern is explicitly designed and touch affordances are obvious.
+- **Sticky and overlay UI:** Verify sticky headers, drawers, dialogs, filter sheets, and fixed actions on short-height mobile states before accepting the design.
+
+### Mode-Specific Layout Rhythm
+
+| Surface                   | Mobile rhythm                                        | Desktop rhythm                                                                        | Notes                                                                           |
+| ------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Landing hero              | `py-14`, minimum around 32rem, centered stack.       | `py-20`, minimum 39-48rem, optional floating search or CTA panel.                     | Image-backed, light overlay, one message, one primary action.                   |
+| Landing narrative section | `py-14` to `py-16`, one column.                      | `py-20`, 2-3 editorial columns or a composed image grid.                              | Low density; avoid more than one major decision per band.                       |
+| Landing image/card grid   | Stack cards with 16-24px gaps.                       | 2-4 cards, large image masks, optional hover reveal for non-essential copy only.      | Cards may be much rounder than content cards.                                   |
+| Landing accent band       | 48-64px vertical padding.                            | 64-80px vertical padding.                                                             | Accent can dominate this one band; keep adjacent sections quiet.                |
+| Content hero              | 48-64px vertical padding.                            | 72-96px vertical padding.                                                             | May use secondary/navy block for clear context and trust.                       |
+| Filter/results layout     | Filters stack before results or use a jump bar.      | 12-column composition with a roughly 320px filter column and flexible results column. | Dense but readable; all controls remain labeled.                                |
+| Clinic detail layout      | Stack overview, evidence cards, media, then actions. | 12-column hero composition with evidence cards and media overlap when useful.         | Detail pages can use larger hero cards, but evidence sections stay inspectable. |
+
+### Exported Token Names
+
+The Google `css-tailwind` export emits literal token names. Runtime compatibility aliases may exist only in addition to exported names, never instead of them.
+
+| DESIGN.md token      | Exported CSS variable  | Optional runtime alias |
+| -------------------- | ---------------------- | ---------------------- |
+| `rounded.xxl`        | `--radius-xxl`         | `--radius-2xl`         |
+| `rounded.xxxl`       | `--radius-xxxl`        | `--radius-3xl`         |
+| `rounded.xxxxl`      | `--radius-xxxxl`       | `--radius-4xl`         |
+| `spacing.legacy-136` | `--spacing-legacy-136` | `--spacing-136`        |
+
+## Breakpoints & Responsive Behavior
+
+Use the repository breakpoint scale from `src/cssVariables.js` as the responsive contract unless a route-level design explicitly documents a narrower constraint.
+
+| Breakpoint | Width       | Layout contract                                                                     |
+| ---------- | ----------- | ----------------------------------------------------------------------------------- |
+| `base`     | `< 640px`   | Single-column mobile flow; primary actions visible before metadata.                 |
+| `sm`       | `>= 640px`  | Single-column or simple two-column local groups when labels still fit.              |
+| `md`       | `>= 768px`  | Two-column content groups, wider forms, and side-by-side supporting media.          |
+| `lg`       | `>= 1024px` | 12-column page composition becomes available for route shells and comparison views. |
+| `xl`       | `>= 1280px` | Dense comparison, filters, and clinic-detail layouts may add supporting columns.    |
+| `2xl`      | `>= 1536px` | Use the full `container-content` width only when density improves scanning.         |
+| `3xl`      | `>= 1920px` | Preserve centered content; do not stretch text lines or cards just to fill space.   |
+
+- **Stack-to-grid rule:** Start stacked. Move to grid only when the reading order remains obvious and the primary action does not move below secondary content.
+- **12-column desktop rule:** Use 12 columns for wide page composition, not for tiny internal card layouts. Components may use local flex/grid rules inside their own bounds.
+- **Forms:** Keep one field per row on mobile. At `md` and above, pair short fields only when labels, helper text, errors, and values remain visible without truncation.
+- **Cards and lists:** Clinic, doctor, and treatment cards stack on mobile. At `md` and above, cards may become grids if all primary comparison data remains visible.
+- **Comparison layouts:** Mobile comparison uses stacked cards, tabs, accordions, or horizontal affordances with explicit scroll cues. Desktop comparison can use columns when sticky labels and row headers remain readable.
+- **Drawers and dialogs:** Mobile drawers use safe-area padding and must fit short-height states with internal scroll. Desktop dialogs may center, but focus and escape behavior stay identical.
+- **Sticky UI:** Sticky headers, filter bars, and CTAs must account for safe areas, browser chrome, validation messages, and keyboard overlap before release.
+
+## Elevation & Depth
+
+Depth is quiet and functional. Use borders before shadows when separation is enough.
+
+Google DESIGN.md does not export shadow or border tokens in the current `css-tailwind` format. The following table is still normative as the runtime effects contract; CSS variables, Tailwind utilities, Storybook fixtures, and generated mockups must use these exact names and values until the exporter supports effects directly.
+
+| Token                    | Value                                     | Use                                                             |
+| ------------------------ | ----------------------------------------- | --------------------------------------------------------------- |
+| `border-default`         | `1px solid #E2E8F0`                       | Cards, inputs, dividers, low-emphasis panels                    |
+| `shadow-xs`              | `0px 1px 2px 0px rgb(0 0 0 / 0.05)`       | Default card lift with a visible border                         |
+| `shadow-brand-soft`      | `0px 4px 21px 1px rgb(48 123 196 / 0.10)` | Brand-matched cards/images and Figma-derived marketing surfaces |
+| `shadow-elevated-strong` | `0px 4px 4px 0px rgb(0 0 0 / 0.25)`       | Intentionally raised overlays or dense content separation       |
+
+- **Default card elevation:** Use a subtle `shadow-xs` with a border on card surfaces.
+- **Soft brand image/card shadow:** Use the brand soft shadow only for Figma-matched marketing cards, media, or hero support imagery.
+- **Strong elevation:** Use the stronger elevated shadow only for intentionally raised cards or overlays that must separate from dense content.
+- **No decorative depth:** Do not add bokeh, floating orbs, glow fields, or decorative gradient blobs. Depth must clarify hierarchy, not add atmosphere.
+
+## Shapes
+
+The default radius is `0.5rem` (8px). Component shape should feel precise and medical rather than plush.
+
+- **Controls:** Buttons use `rounded-lg` by default. Inputs use `rounded-md`. Icon-only primary controls can use `rounded-full` when the hit area is symmetric.
+- **Cards:** Standard cards use `rounded-lg`. Avoid nested cards and avoid turning entire page sections into floating cards.
+- **Pills:** Use `rounded-full` for badges, tags, and compact status chips only.
+- **Large radius:** `xxl` and above are reserved for feature panels, media masks, or special landing sections. Do not use them for dense operational UI.
+- **Landing-editorial radius:** Large media cards, pricing panels, contact panels, search shells, and testimonial cards may use 24-40px radii (`xxl` through `xxxxl`). Pair the larger radius with generous padding and low density.
+- **Content-evidence radius:** Filters, listing cards, form controls, dropdowns, and compact comparison surfaces default to 8-16px (`md` through `xl`). Clinic-detail hero media, treatment strips, and evidence snapshots may use 20-32px when the section is spacious enough.
+- **Mode mismatch:** A dense filter, table, or comparison card with 32-40px radius reads like landing UI and should be tightened. A narrative landing section with only 8px cards reads like a utility tool and should be softened.
+
+## Components
+
+Components should consume the YAML tokens through Tailwind theme variables and shared atom variants. Do not introduce persistent color, type, spacing, or radius choices directly inside one-off feature components.
+
+- **Buttons:** Primary buttons are blue with white text. Secondary buttons use white card surfaces, primary text, and a subtle primary border. Accent buttons use mint with navy text. Destructive buttons are red with white text.
+- **Button borders:** `secondary` and `outline` use `1px solid {colors.primary}`. `brandOutlineThick` uses `2px solid {colors.primary}`. `ghost`, `ghostWhite`, `accent`, `filter`, `primary`, and `destructive` do not add persistent borders unless a focus ring is active.
+- **Button inventory:** Canonical variants are `primary`, `secondary`, `accent`, `filter`, `destructive`, `outline`, and `link`. Allowed special-case variants are `ghost`, `ghostWhite`, and `brandOutlineThick`; use them only when an existing component contract already requires them. New durable variants require a `DESIGN.md` update in the same change.
+- **Inputs:** Inputs use white background, foreground text, input border, 40px height, 16px mobile text, and a visible primary focus ring.
+- **Cards:** Cards use white background, foreground text, border, `rounded-lg`, `shadow-xs`, and 24px padding by default.
+- **Popovers and dropdowns:** Use white popover surfaces, foreground text, `rounded-md`, subtle border, and compact spacing.
+- **Links:** Default links use primary and shift to primary-hover on hover, active, or current-page state. Accent-colored text is contextual only and must be checked against its actual background.
+- **VerificationBadge:** Preserve the bronze/silver/gold token mapping exactly; generated mockups must not redefine badge shapes, colors, or icon treatment.
+- **Trust surfaces:** Verification, accreditation, reviews, prices, location, treatment availability, and contact actions must be visibly labeled and easy to compare. Prefer explicit empty or unavailable states over hiding missing information.
+- **Transparency cues:** Use supporting metadata, captions, timestamps, source labels, and explanatory helper text when a user could reasonably ask "why should I trust this?" or "what happens next?" Do not bury these cues behind hover-only interactions.
+- **Charts:** Use the chart series colors only for chart marks. Text, legends, and axes remain foreground, secondary, or muted foreground depending on hierarchy.
+- **Icons:** Use lucide icons where available. Icon buttons need accessible names and at least 44px touch targets on mobile.
+
+### Mode-Specific Component Contracts
+
+- **LandingHero:** Use `landing-hero` behavior: image backdrop or soft visual field, light site-canvas overlay, centered headline, short supporting copy, and a single search/CTA surface. Homepage search can float over the next section on desktop; mobile keeps it in flow.
+- **Landing search shell:** Use white/card surface, high radius (`xxl` or larger), subtle shadow, compact labels, and a primary pill CTA. It should feel like an invitation, not a full filter panel.
+- **Landing category cards:** Use image-first cards with large radii, dark bottom overlay for text, and optional hover reveal only for supporting copy. Essential category labels and links must be visible without hover.
+- **Landing feature bands:** Use large section spacing, icon circles, three-column desktop rhythm, and short copy. Mint/accent bands are allowed when the section communicates benefits or proof.
+- **Landing pricing/team/contact panels:** Use 30-32px radii, soft borders, translucent white or white/95 surfaces, brand-soft shadows, and generous padding. These panels should not adopt listing-card density.
+- **FeatureHero and listing comparison:** Use `content-hero` behavior: secondary/navy hero, compact feature bullets, filter/results grid, strong primary price/action treatment, and listing cards with tight information hierarchy.
+- **Listing cards:** Use `comparison-card` behavior: image thumbnail, clinic name, location, verification, rating, tags, price, favorite action, and details CTA in one scan path. Keep radii and padding compact enough for repeated comparison.
+- **Clinic detail overview:** Use `detail-evidence-card` for quality snapshots and doctor preview cards, with larger hero media and overlap allowed. The page is still `content-evidence`; every large card must carry inspectable facts or a clear next action.
+- **Clinic treatment strips:** May use a saturated primary block and larger radius when it separates a curated action set. Keep treatment names, price cues, and CTA labels explicit.
+
+## Component States
+
+State styling is part of the design contract, not a local implementation detail.
+
+| Component        | State             | Visual contract                                                                                                            | Semantic contract                                                                                               |
+| ---------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Buttons          | Hover             | Primary shifts to `primary-hover`; secondary/outline keep white background and may tint border/text to `primary-hover`.    | Pointer-only enhancement; no information may depend on hover alone.                                             |
+| Buttons          | Focus visible     | Show a 2px primary ring with at least 2px offset or an equivalent visible outline.                                         | Use `:focus-visible`; preserve keyboard tab order.                                                              |
+| Buttons          | Disabled          | Reduce opacity, keep label visible, remove hover effects, and keep layout dimensions stable.                               | Use `disabled` for native buttons or `aria-disabled="true"` with blocked activation for non-native controls.    |
+| Buttons          | Loading           | Preserve width, keep the action label or an accessible loading label, and show a spinner/icon only as supporting feedback. | Expose busy state with `aria-busy` or equivalent status text when the wait is user-visible.                     |
+| Buttons          | Pressed/selected  | Use active/current styling with primary or secondary emphasis, not a new color.                                            | Use `aria-pressed`, `aria-selected`, or `aria-current` according to the interaction pattern.                    |
+| Inputs           | Focus             | Border/ring uses primary; helper text remains visible.                                                                     | Move focus programmatically only after explicit user action or validation flow.                                 |
+| Inputs           | Error             | Use destructive text or icon plus clear error copy; never rely on red alone.                                               | Connect errors with `aria-describedby`; announce submit-time errors through an assertive or polite live region. |
+| Inputs           | Success           | Use success surface only for confirmed validation or saved states.                                                         | Announce saved/validated state when it changes after user action.                                               |
+| Inputs           | Read-only         | Keep foreground contrast and show the value as copyable content when useful.                                               | Use `readonly` rather than `disabled` when the value should remain discoverable.                                |
+| Links/navigation | Active/current    | Use primary or secondary emphasis plus underline, icon, or weight change when needed.                                      | Use `aria-current="page"` or a route-equivalent state for current navigation items.                             |
+| Chips/badges     | Selected          | Keep text legible and pair color with label/icon state.                                                                    | Use `aria-selected` only inside selectable collections.                                                         |
+| Trust badges     | Empty/unavailable | Show explicit "Not verified", "No reviews yet", "Price unavailable", or equivalent copy.                                   | Do not hide missing trust data or imply verification through color alone.                                       |
+| Cards/lists      | Empty             | Use concise empty copy plus the next available action or recovery path.                                                    | Empty states must be reachable by keyboard and screen readers like normal content.                              |
+
+## Trust Surface Contract
+
+Trust surfaces must show what is known, where it came from, how current it is when available, and what is missing. Do not imply clinical quality, pricing certainty, availability, or verification beyond the available source.
+
+| Surface              | Required visible labels                                                             | Source and freshness                                                       | Missing state                                                    | Forbidden shortcut                                                     |
+| -------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Clinic identity      | Clinic name, location, specialty scope where relevant.                              | CMS/profile source; show last updated when exposed by the product surface. | "Clinic details unavailable" with recovery action when possible. | Do not infer identity from image, slug, or marketing copy alone.       |
+| Verification         | Verification level and what it means.                                               | Verification source or internal verification status when available.        | "Not verified" or "Verification pending".                        | Do not use bronze/silver/gold styling without the matching status.     |
+| Reviews              | Rating, count, review source, and date/freshness where available.                   | Review provider or internal review source.                                 | "No reviews yet" or "Reviews unavailable".                       | Do not show a rating without count/source context.                     |
+| Prices               | Currency, range/fixed price label, treatment scope, and caveat when estimate-based. | Clinic/treatment price source and update date when available.              | "Price unavailable" plus next step for inquiry.                  | Do not imply a quote, guarantee, or included services unless sourced.  |
+| Availability/contact | Contact method, expected response path, and next step.                              | Clinic profile, platform workflow, or form state.                          | "Contact option unavailable" with alternate action if present.   | Do not imply confirmed appointment availability from a contact CTA.    |
+| Treatment scope      | Treatment name, specialty/category, and relevant clinic/doctor relation.            | CMS relationship or curated taxonomy.                                      | "Treatment details unavailable".                                 | Do not imply a clinic provides a treatment unless the relation exists. |
+
+## Accessibility
+
+Accessibility is part of the visual system because trust depends on users being able to inspect and complete flows.
+
+- **Contrast:** Body text and interactive labels require at least 4.5:1 contrast. Large text requires at least 3:1. UI boundaries, focus indicators, icons that carry meaning, and chart distinctions require at least 3:1 against adjacent colors.
+- **Focus:** Every interactive element needs a visible focus state. Focus rings use primary by default and must not be clipped by overflow, sticky containers, or rounded masks.
+- **Keyboard:** Buttons, links, inputs, menus, dialogs, popovers, drawers, tabs, accordions, filters, and comparison controls must be fully operable by keyboard.
+- **Dialogs and popovers:** Trap focus only for modal dialogs and drawers. Return focus to the invoking control on close. Non-modal popovers must close predictably with Escape and outside interaction.
+- **Forms:** Required labels, helper text, errors, and success messages must remain visible and programmatically associated with fields. Validation must not rely on color alone.
+- **Status updates:** Loading, saved, error, and async result states that change after user action need accessible status text or `aria-live` behavior.
+- **Icons:** Decorative icons are hidden from assistive technology. Meaningful icons require labels or adjacent text.
+- **Motion:** Motion may clarify state changes, but reduced-motion preferences must disable non-essential transitions and animations.
+- **Touch:** Mobile targets are at least 44px high/wide unless the target is part of dense text content with an equivalent larger action nearby.
+
+## Governance & Implementation Handoff
+
+`DESIGN.md` owns durable design decisions. Runtime code owns implementation mechanics, but it must not redefine design intent.
+
+- **Owners:** Product/design and frontend engineering jointly own this file. Changes that affect tokens, component variants, trust surfaces, accessibility behavior, or responsive contracts require both design intent and implementation review.
+- **Update package:** Token or component changes must include this file, runtime CSS/theme mapping, affected shared atoms or variants, and Storybook or route-level visual evidence when UI output changes.
+- **Versioning:** Keep `version: alpha` until the design system is actively consumed by runtime generation and drift checks. Breaking token renames require a migration note in the same change.
+- **Deprecation:** Do not delete a token or variant in the same change that introduces a replacement unless all runtime references are migrated. Mark the replacement path in prose first.
+- **Validation:** After token changes, run Google DESIGN.md lint and export, then compare exported color, type, spacing, radius, and component tokens with runtime CSS. For UI changes, capture mobile-first evidence before desktop polish.
+- **Specialist review:** Use accessibility review for semantics/focus/forms/dialogs, mobile UI review for responsive/touch/sticky risk, and web-vitals review for image-heavy or animation-heavy surfaces.
+
+## Do's and Don'ts
+
+- Do treat this file as the single source of truth for visual design decisions.
+- Do choose `landing-editorial` or `content-evidence` before composing a route, section, or generated mockup.
+- Do update this file first, or in the same change, when changing durable design tokens, component styles, or brand-level UI behavior.
+- Do define component states, trust-source labels, accessibility behavior, and responsive collapse behavior here before implementing reusable UI patterns.
+- Do keep `src/app/(frontend)/globals.css`, Tailwind theme tokens, shadcn atom variants, and Storybook fixtures aligned with this file.
+- Do run `rtk npx --yes @google/design.md lint DESIGN.md` and `rtk npx --yes @google/design.md export --format css-tailwind DESIGN.md` after token changes.
+- Do compare exported tokens with `src/app/(frontend)/globals.css` when colors, typography, spacing, radius, shadows, or durable component variants change.
+- Do use existing atoms, molecules, templates, and CMS adapters before creating new visual patterns.
+- Do verify mobile layouts for overflow, clipping, touch target crowding, sticky overlap, drawer height, and form validation states.
+- Don't create new brand colors, font scales, shadow styles, component radii, or CTA treatments only in local component code.
+- Don't apply dense comparison-card styling to landing pages, and don't apply oversized landing-card styling to filters, repeated results, or compact evidence rows.
+- Don't use muted foreground for critical comparison data, prices, form labels, errors, or clinic/provider names.
+- Don't use hover-only disclosure for essential actions or navigation.
+- Don't use decorative gradient blobs, bokeh, one-off orbs, or generic SaaS hero styling.
+- Don't capitalize the brand as FindMyDoc, Findmydoc, or any other variant unless quoting an external source.


### PR DESCRIPTION
## Management summary

### Deutsch

findmydoc erhält eine zentrale Designgrundlage, die die visuelle Identität, Vertrauenssignale und die unterschiedlichen Seitentypen klar beschreibt. Das hilft dabei, Landingpages weiterhin großzügig und markenstark zu gestalten, während Vergleichs- und Klinikdetailseiten dicht, prüfbar und entscheidungsorientiert bleiben.

### English

findmydoc gains a central design foundation that clearly describes the visual identity, trust signals, and different page types. This helps landing pages stay spacious and brand-led while comparison and clinic-detail pages remain dense, inspectable, and decision-oriented.

## What changed

- Added [DESIGN.md](./DESIGN.md) as the canonical design-system source of truth.
- Documented machine-readable design tokens for colors, typography, radius, spacing, and reusable components.
- Defined the two canonical visual modes: `landing-editorial` and `content-evidence`.
- Added design contracts for component states, trust/transparency surfaces, accessibility, responsive behavior, and implementation governance.
- Captured scrolled landing screenshots locally to ground the mode split; no runtime UI files were changed.

## Validation

- [x] `pnpm format`: passed.
- [ ] `pnpm check`: skipped; docs-only change with no runtime, lint-relevant source, schema, hook, or config changes.
- [ ] `pnpm build`: skipped; docs-only change with no build-relevant source changes.
- [x] Focused tests: `rtk npx --yes @google/design.md lint DESIGN.md`; `rtk npx --yes @google/design.md export --format css-tailwind DESIGN.md`; `rtk npx --yes @google/design.md export --format json-tailwind DESIGN.md`; `rtk npx --yes @google/design.md export --format dtcg DESIGN.md`.
- [x] UI/mobile QA: reviewed local Playwright screenshots for `/`, `/partners/clinics`, `/listing-comparison`, and `/clinics/izmir-coast-dental-and-derm`; no runtime UI changed.
- [ ] Security/privacy review: not applicable; documentation-only design-system change.
- [ ] Migration/schema check: not applicable; no schema or data-model changes.
- [x] Documentation/instructions check: Google DESIGN.md lint returned 0 errors and 0 warnings.

## Risk and rollout

None known. This adds documentation only and does not change runtime behavior, data models, migrations, environment variables, or deployment configuration.

## Development

Closes #1263
