### PR TITLE
ci: add cancel-in-progress to pr workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,6 +17,10 @@ on:
         default: '48'
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/pr-gates.yml
+++ b/.github/workflows/pr-gates.yml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Management summary

### Deutsch

Mehrere Prüf- und Verwaltungs-Workflows brechen jetzt ältere Läufe für dieselbe Pull Request oder denselben Referenzstand automatisch ab. Dadurch bleiben Rückmeldungen aktueller, und die CI wird nicht mehr mit überholten Läufen belastet.

### English

Several review and maintenance workflows now cancel older runs for the same pull request or ref automatically. That keeps feedback current and avoids wasting CI capacity on obsolete runs.

## What changed

Added a shared `concurrency` block with `cancel-in-progress: true` to the four PR-facing workflow files that previously allowed overlapping runs:

- `.github/workflows/pr-gates.yml`
- `.github/workflows/dependency-review.yml`
- `.github/workflows/docs-check.yml`
- `.github/workflows/dependabot-auto-merge.yml`

The concurrency key scopes cancellation by PR number for `pull_request` events and by ref for the remaining event types, which keeps the cancellation behavior consistent with the existing deploy workflows in this repo.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `.github/workflows/*.yml` | CI scheduling behavior changes can affect how runs are cancelled or retained. | Verify the shared concurrency expression cancels only older runs for the same PR or ref and does not interfere with unrelated workflow executions. | `pnpm format`, `pnpm check` |

## Validation

- [x] `pnpm format`: ran successfully.
- [x] `pnpm check`: ran successfully.
- [ ] `pnpm build`: not run; workflow-only change, no build-relevant source touched.
- [ ] Focused tests: not run; YAML workflow changes only.
- [ ] UI/mobile QA: not applicable; no UI change.
- [ ] Security/privacy review: not requested for this workflow-only change.
- [ ] Migration/schema check: not applicable; no schema or data model change.
- [ ] Documentation/instructions check: not applicable; no instruction sources changed.

## Risk and rollout

Low risk. This only changes workflow scheduling so that newer runs cancel older in-progress runs for the same PR or ref. No application runtime behavior changes.

## Development

Closes #1381
