### PR TITLE
fix: handle missing share action in PostActionBar

### DIFF
--- a/src/components/molecules/PostActionBar/index.tsx
+++ b/src/components/molecules/PostActionBar/index.tsx
@@ -27,6 +27,8 @@ export const PostActionBar: React.FC<PostActionBarProps> = ({
   layoutClassName,
   contentClassName,
 }) => {
+  const isShareButtonEnabled = Boolean(shareButton?.onClick)
+
   return (
     <Container className={className}>
       <div className={cn('grid grid-cols-1 lg:grid-cols-12', layoutClassName)}>
@@ -49,6 +51,7 @@ export const PostActionBar: React.FC<PostActionBarProps> = ({
           <button
             type="button"
             onClick={shareButton?.onClick}
+            disabled={!isShareButtonEnabled}
             className="inline-flex w-full items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground sm:w-auto sm:justify-start sm:py-1.5"
             aria-label={shareButton?.label || 'Share'}
           >


### PR DESCRIPTION
## Management summary

### Deutsch
Die Share-Schaltfläche im Blog-Header ist jetzt klar als nicht aktiv markiert, wenn kein Handler übergeben ist, statt als aktive Schaltfläche ohne Wirkung.

### English
The blog Share button is now explicitly non-actionable when no handler is provided, avoiding a misleading interactive control.

## What changed

- Added explicit disabled behavior when `PostActionBar` has no `shareButton.onClick` handler.

## Validation

- [ ] `pnpm format`:
- [ ] `pnpm check`:
- [ ] `pnpm build`:
- [ ] Focused tests:
- [ ] UI/mobile QA:
- [ ] Security/privacy review:
- [ ] Migration/schema check:
- [ ] Documentation/instructions check:

## Development

Closes #1313
