### PR TITLE
docs: document trust claim requirements

### DIFF
--- a/pricing-evidence-requirements-task.md
+++ b/pricing-evidence-requirements-task.md
@@ -1,0 +1,214 @@
+# Feature: Evidenzanforderungen für öffentliche Preis-Claims definieren
+
+## Problem
+
+Die öffentliche Listing-Comparison Route nutzt Preis-Wording, das eine Prüfung oder Qualitätssicherung nahelegen kann, die das aktuelle Runtime-Datenmodell noch nicht beweist. Die UI kann Preise anzeigen, aber sie erzwingt aktuell keinen dokumentierten Prozess für Quelle, Review-Status, Aktualität oder Claim-Berechtigung.
+
+Solange diese Kontrollen fehlen, sind stärkere Aussagen wie `Transparent pricing`, `Reviewed prices`, `Verified prices` oder `Checked prices` riskant.
+
+Aktuelle öffentliche Runtime-Fläche:
+
+- `/listing-comparison`
+- `src/app/(frontend)/listing-comparison/page.tsx`
+
+Aktuelles Hochrisiko-Wording auf dieser Route:
+
+- `Transparent pricing for medical treatments near you`
+- `Reviewed prices`
+
+## Ziel
+
+findmydoc braucht ein dokumentiertes und implementierbares Anforderungsset dafür, wann öffentliche Preis-Claims erlaubt sind.
+
+Das Team soll unterscheiden können zwischen:
+
+- neutraler Preisanzeige, die mit dem aktuellen Datenmodell grundsätzlich möglich ist
+- stärkeren Pricing Claims, die erst nach definiertem Evidenzprozess, Datenmodell und Runtime-Gating erlaubt sind
+
+Das Ergebnis soll konkret genug sein, damit Product, Content, Engineering und Compliance entscheiden können, ob findmydoc:
+
+- nur neutrales Wording nutzt
+- später einen geprüften Pricing-Prozess einführt
+- technische Enforcement-Regeln für stärkere Claims baut
+
+## Nicht-funktionale Anforderungen
+
+1. Claim-Integrität
+   Öffentliche Copy darf keine stärkere Preisqualität versprechen, als die Runtime-Daten beweisen.
+
+2. Quellennachvollziehbarkeit
+   Jeder Preis, der für stärkere Claims zählt, braucht eine gespeicherte Quelle.
+
+3. Aktualität
+   Jeder qualifizierende Preis braucht ein Erfassungs- oder Review-Datum und eine definierte Re-Check-Regel.
+
+4. Auditierbarkeit
+   Das System muss beantworten können, wer einen Preis eingegeben oder geprüft hat, wann das passiert ist und auf welcher Grundlage.
+
+5. Runtime Enforcement
+   Starke Pricing Claims müssen durch Runtime-Logik gesteuert werden, nicht nur durch redaktionelle Disziplin.
+
+6. Fail-safe Verhalten
+   Fehlende, ungültige oder abgelaufene Evidenz muss auf neutrales Wording zurückfallen, statt stärkere Claims sichtbar zu lassen.
+
+7. Scope-Klarheit
+   Die Regeln müssen trennen zwischen:
+   - reiner Preisanzeige
+   - quellenbasierter Preisanzeige
+   - geprüfter oder bestätigter Preisanzeige
+
+8. Redaktionelle Kontrolle
+   Content Owner dürfen aus freigegebenen Wording-Stufen wählen, aber technische Eligibility-Regeln für stärkere Claims nicht umgehen.
+
+9. Kompatibilität mit bestehenden Daten
+   Bestehende Preisdatensätze müssen neutral weiter angezeigt werden können, ohne vorher vollständig backfilled zu sein.
+
+10. Operative Wartbarkeit
+    Der Prozess muss wiederholbar sein. Wenn Review-Aufwand zu hoch ist, soll das System schwächeres Wording wählen statt versteckte Prozessschuld zu erzeugen.
+
+## Claim-Stufen
+
+### Mit aktuellem Datenstil grundsätzlich erlaubbar
+
+- `Compare clinic prices`
+- `Price information`
+- `Listed starting prices`
+- `Price fields where available`
+- `From`
+- `Price range`
+
+### Nur nach Evidenzprozess plus technischem Gating erlaubbar
+
+- `Transparent pricing`
+- `Reviewed prices`
+- `Verified prices`
+- `Checked prices`
+
+## Mindeststandard für stärkere Preis-Claims
+
+Wenn findmydoc stärkere öffentliche Pricing Claims nutzen will, sollte jeder qualifizierende öffentliche Preis mindestens haben:
+
+- einen Quellentyp
+- eine Quellenreferenz oder interne Quellennotiz
+- ein Datum der Einreichung, Erfassung oder Übernahme
+- einen Review-Status
+- einen Review-Zeitpunkt
+- eine verantwortliche prüfende Person oder Rolle
+- eine Gültigkeitsregel oder ein Ablaufdatum
+
+Ohne diesen Mindeststandard sollten stärkere Pricing Claims deaktiviert bleiben.
+
+## Vorgeschlagene technische Richtung
+
+Der naheliegende Ort für Pricing Evidence ist `clinictreatments`, weil dort die öffentlichen klinikspezifischen Preise bereits liegen.
+
+### Implementierungs-Feldtabelle: `ClinicTreatments`
+
+| Schema-Feld            | Wofür ist es da?                                                                                                                       | Warum braucht man es?                                                                                                     | Warum ggf. nicht oder nur optional?                                                                                                                   |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `priceSourceType`      | Klassifiziert die Preisquelle, z. B. `clinic_submitted`, `clinic_document`, `email_confirmation`, `contract`, `manual_platform_entry`. | Ohne Quellentyp ist nicht klar, ob der Preis von einer Klinik, einem Dokument, einer E-Mail oder interner Eingabe stammt. | Für MVP kann ein grober Typ reichen. Wenn alle Preise nur aus einer einzigen Quelle kommen, ist das Feld zunächst weniger wichtig.                    |
+| `priceSourceReference` | Interne Referenz oder Notiz zur Quelle.                                                                                                | Ermöglicht spätere Prüfung, ohne Quellendokumente öffentlich zu machen.                                                   | Wenn Nachweise in einem externen System liegen, kann nur eine externe ID gespeichert werden.                                                          |
+| `priceSubmittedAt`     | Zeitpunkt, an dem der Preis eingereicht, übernommen oder erfasst wurde.                                                                | Trennt das Eingangsdatum vom Review-Datum und hilft bei Aktualitätsregeln.                                                | Wenn Preise nur direkt im Review erfasst werden, kann `priceReviewedAt` für den Start reichen.                                                        |
+| `priceReviewStatus`    | Status des Preisreviews, z. B. `unreviewed`, `reviewed`, `expired`, `rejected`.                                                        | Stärkere Claims wie `Reviewed prices` brauchen eine eindeutige Freigabe.                                                  | Nicht nötig für rein neutrale Preisanzeige. Für stärkere Claims aber zentral.                                                                         |
+| `priceReviewedAt`      | Zeitpunkt, an dem der Preis geprüft wurde.                                                                                             | Freshness und Ablaufregeln brauchen ein belastbares Datum.                                                                | Optional nur, solange kein stärkerer Preis-Claim öffentlich ausgespielt wird.                                                                         |
+| `priceReviewedBy`      | Verantwortliche prüfende Person oder Rolle.                                                                                            | Macht die Freigabe auditierbar und verhindert unklare manuelle Claims.                                                    | Eine Rolle kann fürs MVP reichen, wenn personenbezogene Reviewer-Zuordnung nicht gewünscht ist.                                                       |
+| `priceReviewNotes`     | Interne Notiz dazu, was geprüft wurde.                                                                                                 | Hilft bei Grenzfällen, z. B. wenn Preise aus mehreren Quellen oder mit Einschränkungen übernommen wurden.                 | Kann optional bleiben, wenn strukturierte Felder die Entscheidung ausreichend erklären.                                                               |
+| `priceValidUntil`      | Ablaufdatum oder expliziter Re-Check-Zeitpunkt.                                                                                        | Verhindert, dass alte Preise dauerhaft als geprüft oder transparent gelten.                                               | Wenn kein fixes Ablaufdatum existiert, kann die Gültigkeit aus `priceReviewedAt` plus Regel abgeleitet werden.                                        |
+| `publicPriceClaimTier` | Öffentliche Claim-Stufe, z. B. `neutral`, `source_backed`, `reviewed`.                                                                 | Das Frontend soll eine einfache, sichere Entscheidung bekommen und nicht selbst Compliance-Felder interpretieren.         | Besser als abgeleiteter Wert, wenn die Berechnung einfach und performant ist. Als gespeichertes Feld nur, wenn Reporting oder Performance es braucht. |
+
+### Abgeleitetes Eligibility-Modell
+
+UI-Komponenten sollten nicht selbst aus einzelnen Evidenzfeldern ableiten, wie stark ein Claim sein darf. Dafür sollte es eine serverseitige Eligibility-Funktion geben, zum Beispiel:
+
+- `isPriceEvidenceFresh(record)`
+- `isPriceReviewed(record)`
+- `getPublicPriceClaimTier(record)`
+
+Vorgeschlagenes Verhalten:
+
+- `neutral`
+  Preis existiert, unabhängig von vollständiger Evidenz.
+- `source_backed`
+  Preis existiert und hat eine nachvollziehbare Quelle.
+- `reviewed`
+  Preis existiert, Quellenfelder sind vorhanden, Review-Status ist `reviewed`, und die Evidenz ist noch gültig.
+- `expired`
+  Preis existiert, aber stärkere Claim-Berechtigung ist abgelaufen.
+
+### Implementierungs-Feldtabelle: abgeleitete Felder und Funktionen
+
+| Feld oder Funktion                | Wofür ist es da?                                                                                   | Warum braucht man es?                                                              | Warum ggf. nicht oder nur optional?                                                                        |
+| --------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `isPriceEvidenceFresh(record)`    | Prüft, ob Review-Datum und Gültigkeit noch aktuell sind.                                           | Starke Claims dürfen nicht auf alten Preisen hängen bleiben.                       | Kann in `getPublicPriceClaimTier` aufgehen, wenn keine separate Wiederverwendung nötig ist.                |
+| `isPriceReviewed(record)`         | Prüft, ob ein Preis den Review-Mindeststandard erfüllt.                                            | Trennt neutrale Preisanzeige von `Reviewed prices`.                                | Kann entfallen, wenn nur Claim-Tier statt Boolean genutzt wird.                                            |
+| `getPublicPriceClaimTier(record)` | Liefert die erlaubte öffentliche Claim-Stufe pro Preis.                                            | Das Frontend braucht eine sichere, einheitliche Entscheidung.                      | Kann als gespeichertes Feld umgesetzt werden, wenn Runtime-Berechnung zu teuer wird.                       |
+| `routePriceClaimTier`             | Aggregierte Claim-Stufe für die gesamte Listing-Comparison Route oder den aktuellen Ergebnis-Satz. | Die Route darf keinen Claim versprechen, der stärker ist als die sichtbaren Daten. | Kann on demand berechnet werden; als Feld nur nötig, wenn die Route stark gecacht oder voraggregiert wird. |
+
+## Route-Level Runtime-Gating
+
+Die wichtigste aktuelle öffentliche Claim-Fläche ist:
+
+- `src/app/(frontend)/listing-comparison/page.tsx`
+
+Vorgeschlagener Ansatz:
+
+- neutrales Wording bleibt Default
+- Preis-Evidenzmetriken werden serverseitig aggregiert
+- stärkeres Wording rendert nur, wenn die aggregierte Eligibility erfüllt ist
+
+Beispielregeln:
+
+- Wenn die Route nur neutrale Preisdatensätze hat:
+  - Subtitle bleibt neutral
+  - Bullet nutzt z. B. `Price fields where available`
+- Wenn alle sichtbaren Preisdatensätze die reviewed-Schwelle erfüllen:
+  - stärkeres Wording wird berechtigt
+- Wenn der sichtbare Datensatz gemischt ist:
+  - Route bleibt bei neutralem Wording
+
+So verspricht die Route nie mehr als der schwächste sichtbare Preisdatensatz belegt.
+
+## Admin- und Workflow-Anforderungen
+
+Wenn der Prozess real sein soll, muss die Admin UI ihn unterstützen. Versteckte manuelle Konventionen reichen nicht.
+
+Vorgeschlagene Workflow-Unterstützung:
+
+- klare Admin-Beschreibungen, was als gültige Evidenz zählt
+- Reviewer-Hinweise, wann ein Preis auf `reviewed` gesetzt werden darf
+- Listen oder Filter für stale oder bald ablaufende Preis-Evidenz
+- optionaler Reminder- oder Reporting-Pfad für Re-Checks
+
+Ohne diese Unterstützung existiert das Evidenzmodell nur im Schema und wird operativ schnell unzuverlässig.
+
+## Migration und Rollout
+
+Vorgeschlagener Ablauf:
+
+1. Neutrales Wording ausliefern.
+2. Schema-Felder und internen Workflow hinzufügen.
+3. Nur Preise backfillen, die echte Evidenz haben.
+4. Runtime-Gating hinzufügen.
+5. Erst danach öffentliches Wording auf stärkere Claims umstellen, wenn die Datenabdeckung ausreicht.
+
+Wichtige Regel:
+
+- Keine Migration darf Legacy-Preise automatisch als reviewed markieren, wenn dafür keine echte Evidenz existiert.
+
+## Akzeptanzkriterien
+
+- Das Dokument definiert, wann neutrales Pricing Wording erlaubt ist und wann stärkere Claims Evidenz brauchen.
+- Es ist klar dokumentiert, dass ein Prozesspapier allein für stärkere Runtime Claims nicht reicht.
+- `/listing-comparison` ist als aktuelle öffentliche Hauptfläche benannt.
+- Das minimale Evidenzmodell für stärkere Pricing Claims ist beschrieben.
+- Fail-safe Verhalten für fehlende, veraltete oder unvollständige Evidenz ist definiert.
+- Jede vorgeschlagene Feldrolle erklärt Zweck, Nutzen und mögliche Gründe gegen das Feld.
+- Es gibt eine plausible technische Richtung für eine spätere Implementierung.
+
+## Out of Scope
+
+- Finale Copy-Freigabe für `/listing-comparison`.
+- Legal Sign-off.
+- Sofortige Implementierung des Pricing-Prozesses.
+- Demo-Seed Cleanup oder Storybook-only Pricing Copy.
+- Vollständige Trust-Claim Policy außerhalb pricing-spezifischer Claims.

