### PR TITLE
fix(auth): hide password reset provider errors

### DIFF
--- a/src/app/api/auth/password/reset/route.ts
+++ b/src/app/api/auth/password/reset/route.ts
@@ -32,20 +32,27 @@ export async function POST(request: NextRequest) {
     const redirectTo = `${baseUrl}/auth/callback?next=/auth/password/reset/complete`
 
     const supabase = await createClient()
-    const { error } = await supabase.auth.resetPasswordForEmail(validation.data.email, {
-      redirectTo,
-    })
+    let resetError: unknown = null
 
-    if (error) {
+    try {
+      const { error } = await supabase.auth.resetPasswordForEmail(validation.data.email, {
+        redirectTo,
+      })
+      resetError = error
+    } catch (error) {
+      resetError = error
+    }
+
+    if (resetError) {
       logger.warn(
         {
           emailHash: hashLogValue(validation.data.email),
-          err: toLoggedError(error),
+          err: toLoggedError(resetError),
           event: 'auth.supabase.password_reset.rejected',
         },
         'Password reset request was rejected by Supabase',
       )
-      return NextResponse.json({ error: error.message }, { status: 400 })
+      return NextResponse.json({ success: true })
     }
 
     return NextResponse.json({ success: true })

--- a/tests/unit/app/api/auth/password/reset.test.ts
+++ b/tests/unit/app/api/auth/password/reset.test.ts
@@ -77,7 +77,7 @@ describe('POST /api/auth/password/reset', () => {
     expect(mockSupabaseClient.auth.resetPasswordForEmail).not.toHaveBeenCalled()
   })
 
-  it('bubbles up supabase errors', async () => {
+  it('returns a generic success response when Supabase rejects the reset request', async () => {
     mockSupabaseClient.auth.resetPasswordForEmail.mockResolvedValue({ error: { message: 'Unknown account' } })
 
     const request = new NextRequest('http://localhost/api/auth/password/reset', {
@@ -89,8 +89,32 @@ describe('POST /api/auth/password/reset', () => {
     const response = await POST(request)
     const json = await response.json()
 
-    expect(response.status).toBe(400)
-    expect(json.error).toBe('Unknown account')
+    expect(response.status).toBe(200)
+    expect(json).toEqual({ success: true })
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailHash: expect.any(String),
+        event: 'auth.supabase.password_reset.rejected',
+        scope: 'auth.supabase',
+      }),
+      'Password reset request was rejected by Supabase',
+    )
+  })
+
+  it('returns a generic success response when Supabase throws during the reset request', async () => {
+    mockSupabaseClient.auth.resetPasswordForEmail.mockRejectedValue(new Error('Unknown account'))
+
+    const request = new NextRequest('http://localhost/api/auth/password/reset', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'throw@example.com' }),
+    })
+
+    const response = await POST(request)
+    const json = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(json).toEqual({ success: true })
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         emailHash: expect.any(String),


### PR DESCRIPTION
## Management summary

### Deutsch

Der Passwort-Zuruecksetzen-Flow gibt Angreifern weniger Rueckschlussmoeglichkeiten auf Kontozustaende. Nutzer erhalten weiterhin eine neutrale Antwort, waehrend Betreiber die relevanten Ablehnungen intern nachvollziehen koennen.

### English

The password reset flow now gives attackers fewer ways to infer account states. Users still receive a neutral response, while operators can continue to inspect relevant rejected reset requests internally.

## What changed

- Normalized Supabase password-reset provider rejections to the same public success response as accepted requests.
- Added handling for reset-password SDK exceptions so thrown provider errors also stay internal.
- Kept structured warning logs with hashed email values for rejected reset attempts.
- Updated API route unit coverage for returned provider errors and thrown provider errors.

## Points to review

| Priority | Files / paths                                              | Why focus here                             | Reviewer should verify                                                               | Evidence                                                       |
| -------- | ---------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
| P1       | `src/app/api/auth/password/reset/route.ts`                 | Auth recovery endpoint and trust boundary. | Provider errors are logged internally and never reflected to password-reset clients. | Focused Vitest, `pnpm check`, `pnpm build`, security reviewer. |
| P1       | `tests/unit/app/api/auth/password/reset.test.ts`           | Regression coverage for enumeration risk.  | Tests cover both Supabase `{ error }` responses and thrown reset SDK errors.         | Focused Vitest.                                                |

## Validation

- [x] `pnpm format`: Passed.
- [x] `pnpm check`: Passed. Existing test-sense warnings were reported by the script, and the command exited successfully.
- [x] `pnpm build`: Passed with `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret}`. Local Node version emitted the existing engine warning because this environment uses Node 26 while the project expects Node 24.
- [x] Focused tests: `pnpm vitest tests/unit/app/api/auth/password/reset.test.ts --run` passed, 5/5 tests.
- [ ] UI/mobile QA: Not applicable; backend API behavior and unit tests only.
- [x] Security/privacy review: `security_reviewer` ran on the final diff and reported no credible findings with severity `>=5/10`.
- [ ] Migration/schema check: Not applicable; no schema, migration, or data-model changes.
- [ ] Documentation/instructions check: Not applicable; no documentation or instruction files changed.

## Risk and rollout

Password-reset clients will receive a neutral success response even when the auth provider rejects or throws during the reset request. That is intentional for enumeration resistance, but operators should rely on the structured warning logs for delivery/provider troubleshooting. No migrations, environment changes, or rollout steps are required. Rollback is a normal revert of this change.

## Development

Closes #1336
