### PR TITLE
test: cover preview sitemap blocking

### DIFF
--- a/tests/unit/config/next-sitemap-config.test.ts
+++ b/tests/unit/config/next-sitemap-config.test.ts
@@ -39,4 +39,32 @@ describe('next-sitemap config', () => {
       'https://findmydoc.eu/posts-sitemap.xml',
     ])
   })
+
+  it('blocks robots and hides sitemap references in Vercel preview runtime', () => {
+    process.env = {
+      ...originalEnv,
+      DEPLOYMENT_ENV: undefined,
+      NEXT_PUBLIC_SERVER_URL: 'https://preview.findmydoc.eu',
+      VERCEL_ENV: 'preview',
+    }
+
+    const config = loadConfig()
+
+    expect(config.robotsTxtOptions.policies).toEqual([{ disallow: '/', userAgent: '*' }])
+    expect(config.robotsTxtOptions.additionalSitemaps).toEqual([])
+  })
+
+  it('blocks robots and hides sitemap references in explicit preview runtime', () => {
+    process.env = {
+      ...originalEnv,
+      DEPLOYMENT_ENV: 'preview',
+      NEXT_PUBLIC_SERVER_URL: 'https://preview.findmydoc.eu',
+      VERCEL_ENV: undefined,
+    }
+
+    const config = loadConfig()
+
+    expect(config.robotsTxtOptions.policies).toEqual([{ disallow: '/', userAgent: '*' }])
+    expect(config.robotsTxtOptions.additionalSitemaps).toEqual([])
+  })
 })


### PR DESCRIPTION
## Management summary

### Deutsch

findmydoc hält die aktuelle Launch-Phase weiterhin konsequent aus Suchmaschinen- und Agenten-Crawling heraus. Die bestehende Schutzlogik bleibt unverändert; die Absicherung stellt sicher, dass Preview- und Launch-Zustände keine tieferen öffentlichen Inhalte bewerben.

### English

findmydoc continues to keep the current launch phase out of search engine and agent crawling. The existing protection behavior remains unchanged; this coverage ensures preview and launch states do not advertise deeper public content.

## What changed

- Added missing `next-sitemap` configuration coverage for preview runtimes driven by `VERCEL_ENV=preview` and `DEPLOYMENT_ENV=preview`.
- Finding: runtime behavior already blocks indexing for preview and temporary launch surfaces; this PR intentionally adds test coverage only and does not change production/runtime behavior.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P2 | `tests/unit/config/next-sitemap-config.test.ts` | This is the only changed file and codifies the sitemap/robots finding. | Preview runtime should disallow all robots and avoid advertising additional dynamic sitemaps. | Focused Vitest suite; live header and sitemap checks. |

## Validation

- [x] `pnpm format`: `rtk pnpm format`
- [x] `pnpm check`: `rtk pnpm check`
- [ ] `pnpm build`: Not run; this is a test-only change with no runtime, routing, Payload, or build-output source changes.
- [x] Focused tests: `rtk pnpm vitest tests/unit/config/next-sitemap-config.test.ts tests/unit/features/searchIndexing/index.test.ts tests/unit/features/searchIndexing/sitemapGuards.test.ts tests/unit/app/frontend/sitemap.routes.test.ts tests/unit/app/frontend/previewLock.middleware.test.ts`
- [ ] UI/mobile QA: Not applicable; no UI changed.
- [ ] Security/privacy review: Not run; recommended reviewers are SEO and security because the covered behavior concerns indexing and crawl exposure.
- [ ] Migration/schema check: Not applicable; no schema or migration files changed.
- [ ] Documentation/instructions check: Not applicable; no docs or instruction surfaces changed.

## Risk and rollout

No runtime rollout risk is expected because the production code path is unchanged. Production currently remains intentionally blocked by the temporary launch mode; public crawl enablement belongs to the later launch/removal step.

## Development

Closes #1032