--- a/trust-claim-accreditation-evidence-requirements-task.md
+++ b/trust-claim-accreditation-evidence-requirements-task.md
@@ -1,0 +1,166 @@
+# Feature: Evidenzanforderungen für öffentliche Akkreditierungsclaims definieren
+
+## Problem
+
+Öffentliche Akkreditierungen wirken als starke Vertrauenssignale. Wenn Klinikdaten Namen von Akkreditierungen, Zertifikaten oder Qualitätssiegeln enthalten, heißt das noch nicht automatisch, dass findmydoc Aussteller, Scope, Gültigkeit und Nachweis geprüft hat.
+
+Ohne Evidenzprozess können öffentliche Chips, Counts oder Texte mehr Verlässlichkeit suggerieren, als die aktuelle Implementierung beweisen kann.
+
+## Ziel
+
+findmydoc braucht ein dokumentiertes und implementierbares Anforderungsset dafür, wann Akkreditierungen öffentlich als Trust Claim angezeigt werden dürfen.
+
+Das Team soll unterscheiden können zwischen:
+
+- intern erfassten oder von Kliniken gelieferten Akkreditierungsdaten
+- neutraler Anzeige ohne stärkeren Prüfclaim
+- geprüften öffentlichen Akkreditierungsclaims mit dokumentierter Quelle, Scope und Gültigkeit
+
+## Nicht-funktionale Anforderungen
+
+1. Claim-Integrität
+   Öffentliche Akkreditierungs-Copy darf keine geprüfte Anerkennung behaupten, wenn Aussteller, Scope und Gültigkeit nicht geprüft wurden.
+
+2. Quellennachvollziehbarkeit
+   Jede öffentliche Akkreditierung braucht eine gespeicherte Quelle oder interne Referenz.
+
+3. Scope-Klarheit
+   Das System muss wissen, worauf die Akkreditierung gilt, damit sie nicht zu breit ausgespielt wird.
+
+4. Aktualität
+   Akkreditierungen brauchen ein Ablaufdatum oder eine Re-Check-Regel.
+
+5. Auditierbarkeit
+   Das System muss beantworten können, wer die Akkreditierung geprüft hat, wann das passiert ist und auf welcher Grundlage.
+
+6. Runtime Enforcement
+   Public Chips, Counts und Claims müssen durch Runtime-Logik gesteuert werden, nicht nur durch redaktionelle Disziplin.
+
+7. Fail-safe Verhalten
+   Fehlende, ungültige oder abgelaufene Evidenz muss auf neutrale Darstellung zurückfallen oder die Akkreditierung ausblenden.
+
+8. Kompatibilität mit bestehenden Daten
+   Bestehende Akkreditierungsdaten dürfen nicht automatisch als geprüft gelten.
+
+9. Operative Wartbarkeit
+   Der Prozess muss wiederholbar sein und stale Akkreditierungen sichtbar machen.
+
+10. Datenmodell-Klarheit
+    Wenn Akkreditierungen bereits als eigene Collection existieren, darf die neue Evidenzlogik nicht unnötig doppelte Stammdaten erzeugen.
+
+## Claim-Stufen
+
+### Mit aktuellem Datenstil grundsätzlich erlaubbar
+
+- interne Akkreditierungserfassung
+- neutrale Anzeige von hinterlegten Informationen, wenn keine Prüfung behauptet wird
+- ausgeblendete Akkreditierungsdaten bis zur Prüfung
+
+### Nur nach Evidenzprozess plus technischem Gating erlaubbar
+
+- `Accredited clinic`
+- `Verified accreditation`
+- `Certified`
+- Public Chips oder Counts, die geprüfte Akkreditierungen implizieren
+
+## Mindeststandard für öffentliche Akkreditierungsclaims
+
+Jede öffentlich ausgespielte Akkreditierung sollte mindestens haben:
+
+- offiziellen Aussteller
+- Scope oder Geltungsbereich
+- Evidenzstatus
+- Quellenreferenz
+- Prüfzeitpunkt
+- verantwortliche prüfende Person oder Rolle
+- Ablaufdatum oder Re-Check-Regel
+- abgeleitete Public-Eligibility
+
+Ohne diesen Mindeststandard sollten Akkreditierungsclaims neutral bleiben oder nicht öffentlich angezeigt werden.
+
+## Vorgeschlagene technische Richtung
+
+Wenn eine eigene `accreditation` Collection existiert, sollten Stammdaten wie Name und Aussteller dort normalisiert werden. Die öffentliche Claim-Berechtigung kann am Klinik-Akkreditierungs-Link oder einem Accreditation-Evidence-Record hängen, damit eine Klinik nicht automatisch public-eligible wird, nur weil ein Akkreditierungsname existiert.
+
+### Implementierungs-Feldtabelle: Accreditation Evidence
+
+| Schema-Feld                    | Wofür ist es da?                              | Warum braucht man es?                                                                      | Warum ggf. nicht oder nur optional?                                                                 |
+| ------------------------------ | --------------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `accreditationIssuer`          | Offizieller Aussteller der Akkreditierung.    | Ohne Aussteller ist der Claim nicht prüfbar.                                               | Wenn der Aussteller bereits in einer eigenen `accreditation` Collection steht, reicht die Relation. |
+| `accreditationScope`           | Beschreibt, worauf die Akkreditierung gilt.   | Verhindert, dass eine allgemeine oder fachfremde Akkreditierung zu breit ausgespielt wird. | Kann optional starten, wenn nur einfache, gut definierte Akkreditierungen erlaubt sind.             |
+| `accreditationEvidenceStatus`  | Prüfstatus des Nachweises.                    | Public Chips oder Counts dürfen nur bei geprüfter Evidenz erscheinen.                      | Nicht nötig, wenn Akkreditierungen nur intern gespeichert und nicht öffentlich angezeigt werden.    |
+| `accreditationSourceReference` | Interne Referenz auf Dokument oder Quelle.    | Macht den Claim auditierbar.                                                               | Kann eine externe ID sein, wenn Dokumente nicht in Payload liegen.                                  |
+| `accreditationReviewedAt`      | Zeitpunkt der Prüfung.                        | Gültigkeit und Aktualität brauchen ein Datum.                                              | Optional nur bei rein internem Draft-Status.                                                        |
+| `accreditationReviewedBy`      | Prüfer oder prüfende Rolle.                   | Stellt Verantwortlichkeit her.                                                             | Rolle statt Person kann fürs MVP reichen.                                                           |
+| `accreditationValidUntil`      | Ablaufdatum der Akkreditierung.               | Akkreditierungen laufen oft ab; Runtime-Gating muss das beachten.                          | Wenn eine Quelle kein Ablaufdatum hat, kann ein Re-Check-Intervall genutzt werden.                  |
+| `publicAccreditationEligible`  | Abgeleitete Freigabe für öffentliche Anzeige. | Das Frontend braucht eine einfache, sichere Anzeigeentscheidung.                           | Sollte abgeleitet statt manuell gepflegt werden, wenn die Felder vollständig genug sind.            |
+
+### Abgeleitetes Eligibility-Modell
+
+UI-Komponenten sollten nicht selbst aus einzelnen Evidenzfeldern ableiten, ob eine Akkreditierung öffentlich erscheinen darf. Dafür sollte es eine serverseitige Eligibility-Funktion geben, zum Beispiel:
+
+- `isAccreditationEvidenceFresh(accreditationEvidence)`
+- `getPublicAccreditationEligibility(clinicAccreditation)`
+
+Vorgeschlagenes Verhalten:
+
+- `hidden`
+  Akkreditierung wird nicht öffentlich angezeigt.
+- `neutral`
+  Akkreditierung kann ohne stärkeren Prüfclaim angezeigt werden, falls fachlich erlaubt.
+- `verified`
+  Akkreditierung hat Quelle, Scope, Review und gültige Aktualität.
+- `expired`
+  Akkreditierung existiert, darf aber nicht mehr als aktueller Trust Claim erscheinen.
+
+## Route-Level Runtime-Gating
+
+Alle öffentlichen Flächen mit Akkreditierungen müssen Eligibility prüfen, bevor Chips, Counts oder Texte gerendert werden.
+
+Vorgeschlagener Ansatz:
+
+- Default ist `hidden` oder neutrale Darstellung ohne Trust-Signal.
+- Public Counts zählen nur eligible Akkreditierungen.
+- Public Chips erscheinen nur bei gültiger Eligibility.
+- Abgelaufene Akkreditierungen werden nicht als Trust Signal ausgespielt.
+
+## Admin- und Workflow-Anforderungen
+
+Wenn der Prozess real sein soll, muss die Admin UI ihn unterstützen. Versteckte manuelle Konventionen reichen nicht.
+
+Vorgeschlagene Workflow-Unterstützung:
+
+- klare Admin-Beschreibungen, welche Quelle als Akkreditierungsnachweis zählt
+- Pflicht oder Hinweis für Aussteller, Scope und Gültigkeit
+- Filter für ablaufende, abgelaufene oder ungeprüfte Akkreditierungen
+- Hinweis, dass Klinikangaben nicht automatisch öffentliche Trust Claims sind
+
+## Migration und Rollout
+
+Vorgeschlagener Ablauf:
+
+1. Bestehende Akkreditierungsdaten neutral halten.
+2. Schema-Felder und Admin-Hinweise ergänzen.
+3. Nur Akkreditierungen backfillen, die echte Evidenz haben.
+4. Runtime-Gating für Public Chips, Counts und Texte hinzufügen.
+5. Erst danach stärkere öffentliche Akkreditierungsclaims aktivieren.
+
+Wichtige Regel:
+
+- Keine Migration darf bestehende Akkreditierungen automatisch als verified markieren, wenn dafür keine echte Evidenz existiert.
+
+## Akzeptanzkriterien
+
+- Das Dokument definiert, wann öffentliche Akkreditierungsclaims erlaubt sind.
+- Aussteller, Scope, Quelle und Gültigkeit sind als Mindeststandard beschrieben.
+- Fail-safe Verhalten für fehlende oder abgelaufene Evidenz ist definiert.
+- Jede vorgeschlagene Feldrolle erklärt Zweck, Nutzen und mögliche Gründe gegen das Feld.
+- Es gibt eine plausible technische Richtung für eine spätere Implementierung.
+
+## Out of Scope
+
+- Finale Copy-Freigabe.
+- Legal Sign-off.
+- Sofortige Implementierung der Akkreditierungs-Evidenz.
+- Vollständige Normalisierung aller Akkreditierungs-Stammdaten.
+- Demo-Seed Cleanup oder Storybook-only Content.

