### PR TITLE
fix: compare price ranges with tolerance

### DIFF
--- a/src/components/organisms/Listing/ListingFilters.tsx
+++ b/src/components/organisms/Listing/ListingFilters.tsx
@@ -16,8 +16,12 @@ import { cn } from '@/utilities/ui'
 
 const DEFAULT_PRICE_STEP = 500
 
+const EPSILON_PRICE_COMPARE = 1e-9
+
+const isApproximatelyEqual = (left: number, right: number): boolean => Math.abs(left - right) <= EPSILON_PRICE_COMPARE
+
 const isSamePriceRange = (left: [number, number], right: [number, number]): boolean =>
-  left[0] === right[0] && left[1] === right[1]
+  isApproximatelyEqual(left[0], right[0]) && isApproximatelyEqual(left[1], right[1])
 
 export type ListingFiltersValue = {
   priceRange: [number, number]
@@ -183,7 +187,7 @@ const Price = ({ className, min, max, step }: { className?: string; min?: number
   const displayedRange = clampPriceRange(priceRange, { min: resolvedMin, max: resolvedMax })
 
   useEffect(() => {
-    if (displayedRange[0] === priceRange[0] && displayedRange[1] === priceRange[1]) return
+    if (isSamePriceRange(displayedRange, priceRange)) return
     setPriceRange(displayedRange)
   }, [displayedRange, priceRange, setPriceRange])
 


### PR DESCRIPTION
## Management summary

### Deutsch
Preisbereichsvergleiche tolerieren jetzt numerische Rundungsabweichungen und verhindern unnötige UI-Updates.

### English
Price-range comparisons now use tolerance-aware logic to avoid unnecessary UI churn from floating-point jitter.

## What changed

- Update range comparison logic in `ListingFilters` to use numeric epsilon checks instead of strict equality.

## Validation

- [ ] `pnpm format`:
- [ ] `pnpm check`:
- [ ] `pnpm build`:
- [ ] Focused tests:
- [ ] UI/mobile QA:
- [ ] Security/privacy review:
- [ ] Migration/schema check:
- [ ] Documentation/instructions check:

## Development

Closes #1315
