### PR TITLE
feat: simplify password reset flash handling

### DIFF
--- a/src/app/(frontend)/_components/AuthFlashStatus.tsx
+++ b/src/app/(frontend)/_components/AuthFlashStatus.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { consumeAuthFlash, getAuthFlashMessage } from '@/auth/utilities/authFlash'
+import { Alert } from '@/components/atoms/alert'
+
+export function AuthFlashStatus() {
+  const [message, setMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    const flash = consumeAuthFlash()
+    setMessage(flash ? getAuthFlashMessage(flash) : null)
+  }, [])
+
+  if (!message) return null
+
+  return (
+    <div className="mb-4">
+      <Alert variant="success" role="status" aria-live="polite" aria-atomic="true" className="text-left break-words">
+        {message}
+      </Alert>
+    </div>
+  )
+}

--- a/src/app/(frontend)/admin/login/page.tsx
+++ b/src/app/(frontend)/admin/login/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation'
 import { headers } from 'next/headers'
 import { getLocalPlatformStaffUserState } from '@/auth/utilities/firstAdminCheck'
 import { extractSupabaseUserData } from '@/auth/utilities/jwtValidation'
+import { AuthFlashStatus } from '@/app/(frontend)/_components/AuthFlashStatus'
 import { Logo } from '@/components/molecules/Logo/Logo'
 import * as LoginForm from '@/components/organisms/Auth/LoginForm'
 import { getPayload } from 'payload'