--- a/trust-claim-gallery-evidence-requirements-task.md
+++ b/trust-claim-gallery-evidence-requirements-task.md
@@ -1,0 +1,165 @@
+# Feature: Evidenzanforderungen für öffentliche Before-/After Case Gallery definieren
+
+## Problem
+
+Before-/After-Fälle sind öffentliche Trust Claims mit besonders hoher Sensibilität. Ein sichtbarer Fall kann implizieren, dass Bildmaterial, Behandlungskontext, Ergebnisdarstellung und Einwilligung geprüft wurden.
+
+Ohne fallbezogenen Evidenzprozess reicht eine klinikweite Freigabe nicht aus. Jeder öffentliche Case braucht eigene Nachweise, Consent-Status, Review-Status und Runtime-Gating.
+
+## Ziel
+
+findmydoc braucht ein dokumentiertes und implementierbares Anforderungsset dafür, wann Before-/After-Fälle öffentlich angezeigt werden dürfen.
+
+Das Team soll unterscheiden können zwischen:
+
+- internen oder deaktivierten Case-Daten, die nicht öffentlich ausgespielt werden
+- neutraler Galerieanzeige ohne stärkeren Ergebnis-Claim
+- geprüfter öffentlicher Darstellung mit dokumentiertem Consent und fallbezogener Evidenz
+
+## Nicht-funktionale Anforderungen
+
+1. Claim-Integrität
+   Öffentliche Case-Darstellung darf keine geprüfte Ergebnisqualität suggerieren, wenn die Fall-Evidenz das nicht belegt.
+
+2. Consent-Sicherheit
+   Kein Case darf öffentlich erscheinen, wenn Consent fehlt, unklar ist oder widerrufen wurde.
+
+3. Fallbezogene Nachvollziehbarkeit
+   Nachweise müssen pro Case referenziert werden, nicht nur auf Klinik- oder Behandlungsebene.
+
+4. Aktualität
+   Re-Check oder Ablaufregeln müssen definieren, wann ein Case erneut geprüft oder entfernt werden muss.
+
+5. Auditierbarkeit
+   Das System muss beantworten können, wer den Case geprüft hat, wann das passiert ist und auf welcher Grundlage.
+
+6. Runtime Enforcement
+   Öffentliche Case-Anzeige muss durch Runtime-Logik gesteuert werden, nicht nur durch redaktionelle Disziplin.
+
+7. Fail-safe Verhalten
+   Fehlende, ungültige oder abgelaufene Evidenz muss den Case aus der öffentlichen Anzeige entfernen.
+
+8. Datenschutz
+   Private Nachweise und Consent-Dokumente dürfen nicht öffentlich ausgeliefert werden.
+
+9. Kompatibilität mit bestehenden Daten
+   Bestehende Case-Daten dürfen neutral intern weiter bestehen, ohne automatisch public-eligible zu werden.
+
+10. Operative Wartbarkeit
+    Der Prozess muss wiederholbar sein. Wenn Review- oder Consent-Aufwand nicht leistbar ist, soll die Galerie deaktiviert bleiben statt riskant ausgespielt zu werden.
+
+## Claim-Stufen
+
+### Mit aktuellem Datenstil grundsätzlich erlaubbar
+
+- Keine öffentliche Case Gallery.
+- Interne Case-Erfassung.
+- Neutraler interner Review-Status ohne öffentliche Ausgabe.
+
+### Nur nach Evidenzprozess plus technischem Gating erlaubbar
+
+- Öffentliche Before-/After Case Gallery.
+- Fallbezogene Ergebnisdarstellung.
+- Claims wie `verified case`, `reviewed result`, `checked before and after` oder vergleichbare Signale.
+
+## Mindeststandard für öffentliche Case-Anzeige
+
+Jeder öffentliche Case sollte mindestens haben:
+
+- fallbezogenen Evidence-Status
+- dokumentierten Consent-Status
+- Consent-Referenz oder interne Consent-ID
+- Review-Zeitpunkt
+- verantwortliche prüfende Person oder Rolle
+- Re-Check- oder Ablaufregel
+- abgeleitete Public-Eligibility
+
+Ohne diesen Mindeststandard sollte ein Case nicht öffentlich angezeigt werden.
+
+## Vorgeschlagene technische Richtung
+
+Der naheliegende Ort ist `clinicGalleryEntries`, weil dort die fallbezogenen Galerieeinträge liegen. Media-Collections können weiterhin die Dateien verwalten, aber die öffentliche Claim-Berechtigung sollte am konkreten Case hängen.
+
+### Implementierungs-Feldtabelle: `clinicGalleryEntries`
+
+| Schema-Feld            | Wofür ist es da?                                                                | Warum braucht man es?                                                                                   | Warum ggf. nicht oder nur optional?                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `caseEvidenceStatus`   | Prüfstatus des konkreten Before-/After-Falls.                                   | Ein veröffentlichter Case kann nur public-safe sein, wenn genau dieser Case geprüft wurde.              | Wenn die Galerie für MVP deaktiviert bleibt, wird das Feld erst mit der Gallery-Story benötigt.      |
+| `caseConsentStatus`    | Status der dokumentierten Einwilligung, z. B. `missing`, `received`, `revoked`. | Before-/After-Bilder sind besonders sensibel; ohne Consent darf keine öffentliche Darstellung erfolgen. | Nicht optional, sobald echte Patientenfälle öffentlich gezeigt werden.                               |
+| `caseConsentReference` | Interne Referenz auf die Einwilligung.                                          | Erlaubt spätere Prüfung, ohne private Dokumente öffentlich zu machen.                                   | Kann bei externer Dokumentenablage nur eine externe ID sein.                                         |
+| `caseReviewedAt`       | Zeitpunkt der Fallprüfung.                                                      | Belegt, wann Bild, Text, Nachweis und Einwilligung geprüft wurden.                                      | Optional nur für nicht veröffentlichte Entwürfe.                                                     |
+| `caseReviewedBy`       | Verantwortliche prüfende Person oder Rolle.                                     | Case-Freigaben brauchen Accountability.                                                                 | Eine Rolle kann fürs MVP reichen, wenn personenbezogene Reviewer-Zuordnung noch nicht gewünscht ist. |
+| `caseValidUntil`       | Re-Check- oder Ablaufdatum.                                                     | Hilft, abgelaufene oder zu überprüfende Fälle automatisch zu neutralisieren oder zu verstecken.         | Nicht jeder Case braucht ein Ablaufdatum; Consent-Widerruf muss aber unabhängig davon möglich sein.  |
+| `publicCaseEligible`   | Abgeleiteter Boolean oder Claim-Level für öffentliche Anzeige.                  | Das Frontend braucht eine einfache Entscheidung: anzeigen oder nicht anzeigen.                          | Sollte idealerweise aus Statusfeldern abgeleitet werden, damit keine manuelle Abweichung entsteht.   |
+
+### Abgeleitetes Eligibility-Modell
+
+UI-Komponenten sollten nicht selbst aus einzelnen Evidenzfeldern ableiten, ob ein Case öffentlich erscheinen darf. Dafür sollte es eine serverseitige Eligibility-Funktion geben, zum Beispiel:
+
+- `isCaseConsentValid(caseEntry)`
+- `isCaseEvidenceFresh(caseEntry)`
+- `getPublicCaseEligibility(caseEntry)`
+
+Vorgeschlagenes Verhalten:
+
+- `hidden`
+  Case ist nicht öffentlich sichtbar.
+- `neutral`
+  Case ist sichtbar, aber ohne stärkeren Prüf- oder Ergebnis-Claim.
+- `reviewed`
+  Case hat gültigen Consent, Evidence-Status, Review-Datum und ist nicht abgelaufen.
+- `revoked`
+  Case war ggf. früher erlaubt, ist aber wegen Consent-Widerruf oder Ablauf nicht mehr öffentlich sichtbar.
+
+## Route-Level Runtime-Gating
+
+Alle öffentlichen Galerieflächen müssen Case-Eligibility serverseitig prüfen, bevor Cases an UI-Komponenten übergeben werden.
+
+Vorgeschlagener Ansatz:
+
+- Default ist `hidden`.
+- Nur `publicCaseEligible` oder eine zentrale Eligibility-Funktion erlaubt Rendering.
+- Abgelaufene oder widerrufene Cases werden nicht ausgeliefert.
+- Öffentliche Count- oder Trust-Copy darf nur sichtbare eligible Cases zählen.
+
+## Admin- und Workflow-Anforderungen
+
+Wenn der Prozess real sein soll, muss die Admin UI ihn unterstützen. Versteckte manuelle Konventionen reichen nicht.
+
+Vorgeschlagene Workflow-Unterstützung:
+
+- klare Admin-Beschreibungen, was als gültiger Consent zählt
+- Reviewer-Hinweise für fallbezogene Evidence-Prüfung
+- sichtbarer Status für fehlende, widerrufene oder ablaufende Einwilligungen
+- Filter für Cases, die bald ablaufen oder erneut geprüft werden müssen
+- keine einfache öffentliche Freigabe ohne Consent- und Evidence-Status
+
+## Migration und Rollout
+
+Vorgeschlagener Ablauf:
+
+1. Öffentliche Galerie standardmäßig deaktiviert oder leer lassen.
+2. Schema-Felder und Admin-Hinweise hinzufügen.
+3. Nur Cases backfillen, die echte Evidenz und gültigen Consent haben.
+4. Runtime-Gating hinzufügen.
+5. Erst danach öffentliche Case-Darstellung aktivieren.
+
+Wichtige Regel:
+
+- Keine Migration darf Legacy-Cases automatisch public-eligible machen, wenn dafür keine echte Evidenz und kein gültiger Consent existieren.
+
+## Akzeptanzkriterien
+
+- Das Dokument definiert, wann Before-/After Cases öffentlich sichtbar sein dürfen.
+- Consent, Evidence, Review und Ablauf sind getrennt beschrieben.
+- Fail-safe Verhalten für fehlende, widerrufene oder abgelaufene Evidenz ist definiert.
+- Jede vorgeschlagene Feldrolle erklärt Zweck, Nutzen und mögliche Gründe gegen das Feld.
+- Es gibt eine plausible technische Richtung für eine spätere Implementierung.
+
+## Out of Scope
+
+- Finale Copy-Freigabe.
+- Legal Sign-off.
+- Sofortige Implementierung der Case Gallery.
+- Bildbearbeitung oder Media-Upload UX.
+- Demo-Seed Cleanup oder Storybook-only Content.

