### PR TITLE
fix: expose doctor selection state via aria

### DIFF
--- a/src/components/molecules/ClinicDetail/DoctorPreviewListItem.tsx
+++ b/src/components/molecules/ClinicDetail/DoctorPreviewListItem.tsx
@@ -18,6 +18,7 @@ export function DoctorPreviewListItem({ doctor, selected, ratingText, onSelect }
       type="button"
       onClick={onSelect}
       aria-label={`Select ${doctor.name}`}
+      aria-pressed={selected}
       className={cn(
         'grid w-full cursor-pointer grid-cols-[56px_1fr] items-center gap-3 rounded-xl px-2 py-2 text-left transition-colors',
         selected ? 'bg-primary/10' : 'hover:bg-primary/5',


### PR DESCRIPTION
## Management summary

### Deutsch
Der Auswahlezustand der Ärzteliste ist als `aria-pressed` verfügbar und damit besser für Hilfstechniken lesbar.

### English
Doctor row selection is now exposed via ARIA state so the selected item is visible to assistive technologies.

## What changed

- Add `aria-pressed` on the doctor preview button tied to `selected` state.

## Validation

- [ ] `pnpm format`:
- [ ] `pnpm check`:
- [ ] `pnpm build`:
- [ ] Focused tests:
- [ ] UI/mobile QA:
- [ ] Security/privacy review:
- [ ] Migration/schema check:
- [ ] Documentation/instructions check:

## Development

Closes #1318