@@ -145,6 +146,7 @@ export default async function LoginPage({
       >
         <LoginForm.Header title="Staff Login" description="Sign in to your account to continue" />
         <LoginForm.Status message={statusMessage} variant={statusVariant} />
+        <AuthFlashStatus />
         <LoginForm.Form>
           <LoginForm.EmailField placeholder="staff@example.com" />
           <LoginForm.PasswordField forgotPasswordHref="/auth/password/reset" />

--- a/src/app/(frontend)/auth/password/reset/ResetPasswordRequestForm.tsx
+++ b/src/app/(frontend)/auth/password/reset/ResetPasswordRequestForm.tsx
@@ -2,12 +2,13 @@
 
 import { useState } from 'react'
 import { z } from 'zod'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/atoms/card'
+import { Card, CardContent, CardDescription, CardHeader } from '@/components/atoms/card'
 import { Field, FieldError } from '@/components/atoms/field'
 import { Input } from '@/components/atoms/input'
 import { Label } from '@/components/atoms/label'
 import { Button } from '@/components/atoms/button'
 import { Alert } from '@/components/atoms/alert'
+import { Heading } from '@/components/atoms/Heading'
 import { usePublicFormValidation } from '@/components/molecules/PublicFormValidation'
 
 const formSchema = z.object({
@@ -81,10 +82,12 @@ export function ResetPasswordRequestForm() {
   const isSuccess = formState.status === 'success'
 
   return (
-    <div className="flex items-start justify-center px-4 py-12">
+    <div className="flex items-start justify-center py-6 sm:px-4 sm:py-12">
       <Card className="w-full max-w-md">
         <CardHeader>
-          <CardTitle className="text-center text-2xl">Reset your password</CardTitle>
+          <Heading as="h1" align="center" size="h4" className="font-semibold">
+            Reset your password
+          </Heading>
           <CardDescription className="text-center">
             Enter the email associated with your account and we&apos;ll send instructions to reset your password.
           </CardDescription>

--- a/src/app/(frontend)/auth/password/reset/complete/ResetPasswordCompleteForm.tsx
+++ b/src/app/(frontend)/auth/password/reset/complete/ResetPasswordCompleteForm.tsx
@@ -2,15 +2,20 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { z } from 'zod'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/atoms/card'
+import { Card, CardContent, CardDescription, CardHeader } from '@/components/atoms/card'
 import { Field, FieldError } from '@/components/atoms/field'
 import { Input } from '@/components/atoms/input'
 import { Label } from '@/components/atoms/label'
 import { Button } from '@/components/atoms/button'
 import { Alert } from '@/components/atoms/alert'
+import { Heading } from '@/components/atoms/Heading'
+import { createPasswordResetCompleteFlash, writeAuthFlash } from '@/auth/utilities/authFlash'
+import { resolvePasswordResetLoginTarget, type PasswordResetLoginTarget } from '@/auth/utilities/loginRedirects'
 import { createClient } from '@/auth/utilities/supaBaseClient'
 import { usePublicFormValidation } from '@/components/molecules/PublicFormValidation'
+import { resetPostHogBrowserIdentity } from '@/posthog/client-api'
 
 const passwordSchema = z
   .object({
@@ -26,7 +31,11 @@ type PasswordState = z.infer<typeof passwordSchema>
 
 export function ResetPasswordCompleteForm({ error }: { error?: string }) {
   const supabase = useMemo(() => createClient(), [])
+  const router = useRouter()
   const [isSessionReady, setSessionReady] = useState(false)
+  const [loginTarget, setLoginTarget] = useState<PasswordResetLoginTarget>(() =>
+    resolvePasswordResetLoginTarget(undefined),
+  )
   const formValidation = usePublicFormValidation({
     messages: {
       confirmPassword: { valueMissing: 'Confirm your new password.' },
@@ -36,10 +45,12 @@ export function ResetPasswordCompleteForm({ error }: { error?: string }) {
       },
     },
   })
-  const [formState, setFormState] = useState<{ status: 'idle' | 'saving'; error: string | null; success: boolean }>({
+  const [formState, setFormState] = useState<{
+    status: 'idle' | 'saving' | 'redirecting' | 'sign-out-warning'
+    error: string | null
+  }>({
     status: 'idle',
     error: error ? decodeURIComponent(error) : null,
-    success: false,
   })
 
   useEffect(() => {
@@ -59,6 +70,7 @@ export function ResetPasswordCompleteForm({ error }: { error?: string }) {
         return
       }
 
+      setLoginTarget(resolvePasswordResetLoginTarget(session.user.app_metadata?.user_type))
       setSessionReady(true)
     }
 
@@ -75,7 +87,7 @@ export function ResetPasswordCompleteForm({ error }: { error?: string }) {
       return
     }
 
-    setFormState((prev) => ({ ...prev, error: null, success: false }))
+    setFormState((prev) => ({ ...prev, error: null }))
 
     const form = event.currentTarget
     if (!formValidation.validateForm(form)) return
@@ -96,44 +108,93 @@ export function ResetPasswordCompleteForm({ error }: { error?: string }) {
         formValidation.setCustomFieldError(fieldName, message)
         document.getElementById(fieldName)?.focus()
       } else {
-        setFormState({ status: 'idle', error: message, success: false })
+        setFormState({ status: 'idle', error: message })
       }
       return
     }
 
-    setFormState({ status: 'saving', error: null, success: false })
+    setFormState({ status: 'saving', error: null })
 
     const { error } = await supabase.auth.updateUser({ password: validation.data.password })
 
     if (error) {
-      setFormState({ status: 'idle', error: error.message || 'Unable to update password.', success: false })
+      setFormState({ status: 'idle', error: error.message || 'Unable to update password.' })
       return
     }
 
-    setFormState({ status: 'idle', error: null, success: true })
+    const { error: signOutError } = await supabase.auth.signOut({ scope: 'global' })
+
+    if (signOutError) {
+      const { error: localSignOutError } = await supabase.auth.signOut({ scope: 'local' })
+
+      if (localSignOutError) {
+        setFormState({
+          status: 'idle',
+          error: signOutError.message || 'Password updated, but we could not finish signing you out.',
+        })
+        return
+      }
+
+      resetPostHogBrowserIdentity()
+      setSessionReady(false)
+      setFormState({
+        status: 'sign-out-warning',
+        error:
+          'Password updated, but we could not sign out all active sessions. We signed out this browser. Please sign in again and contact support if you notice unfamiliar activity.',
+      })
+      return
+    }
+
+    setFormState({ status: 'redirecting', error: null })
     formValidation.clearAllFieldErrors()
+    resetPostHogBrowserIdentity()
+    writeAuthFlash(createPasswordResetCompleteFlash())
+    router.replace(loginTarget.href)
+    router.refresh()
   }
 
   const isSaving = formState.status === 'saving'
+  const isRedirecting = formState.status === 'redirecting'
 
   return (
-    <div className="flex items-start justify-center px-4 py-12">
+    <div className="flex items-start justify-center py-6 sm:px-4 sm:py-12">
       <Card className="w-full max-w-md">
         <CardHeader>
-          <CardTitle className="text-center text-2xl">Choose a new password</CardTitle>
+          <Heading as="h1" align="center" size="h4" className="font-semibold">
+            Choose a new password
+          </Heading>
           <CardDescription className="text-center">
             Set a new password to finish recovering your account.
           </CardDescription>
         </CardHeader>
         <CardContent className="pt-6">
-          <form className="space-y-4" onSubmit={handleSubmit} onInvalid={formValidation.handleInvalid} noValidate>
-            {formState.error && <Alert variant="error">{formState.error}</Alert>}
-            {formState.success && (
-              <Alert className="space-y-2" variant="success" role="status">
-                <p>Password updated successfully.</p>
+          <form
+            className="space-y-4"
+            onSubmit={handleSubmit}
+            onInvalid={formValidation.handleInvalid}
+            aria-busy={isSaving || isRedirecting}
+            noValidate
+          >
+            {formState.error && formState.status !== 'sign-out-warning' && (
+              <Alert variant="error">{formState.error}</Alert>
+            )}
+            {formState.status === 'sign-out-warning' && formState.error && (
+              <Alert variant="warning" role="status" aria-live="polite" className="space-y-2">
+                <p>{formState.error}</p>
                 <p>
-                  <Link href="/login/patient" className="text-primary hover:underline">
-                    Return to sign in
+                  <Link href={loginTarget.href} className="text-primary hover:underline">
+                    Continue to sign in
+                  </Link>
+                  .
+                </p>
+              </Alert>
+            )}
+            {isRedirecting && (
+              <Alert variant="success" role="status" aria-live="polite" className="space-y-2">
+                <p>Password updated successfully. Redirecting to sign in.</p>
+                <p>
+                  <Link href={loginTarget.href} className="text-primary hover:underline">
+                    Continue to sign in
                   </Link>
                   .
                 </p>
@@ -147,7 +208,7 @@ export function ResetPasswordCompleteForm({ error }: { error?: string }) {
                 type="password"
                 required
                 minLength={8}
-                disabled={!isSessionReady || isSaving}
+                disabled={!isSessionReady || isSaving || isRedirecting}
                 onChange={formValidation.handleFieldChange}
                 {...formValidation.getFieldProps('password')}
               />
@@ -162,7 +223,7 @@ export function ResetPasswordCompleteForm({ error }: { error?: string }) {
                 name="confirmPassword"
                 type="password"
                 required
-                disabled={!isSessionReady || isSaving}
+                disabled={!isSessionReady || isSaving || isRedirecting}
                 onChange={formValidation.handleFieldChange}
                 {...formValidation.getFieldProps('confirmPassword')}
               />
@@ -170,8 +231,8 @@ export function ResetPasswordCompleteForm({ error }: { error?: string }) {
                 {formValidation.getFieldError('confirmPassword')}
               </FieldError>
             </Field>
-            <Button type="submit" className="w-full" disabled={!isSessionReady || isSaving || formState.success}>
-              {isSaving ? 'Updating password...' : 'Update password'}
+            <Button type="submit" className="w-full" disabled={!isSessionReady || isSaving || isRedirecting}>
+              {isSaving ? 'Updating password...' : isRedirecting ? 'Redirecting...' : 'Update password'}
             </Button>
           </form>
         </CardContent>

--- a/src/app/(frontend)/auth/password/reset/complete/page.tsx
+++ b/src/app/(frontend)/auth/password/reset/complete/page.tsx
@@ -10,16 +10,24 @@ export const metadata: Metadata = createSiteMetadata({
   path: '/auth/password/reset/complete',
 })
 
+const signInOptionLinkClassName =
+  'inline-flex min-h-11 items-center rounded-md px-3 text-sm font-medium text-primary transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+
 export default async function CompleteResetPage({ searchParams }: { searchParams: Promise<{ error?: string }> }) {
   const params = await searchParams
 
   return (
-    <main className="min-h-screen bg-site-canvas py-12">
+    <main className="min-h-svh bg-site-canvas py-6 sm:py-12">
       <div className="mx-auto max-w-4xl px-4">
-        <div className="mb-6">
-          <Link href="/login/patient" className="text-sm text-primary hover:underline">
-            ← Back to sign in
-          </Link>
+        <div className="mb-2 sm:mb-6">
+          <nav aria-label="Sign in options" className="-mx-3 flex flex-wrap gap-1">
+            <Link href="/login/patient" className={signInOptionLinkClassName}>
+              Patient sign in
+            </Link>
+            <Link href="/admin/login" className={signInOptionLinkClassName}>
+              Staff sign in
+            </Link>
+          </nav>
         </div>
         <ResetPasswordCompleteForm error={params.error} />
       </div>

--- a/src/app/(frontend)/auth/password/reset/page.tsx
+++ b/src/app/(frontend)/auth/password/reset/page.tsx
@@ -8,14 +8,22 @@ export const metadata: Metadata = createSiteMetadata({
   path: '/auth/password/reset',
 })
 
+const signInOptionLinkClassName =
+  'inline-flex min-h-11 items-center rounded-md px-3 text-sm font-medium text-primary transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+
 export default function ResetPasswordPage() {
   return (
-    <main className="min-h-screen bg-site-canvas py-12">
+    <main className="min-h-svh bg-site-canvas py-6 sm:py-12">
       <div className="mx-auto max-w-4xl px-4">
-        <div className="mb-6">
-          <Link href="/login/patient" className="text-sm text-primary hover:underline">
-            ← Back to sign in
-          </Link>
+        <div className="mb-2 sm:mb-6">
+          <nav aria-label="Sign in options" className="-mx-3 flex flex-wrap gap-1">
+            <Link href="/login/patient" className={signInOptionLinkClassName}>
+              Patient sign in
+            </Link>
+            <Link href="/admin/login" className={signInOptionLinkClassName}>
+              Staff sign in
+            </Link>
+          </nav>
         </div>
         <ResetPasswordRequestForm />
       </div>

--- a/src/app/(frontend)/login/patient/page.tsx
+++ b/src/app/(frontend)/login/patient/page.tsx
@@ -2,6 +2,7 @@ import {
   PUBLIC_AUTH_FORM_CONTAINER_CLASSNAME,
   PublicAuthRouteShell,
 } from '@/app/(frontend)/_components/PublicAuthRouteShell'
+import { AuthFlashStatus } from '@/app/(frontend)/_components/AuthFlashStatus'
 import * as LoginForm from '@/components/organisms/Auth/LoginForm'
 import { PATIENT_LOGIN_PATH } from '@/features/favorites/redirects'
 import { sanitizeInternalRedirectPath } from '@/utilities/routing/sanitizeInternalRedirectPath'
@@ -40,6 +41,7 @@ export default async function LoginPage({
           description="Sign in to your patient account to access your medical information"
         />
         <LoginForm.Status message={statusMessage?.text} variant={statusMessage?.variant} />
+        <AuthFlashStatus />
         <LoginForm.Form>
           <LoginForm.EmailField placeholder="patient@example.com" />
           <LoginForm.PasswordField forgotPasswordHref="/auth/password/reset" />

--- a/src/auth/utilities/authFlash.ts
+++ b/src/auth/utilities/authFlash.ts
@@ -1,0 +1,83 @@
+export const AUTH_FLASH_STORAGE_KEY = 'findmydoc.auth.flash'
+
+const AUTH_FLASH_TTL_MS = 5 * 60 * 1000
+
+export type AuthFlashKind = 'password-reset-complete'
+
+export type AuthFlashPayload = {
+  kind: AuthFlashKind
+  expiresAt: number
+}
+
+const authFlashMessages: Record<AuthFlashKind, string> = {
+  'password-reset-complete': 'Password updated successfully. Sign in with your new password.',
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
+
+const isAuthFlashKind = (value: unknown): value is AuthFlashKind => value === 'password-reset-complete'
+
+const isAuthFlashPayload = (value: unknown): value is AuthFlashPayload =>
+  isRecord(value) &&
+  isAuthFlashKind(value.kind) &&
+  typeof value.expiresAt === 'number' &&
+  Number.isFinite(value.expiresAt)
+
+const getSessionStorage = (): Storage | null => {
+  if (typeof window === 'undefined') return null
+
+  try {
+    return window.sessionStorage
+  } catch {
+    return null
+  }
+}
+
+export function createPasswordResetCompleteFlash(now = Date.now()): AuthFlashPayload {
+  return {
+    expiresAt: now + AUTH_FLASH_TTL_MS,
+    kind: 'password-reset-complete',
+  }
+}
+
+export function writeAuthFlash(payload: AuthFlashPayload): void {
+  const storage = getSessionStorage()
+  if (!storage) return
+
+  try {
+    storage.setItem(AUTH_FLASH_STORAGE_KEY, JSON.stringify(payload))
+  } catch {}
+}
+
+export function consumeAuthFlash(now = Date.now()): AuthFlashPayload | null {
+  const storage = getSessionStorage()
+  if (!storage) return null
+
+  const rawPayload = storage.getItem(AUTH_FLASH_STORAGE_KEY)
+  if (!rawPayload) return null
+
+  let parsedPayload: unknown
+  try {
+    parsedPayload = JSON.parse(rawPayload)
+  } catch {
+    storage.removeItem(AUTH_FLASH_STORAGE_KEY)
+    return null
+  }
+
+  if (!isAuthFlashPayload(parsedPayload)) {
+    storage.removeItem(AUTH_FLASH_STORAGE_KEY)
+    return null
+  }
+
+  if (parsedPayload.expiresAt <= now) {
+    storage.removeItem(AUTH_FLASH_STORAGE_KEY)
+    return null
+  }
+
+  storage.removeItem(AUTH_FLASH_STORAGE_KEY)
+  return parsedPayload
+}
+
+export function getAuthFlashMessage(payload: AuthFlashPayload): string {
+  return authFlashMessages[payload.kind]
+}

--- a/src/auth/utilities/loginRedirects.ts
+++ b/src/auth/utilities/loginRedirects.ts
@@ -1,0 +1,16 @@
+export const PATIENT_LOGIN_PATH = '/login/patient'
+export const STAFF_LOGIN_PATH = '/admin/login'
+
+export type PasswordResetLoginTarget = {
+  href: typeof PATIENT_LOGIN_PATH | typeof STAFF_LOGIN_PATH
+}
+
+export function resolvePasswordResetLoginTarget(userType: unknown): PasswordResetLoginTarget {
+  const normalizedUserType = typeof userType === 'string' ? userType.trim().toLowerCase() : ''
+
+  if (normalizedUserType === 'clinic' || normalizedUserType === 'platform' || normalizedUserType === 'staff') {
+    return { href: STAFF_LOGIN_PATH }
+  }
+
+  return { href: PATIENT_LOGIN_PATH }
+}

--- a/src/components/organisms/Auth/LoginForm.tsx
+++ b/src/components/organisms/Auth/LoginForm.tsx
@@ -165,9 +165,11 @@ export const Status = ({ message, variant = 'info' }: { message?: string; varian
   const { state } = useLoginFormContext()
 
   if (message) {
+    const role = variant === 'success' || variant === 'info' ? 'status' : 'alert'
+
     return (
       <div className="mb-4">
-        <Alert variant={variant} className="text-left break-words">
+        <Alert variant={variant} role={role} className="text-left break-words">
           {message}
         </Alert>
       </div>

--- a/tests/unit/app/frontend/auth/password/reset/ResetPasswordCompleteForm.test.tsx
+++ b/tests/unit/app/frontend/auth/password/reset/ResetPasswordCompleteForm.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AUTH_FLASH_STORAGE_KEY } from '@/auth/utilities/authFlash'
+import { ResetPasswordCompleteForm } from '@/app/(frontend)/auth/password/reset/complete/ResetPasswordCompleteForm'
+
+const resetPassword = 'RecoveredPass123' // pragma: allowlist secret
+
+const routerMock = vi.hoisted(() => ({
+  refresh: vi.fn(),
+  replace: vi.fn(),
+}))
+
+const supabaseAuthMock = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  signOut: vi.fn(),
+  updateUser: vi.fn(),
+}))
+
+const resetPostHogBrowserIdentityMock = vi.hoisted(() => vi.fn())
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => routerMock,
+}))
+
+vi.mock('@/auth/utilities/supaBaseClient', () => ({
+  createClient: () => ({
+    auth: supabaseAuthMock,
+  }),
+}))
+
+vi.mock('@/posthog/client-api', () => ({
+  resetPostHogBrowserIdentity: resetPostHogBrowserIdentityMock,
+}))
+
+const mockRecoverySession = (userType: unknown) => {
+  supabaseAuthMock.getSession.mockResolvedValue({
+    data: {
+      session: {
+        user: {
+          app_metadata: {
+            user_type: userType,
+          },
+        },
+      },
+    },
+  })
+}
+
+async function submitResetForm() {
+  render(<ResetPasswordCompleteForm />)
+
+  const passwordInput = await screen.findByLabelText('New password')
+  const confirmPasswordInput = screen.getByLabelText('Confirm password')
+
+  await waitFor(() => {
+    expect(passwordInput).toBeEnabled()
+  })
+
+  fireEvent.change(passwordInput, { target: { value: resetPassword } })
+  fireEvent.change(confirmPasswordInput, { target: { value: resetPassword } })
+  fireEvent.click(screen.getByRole('button', { name: 'Update password' }))
+}
+
+describe('ResetPasswordCompleteForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.sessionStorage.clear()
+    mockRecoverySession('patient')
+    supabaseAuthMock.updateUser.mockResolvedValue({ error: null })
+    supabaseAuthMock.signOut.mockResolvedValue({ error: null })
+  })
+
+  it.each([
+    ['patient', '/login/patient'],
+    ['clinic', '/admin/login'],
+    ['platform', '/admin/login'],
+  ] as const)('redirects %s users to the correct login page after updating the password', async (userType, href) => {
+    mockRecoverySession(userType)
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+
+    await submitResetForm()
+
+    await waitFor(() => {
+      expect(routerMock.replace).toHaveBeenCalledWith(href)
+    })
+
+    expect(supabaseAuthMock.updateUser).toHaveBeenCalledWith({ password: resetPassword })
+    expect(supabaseAuthMock.signOut).toHaveBeenCalledWith({ scope: 'global' })
+    expect(resetPostHogBrowserIdentityMock).toHaveBeenCalled()
+    expect(routerMock.refresh).toHaveBeenCalled()
+
+    const rawFlash = window.sessionStorage.getItem(AUTH_FLASH_STORAGE_KEY)
+    expect(rawFlash).not.toBeNull()
+    expect(JSON.parse(rawFlash ?? '{}')).toMatchObject({
+      kind: 'password-reset-complete',
+    })
+
+    const updateUserCallOrder = supabaseAuthMock.updateUser.mock.invocationCallOrder[0]
+    const signOutCallOrder = supabaseAuthMock.signOut.mock.invocationCallOrder[0]
+    const flashWriteCallOrder = setItemSpy.mock.invocationCallOrder[0]
+    const redirectCallOrder = routerMock.replace.mock.invocationCallOrder[0]
+
+    expect(updateUserCallOrder).toEqual(expect.any(Number))
+    expect(signOutCallOrder).toEqual(expect.any(Number))
+    expect(flashWriteCallOrder).toEqual(expect.any(Number))
+    expect(redirectCallOrder).toEqual(expect.any(Number))
+
+    expect(updateUserCallOrder!).toBeLessThan(signOutCallOrder!)
+    expect(signOutCallOrder!).toBeLessThan(flashWriteCallOrder!)
+    expect(flashWriteCallOrder!).toBeLessThan(redirectCallOrder!)
+
+    setItemSpy.mockRestore()
+  })
+
+  it('shows a session error when the recovery link did not create a session', async () => {
+    supabaseAuthMock.getSession.mockResolvedValue({ data: { session: null } })
+
+    render(<ResetPasswordCompleteForm />)
+
+    expect(await screen.findByText('No active session. Please request a new password reset link.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Update password' })).toBeDisabled()
+  })
+
+  it('does not show a success flash when only local sign-out succeeds after global sign-out fails', async () => {
+    supabaseAuthMock.signOut
+      .mockResolvedValueOnce({ error: { message: 'global sign-out failed' } })
+      .mockResolvedValueOnce({ error: null })
+
+    await submitResetForm()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Password updated, but we could not sign out all active sessions/)).toBeInTheDocument()
+    })
+
+    expect(supabaseAuthMock.signOut).toHaveBeenNthCalledWith(1, { scope: 'global' })
+    expect(supabaseAuthMock.signOut).toHaveBeenNthCalledWith(2, { scope: 'local' })
+    expect(resetPostHogBrowserIdentityMock).toHaveBeenCalled()
+    expect(routerMock.replace).not.toHaveBeenCalled()
+    expect(window.sessionStorage.getItem(AUTH_FLASH_STORAGE_KEY)).toBeNull()
+    expect(screen.getByRole('link', { name: 'Continue to sign in' })).toHaveAttribute('href', '/login/patient')
+  })
+})

--- a/tests/unit/auth/utilities/authFlash.test.ts
+++ b/tests/unit/auth/utilities/authFlash.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  AUTH_FLASH_STORAGE_KEY,
+  consumeAuthFlash,
+  createPasswordResetCompleteFlash,
+  getAuthFlashMessage,
+  writeAuthFlash,
+} from '@/auth/utilities/authFlash'
+
+describe('authFlash', () => {
+  afterEach(() => {
+    window.sessionStorage.clear()
+  })
+
+  it('writes and consumes a matching password reset flash once', () => {
+    const payload = createPasswordResetCompleteFlash(1000)
+
+    writeAuthFlash(payload)
+
+    expect(consumeAuthFlash(2000)).toEqual(payload)
+    expect(consumeAuthFlash(2000)).toBeNull()
+    expect(window.sessionStorage.getItem(AUTH_FLASH_STORAGE_KEY)).toBeNull()
+  })
+
+  it('removes expired or malformed flash payloads', () => {
+    writeAuthFlash(createPasswordResetCompleteFlash(1000))
+
+    expect(consumeAuthFlash(1000 + 5 * 60 * 1000 + 1)).toBeNull()
+    expect(window.sessionStorage.getItem(AUTH_FLASH_STORAGE_KEY)).toBeNull()
+
+    window.sessionStorage.setItem(AUTH_FLASH_STORAGE_KEY, '{not-json')
+
+    expect(consumeAuthFlash(2000)).toBeNull()
+    expect(window.sessionStorage.getItem(AUTH_FLASH_STORAGE_KEY)).toBeNull()
+  })
+
+  it('returns the user-facing password reset complete message', () => {
+    expect(getAuthFlashMessage(createPasswordResetCompleteFlash())).toBe(
+      'Password updated successfully. Sign in with your new password.',
+    )
+  })
+})

--- a/tests/unit/auth/utilities/loginRedirects.test.ts
+++ b/tests/unit/auth/utilities/loginRedirects.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolvePasswordResetLoginTarget } from '@/auth/utilities/loginRedirects'
+
+describe('resolvePasswordResetLoginTarget', () => {
+  it.each([
+    ['patient', '/login/patient'],
+    ['clinic', '/admin/login'],
+    ['platform', '/admin/login'],
+    ['staff', '/admin/login'],
+    ['unknown', '/login/patient'],
+    [undefined, '/login/patient'],
+  ] as const)('maps %s recovery users to %s', (userType, href) => {
+    expect(resolvePasswordResetLoginTarget(userType)).toEqual({ href })
+  })
+})


### PR DESCRIPTION
## Management summary

### Deutsch
Das Resetverhalten für Passwörter wurde vereinfacht und robuster: Nach einem erfolgreichen Passwort-Reset landet der Nutzer direkt auf die passende Login-Seite, und die kurze Erfolgsmeldung erscheint direkt dort. Damit wird das Weiterleitungsverhalten konsistent zwischen Mitarbeiter- und Patienten-Accounts, ohne dass sensible Statusinformationen in der URL stehen.

### English
Password reset flows now move users directly to the correct login screen after success, with a short, one-time confirmation shown on the login page. This keeps reset UX consistent for staff and patients while removing login-routing signal data from URLs.

## What changed

- Redirect users after password reset completion are now determined from the active Supabase recovery session user type (`patient`, `clinic`, `platform`, `staff`) and mapped to the correct login page target.
- Added a small client-side auth flash utility stored in `sessionStorage` with a minimal payload (`kind`, `expiresAt`) and one-time consume semantics.
- Replaced URL-based success messaging for reset completion with session flash consumption on login pages.
- Updated reset complete flow to keep secure sign-out and post-login identity reset behavior, then navigate immediately to login and refresh.
- Updated unit coverage for flash utilities, reset redirect mapping, and password reset completion behavior.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| P1 | `src/app/(frontend)/auth/password/reset/complete/ResetPasswordCompleteForm.tsx` | Auth success path and routing are user-facing security-sensitive flow transitions | Verify success path, fallback behavior on partial sign-out failures, and no URL message state remains | Unit tests in `tests/unit/app/frontend/auth/password/reset/ResetPasswordCompleteForm.test.tsx` |
| P1 | `src/auth/utilities/authFlash.ts`, `tests/unit/auth/utilities/authFlash.test.ts` | Flash storage is client-only state used for success feedback | Verify minimal payload, TTL, and one-time consumption/cleanup semantics | Unit tests |
| P2 | `src/app/(frontend)/admin/login/page.tsx`, `src/app/(frontend)/login/patient/page.tsx` | Ensure flash rendering is scoped per login context and does not leak stale state | Verify only success flash appears after reset flow and not on normal direct visits | Unit and manual flow checks previously performed |

## Validation

- [x] `pnpm format`:
- [x] `pnpm check`:
- [ ] `pnpm build`:
  - Not run successfully in this environment because local Postgres is unavailable (`cannot connect to Postgres ... ECONNREFUSED ::1:5432`).
- [ ] Focused tests:
  - Unit tests for touched files were adjusted and added; full rerun not executed in this PR creation pass.
- [ ] UI/mobile QA:
  - Existing implementation was manually verified previously in this workstream before this PR creation.
- [ ] Security/privacy review:
  - No new server-side secrets/data storage added; auth flow paths reviewed with existing guardrails.
- [ ] Migration/schema check:
  - Not applicable.
- [ ] Documentation/instructions check:
  - Not applicable.

## Risk and rollout

No data model or migration changes. Main operational risk is environment-dependent build verification (requires local Postgres for static path generation). Rollback is low-risk because this is a contained front-end/auth-flow refactor.

## Development