--- a/trust-claim-guardrails-findings.md
+++ b/trust-claim-guardrails-findings.md
@@ -14,7 +14,7 @@ Sources:
 - For the MVP disable gate, `verified` means verified by findmydoc through an explicit, documented process, not just clinic-provided or seeded data.
 - Yellow means publishable only with documented evidence: source, owner, proof type, proof date, and an accountable check.
 - Green means generally safe when phrased as comparison, organization, profile structure, or direct contact, without medical advice or quality certification.
-- Current gap: the repository documents review moderation, but does not clearly define a complete findmydoc verification/checking process for public reviews, verified badges, star ratings, or before/after galleries.
+- Current gap: the repository documents review moderation, but does not clearly define a complete findmydoc verification/checking process for public reviews, star ratings, or before/after galleries. Verification badges are handled separately because the trust core has been defined conceptually but not implemented yet.
 
 ## Item Status Overview
 
@@ -24,7 +24,7 @@ Sources:
 | R1   | Listing trust block claims                | Solved in `findmydoc-platform/website#1309` |
 | R2   | Before/after case gallery                 | Decision needed                             |
 | R3   | Public reviews and star ratings           | Decision needed                             |
-| R4   | Verification badges                       | Decision needed                             |
+| R4   | Verification badges                       | Trust core defined; implementation needed   |
 | R5   | Rating-based ranking and filters          | Decision needed                             |
 | R6   | Demo blog disclaimer and `[Demo]` titles  | Solved in `findmydoc-platform/website#1303` |
 | R7   | Storybook and fixture trust claims        | Solved in `findmydoc-platform/website#1305` |
@@ -39,6 +39,17 @@ Sources:
 | G2   | Clinic-provided profile information       | Safe pattern                                |
 | G3   | Direct contact and inquiry flow           | Safe pattern                                |
 | G4   | Transparent non-quality filters           | Safe pattern                                |
+
+## Atomic Task Documents
+
+The process-dependent items are split into separate task documents so each can be estimated, reviewed, and implemented independently:
+
+- Before/After Case Gallery: `trust-claim-gallery-evidence-requirements-task.md`
+- Public Reviews: `trust-claim-review-evidence-requirements-task.md`
+- Rating Eligibility: `trust-claim-rating-eligibility-requirements-task.md`
+- Accreditations: `trust-claim-accreditation-evidence-requirements-task.md`
+- Verification Badges: `trust-claim-verification-badge-requirements-task.md`
+- Pricing Claims: `pricing-evidence-requirements-task.md`
 
 ## Cross-Cutting Process Gap
 
@@ -122,8 +133,9 @@ Sources:
 
 - Severity: `8/10`
 - Notion category: MVP disable gate unless verified and checked
+- Status: Trust core defined; implementation needed
 - Problem: Clinic verification tiers are public UI badges and demo data seeds approved clinics as gold/silver/bronze.
-- Impact: This matches issue #237 risk around badge status without a real badge process. If findmydoc owns and documents that process, the item may become safe case by case; until then it should be disabled/hidden for MVP.
+- Impact: This matches issue #237 risk around badge status when the defined trust core is not implemented as data, admin workflow, and runtime gating yet.
 - Current references:
   - `src/collections/Clinics.ts:410`
   - `src/components/atoms/verification-badge.tsx:31`
@@ -136,7 +148,7 @@ Sources:
   - `src/endpoints/seed/data/demo/clinics.json:285`
   - `src/endpoints/seed/data/demo/clinics.json:343`
   - `src/endpoints/seed/data/demo/clinics.json:517`
-- Decision needed: demote all public badge display to neutral profile status, or create evidence-backed verification workflow before publish.
+- Implementation needed: implement the defined trust-core process as data model, admin workflow, and runtime eligibility before treating public badge tiers as process-backed evidence.
 
 ### R5. Rating-based ranking and filters
 

--- a/trust-claim-process-requirements-task.md
+++ b/trust-claim-process-requirements-task.md
@@ -1,0 +1,69 @@
+# Index: atomare Aufgaben für Trust-Claim Evidenzprozesse
+
+## Problem
+
+findmydoc trennt öffentliche Textflächen inzwischen in CMS Content, Product UI Copy und Admin UI Labels. Damit ist geklärt, wo Texte gepflegt werden sollen. Das löst aber noch nicht, ob stärkere Trust Claims öffentlich angezeigt werden dürfen.
+
+Einige öffentliche Flächen brauchen dafür einen belastbaren Prozess, ein Datenmodell und Runtime-Gating. Ohne diese Grundlage können Begriffe wie `verified`, `reviewed`, `checked`, `accredited` oder vergleichbare Vertrauenssignale mehr versprechen, als die aktuelle Implementierung beweisen kann.
+
+Dieses Dokument ist bewusst nur noch ein Index. Die eigentlichen Aufgaben liegen atomar in einzelnen Dokumenten, damit sie unabhängig priorisiert, geplant und umgesetzt werden können.
+
+## Aktuelle CMS-Entscheidung
+
+Der aktuelle technische Durchlauf hat genau einen sicheren CMS-Kandidaten im aktiven Landing-Scope gefunden:
+
+- `/partners/clinics` Team-CTA: Der sichtbare `About us` CTA gehört zur Partner-Landingpage, weil er eine redaktionelle Landingpage-/Conversion-Steuerung ist und keine wiederverwendbare Product UI Copy.
+- Umgesetztes Ziel: `landingPages.clinicPartners.teamCta`.
+
+Alle anderen bisher geprüften hardcoded Trust-nahen Texte werden nicht automatisch ins CMS verschoben:
+
+- Listing-Comparison Hero-/Trust-Texte sind Product UI Copy Kandidaten, weil die Seite stark datengetrieben ist und die Texte kurz und produktnah sind.
+- Clinic-Detail Labels, Filter, Sortierungen, Buttons, Empty States und ARIA Labels sind Product UI Copy Kandidaten.
+- Temporary-Landing-Copy braucht zuerst eine Produktentscheidung. Wenn der Modus als echte öffentliche Landingpage bleibt, sollten Hero, SEO, Narrative und Signal-Copy ins CMS. Wenn er temporär oder preview-only bleibt, ist keine CMS-Arbeit nötig.
+
+## Zielzustand
+
+Jede Trust-nahe Fläche soll in genau einen Zustand fallen:
+
+- CMS editierbar, wenn es nur um redaktionelle Kontrolle geht.
+- Product UI Copy, wenn der Text kurz, funktional, routennah oder komponentenbezogen ist.
+- Evidenzprozess erforderlich, wenn die öffentliche Aussage von Prüfung, Nachweis, Aktualität oder verantwortlicher Bestätigung abhängt.
+- Bestehender Trust-Core Prozess zu implementieren, speziell bei Verification Badges.
+
+## Atomare Aufgaben
+
+| Aufgabe                   | Dokument                                                  | Zweck                                                                                      |
+| ------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Before/After Case Gallery | `trust-claim-gallery-evidence-requirements-task.md`       | Prozess, Consent, Evidence und Runtime-Gating für öffentliche Before-/After-Fälle.         |
+| Public Reviews            | `trust-claim-review-evidence-requirements-task.md`        | Prozess und Datenmodell dafür, wann Reviews als geprüft oder verifiziert gelten dürfen.    |
+| Rating Eligibility        | `trust-claim-rating-eligibility-requirements-task.md`     | Aggregation, Filter und Sortierung auf Basis berechtigter Review-/Rating-Daten.            |
+| Accreditations            | `trust-claim-accreditation-evidence-requirements-task.md` | Nachweise, Scope und Gültigkeit für öffentlich ausgespielte Akkreditierungen.              |
+| Verification Badges       | `trust-claim-verification-badge-requirements-task.md`     | Implementierungsstory für den vorhandenen, aber noch nicht umgesetzten Trust-Core Prozess. |
+| Pricing Claims            | `pricing-evidence-requirements-task.md`                   | Separater Pricing-Prozess für Quelle, Review-Status, Aktualität und Claim-Berechtigung.    |
+
+## Gemeinsame Regeln für alle atomaren Aufgaben
+
+- Keine Aufgabe schreibt finale öffentliche Copy vor.
+- Jede Aufgabe muss neutrale Anzeige von stärkeren Claims trennen.
+- Jede Aufgabe braucht eine klare Runtime-Eligibility, nicht nur redaktionelle Disziplin.
+- Jede Aufgabe muss erklären, welche Schema-Felder wofür da sind, warum sie gebraucht werden und wann man sie ggf. nicht braucht.
+- Legacy-Daten dürfen nicht automatisch als geprüft, reviewed, verified oder accredited markiert werden, wenn dafür keine echte Evidenz existiert.
+- Fehlende, ungültige oder abgelaufene Evidenz muss auf neutrale Darstellung zurückfallen oder die betreffende Trust-Fläche ausblenden.
+
+## Akzeptanzkriterien
+
+- CMS-only Arbeit ist klar von prozessabhängiger Trust-Arbeit getrennt.
+- Product UI Copy Kandidaten sind für den späteren UI-Copy-/Export-Prozess geparkt.
+- Jedes prozessabhängige Item hat ein eigenes, atomar bearbeitbares Task-Dokument.
+- Verification Badges sind als Implementierungslücke des vorhandenen Trust-Core Konzepts dokumentiert, nicht als fehlende Prozessdefinition.
+- Das Index-Dokument enthält keine große Sammel-Feldtabelle mehr.
+
+## Out of Scope
+
+- Finale Copy-Freigabe.
+- Legal Sign-off.
+- Product UI Copy Extraction.
+- Admin Label Lokalisierung.
+- Demo-Seed Cleanup.
+- Storybook-only Content Cleanup.
+- Entfernen oder Umschreiben öffentlicher Inhalte in diesem Task.

