### PR TITLE
fix(search): repair sitemap health

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -172,6 +172,23 @@ The findmydoc portal uses the [on-demand revalidation](https://nextjs.org/docs/a
 
 > Note: if an image has been changed, for example it's been cropped, you will need to republish the page it's used on in order to be able to revalidate the Nextjs image cache.
 
+## Public Sitemaps
+The public sitemap surface is split between the generated `robots.txt` file and App Router sitemap route handlers.
+
+- `robots.txt` references `/pages-sitemap.xml` and `/posts-sitemap.xml` outside preview runtime.
+- `/pages-sitemap.xml` lists `/`, `/posts`, `/contact`, `/about`, and published CMS pages. It does not list `/search` because there is no dedicated public search route.
+- `/posts-sitemap.xml` lists published post detail URLs with valid single-segment slugs.
+- Preview runtime and Temporary Landing Mode keep deeper public content out of sitemap discovery through preview robots policy and empty guarded sitemap responses.
+
+Run the sitemap status check against local development or production when Temporary Landing Mode is disabled:
+
+```bash
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+for path in /robots.txt /pages-sitemap.xml /posts-sitemap.xml / /posts /contact /about; do
+  curl --fail --location --silent --show-error --output /dev/null --write-out "%{http_code} ${path}\n" "${BASE_URL}${path}"
+done
+```
+
 ## SEO
 Manage SEO settings from the admin panel.
 [Payload SEO Plugin Docs](https://payloadcms.com/docs/plugins/seo)

--- a/src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts
+++ b/src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts
@@ -6,7 +6,29 @@ import { findPageSitemapDocs } from '@/utilities/content/serverData'
 import { SEARCH_ROBOTS_HEADER, SEARCH_ROBOTS_HEADER_VALUE } from '@/features/searchIndexing'
 import { shouldBlockSitemapIndexingForRequest } from '@/features/searchIndexing/sitemapGuards'
 
-const fixedPublicPaths = new Set(['/search', '/posts', '/contact', '/about'])
+const fixedPublicPaths = ['/', '/posts', '/contact', '/about'] as const
+const excludedPublicPaths = new Set(['/search'])
+
+type SitemapEntry = {
+  lastmod: string
+  loc: string
+}
+
+const buildSitemapLocation = (siteUrl: string, path: string): string => {
+  const baseUrl = siteUrl.replace(/\/+$/, '')
+
+  return path === '/' ? `${baseUrl}/` : `${baseUrl}${path}`
+}
+
+const normalizePageSitemapPath = (slug: string | null | undefined): string | null => {
+  if (typeof slug !== 'string') return null
+
+  const normalizedSlug = slug.trim().replace(/^\/+|\/+$/g, '')
+  if (normalizedSlug.length === 0) return null
+  if (normalizedSlug === 'home') return '/'
+
+  return `/${normalizedSlug}`
+}
 
 const getPagesSitemap = unstable_cache(
   async () => {
@@ -18,39 +40,26 @@ const getPagesSitemap = unstable_cache(
 
     const dateFallback = new Date().toISOString()
 
-    const defaultSitemap = [
-      {
-        loc: `${SITE_URL}/search`,
-        lastmod: dateFallback,
-      },
-      {
-        loc: `${SITE_URL}/posts`,
-        lastmod: dateFallback,
-      },
-      {
-        loc: `${SITE_URL}/contact`,
-        lastmod: dateFallback,
-      },
-      {
-        loc: `${SITE_URL}/about`,
-        lastmod: dateFallback,
-      },
-    ]
+    const sitemapByPath = new Map<string, SitemapEntry>()
 
-    const sitemap = results
-      .filter((page) => Boolean(page?.slug))
-      .filter((page) => {
-        const path = page?.slug === 'home' ? '/' : `/${page?.slug}`
-        return !fixedPublicPaths.has(path)
+    for (const path of fixedPublicPaths) {
+      sitemapByPath.set(path, {
+        loc: buildSitemapLocation(SITE_URL, path),
+        lastmod: dateFallback,
       })
-      .map((page) => {
-        return {
-          loc: page?.slug === 'home' ? `${SITE_URL}/` : `${SITE_URL}/${page?.slug}`,
-          lastmod: page.updatedAt || dateFallback,
-        }
-      })
+    }
 
-    return [...defaultSitemap, ...sitemap]
+    for (const page of results) {
+      const path = normalizePageSitemapPath(page?.slug)
+      if (!path || excludedPublicPaths.has(path) || sitemapByPath.has(path)) continue
+
+      sitemapByPath.set(path, {
+        loc: buildSitemapLocation(SITE_URL, path),
+        lastmod: page.updatedAt || dateFallback,
+      })
+    }
+
+    return Array.from(sitemapByPath.values())
   },
   ['pages-sitemap'],
   {

--- a/src/app/(frontend)/(sitemaps)/posts-sitemap.xml/route.ts
+++ b/src/app/(frontend)/(sitemaps)/posts-sitemap.xml/route.ts
@@ -6,6 +6,21 @@ import { findPostSitemapDocs } from '@/utilities/content/serverData'
 import { SEARCH_ROBOTS_HEADER, SEARCH_ROBOTS_HEADER_VALUE } from '@/features/searchIndexing'
 import { shouldBlockSitemapIndexingForRequest } from '@/features/searchIndexing/sitemapGuards'
 
+const buildSitemapLocation = (siteUrl: string, path: string): string => {
+  const baseUrl = siteUrl.replace(/\/+$/, '')
+
+  return `${baseUrl}${path}`
+}
+
+const normalizePostSitemapSlug = (slug: string | null | undefined): string | null => {
+  if (typeof slug !== 'string') return null
+
+  const normalizedSlug = slug.trim().replace(/^\/+|\/+$/g, '')
+  if (normalizedSlug.length === 0 || normalizedSlug.includes('/')) return null
+
+  return normalizedSlug
+}
+
 const getPostsSitemap = unstable_cache(
   async () => {
     const payload = await getPayload({ config })
@@ -16,12 +31,15 @@ const getPostsSitemap = unstable_cache(
 
     const dateFallback = new Date().toISOString()
 
-    const sitemap = results
-      .filter((post) => Boolean(post?.slug))
-      .map((post) => ({
-        loc: `${SITE_URL}/posts/${post?.slug}`,
+    const sitemap = results.flatMap((post) => {
+      const slug = normalizePostSitemapSlug(post?.slug)
+      if (!slug) return []
+
+      return {
+        loc: buildSitemapLocation(SITE_URL, `/posts/${slug}`),
         lastmod: post.updatedAt || dateFallback,
-      }))
+      }
+    })
 
     return sitemap
   },

--- a/tests/unit/app/frontend/sitemap.routes.test.ts
+++ b/tests/unit/app/frontend/sitemap.routes.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const routeMocks = vi.hoisted(() => ({
   findPageSitemapDocs: vi.fn(),
@@ -34,14 +34,27 @@ vi.mock('@/features/searchIndexing/sitemapGuards', () => ({
   shouldBlockSitemapIndexingForRequest: routeMocks.shouldBlockSitemapIndexingForRequest,
 }))
 
+const getEntryLocations = (entries: Array<{ loc: string }>) => entries.map((entry) => entry.loc)
+
 describe('frontend sitemap routes', () => {
+  const originalEnv = process.env
+
   beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_SERVER_URL: 'https://findmydoc.eu',
+    }
+
     vi.clearAllMocks()
     routeMocks.getPayload.mockResolvedValue({})
     routeMocks.getServerSideSitemap.mockImplementation((entries: unknown[], headers?: Record<string, string>) => {
       return Response.json({ entries, headers })
     })
     routeMocks.shouldBlockSitemapIndexingForRequest.mockResolvedValue(false)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
   })
 
   it('returns an empty noindex pages sitemap when temporary landing mode blocks indexing', async () => {
@@ -87,31 +100,61 @@ describe('frontend sitemap routes', () => {
 
     const response = await GET(request)
     const body = await response.json()
+    const locs = getEntryLocations(body.entries)
 
-    expect(body.entries).toEqual(
+    expect(locs).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ loc: expect.stringMatching(/\/posts$/) }),
-        expect.objectContaining({ loc: expect.stringMatching(/\/contact$/) }),
-        expect.objectContaining({ loc: expect.stringMatching(/\/about$/) }),
+        'https://findmydoc.eu/',
+        'https://findmydoc.eu/posts',
+        'https://findmydoc.eu/contact',
+        'https://findmydoc.eu/about',
       ]),
     )
+    expect(locs).not.toContain('https://findmydoc.eu/search')
   })
 
-  it('does not duplicate fixed public routes from CMS pages in the pages sitemap', async () => {
+  it('normalizes and deduplicates CMS pages in the pages sitemap', async () => {
     routeMocks.findPageSitemapDocs.mockResolvedValue([
+      { slug: 'home', updatedAt: '2026-01-01T00:00:00.000Z' },
       { slug: 'about', updatedAt: '2026-01-01T00:00:00.000Z' },
       { slug: 'search', updatedAt: '2026-01-01T00:00:00.000Z' },
+      { slug: 'privacy-policy', updatedAt: '2026-01-02T00:00:00.000Z' },
+      { slug: 'imprint', updatedAt: '2026-01-03T00:00:00.000Z' },
       { slug: 'custom-page', updatedAt: '2026-01-01T00:00:00.000Z' },
+      { slug: '/custom-page/', updatedAt: '2026-01-04T00:00:00.000Z' },
+      { slug: '', updatedAt: '2026-01-01T00:00:00.000Z' },
     ])
     const request = new Request('https://findmydoc.eu/pages-sitemap.xml')
     const { GET } = await import('@/app/(frontend)/(sitemaps)/pages-sitemap.xml/route')
 
     const response = await GET(request)
     const body = await response.json()
-    const locs = body.entries.map((entry: { loc: string }) => entry.loc)
+    const locs = getEntryLocations(body.entries)
 
+    expect(locs.filter((loc: string) => loc === 'https://findmydoc.eu/')).toHaveLength(1)
     expect(locs.filter((loc: string) => loc.endsWith('/about'))).toHaveLength(1)
-    expect(locs.filter((loc: string) => loc.endsWith('/search'))).toHaveLength(1)
-    expect(locs.some((loc: string) => loc.endsWith('/custom-page'))).toBe(true)
+    expect(locs.filter((loc: string) => loc.endsWith('/search'))).toHaveLength(0)
+    expect(locs.filter((loc: string) => loc.endsWith('/custom-page'))).toHaveLength(1)
+    expect(locs).toEqual(
+      expect.arrayContaining(['https://findmydoc.eu/privacy-policy', 'https://findmydoc.eu/imprint']),
+    )
+  })
+
+  it('includes only valid post detail routes in the posts sitemap', async () => {
+    routeMocks.findPostSitemapDocs.mockResolvedValue([
+      { slug: 'first-post', updatedAt: '2026-01-01T00:00:00.000Z' },
+      { slug: ' second-post ', updatedAt: '2026-01-02T00:00:00.000Z' },
+      { slug: '', updatedAt: '2026-01-03T00:00:00.000Z' },
+      { slug: null, updatedAt: '2026-01-04T00:00:00.000Z' },
+      { slug: 'nested/post', updatedAt: '2026-01-05T00:00:00.000Z' },
+    ])
+    const request = new Request('https://findmydoc.eu/posts-sitemap.xml')
+    const { GET } = await import('@/app/(frontend)/(sitemaps)/posts-sitemap.xml/route')
+
+    const response = await GET(request)
+    const body = await response.json()
+    const locs = getEntryLocations(body.entries)
+
+    expect(locs).toEqual(['https://findmydoc.eu/posts/first-post', 'https://findmydoc.eu/posts/second-post'])
   })
 })


### PR DESCRIPTION
## Management summary

### Deutsch

findmydoc bewirbt in öffentlichen Sitemaps nur noch erreichbare Seiten. Suchmaschinen und Crawlersysteme bekommen damit sauberere Einstiegspunkte, während nicht vorhandene Routen aus der Discovery entfernt bleiben.

### English

findmydoc now advertises only reachable pages in public sitemaps. Search engines and crawler systems receive cleaner discovery entry points while unavailable routes stay out of public discovery.

## What changed

- Updated the App Router page sitemap to always include `/`, `/posts`, `/contact`, and `/about` while excluding `/search`.
- Normalized and deduplicated CMS page sitemap entries so `home` maps to `/`, fixed routes are not duplicated, and published legal pages remain included through CMS data.
- Hardened post sitemap generation so only valid single-segment post slugs become public post detail URLs.
- Documented the public sitemap surface and a manual status check in `docs/features.md`.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P2 | `src/app/(frontend)/(sitemaps)/**` | Public discovery behavior changes sitemap contents. | `/search` is removed, fixed routes remain, CMS legal pages stay discoverable, and guarded empty sitemap responses still work. | Focused Vitest sitemap route tests, `pnpm check`, `pnpm build` |

## Validation

- [x] `pnpm format`: passed
- [x] `pnpm check`: passed; existing `tests:sense-check` warnings only
- [x] `pnpm build`: passed with `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret}`; local Node engine warning because this shell uses Node v26 while the repo expects `>=24 <25`
- [x] Focused tests: `pnpm vitest tests/unit/app/frontend/sitemap.routes.test.ts tests/unit/config/next-sitemap-config.test.ts tests/unit/features/searchIndexing/sitemapGuards.test.ts` passed
- [ ] UI/mobile QA: not applicable; no UI or responsive rendering changed
- [ ] Security/privacy review: not run; no auth, access, secrets, logging, or private data surface changed
- [ ] Migration/schema check: not applicable; no Payload schema, migration, or data model changed
- [x] Documentation/instructions check: `pnpm docs:check` passed

## Risk and rollout

Risk is limited to public discovery metadata. Rollback is the sitemap route and documentation diff; no migration, data change, or environment change is required.

## Development

Closes #1031
