### PR TITLE
feat: add public discovery freshness signals

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Use this index as the main entry point for project documentation.
 
 - [Setup & Development](./setup.md)
 - [Features & Integrations](./features.md)
+- [Public Discovery Strategy](./public-discovery-strategy.md)
 - [Codex Specialist Subagents](./integrations/codex-specialists.md)
 - [Deployment & Migration Runbook](./deployment-runbook.md)
 - [CI Modularization Plan](./engineering/ci-modularization-plan.md)

--- a/docs/features.md
+++ b/docs/features.md
@@ -193,6 +193,8 @@ done
 Manage SEO settings from the admin panel.
 [Payload SEO Plugin Docs](https://payloadcms.com/docs/plugins/seo)
 
+Strategic rules for SEO, GEO / agent discovery, public entity URLs, sitemap freshness, and trust signals live in [Public Discovery Strategy](./public-discovery-strategy.md).
+
 ### Search-facing rendering
 
 Public discovery routes expose their core facts in initial HTML so search engines and AI agents can inspect the main content before client hydration. Interactive enhancements such as filters, saved-clinic actions, maps, consent controls, sharing, and forms can remain client-side as long as the route still renders the primary content, semantic main structure, and public internal links without browser-only state.

--- a/docs/public-discovery-strategy.md
+++ b/docs/public-discovery-strategy.md
@@ -1,0 +1,65 @@
+# Public Discovery Strategy
+
+This document defines the strategic rules for public discovery across SEO and GEO (Generative Engine Optimization / agent discovery). It is intentionally not an implementation guide. Feature details live in code, tests, issues, and PRs. Architecture decisions live in ADRs and are linked here instead of repeated.
+
+## Strategic Goal
+
+findmydoc public content should be easy for search engines and AI agents to crawl, understand, cite, and evaluate for freshness without exposing private, draft, unpublished, or admin-only data.
+
+Public discovery work must support three outcomes:
+
+- Search engines can discover stable, crawlable, canonical URLs.
+- AI agents can identify public entities, freshness, trust boundaries, and source-backed facts.
+- Patients see and agents cite only claims that are backed by source data or an approved operating process.
+
+## SEO And GEO Scope
+
+SEO covers crawlability, canonical URLs, metadata, sitemap inclusion, structured data, internal linking, and indexability.
+
+GEO covers the same public surfaces from an agent perspective: agent-readable context, stable public identifiers, freshness signals, source-backed trust metadata, and content that renders before client-only enhancements.
+
+Both scopes use the same safety rule: public discovery surfaces must never expose private records, admin-only fields, drafts, unpublished records, pending/rejected reviews, or unverifiable medical claims.
+
+## Public Entity Strategy
+
+An entity becomes independently indexable only when it has a stable public route, enough useful public content, canonical metadata, sitemap inclusion, and clear visibility rules.
+
+The current public entity surfaces are:
+
+- `/clinics/[slug]`: approved clinic profiles; the public slug is the URL identifier.
+- `/listing-comparison`: the indexable clinic comparison entry point.
+- Published CMS pages and posts.
+
+Doctors, treatments, locations, specialties, tags, and query-filter combinations can support discovery and internal linking, but they are not independently indexable unless a future decision gives them dedicated public routes and sitemap rules.
+
+## Canonical And Sitemap Rules
+
+Public canonical URLs should prefer readable slug routes over query URLs. Query variants remain useful for users, filters, saved links, sorting, and pagination, but they should be canonicalized or marked `noindex` unless they become dedicated landing pages.
+
+Sitemap entries should use real content timestamps when available. Request-time timestamps must not be used as freshness signals because they imply content freshness that did not happen.
+
+Preview, temporary landing, draft, unpublished, private, and admin-only states stay out of public sitemap discovery.
+
+## Freshness, Trust, And Review Signals
+
+Freshness signals are source-backed only. Allowed sources include Payload timestamps such as `updatedAt`, publication timestamps such as `publishedAt`, approved patient review dates such as `reviewDate`, and explicit verification fields that already exist in the public model.
+
+Review and trust metadata must describe the source process accurately:
+
+- Approved patient reviews can expose review dates and moderation-backed visibility.
+- Clinic verification tiers can be exposed when they come from the public clinic model.
+- Clinical or medical review claims must not be emitted unless a real review process and source field exist.
+
+When no source exists, the public surface should omit the signal instead of inventing manual freshness or review values.
+
+## ADR Boundary
+
+This strategy records operating rules and scope boundaries. ADRs record architecture decisions.
+
+Use an ADR when a decision changes the architecture of public discovery, such as localized public URL structure, `hreflang` and locale sitemap behavior, a dedicated public discovery API, new canonical entity route families, or a new structured-data framework.
+
+Relevant ADRs:
+
+- [ADR 018 - Native Payload CMS localization strategy](./adrs/018-adr-native-payload-localization-strategy.md): establishes the current Payload localization foundation and leaves URL, SEO, publishing nuance, and translation workflow decisions to follow-up architecture decisions.
+
+Keep this document as the strategy layer. Do not duplicate ADR rationale here.

--- a/src/app/(frontend)/(pages)/[...slug]/page.tsx
+++ b/src/app/(frontend)/(pages)/[...slug]/page.tsx
@@ -85,6 +85,7 @@ export async function generateMetadata({
   return generateMeta({
     doc: page,
     path: appendContentLocaleToPath(`/${slug.join('/')}`, contentLocale.locale),
+    sourceCollection: 'pages',
   })
 }
 

--- a/src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts
+++ b/src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts
@@ -5,12 +5,13 @@ import { unstable_cache } from 'next/cache'
 import { findPageSitemapDocs } from '@/utilities/content/serverData'
 import { SEARCH_ROBOTS_HEADER, SEARCH_ROBOTS_HEADER_VALUE } from '@/features/searchIndexing'
 import { shouldBlockSitemapIndexingForRequest } from '@/features/searchIndexing/sitemapGuards'
+import { getListingComparisonServerData } from '@/utilities/listingComparison/serverData'
 
 const fixedPublicPaths = ['/', '/posts', '/contact', '/about', '/listing-comparison'] as const
 const excludedPublicPaths = new Set(['/search'])
 
 type SitemapEntry = {
-  lastmod: string
+  lastmod?: string
   loc: string
 }
 
@@ -36,26 +37,38 @@ const getPagesSitemap = unstable_cache(
     const SITE_URL =
       process.env.NEXT_PUBLIC_SERVER_URL || process.env.VERCEL_PROJECT_PRODUCTION_URL || 'https://example.com'
 
-    const results = await findPageSitemapDocs(payload)
-
-    const dateFallback = new Date().toISOString()
+    const [results, listingComparisonData] = await Promise.all([
+      findPageSitemapDocs(payload),
+      getListingComparisonServerData(payload),
+    ])
 
     const sitemapByPath = new Map<string, SitemapEntry>()
 
     for (const path of fixedPublicPaths) {
       sitemapByPath.set(path, {
         loc: buildSitemapLocation(SITE_URL, path),
-        lastmod: dateFallback,
+        ...(path === '/listing-comparison' && listingComparisonData.freshness.updatedAt
+          ? { lastmod: listingComparisonData.freshness.updatedAt }
+          : {}),
       })
     }
 
     for (const page of results) {
       const path = normalizePageSitemapPath(page?.slug)
-      if (!path || excludedPublicPaths.has(path) || sitemapByPath.has(path)) continue
+      if (!path || excludedPublicPaths.has(path)) continue
+
+      const existingEntry = sitemapByPath.get(path)
+      if (existingEntry) {
+        sitemapByPath.set(path, {
+          ...existingEntry,
+          ...(page.updatedAt ? { lastmod: page.updatedAt } : {}),
+        })
+        continue
+      }
 
       sitemapByPath.set(path, {
         loc: buildSitemapLocation(SITE_URL, path),
-        lastmod: page.updatedAt || dateFallback,
+        ...(page.updatedAt ? { lastmod: page.updatedAt } : {}),
       })
     }
 

--- a/src/app/(frontend)/(sitemaps)/posts-sitemap.xml/route.ts
+++ b/src/app/(frontend)/(sitemaps)/posts-sitemap.xml/route.ts
@@ -29,15 +29,13 @@ const getPostsSitemap = unstable_cache(
 
     const results = await findPostSitemapDocs(payload)
 
-    const dateFallback = new Date().toISOString()
-
     const sitemap = results.flatMap((post) => {
       const slug = normalizePostSitemapSlug(post?.slug)
       if (!slug) return []
 
       return {
         loc: buildSitemapLocation(SITE_URL, `/posts/${slug}`),
-        lastmod: post.updatedAt || dateFallback,
+        ...(post.updatedAt ? { lastmod: post.updatedAt } : {}),
       }
     })
 

--- a/src/app/(frontend)/clinics/[slug]/page.tsx
+++ b/src/app/(frontend)/clinics/[slug]/page.tsx
@@ -87,5 +87,6 @@ export async function generateMetadata({ params: paramsPromise }: ClinicDetailPa
     title: clinicDetailData.clinicName,
     description: clinicDetailData.description,
     path: `/clinics/${slug}`,
+    freshness: clinicDetailData.freshness,
   })
 }

--- a/src/app/(frontend)/listing-comparison/page.tsx
+++ b/src/app/(frontend)/listing-comparison/page.tsx
@@ -5,6 +5,7 @@ import { getPayload } from 'payload'
 
 import { findFavoriteClinicStateRecord, resolveFavoriteClinicAuthContext } from '@/features/favorites/server'
 import { buildIndexingMetadata, resolveListingComparisonIndexing } from '@/features/searchIndexing'
+import { buildFreshnessMetadata } from '@/utilities/freshness'
 import { getListingComparisonServerData } from '@/utilities/listingComparison/serverData'
 import { DISCLAIMER_COPY } from '@/utilities/legal/disclaimers'
 
@@ -21,8 +22,13 @@ export async function generateMetadata({
   searchParams: searchParamsPromise,
 }: ListingComparisonPageArgs): Promise<Metadata> {
   const searchParams = (await searchParamsPromise) ?? {}
+  const payload = await getPayload({ config: configPromise })
+  const listingData = await getListingComparisonServerData(payload, searchParams)
 
-  return buildIndexingMetadata(resolveListingComparisonIndexing(searchParams))
+  return {
+    ...buildIndexingMetadata(resolveListingComparisonIndexing(searchParams)),
+    ...buildFreshnessMetadata(listingData.freshness),
+  }
 }
 
 export default async function ListingComparisonPage({ searchParams: searchParamsPromise }: ListingComparisonPageArgs) {

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -149,7 +149,7 @@ export async function generateMetadata({
   const contentLocale = resolveContentLocaleContext(searchParams.locale)
   const post = await queryPostBySlug({ contentLocale, slug })
 
-  return generateMeta({ doc: post, path: buildPostPath(slug, contentLocale) })
+  return generateMeta({ doc: post, path: buildPostPath(slug, contentLocale), sourceCollection: 'posts' })
 }
 
 const queryPostBySlug = cache(

--- a/src/components/templates/ClinicDetailConcepts/types.ts
+++ b/src/components/templates/ClinicDetailConcepts/types.ts
@@ -1,4 +1,5 @@
 import type { CookieConsentConfig, CookieConsentState } from '@/features/cookieConsent'
+import type { FreshnessSignals } from '@/utilities/freshness'
 
 export type ClinicVerificationTier = 'unverified' | 'bronze' | 'silver' | 'gold'
 
@@ -86,6 +87,7 @@ export type ClinicDetailData = {
   doctors: ClinicDetailDoctor[]
   beforeAfterEntries: ClinicBeforeAfterEntry[]
   location: ClinicDetailLocation
+  freshness: FreshnessSignals
   contact?: ClinicDetailContact
   contactHref: string
 }

--- a/src/stories/fixtures/clinicDetail.ts
+++ b/src/stories/fixtures/clinicDetail.ts
@@ -132,6 +132,12 @@ export const clinicDetailFixture: ClinicDetailData = {
       },
     ],
   },
+  freshness: {
+    updatedAt: '2026-01-12T09:15:00.000Z',
+    latestPatientReviewAt: '2026-01-12T09:15:00.000Z',
+    verificationTier: 'gold',
+    sourceCollections: ['clinics', 'reviews'],
+  },
   treatments: [
     { id: 'treatment-1', name: 'Routine Checkup', category: 'Preventive Care', priceFromUsd: 120 },
     { id: 'treatment-2', name: 'Developmental Screening', category: 'Diagnostics', priceFromUsd: 180 },

--- a/src/utilities/clinicDetail/serverData/mappers.ts
+++ b/src/utilities/clinicDetail/serverData/mappers.ts
@@ -24,6 +24,8 @@ import type {
 } from '@/components/templates/ClinicDetailConcepts/types'
 import { resolveMediaDescriptorFromLoadedRelation } from '@/utilities/media/relationMedia'
 import { resolveAvatarPlaceholder } from '@/utilities/placeholders/avatar'
+import { buildFreshnessSignals } from '@/utilities/freshness'
+import { findLatestIsoTimestampString } from '@/utilities/timestamps'
 
 import type { ClinicDetailMappingArgs } from './types'
 
@@ -452,6 +454,41 @@ function mapCitiesToNameMap(cities: City[]): Map<number, string> {
   )
 }
 
+function mapClinicFreshness({
+  clinic,
+  clinicTreatments,
+  doctors,
+  doctorSpecialties,
+  approvedClinicReviews,
+  galleryEntries,
+  accreditations,
+  cities,
+}: ClinicDetailMappingArgs) {
+  return buildFreshnessSignals({
+    updatedAt: findLatestIsoTimestampString([
+      clinic.updatedAt,
+      ...clinicTreatments.map((item) => item.updatedAt),
+      ...doctors.map((item) => item.updatedAt),
+      ...doctorSpecialties.map((item) => item.updatedAt),
+      ...galleryEntries.map((item) => item.updatedAt),
+      ...accreditations.map((item) => item.updatedAt),
+      ...cities.map((item) => item.updatedAt),
+    ]),
+    latestPatientReviewAt: findLatestIsoTimestampString(approvedClinicReviews.map((review) => review.reviewDate)),
+    verificationTier: toVerificationTier(clinic.verification),
+    sourceCollections: [
+      'accreditation',
+      'cities',
+      'clinics',
+      'clinicGalleryEntries',
+      'clinictreatments',
+      'doctors',
+      'doctorspecialties',
+      'reviews',
+    ],
+  })
+}
+
 export function mapClinicToClinicDetailData({
   clinic,
   clinicTreatments,
@@ -491,6 +528,18 @@ export function mapClinicToClinicDetailData({
     }),
     beforeAfterEntries: mapBeforeAfterEntries(clinic, galleryEntries),
     location: buildLocation(clinic, cityNameById),
+    freshness: mapClinicFreshness({
+      clinic,
+      clinicTreatments,
+      doctors,
+      doctorSpecialties,
+      clinicReviewCount,
+      approvedClinicReviews,
+      doctorReviewCounts,
+      galleryEntries,
+      accreditations,
+      cities,
+    }),
     contactHref,
   }
 }

--- a/src/utilities/clinicDetail/serverData/repositories.ts
+++ b/src/utilities/clinicDetail/serverData/repositories.ts
@@ -104,6 +104,7 @@ export async function findClinicTreatmentsByClinicId(payload: Payload, clinicId:
         price: true,
         clinic: true,
         treatment: true,
+        updatedAt: true,
       },
     })
 
@@ -141,6 +142,7 @@ export async function findDoctorsByClinicId(payload: Payload, clinicId: number):
         qualifications: true,
         experienceYears: true,
         languages: true,
+        updatedAt: true,
       },
     })
 