--- a/trust-claim-rating-eligibility-requirements-task.md
+++ b/trust-claim-rating-eligibility-requirements-task.md
@@ -1,0 +1,163 @@
+# Feature: Evidenzanforderungen für öffentliche Rating-Eligibility definieren
+
+## Problem
+
+Rating-Sortierung, Rating-Filter, Sterne-Durchschnitte und Review-Counts wirken wie objektive Qualitäts- oder Trust-Signale. Wenn sie ungeprüfte, gemischte oder nicht eindeutig berechtigte Daten aggregieren, kann die öffentliche UI mehr Sicherheit suggerieren, als die Datenbasis erlaubt.
+
+Diese Aufgabe erzeugt keine eigene Review-Wahrheit. Sie definiert, wie Rating-Funktionen nur auf berechtigten Review-/Rating-Daten aufbauen dürfen.
+
+## Ziel
+
+findmydoc braucht ein dokumentiertes und implementierbares Anforderungsset dafür, wann Rating-Aggregate, Filter und Sortierungen öffentlich genutzt werden dürfen.
+
+Das Team soll unterscheiden können zwischen:
+
+- neutralen oder deaktivierten Rating-Funktionen
+- Rating-Anzeige auf Basis moderierter Reviews
+- stärkeren Rating-Funktionen, die nur mit verified oder public-eligible Reviews erlaubt sind
+
+## Nicht-funktionale Anforderungen
+
+1. Claim-Integrität
+   Rating UI darf keine geprüfte Qualität suggerieren, wenn die zugrunde liegenden Reviews dafür nicht berechtigt sind.
+
+2. Input-Nachvollziehbarkeit
+   Aggregationen müssen nachvollziehbar machen, welche Review-Menge einbezogen wurde.
+
+3. Trennung von Review-Verifikation und Rating-Aggregation
+   Rating-Logik darf Review-Verifikation nicht ersetzen oder selbst erfinden.
+
+4. Aktualität
+   Rating-Aggregate brauchen einen Berechnungszeitpunkt oder müssen live berechnet werden.
+
+5. Auditierbarkeit
+   Das System muss erklären können, warum ein Rating angezeigt, gefiltert oder sortiert wurde.
+
+6. Runtime Enforcement
+   Rating-Filter und Sortierungen müssen von Eligibility abhängen, nicht nur von UI-Copy.
+
+7. Fail-safe Verhalten
+   Fehlende oder gemischte Eligibility muss auf neutrale Darstellung oder deaktivierte Rating-Funktionen zurückfallen.
+
+8. Kompatibilität mit bestehenden Daten
+   Bestehende Ratings dürfen nicht automatisch als verified oder public-eligible gelten.
+
+9. Performance
+   Aggregation darf effizient sein, muss aber korrekt bleiben. Voraggregation darf keine stale Trust-Signale erzeugen.
+
+10. Operative Wartbarkeit
+    Rating-Regeln müssen zentral sein, damit mehrere Routes nicht verschiedene Wahrheiten erzeugen.
+
+## Claim-Stufen
+
+### Mit aktuellem Datenstil grundsätzlich erlaubbar
+
+- neutrale Rating-Anzeige, wenn klar nicht als geprüft behauptet
+- Review-Count ohne stärkeren Verifikationsclaim
+- deaktivierte Rating-Sortierung, wenn Datenbasis unklar ist
+
+### Nur nach Evidenzprozess plus technischem Gating erlaubbar
+
+- Rating-Sortierung als Qualitätsindikator
+- Rating-Filter, die geprüfte Review-Qualität implizieren
+- `verified rating`, `reviewed rating`, `trusted rating` oder vergleichbare Claims
+
+## Mindeststandard für stärkere Rating-Funktionen
+
+Jede stärkere Rating-Funktion sollte mindestens haben:
+
+- definierte Review-Input-Menge
+- Eligibility-Regel für einbezogene Reviews
+- Aggregationsstatus
+- Berechnungszeitpunkt
+- Regel für gemischte oder unvollständige Daten
+- abgeleitete Route- oder Komponenten-Eligibility
+
+Ohne diesen Mindeststandard sollten Rating-Funktionen neutral bleiben oder deaktiviert werden.
+
+## Vorgeschlagene technische Richtung
+
+Rating-Eligibility sollte auf dem Review-Prozess aus `trust-claim-review-evidence-requirements-task.md` aufbauen. Die Rating-Aufgabe darf `publicReviewClaimTier` oder eine zentrale Review-Eligibility-Funktion verwenden, aber nicht eigene Verifikationslogik duplizieren.
+
+### Implementierungs-Feldtabelle: Rating-Aggregate und Eligibility
+
+| Schema-Feld oder Funktion      | Wofür ist es da?                                                                  | Warum braucht man es?                                                                                       | Warum ggf. nicht oder nur optional?                                                                 |
+| ------------------------------ | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `publicRatingEligible`         | Markiert Reviews oder Aggregate als verwendbar für öffentliche Rating-Funktionen. | Sortierung und Filter dürfen nicht ungeprüfte oder gemischte Rating-Daten wie geprüfte Qualität darstellen. | Wenn Review-Eligibility eine serverseitige Funktion liefert, sollte Rating diese Funktion nutzen.   |
+| `ratingAggregationStatus`      | Status eines Klinik-Rating-Aggregats, z. B. `none`, `partial`, `eligible`.        | Die Listing-Seite braucht eine einfache Entscheidung, ob Rating-Sortierung angeboten werden darf.           | Kann virtuell bleiben, wenn Aggregation on demand günstig genug ist.                                |
+| `ratingAggregatedAt`           | Zeitpunkt der letzten Aggregation.                                                | Hilft bei Caching und Nachvollziehbarkeit.                                                                  | Nicht nötig, wenn Ratings immer live berechnet werden.                                              |
+| `ratingEligibleReviewCount`    | Anzahl der Reviews, die in das öffentliche Rating eingeflossen sind.              | Public Counts und Durchschnitte müssen zur tatsächlich verwendeten Datenbasis passen.                       | Kann on demand berechnet werden, wenn Performance reicht.                                           |
+| `ratingExcludedReviewCount`    | Anzahl ausgeschlossener Reviews wegen fehlender Eligibility.                      | Macht gemischte Datenlagen intern sichtbar und hilft beim Debugging.                                        | Für öffentliche UI nicht nötig; intern optional, wenn Monitoring anders gelöst ist.                 |
+| `ratingEligibilityReason`      | Interner Grund, warum ein Rating eligible, partial oder nicht eligible ist.       | Hilft Admins und Support zu verstehen, warum Sortierung oder Filter deaktiviert sind.                       | Kann durch strukturierte Statusfelder ersetzt werden, wenn kein Freitext gewünscht ist.             |
+| `getPublicRatingEligibility()` | Zentrale Funktion für Anzeige, Filter und Sortierung.                             | Verhindert, dass jede UI-Fläche eigene Rating-Regeln implementiert.                                         | Kann später in einen gespeicherten Wert überführt werden, wenn Performance oder Caching es fordert. |
+
+### Abgeleitetes Eligibility-Modell
+
+UI-Komponenten sollten nicht selbst aus Review- und Aggregationsfeldern ableiten, welche Rating-Funktion erlaubt ist. Dafür sollte es eine serverseitige Eligibility-Funktion geben, zum Beispiel:
+
+- `getEligibleReviewsForRating(clinic)`
+- `getPublicRatingEligibility(clinic)`
+- `getRouteRatingEligibility(results)`
+
+Vorgeschlagenes Verhalten:
+
+- `disabled`
+  Rating-Funktion wird nicht angeboten.
+- `neutral`
+  Rating kann neutral angezeigt werden, aber nicht als geprüftes Trust Signal.
+- `eligible`
+  Rating-Filter, Sortierung oder stärkerer Rating-Claim darf genutzt werden.
+- `partial`
+  Rating-Daten sind gemischt; die Route bleibt bei neutraler Darstellung.
+
+## Route-Level Runtime-Gating
+
+Betroffene öffentliche Flächen können unter anderem Listing- und Klinikdetailseiten sein. Die konkrete Route muss beim Implementierungsticket erneut gegen Runtime-Code geprüft werden.
+
+Vorgeschlagener Ansatz:
+
+- Rating-Sortierung wird nur angeboten, wenn `getRouteRatingEligibility` sie erlaubt.
+- Rating-Filter erscheinen nur, wenn die sichtbare Datenbasis eligible ist.
+- Public Copy darf keinen stärkeren Claim anzeigen als die schwächste sichtbare Datenlage erlaubt.
+- Gemischte Ergebnisse fallen auf neutrale Darstellung zurück.
+
+## Admin- und Workflow-Anforderungen
+
+Wenn der Prozess real sein soll, muss die Admin UI ihn unterstützen. Versteckte manuelle Konventionen reichen nicht.
+
+Vorgeschlagene Workflow-Unterstützung:
+
+- Anzeige, welche Reviews ins Rating einfließen
+- Hinweis auf ausgeschlossene Reviews oder unvollständige Eligibility
+- Filter für Kliniken mit partial oder disabled Rating-Eligibility
+- Debug-Ansicht für Aggregationsstatus und Aktualität
+
+## Migration und Rollout
+
+Vorgeschlagener Ablauf:
+
+1. Bestehende Rating-Anzeige neutral halten.
+2. Review-Eligibility als Input stabilisieren.
+3. Rating-Eligibility und Aggregationsregeln hinzufügen.
+4. Runtime-Gating für Filter und Sortierung ergänzen.
+5. Erst danach stärkere Rating-Claims oder prominente Rating-Funktionen aktivieren.
+
+Wichtige Regel:
+
+- Keine Migration darf bestehende Ratings automatisch als public-eligible markieren, wenn die zugrunde liegenden Reviews nicht eindeutig berechtigt sind.
+
+## Akzeptanzkriterien
+
+- Rating-Eligibility ist von Review-Verifikation getrennt, nutzt sie aber als Input.
+- Das Dokument definiert, wann Rating-Filter, Sortierung und Aggregate erlaubt sind.
+- Fail-safe Verhalten für gemischte oder unvollständige Daten ist definiert.
+- Jede vorgeschlagene Feldrolle erklärt Zweck, Nutzen und mögliche Gründe gegen das Feld.
+- Es gibt eine plausible technische Richtung für eine spätere Implementierung.
+
+## Out of Scope
+
+- Finale Copy-Freigabe.
+- Legal Sign-off.
+- Sofortige Implementierung der Rating-Aggregation.
+- Definition, wann eine einzelne Review verified ist.
+- Demo-Seed Cleanup oder Storybook-only Content.

