### PR TITLE
docs: add discovery rendering guardrails

### DIFF
--- a/.codex/agents/seo-reviewer.toml
+++ b/.codex/agents/seo-reviewer.toml
@@ -14,6 +14,7 @@ Primary focus:
 - route metadata, titles, descriptions, Open Graph, and canonical URLs
 - robots, sitemap, redirects, and duplicate-content risks
 - heading structure, internal linking, and rendering choices that affect search bots
+- initial HTML and no-JavaScript visibility for public discovery facts
 - structured data and route-level search visibility signals
 
 Repository-specific focus areas:
@@ -25,6 +26,10 @@ Working style:
 - Ground every finding in a real route, utility, or metadata path.
 - Prefer technical SEO issues over broad content suggestions.
 - Separate confirmed issues from opportunities or follow-up checks.
+- For rendering concerns, prefer raw HTML, no-JavaScript browser evidence, or route-level code paths over component-label inference.
+- Do not treat `use client` as a finding by itself; report it only when core public facts are unavailable until hydration.
+- Flag concrete search-facing rendering drift, such as empty app shells, core facts moved behind browser-only state, blocking consent gates, or missing semantic main content.
+- Avoid brittle claims based on exact CMS snippets, prices, doctor names, DOM depth, Tailwind classes, or full HTML snapshots.
 - Score each finding on the repository's absolute `1-10` severity scale instead of using relative labels such as high, medium, or low.
 - Use `7-10` only for clear crawlability, indexation, canonical, or metadata failures with meaningful search impact; use `3-4` for softer opportunities.
 - If no credible SEO issue is present in scope, say so explicitly.

--- a/docs/features.md
+++ b/docs/features.md
@@ -193,6 +193,12 @@ done
 Manage SEO settings from the admin panel.
 [Payload SEO Plugin Docs](https://payloadcms.com/docs/plugins/seo)
 
+### Search-facing rendering
+
+Public discovery routes expose their core facts in initial HTML so search engines and AI agents can inspect the main content before client hydration. Interactive enhancements such as filters, saved-clinic actions, maps, consent controls, sharing, and forms can remain client-side as long as the route still renders the primary content, semantic main structure, and public internal links without browser-only state.
+
+SEO rendering audits should check for coarse drift signals: empty app shells, core facts hidden until hydration, blocking consent gates, missing `main` or heading structure, and broken public links. They should not rely on full HTML snapshots or exact CMS content such as specific clinic names, prices, doctors, or copy snippets.
+
 ## Search
 Implement SSR search features with Payload Search Plugin.
 [Payload Search Plugin Docs](https://payloadcms.com/docs/plugins/search)

--- a/docs/integrations/codex-specialists.md
+++ b/docs/integrations/codex-specialists.md
@@ -44,7 +44,7 @@ Important:
 - `web_vitals_reviewer`
   - Read-only reviewer for LCP, INP, CLS, hydration cost, asset loading, and route-level frontend performance risks.
 - `seo_reviewer`
-  - Read-only reviewer for crawlability, indexation, metadata, structured data, and search-facing rendering behavior.
+  - Read-only reviewer for crawlability, indexation, metadata, structured data, initial HTML, and search-facing rendering behavior.
 - `storybook_reviewer`
   - Read-only reviewer for Storybook preview setup, story isolation, MSW usage, play functions, and story governance.
 - `agent_instruction_reviewer`


### PR DESCRIPTION
## Management summary

### Deutsch

Diese Änderung hält die öffentliche Auffindbarkeit von findmydoc stabiler: SEO-Reviews bekommen klarere Kriterien, um echte Rendering-Drifts zu erkennen, ohne unnötig fragile Inhalts- oder HTML-Detailtests einzuführen.

### English

This change keeps public findmydoc discovery more stable: SEO reviews get clearer criteria for spotting real rendering drift without introducing unnecessarily brittle content or HTML-detail tests.

## What changed

- Added SEO reviewer guidance for initial HTML and no-JavaScript visibility checks.
- Documented the search-facing rendering expectation for public discovery routes.
- Clarified the specialist overview so initial-HTML questions route to `seo_reviewer`.
- Kept the scope to governance and documentation; no runtime rendering, test harness, or ADR change is included.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P2 | `.codex/agents/seo-reviewer.toml` | Specialist behavior changed for SEO rendering reviews. | The reviewer criteria catch real drift without treating `use client` or exact CMS snippets as standalone failures. | `pnpm ai:slop-check` |
| P3 | `docs/features.md` | Public SEO documentation now records the current rendering expectation. | The wording describes the status quo and does not imply a new test or ADR requirement. | `pnpm format` |

## Validation

- [x] `pnpm format`: `rtk pnpm format`
- [ ] `pnpm check`: Not run; docs/instruction-only change with no runtime code, schema, hooks, or lint-relevant app source changes.
- [ ] `pnpm build`: Not run; no build-relevant source changed.
- [ ] Focused tests: Not run; no test harness or runtime behavior changed.
- [ ] UI/mobile QA: Not applicable; no UI change.
- [ ] Security/privacy review: Not applicable; no access, auth, secrets, or runtime trust-boundary change.
- [ ] Migration/schema check: Not applicable; no Payload schema or migration change.
- [x] Documentation/instructions check: `rtk pnpm ai:slop-check`

## Risk and rollout

None known. This is a documentation and specialist-instruction guardrail change. Rollback is reverting the documentation and reviewer guidance.

## Development

Closes #1043