@@ -179,6 +181,7 @@ export async function findDoctorSpecialtiesByDoctorIds(
           doctor: true,
           medicalSpecialty: true,
           specializationLevel: true,
+          updatedAt: true,
         },
       })
 
@@ -251,6 +254,7 @@ export async function findApprovedClinicReviewsByClinicId(
     select: {
       id: true,
       reviewDate: true,
+      updatedAt: true,
       starRating: true,
       comment: true,
       publicAuthorName: true,
@@ -345,6 +349,7 @@ export async function findClinicGalleryEntriesByIds(
           description: true,
           status: true,
           publishedAt: true,
+          updatedAt: true,
         },
       })
 
@@ -383,6 +388,7 @@ export async function findAccreditationsByIds(payload: Payload, accreditationIds
         select: {
           id: true,
           name: true,
+          updatedAt: true,
         },
       })
 
@@ -421,6 +427,7 @@ export async function findCitiesByIds(payload: Payload, cityIds: number[]): Prom
         select: {
           id: true,
           name: true,
+          updatedAt: true,
         },
       })
 

--- a/src/utilities/content/serverData/pages.ts
+++ b/src/utilities/content/serverData/pages.ts
@@ -4,7 +4,7 @@ import type { Page, PagesSelect } from '@/payload-types'
 
 import { buildLocalizedQueryOptions, mergePublishedWhere, type LocalizedDocQuery, type PagedResult } from './shared'
 