--- a/trust-claim-review-evidence-requirements-task.md
+++ b/trust-claim-review-evidence-requirements-task.md
@@ -1,0 +1,162 @@
+# Feature: Evidenzanforderungen für öffentliche Review-Claims definieren
+
+## Problem
+
+Öffentliche Reviews können schnell als Trust Signal verstanden werden. Die aktuelle Umsetzung kann Review-Inhalte moderieren, aber Moderation ist nicht dasselbe wie Verifikation.
+
+Stärkere Aussagen wie `verified review`, `reviewed patient feedback` oder ähnliche Claims brauchen einen definierten Prozess dafür, wann eine Review mit einem echten Kontakt, einer zulässigen Quelle oder einem geprüften Nachweis verbunden ist.
+
+## Ziel
+
+findmydoc braucht ein dokumentiertes und implementierbares Anforderungsset dafür, wann öffentliche Review-Claims erlaubt sind.
+
+Das Team soll unterscheiden können zwischen:
+
+- moderierten Reviews, die inhaltlich freigegeben sind
+- verifizierten Reviews, die eine zusätzliche Nachweisprüfung bestanden haben
+- Review-Daten, die zwar intern existieren, aber nicht für stärkere öffentliche Claims genutzt werden dürfen
+
+## Nicht-funktionale Anforderungen
+
+1. Claim-Integrität
+   Öffentliche Review-Copy darf keine Verifikation behaupten, wenn nur Moderation stattgefunden hat.
+
+2. Quellennachvollziehbarkeit
+   Jede verifizierte Review braucht eine gespeicherte Quelle oder interne Referenz.
+
+3. Datenschutz
+   Patientenkontakte oder private Nachweise dürfen nicht öffentlich ausgeliefert werden.
+
+4. Auditierbarkeit
+   Das System muss beantworten können, wer eine Review verifiziert hat, wann das passiert ist und auf welcher Grundlage.
+
+5. Trennung von Moderation und Verifikation
+   Inhaltsfreigabe und Trust-Verifikation müssen unterschiedliche Zustände bleiben.
+
+6. Runtime Enforcement
+   Starke Review-Claims müssen durch Runtime-Logik gesteuert werden, nicht nur durch redaktionelle Disziplin.
+
+7. Fail-safe Verhalten
+   Fehlende oder ungültige Verifikation muss auf neutrale Review-Darstellung zurückfallen.
+
+8. Kompatibilität mit bestehenden Daten
+   Bestehende Reviews dürfen nicht automatisch als verifiziert gelten.
+
+9. Operative Wartbarkeit
+   Der Prozess muss wiederholbar sein und darf keine versteckte manuelle Konvention bleiben.
+
+10. Aggregationsgrenze
+    Diese Aufgabe definiert Review-Verifikation. Rating-Aggregation, Filter und Sortierung werden in einem eigenen Task geregelt.
+
+## Claim-Stufen
+
+### Mit aktuellem Datenstil grundsätzlich erlaubbar
+
+- `Reviews`
+- `Patient feedback`
+- `Approved reviews`
+- neutrale Sterne- oder Review-Anzeige, wenn klar nicht als verifiziert behauptet
+
+### Nur nach Evidenzprozess plus technischem Gating erlaubbar
+
+- `Verified reviews`
+- `Reviewed patient feedback`
+- `Checked patient reviews`
+- Review-Claims, die Patientenkontakt oder Prüfung implizieren
+
+## Mindeststandard für stärkere Review-Claims
+
+Jede verifizierte Review sollte mindestens haben:
+
+- Moderationsstatus
+- Verifikationsstatus
+- Quellentyp
+- interne Evidenzreferenz
+- Verifikationszeitpunkt
+- verantwortliche prüfende Person oder Rolle
+- abgeleitete Public-Eligibility für stärkere Review-Claims
+
+Ohne diesen Mindeststandard sollten Review-Claims neutral bleiben.
+
+## Vorgeschlagene technische Richtung
+
+Der naheliegende Ort ist `reviews` oder ein separater Review-Evidence-Record, wenn Nachweise aus Datenschutz- oder Lifecycle-Gründen nicht direkt an der Review gespeichert werden sollen.
+
+### Implementierungs-Feldtabelle: `reviews` oder Review-Evidence-Record
+
+| Schema-Feld                | Wofür ist es da?                                                             | Warum braucht man es?                                                                                  | Warum ggf. nicht oder nur optional?                                                                        |
+| -------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `reviewModerationStatus`   | Trennt Inhaltsmoderation von Trust-Verifikation.                             | Eine Review kann moderiert, aber nicht verifiziert sein. Beide Zustände dürfen nicht vermischt werden. | Falls bereits ein Moderationsfeld existiert, muss es nicht neu angelegt, aber klar weiterverwendet werden. |
+| `reviewVerificationStatus` | Status, ob die Review als verifiziert gelten darf.                           | Öffentliche `Verified review` Claims müssen an diesen Status gebunden sein.                            | Nicht nötig, wenn findmydoc bewusst nur unverified Reviews mit neutraler Sprache zeigt.                    |
+| `reviewSourceType`         | Beschreibt, woher die Review stammt oder wie sie eingegangen ist.            | Hilft zu prüfen, ob die Review mit einem echten Patientenkontakt verknüpft werden kann.                | Bei Datenschutzgrenzen kann der Quellentyp grob bleiben.                                                   |
+| `reviewEvidenceReference`  | Interne Referenz auf Nachweis oder Patientenkontakt.                         | Macht die Verifikation auditierbar.                                                                    | Kann nur eine interne ID sein, wenn direkte Nachweise nicht in Payload liegen sollen.                      |
+| `reviewVerifiedAt`         | Zeitpunkt der Verifikation.                                                  | `verified` Claims brauchen ein Prüfdatum.                                                              | Optional, wenn `reviewVerificationStatus` nie öffentlich benutzt wird.                                     |
+| `reviewVerifiedBy`         | Prüfer oder prüfende Rolle.                                                  | Verhindert nicht nachvollziehbare manuelle Freigaben.                                                  | Eine Rolle kann reichen, wenn keine personenbezogene Reviewer-Historie gewünscht ist.                      |
+| `publicReviewClaimTier`    | Abgeleitete öffentliche Review-Claim-Stufe, z. B. `neutral` oder `verified`. | Das Frontend soll nicht selbst aus Moderations- und Evidenzfeldern interpretieren.                     | Kann virtuell bleiben, wenn eine zentrale Eligibility-Funktion genutzt wird.                               |
+
+### Abgeleitetes Eligibility-Modell
+
+UI-Komponenten sollten nicht selbst aus einzelnen Evidenzfeldern ableiten, wie stark ein Review-Claim sein darf. Dafür sollte es eine serverseitige Eligibility-Funktion geben, zum Beispiel:
+
+- `isReviewVerified(review)`
+- `getPublicReviewClaimTier(review)`
+
+Vorgeschlagenes Verhalten:
+
+- `hidden`
+  Review ist nicht öffentlich freigegeben.
+- `neutral`
+  Review ist moderiert und darf neutral angezeigt werden.
+- `verified`
+  Review ist moderiert, verifiziert und hat eine nachvollziehbare Evidenzreferenz.
+
+## Route-Level Runtime-Gating
+
+Alle öffentlichen Review-Flächen müssen Review-Eligibility prüfen, bevor Claims wie `verified` gerendert werden.
+
+Vorgeschlagener Ansatz:
+
+- Default ist neutrale Review-Darstellung.
+- `verified` wird nur gerendert, wenn `getPublicReviewClaimTier` diese Stufe erlaubt.
+- Rating-Aggregation nutzt Review-Eligibility nur als Input und wird im Rating-Dokument separat geregelt.
+
+## Admin- und Workflow-Anforderungen
+
+Wenn der Prozess real sein soll, muss die Admin UI ihn unterstützen. Versteckte manuelle Konventionen reichen nicht.
+
+Vorgeschlagene Workflow-Unterstützung:
+
+- getrennte Admin-Hinweise für Moderation und Verifikation
+- klare Beschreibung, welche Quelle als Review-Evidenz zählt
+- Filter für nicht verifizierte, verifizierte und unklare Reviews
+- keine automatische Verifikation bei Legacy-Reviews
+
+## Migration und Rollout
+
+Vorgeschlagener Ablauf:
+
+1. Neutrale Review-Anzeige beibehalten.
+2. Schema-Felder und internen Workflow hinzufügen.
+3. Nur Reviews backfillen, die echte Evidenz haben.
+4. Runtime-Gating für stärkere Review-Claims hinzufügen.
+5. Erst danach öffentliche `verified` Review-Copy aktivieren.
+
+Wichtige Regel:
+
+- Keine Migration darf bestehende Reviews automatisch als verified markieren, wenn dafür keine echte Evidenz existiert.
+
+## Akzeptanzkriterien
+
+- Moderation und Verifikation sind fachlich und technisch getrennt.
+- Das Dokument definiert, wann stärkere Review-Claims erlaubt sind.
+- Fail-safe Verhalten für fehlende oder unvollständige Evidenz ist definiert.
+- Jede vorgeschlagene Feldrolle erklärt Zweck, Nutzen und mögliche Gründe gegen das Feld.
+- Rating-Aggregation ist bewusst ausgelagert.
+
+## Out of Scope
+
+- Finale Copy-Freigabe.
+- Legal Sign-off.
+- Sofortige Implementierung der Review-Verifikation.
+- Rating-Sortierung, Rating-Filter und Rating-Aggregation.
+- Demo-Seed Cleanup oder Storybook-only Content.

