### PR TITLE
chore: add handoff skill

### DIFF
--- a/.codex/skills/productivity/handoff/SKILL.md
+++ b/.codex/skills/productivity/handoff/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: handoff
+description: Compact the current conversation into a handoff document for another agent to pick up.
+argument-hint: 'What will the next session be used for?'
+---
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save to the temporary directory of the user's OS - not the current workspace.
+
+Include a "suggested skills" section in the document, which suggests skills that the agent should invoke.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+Redact any sensitive information, such as API keys, passwords, or personally identifiable information.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.


### PR DESCRIPTION
## Management summary
Neue handoff-Skill-Datei wurde als `.codex/skills/productivity/handoff/SKILL.md` ergänzt, damit sie wie andere lokale Skills direkt per `@skill` aufgerufen werden kann.

A new handoff skill has been added as `.codex/skills/productivity/handoff/SKILL.md` so local automation can use it for structured session handoffs.

## What changed
- Added `.codex/skills/productivity/handoff/SKILL.md` with content from upstream source, copied 1:1.

## Validation
- pnpm format: run

## Deployment
- N/A