-export type PageDetailDoc = Pick<Page, 'id' | 'title' | 'slug' | 'layout' | 'publishedAt' | 'meta'>
+export type PageDetailDoc = Pick<Page, 'id' | 'title' | 'slug' | 'layout' | 'publishedAt' | 'updatedAt' | 'meta'>
 export type PageSlugDoc = Pick<Page, 'id' | 'slug'>
 export type PageSitemapDoc = Pick<Page, 'id' | 'slug' | 'updatedAt'>
 
@@ -24,6 +24,7 @@ const PAGE_DETAIL_SELECT = {
   slug: true,
   layout: true,
   publishedAt: true,
+  updatedAt: true,
   meta: {
     title: true,
     image: true,

--- a/src/utilities/content/serverData/posts.ts
+++ b/src/utilities/content/serverData/posts.ts
@@ -20,6 +20,7 @@ export type PostSummaryDoc = Pick<
   | 'authors'
   | 'populatedAuthors'
   | 'publishedAt'
+  | 'updatedAt'
   | 'heroImage'
   | 'meta'
 >
@@ -38,6 +39,7 @@ export type PostDetailDoc = Omit<
     | 'authors'
     | 'populatedAuthors'
     | 'publishedAt'
+    | 'updatedAt'
     | 'heroImage'
     | 'relatedPosts'
     | 'meta'
@@ -69,6 +71,7 @@ const POST_LIST_SELECT = {
   authors: true,
   populatedAuthors: true,
   publishedAt: true,
+  updatedAt: true,
   heroImage: true,
   meta: {
     image: true,
@@ -89,6 +92,7 @@ const POST_RELATED_SELECT = {
   authors: true,
   populatedAuthors: true,
   publishedAt: true,
+  updatedAt: true,
   heroImage: true,
   meta: {
     image: true,
@@ -105,6 +109,7 @@ const POST_DETAIL_SELECT = {
   authors: true,
   populatedAuthors: true,
   publishedAt: true,
+  updatedAt: true,
   heroImage: true,
   relatedPosts: true,
   meta: {

--- a/src/utilities/freshness.ts
+++ b/src/utilities/freshness.ts
@@ -1,0 +1,71 @@
+import type { Metadata } from 'next'
+
+import { findLatestIsoTimestampString, normalizeToIsoTimestampString } from './timestamps'
+
+export type FreshnessSignals = {
+  updatedAt?: string
+  publishedAt?: string
+  latestPatientReviewAt?: string
+  verificationTier?: string
+  sourceCollections: string[]
+}
+
+export type FreshnessInput = {
+  updatedAt?: unknown
+  publishedAt?: unknown
+  latestPatientReviewAt?: unknown
+  verificationTier?: unknown
+  sourceCollections?: string[]
+}
+
+function normalizeFreshnessSourceCollectionNames(sourceCollections: string[] | undefined): string[] {
+  if (!sourceCollections) return []
+
+  return Array.from(
+    new Set(sourceCollections.map((source) => source.trim()).filter((source) => source.length > 0)),
+  ).sort((left, right) => left.localeCompare(right, 'en'))
+}
+
+export function buildFreshnessSignals(input: FreshnessInput = {}): FreshnessSignals {
+  const latestPatientReviewAt = normalizeToIsoTimestampString(input.latestPatientReviewAt)
+  const updatedAt = findLatestIsoTimestampString([input.updatedAt, latestPatientReviewAt])
+  const publishedAt = normalizeToIsoTimestampString(input.publishedAt)
+  const verificationTier = typeof input.verificationTier === 'string' ? input.verificationTier.trim() : ''
+
+  return {
+    ...(updatedAt ? { updatedAt } : {}),
+    ...(publishedAt ? { publishedAt } : {}),
+    ...(latestPatientReviewAt ? { latestPatientReviewAt } : {}),
+    ...(verificationTier.length > 0 ? { verificationTier } : {}),
+    sourceCollections: normalizeFreshnessSourceCollectionNames(input.sourceCollections),
+  }
+}
+
+export function buildFreshnessMetadata(freshness?: FreshnessSignals | null): Pick<Metadata, 'other'> {
+  if (!freshness) return {}
+
+  const other: NonNullable<Metadata['other']> = {}
+
+  if (freshness.updatedAt) {
+    other['last-modified'] = freshness.updatedAt
+    other['findmydoc:updated_at'] = freshness.updatedAt
+  }
+
+  if (freshness.publishedAt) {
+    other['findmydoc:published_at'] = freshness.publishedAt
+  }
+
+  if (freshness.latestPatientReviewAt) {
+    other['findmydoc:latest_patient_review_at'] = freshness.latestPatientReviewAt
+  }
+
+  if (freshness.verificationTier) {
+    other['findmydoc:verification_tier'] = freshness.verificationTier
+  }
+
+  if (freshness.sourceCollections.length > 0) {
+    other['findmydoc:freshness_sources'] = freshness.sourceCollections.join(',')
+  }
+
+  return Object.keys(other).length > 0 ? { other } : {}
+}

--- a/src/utilities/generateMeta.ts
+++ b/src/utilities/generateMeta.ts
@@ -12,6 +12,7 @@ import {
   type SocialPreviewImage,
 } from './socialPreview'
 import { resolveMediaImage } from './media/resolveMediaImage'
+import { buildFreshnessMetadata, buildFreshnessSignals, type FreshnessSignals } from './freshness'
 
 /**
  * Generates an image URL for OpenGraph metadata.
@@ -40,11 +41,13 @@ export const createSiteMetadata = (
     description?: string | null
     path?: string
     image?: SocialPreviewImage | null
+    freshness?: FreshnessSignals | null
   } = {},
 ): Metadata => {
   const title = formatSiteTitle(args.title)
   const description = normalizeSiteDescription(args.description)
   const images = getOpenGraphImages(args.image)
+  const freshnessMetadata = buildFreshnessMetadata(args.freshness)
 
   return {
     title,
@@ -61,6 +64,7 @@ export const createSiteMetadata = (
       description,
       images: getTwitterImages(args.image),
     },
+    ...freshnessMetadata,
   }
 }
 
@@ -79,6 +83,7 @@ export const createSiteMetadata = (
 export const generateMeta = async (args: {
   doc: Partial<Page> | Partial<Post> | null
   path?: string
+  sourceCollection?: 'pages' | 'posts'
 }): Promise<Metadata> => {
   const { doc } = args
 
@@ -97,5 +102,12 @@ export const generateMeta = async (args: {
     description: doc?.meta?.description,
     path: args.path ?? slugPath,
     image: ogImage ? { url: ogImage } : null,
+    freshness: doc
+      ? buildFreshnessSignals({
+          updatedAt: doc.updatedAt,
+          publishedAt: doc.publishedAt,
+          sourceCollections: args.sourceCollection ? [args.sourceCollection] : [],
+        })
+      : null,
   })
 }

--- a/src/utilities/listingComparison/serverData/getListingComparisonServerData.ts
+++ b/src/utilities/listingComparison/serverData/getListingComparisonServerData.ts
@@ -1,6 +1,8 @@
 import type { Payload } from 'payload'
 
 import type { Clinic } from '@/payload-types'
+import { buildFreshnessSignals } from '@/utilities/freshness'
+import { findLatestIsoTimestampString } from '@/utilities/timestamps'
 import { slugify } from '@/utilities/slugify'
 import {
   buildListingComparisonHref,
@@ -23,6 +25,7 @@ import { extractRelationId } from './relations'
 import {
   countApprovedReviewsByClinic,
   findClinicTreatmentsForClinics,
+  findLatestApprovedReviewDateForClinics,
   findListingComparisonCatalog,
 } from './repositories'
 import {
@@ -122,8 +125,19 @@ export async function getListingComparisonServerData(
   const treatmentTypes = treatmentDocs.length
   const cities = countApprovedClinicCities(approvedClinics)
   const approvedClinicIds = approvedClinics.map((clinic) => clinic.id)
-  const catalogClinicTreatments = await findClinicTreatmentsForClinics(payload, approvedClinicIds)
+  const [catalogClinicTreatments, latestApprovedReviewAt] = await Promise.all([
+    findClinicTreatmentsForClinics(payload, approvedClinicIds),
+    findLatestApprovedReviewDateForClinics(payload, approvedClinicIds),
+  ])
   const priceEntries = countPriceEntries(catalogClinicTreatments)
+  const freshness = buildFreshnessSignals({
+    updatedAt: findLatestIsoTimestampString([
+      ...approvedClinics.map((clinic) => clinic.updatedAt),
+      ...catalogClinicTreatments.map((entry) => entry.updatedAt),
+    ]),
+    latestPatientReviewAt: latestApprovedReviewAt,
+    sourceCollections: ['clinics', 'clinictreatments', 'reviews'],
+  })
 
   const cityMeta = toCityMetaFromDocs(cityDocs)
   const cityOptions = toBaseFilterOptions(cityMeta)
@@ -359,5 +373,6 @@ export async function getListingComparisonServerData(
       cities,
       priceEntries,
     },
+    freshness,
   }
 }

--- a/src/utilities/listingComparison/serverData/repositories.ts
+++ b/src/utilities/listingComparison/serverData/repositories.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import type { Payload } from 'payload'
 
 import type { City, Clinic, Clinictreatment, MedicalSpecialty, Review, Treatment } from '@/payload-types'
+import { normalizeToIsoTimestampString } from '@/utilities/timestamps'
 import { chunkArray, extractRelationId } from './relations'
 
 const CLINIC_CHUNK_SIZE = 200
@@ -144,6 +145,7 @@ export async function findAllApprovedClinics(payload: Payload): Promise<Clinic[]
         },
         thumbnail: true,
         tags: true,
+        updatedAt: true,
       },
     })
 
@@ -232,6 +234,7 @@ export async function findClinicTreatmentsForClinics(
           clinic: true,
           treatment: true,
           price: true,
+          updatedAt: true,
         },
       })
 
@@ -245,6 +248,54 @@ export async function findClinicTreatmentsForClinics(
   }
 
   return allDocs
+}
+
+export async function findLatestApprovedReviewDateForClinics(
+  payload: Payload,
+  clinicIds: number[],
+): Promise<string | undefined> {
+  if (clinicIds.length === 0) return undefined
+
+  let latestReviewDate: string | undefined
+  const clinicIdChunks = chunkArray(clinicIds, CLINIC_CHUNK_SIZE)
+
+  for (const clinicIdChunk of clinicIdChunks) {
+    const result = await payload.find({
+      collection: 'reviews',
+      depth: 0,
+      limit: 1,
+      page: 1,
+      pagination: false,
+      overrideAccess: false,
+      sort: '-reviewDate',
+      where: {
+        and: [
+          {
+            status: {
+              equals: 'approved',
+            },
+          },
+          {
+            clinic: {
+              in: clinicIdChunk,
+            },
+          },
+        ],
+      },
+      select: {
+        reviewDate: true,
+      },
+    })
+
+    const review = result.docs[0] as Review | undefined
+    const normalizedReviewDate = normalizeToIsoTimestampString(review?.reviewDate)
+    if (!normalizedReviewDate) continue
+    if (!latestReviewDate || new Date(normalizedReviewDate).getTime() > new Date(latestReviewDate).getTime()) {
+      latestReviewDate = normalizedReviewDate
+    }
+  }
+
+  return latestReviewDate
 }
 
 export async function countApprovedReviewsByClinic(

--- a/src/utilities/listingComparison/serverData/types.ts
+++ b/src/utilities/listingComparison/serverData/types.ts
@@ -1,4 +1,5 @@
 import type { ListingCardData } from '@/components/organisms/Listing'
+import type { FreshnessSignals } from '@/utilities/freshness'
 import type { Clinic } from '@/payload-types'
 import type { ListingComparisonQueryState } from '@/utilities/listingComparison/queryState'
 
@@ -56,6 +57,7 @@ export type ListingComparisonServerData = {
     cities: number
     priceEntries: number
   }
+  freshness: FreshnessSignals
 }
 
 export type CityMeta = {

--- a/src/utilities/timestamps.ts
+++ b/src/utilities/timestamps.ts
@@ -1,0 +1,27 @@
+export function normalizeToIsoTimestampString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return undefined
+
+  const date = new Date(trimmed)
+  if (Number.isNaN(date.getTime())) return undefined
+
+  return date.toISOString()
+}
+
+export function findLatestIsoTimestampString(values: Iterable<unknown>): string | undefined {
+  let latestDate: Date | undefined
+
+  for (const value of values) {
+    const normalized = normalizeToIsoTimestampString(value)
+    if (!normalized) continue
+
+    const candidateDate = new Date(normalized)
+    if (!latestDate || candidateDate.getTime() > latestDate.getTime()) {
+      latestDate = candidateDate
+    }
+  }
+
+  return latestDate?.toISOString()
+}

--- a/tests/unit/app/frontend/listing-comparison.page.test.ts
+++ b/tests/unit/app/frontend/listing-comparison.page.test.ts
@@ -42,6 +42,12 @@ describe('listing comparison page route metadata', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    routeMocks.getPayload.mockResolvedValue({})
+    routeMocks.getListingComparisonServerData.mockResolvedValue({
+      freshness: {
+        sourceCollections: [],
+      },
+    })
   })
 
   it('keeps the canonical base route indexable', async () => {

--- a/tests/unit/app/frontend/sitemap.routes.test.ts
+++ b/tests/unit/app/frontend/sitemap.routes.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const routeMocks = vi.hoisted(() => ({
   findPageSitemapDocs: vi.fn(),
   findPostSitemapDocs: vi.fn(),
+  getListingComparisonServerData: vi.fn(),
   getPayload: vi.fn(),
   getServerSideSitemap: vi.fn(),
   shouldBlockSitemapIndexingForRequest: vi.fn(),
@@ -30,6 +31,10 @@ vi.mock('@/utilities/content/serverData', () => ({
   findPostSitemapDocs: routeMocks.findPostSitemapDocs,
 }))
 
+vi.mock('@/utilities/listingComparison/serverData', () => ({
+  getListingComparisonServerData: routeMocks.getListingComparisonServerData,
+}))
+
 vi.mock('@/features/searchIndexing/sitemapGuards', () => ({
   shouldBlockSitemapIndexingForRequest: routeMocks.shouldBlockSitemapIndexingForRequest,
 }))
@@ -47,6 +52,12 @@ describe('frontend sitemap routes', () => {
 
     vi.clearAllMocks()
     routeMocks.getPayload.mockResolvedValue({})
+    routeMocks.getListingComparisonServerData.mockResolvedValue({
+      freshness: {
+        updatedAt: '2026-01-06T00:00:00.000Z',
+        sourceCollections: ['clinics'],
+      },
+    })
     routeMocks.getServerSideSitemap.mockImplementation((entries: unknown[], headers?: Record<string, string>) => {
       return Response.json({ entries, headers })
     })
@@ -113,6 +124,10 @@ describe('frontend sitemap routes', () => {
     )
     expect(locs).not.toContain('https://findmydoc.eu/search')
     expect(locs.some((loc: string) => loc.includes('?'))).toBe(false)
+    expect(body.entries.find((entry: { loc: string }) => entry.loc.endsWith('/contact'))).not.toHaveProperty('lastmod')
+    expect(body.entries.find((entry: { loc: string }) => entry.loc.endsWith('/listing-comparison'))).toMatchObject({
+      lastmod: '2026-01-06T00:00:00.000Z',
+    })
   })
 
   it('normalizes and deduplicates CMS pages in the pages sitemap', async () => {
@@ -140,6 +155,12 @@ describe('frontend sitemap routes', () => {
     expect(locs).toEqual(
       expect.arrayContaining(['https://findmydoc.eu/privacy-policy', 'https://findmydoc.eu/imprint']),
     )
+    expect(body.entries.find((entry: { loc: string }) => entry.loc === 'https://findmydoc.eu/')).toMatchObject({
+      lastmod: '2026-01-01T00:00:00.000Z',
+    })
+    expect(body.entries.find((entry: { loc: string }) => entry.loc.endsWith('/about'))).toMatchObject({
+      lastmod: '2026-01-01T00:00:00.000Z',
+    })
   })
 
   it('includes only valid post detail routes in the posts sitemap', async () => {
@@ -158,5 +179,6 @@ describe('frontend sitemap routes', () => {
     const locs = getEntryLocations(body.entries)
 
     expect(locs).toEqual(['https://findmydoc.eu/posts/first-post', 'https://findmydoc.eu/posts/second-post'])
+    expect(body.entries[0]).toMatchObject({ lastmod: '2026-01-01T00:00:00.000Z' })
   })
 })

--- a/tests/unit/components/clinicDetailConcepts.test.tsx
+++ b/tests/unit/components/clinicDetailConcepts.test.tsx
@@ -121,6 +121,10 @@ const baseData = {
     totalCount: 0,
     items: [],
   },
+  freshness: {
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    sourceCollections: ['clinics'],
+  },
   treatments: [{ id: 't1', name: 'Treatment 1', priceFromUsd: 1200 }],
   doctors: [
     {

--- a/tests/unit/utilities/clinicDetailServerData.contract.test.ts
+++ b/tests/unit/utilities/clinicDetailServerData.contract.test.ts
@@ -66,6 +66,7 @@ const mockData: MockData = {
       status: 'approved',
       verification: 'gold',
       supportedLanguages: ['english', 'german', 'turkish'],
+      updatedAt: '2026-01-10T00:00:00.000Z',
     },
     {
       id: 2,
@@ -91,6 +92,7 @@ const mockData: MockData = {
       status: 'pending',
       verification: 'silver',
       supportedLanguages: ['english'],
+      updatedAt: '2026-01-03T00:00:00.000Z',
     },
   ],
   clinictreatments: [
@@ -106,6 +108,7 @@ const mockData: MockData = {
         },
       },
       price: 120,
+      updatedAt: '2026-01-11T00:00:00.000Z',
     },
     {
       id: 202,
@@ -119,6 +122,7 @@ const mockData: MockData = {
         },
       },
       price: 180,
+      updatedAt: '2026-01-09T00:00:00.000Z',
     },
   ],
   doctors: [
@@ -139,6 +143,7 @@ const mockData: MockData = {
       qualifications: ['MD', 'FAAP'],
       experienceYears: 9,
       languages: ['english', 'spanish'],
+      updatedAt: '2026-01-09T00:00:00.000Z',
     },
     {
       id: 602,
@@ -153,6 +158,7 @@ const mockData: MockData = {
       qualifications: ['MD'],
       experienceYears: 6,
       languages: ['english', 'german'],
+      updatedAt: '2026-01-08T00:00:00.000Z',
     },
   ],
   doctorspecialties: [
@@ -164,6 +170,7 @@ const mockData: MockData = {
         name: 'Pediatric Cardiology',
       },
       specializationLevel: 'expert',
+      updatedAt: '2026-01-07T00:00:00.000Z',
     },
   ],
   reviews: [
@@ -360,6 +367,14 @@ describe('getClinicDetailServerData (contract)', () => {
     expect(result?.reviews.items.map((review) => review.comment)).not.toContain('Rejected review should not appear.')
     expect(result?.trust.accreditations).toContain('ISO 9001')
     expect(result?.trust.languages).toEqual(expect.arrayContaining(['English', 'German']))
+    expect(result?.freshness).toMatchObject({
+      updatedAt: '2026-01-12T09:15:00.000Z',
+      latestPatientReviewAt: '2026-01-12T09:15:00.000Z',
+      verificationTier: 'gold',
+    })
+    expect(result?.freshness.sourceCollections).toEqual(
+      expect.arrayContaining(['clinics', 'clinictreatments', 'reviews']),
+    )
 
     expect(result?.location.fullAddress).toBe('Lichtenberger Strasse 24, 10179 Berlin, Germany')
     expect(result?.location.coordinates).toEqual({

--- a/tests/unit/utilities/freshness.test.ts
+++ b/tests/unit/utilities/freshness.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildFreshnessMetadata, buildFreshnessSignals } from '@/utilities/freshness'
+
+describe('freshness utilities', () => {
+  it('builds source-backed freshness signals without inventing missing values', () => {
+    expect(
+      buildFreshnessSignals({
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        latestPatientReviewAt: '2026-01-05T00:00:00.000Z',
+        verificationTier: 'gold',
+        sourceCollections: ['reviews', 'clinics', 'reviews'],
+      }),
+    ).toEqual({
+      updatedAt: '2026-01-05T00:00:00.000Z',
+      latestPatientReviewAt: '2026-01-05T00:00:00.000Z',
+      verificationTier: 'gold',
+      sourceCollections: ['clinics', 'reviews'],
+    })
+  })
+
+  it('renders only available metadata fields', () => {
+    expect(
+      buildFreshnessMetadata({
+        updatedAt: '2026-01-05T00:00:00.000Z',
+        latestPatientReviewAt: '2026-01-04T00:00:00.000Z',
+        sourceCollections: ['clinics', 'reviews'],
+      }),
+    ).toEqual({
+      other: {
+        'last-modified': '2026-01-05T00:00:00.000Z',
+        'findmydoc:updated_at': '2026-01-05T00:00:00.000Z',
+        'findmydoc:latest_patient_review_at': '2026-01-04T00:00:00.000Z',
+        'findmydoc:freshness_sources': 'clinics,reviews',
+      },
+    })
+  })
+})

--- a/tests/unit/utilities/generateMeta.test.ts
+++ b/tests/unit/utilities/generateMeta.test.ts
@@ -201,11 +201,23 @@ describe('generateMeta', () => {
         title: 'Localized Post',
       },
       slug: 'localized-post',
+      publishedAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z',
     }
 
-    const result = await generateMeta({ doc: postDoc, path: '/posts/localized-post?locale=de' })
+    const result = await generateMeta({
+      doc: postDoc,
+      path: '/posts/localized-post?locale=de',
+      sourceCollection: 'posts',
+    })
 
     expect(result.openGraph).toMatchObject({ url: 'https://example.com/posts/localized-post?locale=de' })
+    expect(result.other).toMatchObject({
+      'last-modified': '2026-01-02T00:00:00.000Z',
+      'findmydoc:updated_at': '2026-01-02T00:00:00.000Z',
+      'findmydoc:published_at': '2026-01-01T00:00:00.000Z',
+      'findmydoc:freshness_sources': 'posts',
+    })
   })
 
   it('should handle very long titles', async () => {

--- a/tests/unit/utilities/listingComparisonServerData.contract.test.ts
+++ b/tests/unit/utilities/listingComparisonServerData.contract.test.ts
@@ -42,6 +42,7 @@ const baseData: MockCollectionData = {
       },
       thumbnail: null,
       tags: [{ name: 'Premium' }],
+      updatedAt: '2026-01-10T00:00:00.000Z',
     },
     {
       id: 202,
@@ -57,6 +58,7 @@ const baseData: MockCollectionData = {
       },
       thumbnail: null,
       tags: [{ name: 'Modern' }],
+      updatedAt: '2026-01-09T00:00:00.000Z',
     },
     {
       id: 203,
@@ -72,6 +74,7 @@ const baseData: MockCollectionData = {
       },
       thumbnail: null,
       tags: [{ name: 'Dental' }],
+      updatedAt: '2026-01-07T00:00:00.000Z',
     },
     {
       id: 204,
@@ -87,21 +90,22 @@ const baseData: MockCollectionData = {
       },
       thumbnail: null,
       tags: [{ name: 'Draft' }],
+      updatedAt: '2026-01-06T00:00:00.000Z',
     },
   ],
   clinictreatments: [
-    { id: 301, clinic: 201, treatment: 101, price: 5000 },
-    { id: 302, clinic: 201, treatment: 102, price: 7000 },
-    { id: 303, clinic: 202, treatment: 101, price: 5200 },
-    { id: 304, clinic: 202, treatment: 102, price: 6000 },
-    { id: 305, clinic: 203, treatment: 103, price: 2000 },
+    { id: 301, clinic: 201, treatment: 101, price: 5000, updatedAt: '2026-01-11T00:00:00.000Z' },
+    { id: 302, clinic: 201, treatment: 102, price: 7000, updatedAt: '2026-01-08T00:00:00.000Z' },
+    { id: 303, clinic: 202, treatment: 101, price: 5200, updatedAt: '2026-01-07T00:00:00.000Z' },
+    { id: 304, clinic: 202, treatment: 102, price: 6000, updatedAt: '2026-01-06T00:00:00.000Z' },
+    { id: 305, clinic: 203, treatment: 103, price: 2000, updatedAt: '2026-01-05T00:00:00.000Z' },
   ],
   reviews: [
-    { id: 401, status: 'approved', clinic: 201 },
-    { id: 402, status: 'approved', clinic: 201 },
-    { id: 403, status: 'pending', clinic: 201 },
-    { id: 404, status: 'approved', clinic: 202 },
-    { id: 405, status: 'approved', clinic: 203 },
+    { id: 401, status: 'approved', clinic: 201, reviewDate: '2026-01-12T00:00:00.000Z' },
+    { id: 402, status: 'approved', clinic: 201, reviewDate: '2026-01-04T00:00:00.000Z' },
+    { id: 403, status: 'pending', clinic: 201, reviewDate: '2026-01-20T00:00:00.000Z' },
+    { id: 404, status: 'approved', clinic: 202, reviewDate: '2026-01-03T00:00:00.000Z' },
+    { id: 405, status: 'approved', clinic: 203, reviewDate: '2026-01-02T00:00:00.000Z' },
   ],
 }
 
@@ -139,17 +143,24 @@ function createMockPayload(data: MockCollectionData): MockPayload {
       collection: keyof MockCollectionData
       page?: number
       limit?: number
+      sort?: string
       where?: Record<string, unknown>
     }) => {
       const source = data[args.collection] ?? []
       const filtered = args.where ? source.filter((doc) => matchesClause(doc, args.where ?? {})) : source
+      const sorted =
+        args.sort === '-reviewDate'
+          ? [...filtered].sort((left, right) =>
+              String(right.reviewDate ?? '').localeCompare(String(left.reviewDate ?? '')),
+            )
+          : filtered
 
       const page = args.page ?? 1
-      const limit = args.limit ?? (filtered.length || 1)
-      const totalDocs = filtered.length
+      const limit = args.limit ?? (sorted.length || 1)
+      const totalDocs = sorted.length
       const totalPages = Math.max(1, Math.ceil(totalDocs / limit))
       const start = (page - 1) * limit
-      const docs = filtered.slice(start, start + limit)
+      const docs = sorted.slice(start, start + limit)
 
       return {
         docs,
@@ -188,6 +199,11 @@ describe('getListingComparisonServerData (contract)', () => {
     expect(result.metrics.treatmentTypes).toBe(3)
     expect(result.metrics.cities).toBe(2)
     expect(result.metrics.priceEntries).toBe(5)
+    expect(result.freshness).toMatchObject({
+      updatedAt: '2026-01-12T00:00:00.000Z',
+      latestPatientReviewAt: '2026-01-12T00:00:00.000Z',
+      sourceCollections: ['clinics', 'clinictreatments', 'reviews'],
+    })
     expect(result.queryState.specialties).toEqual(['2'])
     expect(result.results.map((clinic) => clinic.name)).toEqual(['Alpha Clinic', 'Bravo Clinic'])
     expect(result.results[0]?.rating.count).toBe(2)

--- a/tests/unit/utilities/timestamps.test.ts
+++ b/tests/unit/utilities/timestamps.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { findLatestIsoTimestampString, normalizeToIsoTimestampString } from '@/utilities/timestamps'
+
+describe('timestamp utilities', () => {
+  it('normalizes valid timestamp strings to ISO strings and ignores invalid values', () => {
+    expect(normalizeToIsoTimestampString('2026-01-01T12:30:00.000Z')).toBe('2026-01-01T12:30:00.000Z')
+    expect(normalizeToIsoTimestampString('not-a-date')).toBeUndefined()
+    expect(normalizeToIsoTimestampString(null)).toBeUndefined()
+  })
+
+  it('selects the latest valid timestamp string as an ISO string', () => {
+    expect(findLatestIsoTimestampString(['2026-01-01T00:00:00.000Z', 'not-a-date', '2026-01-03T00:00:00.000Z'])).toBe(
+      '2026-01-03T00:00:00.000Z',
+    )
+  })
+})


### PR DESCRIPTION
## Management summary

### Deutsch

Öffentliche findmydoc-Inhalte werden für Suche und KI-basierte Discovery verlässlicher, weil ihre Aktualität künftig aus echten öffentlichen Datenständen abgeleitet wird. Gleichzeitig halten wir klare Grenzen fest: Es werden keine privaten, unveröffentlichten oder unbelegten Review- und Prüfbehauptungen nach außen getragen.

### English

Public findmydoc content becomes more reliable for search and AI-based discovery because its freshness is now derived from real public source data. At the same time, the change keeps clear boundaries: private, unpublished, or unsupported review and verification claims are not exposed publicly.

## What changed

- Added `docs/public-discovery-strategy.md` as the central strategy reference for SEO, GEO / agent discovery, public entity surfaces, canonical URLs, sitemaps, freshness, trust, and review-signal boundaries.
- Linked the new strategy from `docs/README.md` and `docs/features.md` while keeping implementation details out of the strategy layer.
- Added reusable timestamp/freshness helpers for source-backed public discovery signals.
- Updated page/post metadata, clinic detail metadata, and listing comparison metadata to expose machine-readable freshness only when source data exists.
- Updated pages and posts sitemap generation so `lastmod` uses real content timestamps instead of request-time fallbacks.
- Limited review signals to approved review data and existing public verification fields; no visible UI, new collection, migration, or clinical-review claim is introduced.
- Created #1377 as a follow-up for broader timestamp-helper refactoring to keep that work out of this PR.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `src/utilities/freshness.ts`, `src/utilities/timestamps.ts`, `src/utilities/generateMeta.ts` | Public metadata now exposes machine-readable freshness fields. | Metadata is source-backed, stable, and does not imply unsupported clinical review. | Focused Vitest, `pnpm check`, `pnpm build` |
| P1 | `src/utilities/clinicDetail/serverData/**`, `src/app/(frontend)/clinics/[slug]/page.tsx` | Clinic detail freshness uses public clinic, related entity, approved review, and verification data. | No private, draft, pending, rejected, or admin-only data is exposed. | Clinic detail contract test, `pnpm check` |
| P1 | `src/utilities/listingComparison/serverData/**`, `src/app/(frontend)/listing-comparison/page.tsx` | Listing comparison metadata and sitemap freshness depend on public aggregate data. | Approved-review filtering and timestamp selection remain correct. | Listing comparison contract test, sitemap test |
| P2 | `src/app/(frontend)/(sitemaps)/**/route.ts` | Sitemap `lastmod` behavior changed from request time to source timestamps. | Fixed routes do not emit invented freshness; CMS and listing comparison timestamps are retained where available. | Sitemap route test |
| P2 | `docs/public-discovery-strategy.md` | Strategy is meant to be durable without duplicating ADRs or implementation details. | Scope, ADR boundary, and SEO/GEO rules are concise and not overdocumented. | `pnpm format` |

## Validation

- [x] `pnpm format`: `rtk pnpm format`
- [x] `pnpm check`: `rtk pnpm check`
- [x] `pnpm build`: `rtk bash -lc 'PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build'`
- [x] Focused tests: `rtk pnpm vitest run tests/unit/utilities/timestamps.test.ts tests/unit/utilities/freshness.test.ts tests/unit/app/frontend/sitemap.routes.test.ts tests/unit/utilities/generateMeta.test.ts tests/unit/utilities/clinicDetailServerData.contract.test.ts tests/unit/utilities/listingComparisonServerData.contract.test.ts`
- [x] UI/mobile QA: no visible UI changes; no screenshot required.
- [ ] Security/privacy review: not run locally; recommended because public metadata and source exposure changed.
- [x] Migration/schema check: no Payload schema or migration changes.
- [x] Documentation/instructions check: public discovery strategy added and linked; no instruction files changed.

## Risk and rollout

Primary risk is semantic: public metadata must not overstate clinical review, verification, or content freshness. Rollout has no migration or configuration step. Reverting the PR removes the new metadata signals and restores previous sitemap behavior.

## Development

Closes #1041