--- a/trust-claim-rewrite-decision-brief.md
+++ b/trust-claim-rewrite-decision-brief.md
@@ -1,0 +1,161 @@
+# Trust-Claim Rewrite Decision Brief
+
+## Zweck
+
+Dieses Dokument bündelt die öffentlichen oder potenziell öffentlichen Copy-Stellen, bei denen noch ein Rewrite oder eine bewusste Freigabe geprüft werden muss.
+
+Es ist kein Implementierungsplan und ersetzt keine Legal-Freigabe. Ziel ist, die offenen Rewrite-Entscheidungen gesammelt an Product, Content, Legal oder Founder-Review weitergeben zu können.
+
+## Entscheidungsoptionen
+
+Für jede Stelle sollte eine Entscheidung in genau eine Richtung fallen:
+
+- `Rewrite neutral`: Die Aussage wird in neutrale Vergleichs-, Profil-, Kontakt- oder Sichtbarkeitscopy umgeschrieben.
+- `Keep with evidence`: Die Aussage bleibt nur, wenn ein dokumentierter Prozess, eine Quelle und ein verantwortlicher Check existieren.
+- `Hide or preview-only`: Die Stelle wird nicht öffentlich ausgespielt oder bleibt explizit nicht-produktiv.
+- `Move to UI Copy process`: Die Stelle ist keine CMS-/Landingpage-Entscheidung, sondern muss über den späteren UI-Copy-Prozess geändert werden.
+
+## Offene Rewrite-Entscheidungen
+
+| ID  | Bereich                                 | Aktuelle Stelle                                                                                                            | Risiko                                                                                                                 | Entscheidung nötig                                                                                                    | Empfehlung                                                                                                         |
+| --- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Y1  | Landing- und Partner-Landing-Copy       | `src/endpoints/seed/data/baseline/globals.json` unter `landingPages`, besonders Home und `clinicPartners`                  | Begriffe wie `trusted`, `verified clinics`, `trust signals`, `verified profiles`, `verified qualifications`            | Satzweise entscheiden, ob es eine belegte Quelle gibt oder die Copy neutraler werden muss.                            | Ohne belastbare Evidenz neutral umschreiben; keine Trust-, Verified- oder Quality-Begriffe als Standard lassen.    |
+| Y2  | Verification- und Quality-Check-Copy    | `landingPages.home.process.steps.2`, `landingPages.clinicPartners.process.steps.2`                                         | `Verification & Quality Check`, `certifications`, `credibility`, `high-quality environment` wirken prozessual geprüft. | Entscheiden, ob ein echter findmydoc Prüfprozess beschrieben werden kann.                                             | Wenn kein dokumentierter Prozess existiert: als Profil-/Onboarding-Prüfung formulieren, nicht als Quality Check.   |
+| Y3  | Akkreditierungs-Copy                    | `src/endpoints/seed/data/baseline/accreditations.json`, besonders `International Health Standard` und Safety-/Quality-Text | Akkreditierung, Safety und Quality wirken wie externe oder geprüfte Zertifizierung.                                    | Nicht als reiner Rewrite behandeln: entweder echte Evidenz und Proof-Metadaten definieren oder öffentlich ausblenden. | Bis Evidenzmodell implementiert ist, nicht als öffentlicher Trust Claim verwenden.                                 |
+| Y4  | Temporary Landing Mode                  | `src/features/temporaryLandingMode/content.ts`                                                                             | Enthält Patient Reviews, Quality Indicators, Verified Comparison, Trusted Comparison und Quality Signals.              | Entscheiden, ob der Modus produktiv öffentlich sein kann oder nur preview-/launch-intern bleibt.                      | Wenn öffentlich: komplett grün-sicher umschreiben. Wenn preview-only: technisch und redaktionell klar markieren.   |
+| Y5  | Listing-Comparison Pricing Copy         | `src/app/(frontend)/listing-comparison/page.tsx`                                                                           | `Transparent pricing for medical treatments near you` und `Reviewed prices` brauchen Quelle, Datum und Review-Prozess. | Entscheiden, ob kurzfristig neutral umgeschrieben wird oder zuerst der Pricing-Evidence-Prozess implementiert wird.   | Kurzfristig neutral umschreiben; stärkere Claims erst nach Pricing-Evidence-Prozess.                               |
+| Y6  | Clinic Registration Verified Visibility | `landingPages.clinicPartners.registrationIntro.title`                                                                      | `Ready for verified visibility?` kann als findmydoc Verifikation verstanden werden.                                    | Copy finalisieren, obwohl die CMS-Editierbarkeit technisch bereits gelöst ist.                                        | Neutraler Richtungsvorschlag: strukturierte Sichtbarkeit, Profilpräsenz oder Partner-Sichtbarkeit ohne `verified`. |
+
+## Konkrete Review-Hinweise je Bereich
+
+### Y1. Landing- und Partner-Landing-Copy
+
+Aktueller Stand:
+
+- Die Landing-Copy kommt aus dem `landingPages` Global und ist damit als Content-Quelle kontrollierbar.
+- Die technische Editierbarkeit ist nicht das Problem.
+- Offen ist, ob die Begriffe fachlich belegt sind oder neutraler formuliert werden müssen.
+
+Prüffrage:
+
+- Können wir für jeden Trust-Begriff eine Quelle, einen Prozess und eine verantwortliche Prüfung benennen?
+
+Wenn nein:
+
+- `trusted comparison platform` eher zu `structured comparison platform`.
+- `verified clinics` eher zu `clinic profiles` oder `listed clinics`.
+- `trust signals` eher zu `profile information`, `comparison details` oder `decision-relevant information`.
+- `verified qualifications` eher zu `clinic-provided qualifications` oder `listed qualifications`, sofern diese nicht geprüft sind.
+
+### Y2. Verification und Quality Check
+
+Aktueller Stand:
+
+- Der Text beschreibt eine Prüfung, die nach außen wie ein findmydoc Qualitätsprozess wirkt.
+- Diese Aussage ist stärker als reine Profilstruktur oder Onboarding.
+
+Prüffrage:
+
+- Gibt es einen dokumentierten Prozess, der sagt, was geprüft wird, wer prüft, welche Nachweise zählen und wann die Prüfung abläuft?
+
+Wenn nein:
+
+- Nicht `Verification & Quality Check` verwenden.
+- Richtung: `Profile Review`, `Profile Setup`, `Profile Completeness Review` oder `Information Review`.
+- Keine Aussage, dass findmydoc medizinische Qualität, Zertifizierungen oder Eignung bestätigt.
+
+### Y3. Akkreditierungen
+
+Aktueller Stand:
+
+- Das vorhandene Accreditation-Modell ist öffentlich lesbar.
+- Die baseline Akkreditierung enthält `International Health Standard` und `patient safety and quality`.
+- Ein reiner Wortlaut-Rewrite reicht hier wahrscheinlich nicht, wenn Akkreditierungen öffentlich als Trust Signal erscheinen.
+
+Prüffrage:
+
+- Ist die Akkreditierung echt, extern belegbar, gültig und mit Scope dokumentiert?
+
+Wenn nein:
+
+- Nicht öffentlich als Akkreditierungsclaim verwenden.
+- Entweder verstecken oder erst das Accreditation-Evidence-Modell aus `trust-claim-accreditation-evidence-requirements-task.md` umsetzen.
+
+### Y4. Temporary Landing Mode
+
+Aktueller Stand:
+
+- Die Copy kann öffentlich werden, wenn der Temporary-Landing-Modus aktiv ist.
+- Die Sprache ist stärker als eine reine Launch- oder Coming-Soon-Seite.
+
+Prüffrage:
+
+- Ist diese Seite produktiv öffentlich oder strikt preview-/launch-intern?
+
+Wenn produktiv öffentlich:
+
+- Patient Reviews, Quality Indicators, Verified Comparison, Trusted Comparison und Quality Signals neutralisieren.
+- Richtung: strukturierte Klinikprofile, Vergleichslogik, Kontaktmöglichkeit und Launch-Hinweis.
+
+Wenn preview-only:
+
+- Technisch und redaktionell klarstellen, dass sie nicht als produktiver Trust Claim verwendet wird.
+
+### Y5. Pricing Copy
+
+Aktueller Stand:
+
+- Die öffentliche Listing-Comparison Route zeigt echte Preisfelder und Preisanzahl.
+- Die Copy `Transparent pricing` und `Reviewed prices` behauptet aber mehr als reine Preisanzeige.
+- Das separate Prozessdokument beschreibt, welcher Pricing-Evidence-Prozess für stärkere Claims nötig wäre.
+
+Prüffrage:
+
+- Gibt es pro Preis Quelle, Erfassungsdatum, Review-Status, Review-Datum und verantwortliche Prüfung?
+
+Wenn nein:
+
+- Kurzfristig neutral umschreiben.
+- Richtung: `Compare clinic prices`, `Listed starting prices`, `Price information where available`, `Price fields where available`.
+- Stärkere Begriffe wie `reviewed`, `verified`, `checked` oder `transparent` erst nach Prozessimplementierung.
+
+### Y6. Clinic Registration Verified Visibility
+
+Aktueller Stand:
+
+- Die Copy ist über `landingPages.clinicPartners.registrationIntro` editierbar.
+- Die technische Grundlage ist gelöst.
+- Der aktuelle Wortlaut ist noch nicht final safe.
+
+Prüffrage:
+
+- Bedeutet `verified visibility`, dass die Klinik nach einem dokumentierten Prozess geprüft wurde?
+
+Wenn nein:
+
+- `verified` entfernen.
+- Richtung: `Ready for structured visibility?`, `Ready to build your clinic profile?`, `Ready for partner visibility?` oder `Ready to present your clinic?`
+
+## Nicht in diesem Rewrite-Brief enthalten
+
+Diese Themen sind keine reinen Rewrite-Entscheidungen und bleiben in eigenen Prozess- oder Implementierungsdokumenten:
+
+- Before/After Case Gallery: `trust-claim-gallery-evidence-requirements-task.md`
+- Public Reviews: `trust-claim-review-evidence-requirements-task.md`
+- Rating Eligibility: `trust-claim-rating-eligibility-requirements-task.md`
+- Verification Badges: `trust-claim-verification-badge-requirements-task.md`
+- Pricing Evidence Prozess: `pricing-evidence-requirements-task.md`
+- Zentrales Cache-/Migrations-Thema: `findmydoc-platform/website#1361`
+
+## Übergabeempfehlung
+
+Für den Review sollte die Entscheidung nicht lauten, ob die Formulierungen schöner sind, sondern ob sie belegbar sind.
+
+Empfohlener Review-Ausgang:
+
+- Y1: Satzweise neutralisieren, außer ein Claim ist eindeutig belegbar.
+- Y2: Neutralisieren, solange kein Verification-/Quality-Prozess implementiert ist.
+- Y3: Nicht als Copy-only lösen; Evidenz oder Ausblendung entscheiden.
+- Y4: Öffentlich nur grün-sicher; sonst preview-only absichern.
+- Y5: Kurzfristig neutralisieren; stärkere Preisclaims später prozessgebunden.
+- Y6: `verified` entfernen, solange keine verifizierte Sichtbarkeit definiert ist.

