### PR TITLE
feat(search): add listing comparison indexing policy

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -176,7 +176,7 @@ The findmydoc portal uses the [on-demand revalidation](https://nextjs.org/docs/a
 The public sitemap surface is split between the generated `robots.txt` file and App Router sitemap route handlers.
 
 - `robots.txt` references `/pages-sitemap.xml` and `/posts-sitemap.xml` outside preview runtime.
-- `/pages-sitemap.xml` lists `/`, `/posts`, `/contact`, `/about`, and published CMS pages. It does not list `/search` because there is no dedicated public search route.
+- `/pages-sitemap.xml` lists `/`, `/posts`, `/contact`, `/about`, `/listing-comparison`, and published CMS pages. It does not list `/search` because there is no dedicated public search route.
 - `/posts-sitemap.xml` lists published post detail URLs with valid single-segment slugs.
 - Preview runtime and Temporary Landing Mode keep deeper public content out of sitemap discovery through preview robots policy and empty guarded sitemap responses.
 
@@ -184,7 +184,7 @@ Run the sitemap status check against local development or production when Tempor
 
 ```bash
 BASE_URL="${BASE_URL:-http://localhost:3000}"
-for path in /robots.txt /pages-sitemap.xml /posts-sitemap.xml / /posts /contact /about; do
+for path in /robots.txt /pages-sitemap.xml /posts-sitemap.xml / /posts /contact /about /listing-comparison; do
   curl --fail --location --silent --show-error --output /dev/null --write-out "%{http_code} ${path}\n" "${BASE_URL}${path}"
 done
 ```
@@ -198,6 +198,24 @@ Manage SEO settings from the admin panel.
 Public discovery routes expose their core facts in initial HTML so search engines and AI agents can inspect the main content before client hydration. Interactive enhancements such as filters, saved-clinic actions, maps, consent controls, sharing, and forms can remain client-side as long as the route still renders the primary content, semantic main structure, and public internal links without browser-only state.
 
 SEO rendering audits should check for coarse drift signals: empty app shells, core facts hidden until hydration, blocking consent gates, missing `main` or heading structure, and broken public links. They should not rely on full HTML snapshots or exact CMS content such as specific clinic names, prices, doctors, or copy snippets.
+
+### Public entity URL rules
+
+Public entity URLs use readable slug routes when an entity has an approved public detail page. The current public entity detail route is `/clinics/[slug]`, where the clinic slug is the public URL identifier and internal database IDs stay out of the path.
+
+Entities without dedicated public detail routes are not independently indexable. Doctors, treatments, locations, and taxonomy terms can support listing filters or internal relations, but they need a dedicated readable slug route, stable content, and explicit sitemap inclusion before they become canonical public landing pages.
+
+Draft, unpublished, private, and admin-only records are not public canonical entities and must stay out of sitemap discovery.
+
+### Public discovery indexing
+
+`/listing-comparison` is the only v1 indexable Listing Comparison URL. It acts as the stable public discovery entry point and is included in `/pages-sitemap.xml`.
+
+Listing Comparison query variants stay functional for users, saved links, filters, sorting, and pagination, but they are not treated as indexable landing pages. Any query parameter on `/listing-comparison` is canonicalized to `/listing-comparison` and emits `noindex, follow`, including current and legacy parameters such as `city`, `specialty`, `treatment`, `ratingMin`, `priceMin`, `priceMax`, `sort`, `page`, `service`, `location`, and `budget`.
+
+Future indexable facets should use dedicated readable slug routes instead of query URLs. Each new route needs a clear search intent, enough stable content and result depth, locale readiness, canonical metadata, and explicit sitemap inclusion before it becomes indexable.
+
+`src/features/searchIndexing/` is the small route-policy foundation for this behavior. It currently provides reusable policy result types, metadata helpers, and the Listing Comparison policy; it is not a full SEO framework or registry.
 
 ## Search
 Implement SSR search features with Payload Search Plugin.

--- a/src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts
+++ b/src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts
@@ -6,7 +6,7 @@ import { findPageSitemapDocs } from '@/utilities/content/serverData'
 import { SEARCH_ROBOTS_HEADER, SEARCH_ROBOTS_HEADER_VALUE } from '@/features/searchIndexing'
 import { shouldBlockSitemapIndexingForRequest } from '@/features/searchIndexing/sitemapGuards'
 
-const fixedPublicPaths = ['/', '/posts', '/contact', '/about'] as const
+const fixedPublicPaths = ['/', '/posts', '/contact', '/about', '/listing-comparison'] as const
 const excludedPublicPaths = new Set(['/search'])
 
 type SitemapEntry = {

--- a/src/app/(frontend)/listing-comparison/page.tsx
+++ b/src/app/(frontend)/listing-comparison/page.tsx
@@ -1,8 +1,10 @@
 import configPromise from '@payload-config'
-import { getPayload } from 'payload'
+import type { Metadata } from 'next'
 import { headers } from 'next/headers'
+import { getPayload } from 'payload'
 
 import { findFavoriteClinicStateRecord, resolveFavoriteClinicAuthContext } from '@/features/favorites/server'
+import { buildIndexingMetadata, resolveListingComparisonIndexing } from '@/features/searchIndexing'
 import { getListingComparisonServerData } from '@/utilities/listingComparison/serverData'
 import { DISCLAIMER_COPY } from '@/utilities/legal/disclaimers'
 
@@ -14,6 +16,14 @@ type ListingComparisonPageArgs = {
 }
 
 export const dynamic = 'force-dynamic'
+
+export async function generateMetadata({
+  searchParams: searchParamsPromise,
+}: ListingComparisonPageArgs): Promise<Metadata> {
+  const searchParams = (await searchParamsPromise) ?? {}
+
+  return buildIndexingMetadata(resolveListingComparisonIndexing(searchParams))
+}
 
 export default async function ListingComparisonPage({ searchParams: searchParamsPromise }: ListingComparisonPageArgs) {
   const searchParams = (await searchParamsPromise) ?? {}

--- a/src/features/searchIndexing/index.ts
+++ b/src/features/searchIndexing/index.ts
@@ -23,3 +23,7 @@ export const shouldBlockSearchIndexingForRequest = ({
 }): boolean => {
   return headers.get(PREVIEW_GUARD_LOCK_REQUEST_HEADER) === '1' || shouldBlockSearchIndexing(env)
 }
+
+export * from './listingComparison'
+export * from './metadata'
+export * from './routePolicies'

--- a/src/features/searchIndexing/listingComparison.ts
+++ b/src/features/searchIndexing/listingComparison.ts
@@ -1,0 +1,22 @@
+import type { ListingComparisonRawSearchParams } from '@/utilities/listingComparison/queryState'
+
+import { hasRouteSearchParams, NOINDEX_FOLLOW_ROBOTS, type IndexingPolicyResult } from './routePolicies'
+
+export const LISTING_COMPARISON_CANONICAL_PATH = '/listing-comparison'
+
+export function resolveListingComparisonIndexing(
+  searchParams?: ListingComparisonRawSearchParams | URLSearchParams | null,
+): IndexingPolicyResult {
+  if (hasRouteSearchParams(searchParams)) {
+    return {
+      canonicalPath: LISTING_COMPARISON_CANONICAL_PATH,
+      robots: NOINDEX_FOLLOW_ROBOTS,
+      reason: 'query-variant',
+    }
+  }
+
+  return {
+    canonicalPath: LISTING_COMPARISON_CANONICAL_PATH,
+    reason: 'canonical-route',
+  }
+}

--- a/src/features/searchIndexing/metadata.ts
+++ b/src/features/searchIndexing/metadata.ts
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next'
+
+import type { IndexingPolicyResult } from './routePolicies'
+
+export type IndexingMetadata = Pick<Metadata, 'alternates' | 'robots'>
+
+export function buildIndexingMetadata(policy: IndexingPolicyResult): IndexingMetadata {
+  return {
+    alternates: {
+      canonical: policy.canonicalPath,
+    },
+    ...(policy.robots ? { robots: policy.robots } : {}),
+  }
+}

--- a/src/features/searchIndexing/routePolicies.ts
+++ b/src/features/searchIndexing/routePolicies.ts
@@ -1,0 +1,29 @@
+export type NoindexFollowRobots = {
+  index: false
+  follow: true
+}
+
+export type IndexingPolicyReason = 'canonical-route' | 'query-variant'
+
+export type IndexingPolicyResult = {
+  canonicalPath: string
+  robots?: NoindexFollowRobots
+  reason?: IndexingPolicyReason
+}
+
+export type RouteSearchParams = Record<string, string | string[] | undefined> | URLSearchParams | null | undefined
+
+export const NOINDEX_FOLLOW_ROBOTS: NoindexFollowRobots = {
+  index: false,
+  follow: true,
+}
+
+export function hasRouteSearchParams(searchParams: RouteSearchParams): boolean {
+  if (!searchParams) return false
+
+  if (typeof (searchParams as URLSearchParams).keys === 'function') {
+    return !((searchParams as URLSearchParams).keys().next().done ?? true)
+  }
+
+  return Object.keys(searchParams).length > 0
+}

--- a/tests/unit/app/frontend/listing-comparison.page.test.ts
+++ b/tests/unit/app/frontend/listing-comparison.page.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const routeMocks = vi.hoisted(() => ({
+  findFavoriteClinicStateRecord: vi.fn(),
+  getListingComparisonServerData: vi.fn(),
+  getPayload: vi.fn(),
+  headers: vi.fn(),
+  listingComparisonPageClient: vi.fn(() => null),
+  resolveFavoriteClinicAuthContext: vi.fn(),
+}))
+
+vi.mock('@payload-config', () => ({
+  default: {},
+}))
+
+vi.mock('next/headers', () => ({
+  headers: routeMocks.headers,
+}))
+
+vi.mock('payload', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('payload')>()
+  return {
+    ...actual,
+    getPayload: routeMocks.getPayload,
+  }
+})
+
+vi.mock('@/features/favorites/server', () => ({
+  findFavoriteClinicStateRecord: routeMocks.findFavoriteClinicStateRecord,
+  resolveFavoriteClinicAuthContext: routeMocks.resolveFavoriteClinicAuthContext,
+}))
+
+vi.mock('@/utilities/listingComparison/serverData', () => ({
+  getListingComparisonServerData: routeMocks.getListingComparisonServerData,
+}))
+
+vi.mock('@/app/(frontend)/listing-comparison/ListingComparisonPage.client', () => ({
+  ListingComparisonPageClient: routeMocks.listingComparisonPageClient,
+}))
+
+describe('listing comparison page route metadata', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('keeps the canonical base route indexable', async () => {
+    const pageModule = await import('@/app/(frontend)/listing-comparison/page')
+
+    await expect(
+      pageModule.generateMetadata({
+        searchParams: Promise.resolve({}),
+      }),
+    ).resolves.toEqual({
+      alternates: {
+        canonical: '/listing-comparison',
+      },
+    })
+  })
+
+  it('canonicalizes query variants and marks them noindex, follow', async () => {
+    const pageModule = await import('@/app/(frontend)/listing-comparison/page')
+
+    await expect(
+      pageModule.generateMetadata({
+        searchParams: Promise.resolve({
+          city: 'berlin',
+        }),
+      }),
+    ).resolves.toEqual({
+      alternates: {
+        canonical: '/listing-comparison',
+      },
+      robots: {
+        index: false,
+        follow: true,
+      },
+    })
+  })
+})

--- a/tests/unit/app/frontend/sitemap.routes.test.ts
+++ b/tests/unit/app/frontend/sitemap.routes.test.ts
@@ -108,9 +108,11 @@ describe('frontend sitemap routes', () => {
         'https://findmydoc.eu/posts',
         'https://findmydoc.eu/contact',
         'https://findmydoc.eu/about',
+        'https://findmydoc.eu/listing-comparison',
       ]),
     )
     expect(locs).not.toContain('https://findmydoc.eu/search')
