### PR TITLE
docs: repair drifted external references

### DIFF
--- a/docs/cost-planning/media-growth-model-current-estimate.md
+++ b/docs/cost-planning/media-growth-model-current-estimate.md
@@ -172,7 +172,7 @@ Note: The adoption overlay is intentionally separate from the `600 clinics` max-
 | [FlyMedi clinic example 2](https://www.flymedi.com/cyberknife-center/58) | Same pattern across another clinic page: preview images + clinic details + review indicators + contact-focused CTA blocks. | Confirms reusable clinic-gallery baseline for `clinicMedia` and recurring staff/brand visuals. | High |
 | [WhatClinic clinic example](https://www.whatclinic.com/cosmetic-plastic-surgery/turkey/antalya-province/antalya/aesthetics-antalya) | Crawled snippets indicate image-backed clinic profiles with review-centric presentation and service metadata. | `clinicMedia` as primary fit; no reliable evidence for structured before/after volume in current crawl. | Medium-Low |
 | [WhatClinic clinic example 2](https://www.whatclinic.com/bariatric-surgery/turkey/istanbul-province/istanbul/atasehir/clinichub) | Crawled snippets show repeated `Image:` entities and badge/service-heavy profile presentation. | `clinicMedia` + optional `platformContentMedia` for standardized badges/icons. | Medium-Low |
-| [WhatClinic photo guidance](https://www.whatclinic.com/info/for-clinics/industry-news/how-to-take-clinic-photos) | Intended policy/guidance source for clinic photography quality. Direct content retrieval was limited in this crawl run. | Use as qualitative direction only; do not treat as hard quantitative input. | Low |
+| [WhatClinic photo guidance](https://www.whatclinic.com/about/toolkit/pdfs/clinic-guide-to-photography.pdf) | Intended policy/guidance source for clinic photography quality. Direct content retrieval was limited in this crawl run. | Use as qualitative direction only; do not treat as hard quantitative input. | Low |
 
 Notes:
 

--- a/docs/roadmap/db-stability/README.md
+++ b/docs/roadmap/db-stability/README.md
@@ -221,13 +221,13 @@ Preview environments, database branching, and schema deployment control:
 
 - [Supabase: Branching](https://supabase.com/docs/guides/deployment/branching) - separate preview environments for testing migrations and config changes without touching production.
 - [Supabase: Branching feature overview](https://supabase.com/features/branching) - high-level branching model and preview deployment integration.
-- [Neon: One branch per preview](https://neon.com/flow/branch-per-preview) - dedicated database branch per Vercel/Netlify preview deployment.
+- [Neon: One branch per preview](https://neon.com/branching/ci-preview-workflows) - dedicated database branch per Vercel/Netlify preview deployment.
 - [PlanetScale: Deploy requests](https://planetscale.com/docs/concepts/deploy-requests) - reviewable schema diffs, safe migrations, gated deploys, and schema revert windows.
 - [PlanetScale Postgres: Branching](https://planetscale.com/docs/postgres/branching) - isolated database branches for development, testing, and backup restore workflows.
 - [Xata: Zero downtime schema changes with Vercel and Xata](https://xata.io/blog/zero-downtime-schema-changes-with-vercel-and-xata) - relevant because this project also combines Vercel previews with Postgres schema changes.
 - [Xata: Schema changes](https://xata.io/docs/core-concepts/schema-changes) - pgroll-backed approach with multi-version schemas and lock-safe migrations.
 - [Xata: How to perform Postgres schema changes in production with zero downtime](https://xata.io/blog/zero-downtime-schema-migrations-postgresql) - advisory material around reversible schema changes and pgroll.
-- [pgroll](https://lite.xata.io/pgroll) - open-source Postgres tool for reversible, zero-downtime schema changes.
+- [pgroll](https://github.com/xataio/pgroll) - open-source Postgres tool for reversible, zero-downtime schema changes.
 
 Framework examples:
 


### PR DESCRIPTION
## Management summary

### Deutsch

Die Entwicklerdokumentation verweist wieder auf die aktuellen externen Quellen, sodass Recherche- und Entscheidungsgrundlagen ohne tote Links nachvollziehbar bleiben. Das senkt Reibung bei technischen Reviews und reduziert das Risiko, dass veraltete Referenzen als Grundlage fuer Folgearbeit genutzt werden.

### English

The engineering documentation now points back to current external sources so research and decision references remain usable without dead links. This reduces friction during technical review and lowers the risk of follow-up work relying on outdated citations.

## What changed

- Updated three drifted external references in docs-only content.
- Replaced the dead WhatClinic photo-guidance target in `docs/cost-planning/media-growth-model-current-estimate.md` with the current PDF toolkit asset.
- Replaced the dead Neon preview-branching target and the removed `pgroll` landing page in `docs/roadmap/db-stability/README.md` with current canonical destinations.
- Left the `management#68` reference untouched because the issue still exists and the earlier `404` was visibility/auth-related rather than a missing target.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P3 | `docs/cost-planning/media-growth-model-current-estimate.md`, `docs/roadmap/db-stability/README.md` | External citations drifted to dead URLs. | Confirm each replacement still matches the original citation intent and stays canonical enough for long-term use. | `curl -IL` checks during the docs drift run; `pnpm docs:check` passed. |

## Validation

- [x] `pnpm format`: passed locally.
- [ ] `pnpm check`: not applicable for docs-only link updates.
- [ ] `pnpm build`: not applicable for docs-only link updates.
- [ ] Focused tests: no runtime behavior changed.
- [ ] UI/mobile QA: not applicable for docs-only link updates.
- [ ] Security/privacy review: not applicable; no auth, secrets, or trust-boundary changes.
- [ ] Migration/schema check: not applicable; no schema or data-model changes.
- [x] Documentation/instructions check: `pnpm docs:check` passed; internal Markdown link scan passed; replacement URLs were revalidated with `curl -IL`.

## Risk and rollout

None known. This PR changes only external reference targets in documentation.

## Development

Closes #1356