--- a/trust-claim-verification-badge-requirements-task.md
+++ b/trust-claim-verification-badge-requirements-task.md
@@ -1,0 +1,167 @@
+# Feature: Trust-Core Verification Badges implementierbar machen
+
+## Problem
+
+Verification Badges sind die genannte Ausnahme unter den Trust-Claim Themen: Der Trust-Core Prozess ist als Konzept bereits definiert, aber noch nicht als Story implementiert.
+
+Das Problem ist deshalb nicht primär, einen neuen Prozess zu erfinden. Die offene Aufgabe ist, den vorhandenen Trust-Core in Datenmodell, Admin-Workflow und Runtime-Gating zu übersetzen, damit Badges nicht aus Demo-Daten, manuellen Tiers oder UI-Copy entstehen.
+
+## Ziel
+
+findmydoc braucht ein implementierbares Anforderungsset dafür, wie der bestehende Trust-Core Prozess technisch in öffentliche Verification Badges übersetzt wird.
+
+Das Team soll unterscheiden können zwischen:
+
+- Trust-Core Konzept, das fachlich bereits existiert
+- fehlender technischer Implementierungsstory
+- öffentlicher Badge-Anzeige, die erst nach implementiertem Trust-Core Gating erlaubt ist
+
+## Nicht-funktionale Anforderungen
+
+1. Prozess-Treue
+   Die Implementierung muss das bestehende Trust-Core Konzept abbilden und darf keine konkurrierende Badge-Logik erfinden.
+
+2. Claim-Integrität
+   Ein Badge darf nur erscheinen, wenn die Trust-Core Bedingungen erfüllt sind.
+
+3. Nachvollziehbarkeit
+   Jede Badge-Entscheidung braucht eine interne Referenz auf die zugrunde liegenden Trust-Core Nachweise oder Checks.
+
+4. Aktualität
+   Trust-Core Prüfungen brauchen entweder Gültigkeit, Re-Check-Regel oder eine dokumentierte Entscheidung gegen Ablauf.
+
+5. Auditierbarkeit
+   Das System muss beantworten können, wer die Trust-Core Prüfung freigegeben hat, wann das passiert ist und auf welcher Grundlage.
+
+6. Runtime Enforcement
+   Badge-Anzeige muss durch Runtime-Logik gesteuert werden, nicht nur durch Admin-Tiers oder UI-Copy.
+
+7. Fail-safe Verhalten
+   Fehlende, ungültige oder nicht implementierte Trust-Core Daten müssen Badge-Anzeige verhindern.
+
+8. Kompatibilität mit bestehenden Daten
+   Bestehende Klinikdaten oder Demo-Werte dürfen nicht automatisch als verified gelten.
+
+9. Operative Wartbarkeit
+   Trust-Core Status muss für Admins verständlich und überprüfbar sein.
+
+10. Konzeptbindung
+    Wenn das Trust-Core Dokument andere Feldnamen oder Statuswerte definiert, müssen diese übernommen werden.
+
+## Claim-Stufen
+
+### Mit aktuellem nicht implementiertem Trust-Core grundsätzlich erlaubbar
+
+- keine öffentliche Badge-Anzeige
+- neutrale Klinikdarstellung ohne `verified` Claim
+- interne Trust-Core Vorbereitung oder manuelle Prüfung ohne öffentliche Ausgabe
+
+### Nur nach Trust-Core Implementierung plus technischem Gating erlaubbar
+
+- `Verified clinic`
+- Verification Badge
+- Badge-Level wie Bronze/Silver/Gold, falls so im Trust-Core Konzept definiert
+- andere öffentliche Claims, die eine findmydoc Prüfung der Klinik behaupten
+
+## Mindeststandard für öffentliche Verification Badges
+
+Jeder öffentliche Badge sollte mindestens haben:
+
+- technischen Trust-Core Status
+- Badge-Level oder abgeleitete Badge-Stufe
+- Review-Zeitpunkt
+- verantwortliche prüfende Person oder Rolle
+- Gültigkeit oder Re-Check-Regel
+- interne Evidenzreferenz auf Trust-Core Nachweise
+- abgeleitete Public-Badge-Eligibility
+
+Ohne diesen Mindeststandard sollte kein Verification Badge öffentlich erscheinen.
+
+## Vorgeschlagene technische Richtung
+
+Diese Aufgabe muss aus dem bestehenden Trust-Core Konzept abgeleitet werden. Falls das Konzept bereits konkrete Status, Tiers oder Checklisten definiert, sind diese Namen und Regeln maßgeblich.
+
+### Implementierungs-Feldtabelle: Trust-Core Feldrollen
+
+Diese Tabelle ersetzt nicht das bestehende Trust-Core Dokument. Sie benennt nur die Feldrollen, die die spätere Implementierungsstory aus dem Trust-Core Konzept ableiten muss.
+
+| Schema-Feld                     | Wofür ist es da?                                                                     | Warum braucht man es?                                                          | Warum ggf. nicht oder nur optional?                                                                            |
+| ------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `verificationStatus`            | Technischer Status, ob die Klinik nach Trust-Core Regeln geprüft ist.                | Badge-Anzeige darf nicht direkt aus Demo-Daten oder manuellen Tiers kommen.    | Falls das Trust-Core Dokument andere Statusnamen definiert, müssen diese übernommen werden.                    |
+| `verificationTier`              | Öffentliches Badge-Level, z. B. Bronze/Silver/Gold oder ein anderes Trust-Core Tier. | Das Frontend braucht eine klare, begrenzte Badge-Ausprägung.                   | Sollte abgeleitet sein, wenn Tier aus mehreren Trust-Core Checks berechnet wird.                               |
+| `verificationReviewedAt`        | Zeitpunkt der letzten Trust-Core Prüfung.                                            | Badge-Freshness und Re-Check brauchen ein Datum.                               | Nicht optional, sobald der Badge als geprüfte Aussage verstanden wird.                                         |
+| `verificationReviewedBy`        | Verantwortliche prüfende Person oder Rolle.                                          | Verhindert nicht nachvollziehbare Badge-Freigaben.                             | Rolle statt Person kann fürs MVP reichen.                                                                      |
+| `verificationValidUntil`        | Ablauf oder nächster Re-Check.                                                       | Badge darf nicht dauerhaft gültig bleiben, wenn der Prozess zeitgebunden ist.  | Kann entfallen, wenn Trust-Core bewusst ohne Ablauf arbeitet; dann braucht es aber eine andere Re-Check-Regel. |
+| `verificationEvidenceReference` | Interne Referenz auf die Trust-Core Nachweise.                                       | Macht Badge-Entscheidungen auditierbar.                                        | Kann durch mehrere spezifische Nachweisfelder ersetzt werden, wenn das Trust-Core Konzept das genauer vorgibt. |
+| `publicBadgeEligible`           | Abgeleitete Freigabe für öffentliche Badge-Anzeige.                                  | Die UI soll nicht selbst aus Rohfeldern ableiten, ob ein Badge angezeigt wird. | Kann virtuell sein, wenn eine zentrale Eligibility-Funktion genutzt wird.                                      |
+
+### Abgeleitetes Eligibility-Modell
+
+UI-Komponenten sollten nicht selbst aus einzelnen Trust-Core Feldern ableiten, ob ein Badge erscheinen darf. Dafür sollte es eine serverseitige Eligibility-Funktion geben, zum Beispiel:
+
+- `getTrustCoreVerificationStatus(clinic)`
+- `getPublicBadgeEligibility(clinic)`
+
+Vorgeschlagenes Verhalten:
+
+- `hidden`
+  Kein Badge erscheint.
+- `pending`
+  Trust-Core Prüfung ist offen oder unvollständig; kein öffentlicher Badge.
+- `verified`
+  Trust-Core Bedingungen sind erfüllt und nicht abgelaufen.
+- `expired`
+  Frühere Prüfung ist abgelaufen; kein öffentlicher Badge oder nur neutrale interne Anzeige.
+
+## Route-Level Runtime-Gating
+
+Alle öffentlichen Badge-Flächen müssen Trust-Core Eligibility prüfen, bevor Badges gerendert werden.
+
+Vorgeschlagener Ansatz:
+
+- Default ist keine Badge-Anzeige.
+- Badge-Level wird nur aus Trust-Core Eligibility abgeleitet.
+- Public Copy darf nicht `verified` sagen, wenn `publicBadgeEligible` false ist.
+- Abgelaufene oder unvollständige Trust-Core Prüfungen verhindern die Badge-Anzeige.
+
+## Admin- und Workflow-Anforderungen
+
+Wenn der Prozess real sein soll, muss die Admin UI ihn unterstützen. Versteckte manuelle Konventionen reichen nicht.
+
+Vorgeschlagene Workflow-Unterstützung:
+
+- Admin-Ansicht für Trust-Core Status und fehlende Checks
+- klare Hinweise, welche Trust-Core Bedingungen für Badge-Anzeige fehlen
+- Filter für pending, verified und expired Kliniken
+- Schutz gegen manuelle öffentliche Badge-Freigabe ohne Trust-Core Eligibility
+
+## Migration und Rollout
+
+Vorgeschlagener Ablauf:
+
+1. Trust-Core Konzept als technische Story referenzieren.
+2. Status, Tiers und Checks aus dem Konzept in Schema und Funktionen übersetzen.
+3. Bestehende Klinikdaten neutral lassen.
+4. Nur Kliniken mit echter Trust-Core Evidenz backfillen.
+5. Runtime-Gating für Badge-Anzeige hinzufügen.
+6. Erst danach öffentliche Verification Badges aktivieren.
+
+Wichtige Regel:
+
+- Keine Migration darf bestehende Kliniken automatisch als verified markieren, wenn dafür keine Trust-Core Evidenz existiert.
+
+## Akzeptanzkriterien
+
+- Das Dokument erfindet keinen neuen Trust-Core Prozess.
+- Die Aufgabe ist als Implementierungslücke des bestehenden Trust-Core Konzepts beschrieben.
+- Fail-safe Verhalten für fehlende oder nicht implementierte Trust-Core Daten ist definiert.
+- Jede vorgeschlagene Feldrolle erklärt Zweck, Nutzen und mögliche Gründe gegen das Feld.
+- Es gibt eine plausible technische Richtung für eine spätere Implementierung.
+
+## Out of Scope
+
+- Finale Copy-Freigabe.
+- Legal Sign-off.
+- Neudefinition des Trust-Core Konzepts.
+- Sofortige Implementierung der Verification Badges.
+- Demo-Seed Cleanup oder Storybook-only Content.


### PR DESCRIPTION
## Management summary

### Deutsch

Die offenen Trust-Claim-Themen sind jetzt als getrennte Entscheidungs- und Aufgabendokumente strukturiert. Dadurch können Produkt, Content, Legal und Engineering die einzelnen Claim-Bereiche separat prüfen, priorisieren und entscheiden, ohne technische Umsetzung und Wording-Freigabe zu vermischen.

### English

The open trust-claim topics are now structured as separate decision and task documents. This lets product, content, legal, and engineering review, prioritize, and decide each claim area independently without mixing technical implementation with wording approval.

## What changed

- Added standalone German requirement task documents for pricing evidence, accreditations, gallery evidence, rating eligibility, review evidence, and verification badges.
- Added an index-style trust-claim process document that points to the atomic work areas.
- Updated the guardrails findings document so solved editability work and remaining wording/process decisions stay separate.
- Added a consolidated German rewrite decision brief for Y1-Y6 wording review.

## Points to review

| Priority | Files / paths                                 | Why focus here                                             | Reviewer should verify                                                                  | Evidence        |
| -------- | --------------------------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------- | --------------- |
| P2       | `trust-claim-*-requirements-task.md`           | These docs define future implementation and review scopes. | Each document is atomic, German, and separates requirements from technical suggestions.  | `pnpm format`   |
| P2       | `pricing-evidence-requirements-task.md`        | Pricing claims need a distinct evidence and review process. | The proposed requirements are decision-ready without implying implemented functionality. | `pnpm format`   |
| P2       | `trust-claim-rewrite-decision-brief.md`        | This is the handoff artifact for wording decisions.        | Y1-Y6 decisions are grouped clearly and not treated as completed rewrites.               | `pnpm format`   |
| P3       | `trust-claim-guardrails-findings.md`           | Existing findings need to point to the new split docs.     | The status language separates solved editability, open rewrites, and process gaps.       | Manual diff     |

## Validation

- [x] `pnpm format`: passed. Node reported the local engine warning for v26 while the project requests Node >=24 <25.
- [ ] `pnpm check`: not run; documentation-only PR with root Markdown changes.
- [ ] `pnpm build`: not run; documentation-only PR with no runtime/build-relevant files.
- [ ] Focused tests: not applicable; documentation-only PR.
- [ ] UI/mobile QA: not applicable; no UI changes.
- [ ] Security/privacy review: not applicable; no runtime, access, secret, or endpoint changes.
- [ ] Migration/schema check: not applicable; no schema or migration changes.
- [x] Documentation/instructions check: root Markdown diff reviewed for scope separation and PR issue linkage.

## Risk and rollout

No runtime rollout risk. The main review risk is document authority: these files describe proposed requirements and decisions, not implemented product behavior or approved legal wording.

## Development

Closes #1363