+    expect(locs.some((loc: string) => loc.includes('?'))).toBe(false)
   })
 
   it('normalizes and deduplicates CMS pages in the pages sitemap', async () => {

--- a/tests/unit/features/searchIndexing/listingComparison.test.ts
+++ b/tests/unit/features/searchIndexing/listingComparison.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildIndexingMetadata,
+  LISTING_COMPARISON_CANONICAL_PATH,
+  resolveListingComparisonIndexing,
+} from '@/features/searchIndexing'
+
+describe('listing comparison search indexing policy', () => {
+  it('keeps the base route indexable with a canonical path', () => {
+    expect(resolveListingComparisonIndexing()).toEqual({
+      canonicalPath: LISTING_COMPARISON_CANONICAL_PATH,
+      reason: 'canonical-route',
+    })
+    expect(resolveListingComparisonIndexing({})).toEqual({
+      canonicalPath: LISTING_COMPARISON_CANONICAL_PATH,
+      reason: 'canonical-route',
+    })
+    expect(resolveListingComparisonIndexing(new URLSearchParams())).toEqual({
+      canonicalPath: LISTING_COMPARISON_CANONICAL_PATH,
+      reason: 'canonical-route',
+    })
+  })
+
+  it.each([
+    { city: 'berlin' },
+    { specialty: 'hair-transplant' },
+    { treatment: 'fue' },
+    { ratingMin: '4' },
+    { priceMin: '1000' },
+    { priceMax: '5000' },
+    { sort: 'price-asc' },
+    { page: '2' },
+    { service: 'consultation' },
+    { location: 'Berlin' },
+    { budget: '3000' },
+  ])('marks known query variants as noindex, follow for %o', (searchParams) => {
+    expect(resolveListingComparisonIndexing(searchParams)).toEqual({
+      canonicalPath: LISTING_COMPARISON_CANONICAL_PATH,
+      robots: {
+        index: false,
+        follow: true,
+      },
+      reason: 'query-variant',
+    })
+  })
+
+  it('marks unknown query parameters as noindex, follow', () => {
+    expect(resolveListingComparisonIndexing({ unknown: 'value' })).toEqual({
+      canonicalPath: LISTING_COMPARISON_CANONICAL_PATH,
+      robots: {
+        index: false,
+        follow: true,
+      },
+      reason: 'query-variant',
+    })
+  })
+
+  it('treats present empty and repeated query values as query variants', () => {
+    expect(resolveListingComparisonIndexing({ specialty: '' })).toMatchObject({
+      robots: {
+        index: false,
+        follow: true,
+      },
+      reason: 'query-variant',
+    })
+    expect(resolveListingComparisonIndexing({ city: ['berlin', 'munich'] })).toMatchObject({
+      robots: {
+        index: false,
+        follow: true,
+      },
+      reason: 'query-variant',
+    })
+    expect(resolveListingComparisonIndexing(new URLSearchParams('specialty='))).toMatchObject({
+      robots: {
+        index: false,
+        follow: true,
+      },
+      reason: 'query-variant',
+    })
+  })
+
+  it('builds Next.js metadata from the indexing policy', () => {
+    expect(buildIndexingMetadata(resolveListingComparisonIndexing({}))).toEqual({
+      alternates: {
+        canonical: LISTING_COMPARISON_CANONICAL_PATH,
+      },
+    })
+    expect(buildIndexingMetadata(resolveListingComparisonIndexing({ city: 'berlin' }))).toEqual({
+      alternates: {
+        canonical: LISTING_COMPARISON_CANONICAL_PATH,
+      },
+      robots: {
+        index: false,
+        follow: true,
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Management summary

### Deutsch

Dieser PR macht die oeffentliche Discovery-Strategie fuer findmydoc klarer: Die Vergleichsseite bleibt als stabile Einstiegsseite auffindbar, waehrend gefilterte Varianten fuer Nutzer weiter funktionieren, aber nicht als eigene Suchergebnisse konkurrieren. Damit werden Suchmaschinen, Nutzer und spaetere Landingpage-Entscheidungen sauberer gefuehrt.

### English

This PR clarifies the public discovery strategy for findmydoc: the comparison page remains discoverable as a stable entry point, while filtered variants keep working for users without competing as separate search results. This gives search engines, users, and future landing-page decisions a cleaner routing model.

## What changed

- Added a small `src/features/searchIndexing/` route-policy layer for canonical and robots decisions.
- Added the `/listing-comparison` indexing policy: base route is canonical and indexable; every query variant is canonicalized to `/listing-comparison` and marked `noindex, follow`.
- Wired the policy into `/listing-comparison` metadata without changing UI, filters, pagination, result calculation, or shareable query URLs.
- Added `/listing-comparison` to `/pages-sitemap.xml`; sitemap entries remain query-free.
- Documented public entity URL rules, Listing Comparison indexing behavior, and future requirements for indexable facet slug routes in `docs/features.md`.
- Added focused unit coverage for the policy, route metadata, and sitemap output.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P2 | `src/features/searchIndexing/**`, `src/app/(frontend)/listing-comparison/page.tsx` | This is the new shared route-policy foundation and first route integration. | The layer stays small, route-owned, and does not become a broad SEO framework. | Focused unit tests, `rtk pnpm check`, `rtk bash -lc "PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build"` |
| P2 | `src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts`, `docs/features.md` | Sitemap and documentation now define which discovery URLs are indexable. | `/listing-comparison` is included, query URLs are excluded, and the docs match the implemented policy. | Focused unit tests, build postbuild sitemap generation |

## Validation

- [x] `pnpm format`: `rtk pnpm format`
- [x] `pnpm check`: `rtk pnpm check` passed; existing test-sense-check warning list remains unchanged.
- [x] `pnpm build`: `rtk bash -lc "PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build"` passed, including `next-sitemap` postbuild. Local Node warning observed: current Node `v26.0.0` is outside the project engine range `>=24.0.0 <25`.
- [x] Focused tests: `rtk pnpm exec vitest run --project unit tests/unit/features/searchIndexing/index.test.ts tests/unit/features/searchIndexing/listingComparison.test.ts tests/unit/features/searchIndexing/sitemapGuards.test.ts tests/unit/app/frontend/listing-comparison.page.test.ts tests/unit/app/frontend/sitemap.routes.test.ts` passed with 5 files and 29 tests.
- [ ] UI/mobile QA: Not applicable; no visual or interaction behavior changed.
- [ ] Security/privacy review: Not run; no auth, access-control, secret, API trust-boundary, or private-data handling changed.
- [ ] Migration/schema check: Not applicable; no Payload schema or migration changes.
- [x] Documentation/instructions check: `docs/features.md` updated for public entity URL rules and discovery indexing policy.

## Risk and rollout

Low runtime risk. Query URLs are not redirected and remain functional for filters, sorting, pagination, saved links, and sharing. The main review risk is SEO policy correctness: `/listing-comparison` should be the only v1 indexable Listing Comparison URL until dedicated facet slug routes are planned and implemented.

## Development

Closes #1039
