### PR TITLE
fix: bump undici for audit pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
       "unrs-resolver"
     ],
     "overrides": {
+      "undici": "^7.28.0",
       "@modelcontextprotocol/sdk": "1.26.0",
       "esbuild": "0.28.1",
       "esbuild@<0.28.1": "0.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  undici: ^7.28.0
   '@modelcontextprotocol/sdk': 1.26.0
   esbuild: 0.28.1
   esbuild@<0.28.1: 0.28.1
@@ -7435,12 +7436,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.24.4:
-    resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
-    engines: {node: '>=20.18.1'}
-
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
@@ -13397,7 +13394,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -14300,7 +14297,7 @@ snapshots:
       sanitize-filename: 1.6.3
       ts-essentials: 10.0.3(typescript@5.9.3)
       tsx: 4.22.4
-      undici: 7.24.4
+      undici: 7.28.0
       uuid: 13.0.2
       ws: 8.21.0
     transitivePeerDependencies:
@@ -15540,9 +15537,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.24.4: {}
-
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unicorn-magic@0.3.0: {}
 


### PR DESCRIPTION
## Management summary

### Deutsch
Dieser Change stabilisiert den nächtlichen Qualitäts-Lauf auf dem Hauptzweig, sodass Sicherheitsprüfungen wieder zuverlässig grünen Status liefern können und damit Release- und Integrationsentscheidungen wieder auf aktuellen, geprüften Ergebnissen basieren.

### English
This change stabilizes the nightly quality run on the main branch so security checks can again report healthy status, restoring reliable signal quality for release and integration decisions.

## What changed

- Added a root dependency override for `undici` to enforce a patched version that removes high-severity vulnerabilities seen by `pnpm deps:audit`.
- Updated the lockfile to align transitive dependency resolution with the override.
- Verified the dependency audit now passes with no high/critical findings.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| P1 | `package.json` | Security-related build gate dependency exception | Confirm the override is scoped and does not unintentionally pin unrelated ranges | `package.json` diff |
| P1 | `pnpm-lock.yaml` | Lockfile changes can affect dependency resolution across CI and deploys | Confirm `undici` resolution is bumped consistently through dependency graph | lockfile diff |
| P1 | `.github/workflows/deep-quality-lane.yml` context | Workflow relies on `deps:audit` high severity gate | No workflow file change needed, only outcome impact; verify `pnpm deps:audit` now passes | `pnpm deps:audit` log |

## Validation

- [x] `pnpm format`:
- [ ] `pnpm check`:
- [ ] `pnpm build`:
- [ ] Focused tests:
- [ ] UI/mobile QA:
- [x] Security/privacy review: `pnpm deps:audit` reports high: 0, critical: 0
- [ ] Migration/schema check:
- [ ] Documentation/instructions check:

## Risk and rollout

- Risk: lockfile and dependency graph update may shift nested dependency versions in a broad tree; this should be safe as it only addresses security-patched transitive resolution.
- Rollback: revert this commit to restore previous dependency graph.

## Development

Closes #1379
