### PR TITLE
feat(search): define agent crawler policy

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -175,10 +175,21 @@ The findmydoc portal uses the [on-demand revalidation](https://nextjs.org/docs/a
 ## Public Sitemaps
 The public sitemap surface is split between the generated `robots.txt` file and App Router sitemap route handlers.
 
-- `robots.txt` references `/pages-sitemap.xml` and `/posts-sitemap.xml` outside preview runtime.
+- `robots.txt` references `/sitemap.xml`, `/pages-sitemap.xml`, and `/posts-sitemap.xml` outside preview runtime.
 - `/pages-sitemap.xml` lists `/`, `/posts`, `/contact`, `/about`, `/listing-comparison`, and published CMS pages. It does not list `/search` because there is no dedicated public search route.
 - `/posts-sitemap.xml` lists published post detail URLs with valid single-segment slugs.
 - Preview runtime and Temporary Landing Mode keep deeper public content out of sitemap discovery through preview robots policy and empty guarded sitemap responses.
+
+Production `robots.txt` treats automated search discovery, user-directed AI retrieval, and model training as separate access classes:
+
+| Bot class | User agents | Policy |
+| --- | --- | --- |
+| Search and answer indexing | `Googlebot`, `bingbot`, `OAI-SearchBot`, `PerplexityBot`, `Claude-SearchBot` | Allowed for public pages; `/admin` and `/admin/*` stay disallowed. |
+| User-directed AI retrieval | `ChatGPT-User`, `Perplexity-User`, `Claude-User` | Allowed for public pages so user requests in ChatGPT, Perplexity, and Claude can retrieve and cite findmydoc content; `/admin` and `/admin/*` stay disallowed. |
+| Model training and generative-AI control | `GPTBot`, `ClaudeBot`, `Google-Extended` | Disallowed across the site unless a separate business decision changes the training-access stance. |
+| General crawlers | `*` | Public pages stay crawlable; `/admin` and `/admin/*` stay disallowed. |
+
+WAF and IP allowlisting for AI crawlers belongs to infrastructure operations, not this repository's sitemap configuration.
 
 Run the sitemap status check against local development or production when Temporary Landing Mode is disabled:
 

--- a/docs/public-discovery-strategy.md
+++ b/docs/public-discovery-strategy.md
@@ -6,6 +6,8 @@ This document defines the strategic rules for public discovery across SEO and GE
 
 findmydoc public content should be easy for search engines and AI agents to crawl, understand, and cite without exposing private, draft, unpublished, or admin-only data.
 
+Public discovery includes both automated search indexing and user-directed AI retrieval; model training access is a separate consent choice.
+
 Public discovery work supports three outcomes:
 
 - Search engines can discover stable, crawlable, canonical URLs.

--- a/next-sitemap.config.cjs
+++ b/next-sitemap.config.cjs
@@ -12,6 +12,39 @@ const isPreviewRuntime =
   (normalizeEnvValue(process.env.VERCEL_ENV) ?? normalizeEnvValue(process.env.DEPLOYMENT_ENV)) === 'preview'
 const blockSearchIndexing = isPreviewRuntime
 
+const PUBLIC_DISCOVERY_USER_AGENTS = [
+  'Googlebot',
+  'bingbot',
+  'OAI-SearchBot',
+  'ChatGPT-User',
+  'PerplexityBot',
+  'Perplexity-User',
+  'Claude-SearchBot',
+  'Claude-User',
+]
+
+const BLOCKED_MODEL_TRAINING_USER_AGENTS = ['GPTBot', 'ClaudeBot', 'Google-Extended']
+
+const PUBLIC_DISCOVERY_POLICY = {
+  allow: '/',
+  disallow: ['/admin', '/admin/*'],
+}
+
+const productionRobotsPolicies = [
+  ...PUBLIC_DISCOVERY_USER_AGENTS.map((userAgent) => ({
+    userAgent,
+    ...PUBLIC_DISCOVERY_POLICY,
+  })),
+  ...BLOCKED_MODEL_TRAINING_USER_AGENTS.map((userAgent) => ({
+    userAgent,
+    disallow: '/',
+  })),
+  {
+    userAgent: '*',
+    ...PUBLIC_DISCOVERY_POLICY,
+  },
+]
+
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
   siteUrl: SITE_URL,
@@ -24,11 +57,8 @@ module.exports = {
             userAgent: '*',
             disallow: '/',
           }
-        : {
-            userAgent: '*',
-            disallow: '/admin/*',
-          },
-    ],
+        : productionRobotsPolicies,
+    ].flat(),
     additionalSitemaps: blockSearchIndexing ? [] : [`${SITE_URL}/pages-sitemap.xml`, `${SITE_URL}/posts-sitemap.xml`],
   },
 }

--- a/tests/unit/config/next-sitemap-config.test.ts
+++ b/tests/unit/config/next-sitemap-config.test.ts
@@ -8,12 +8,25 @@ const configPath = path.resolve(process.cwd(), 'next-sitemap.config.cjs')
 const loadConfig = (): {
   robotsTxtOptions: {
     additionalSitemaps: string[]
-    policies: Array<{ disallow: string; userAgent: string }>
+    policies: Array<{ allow?: string; disallow: string | string[]; userAgent: string }>
   }
 } => {
   delete require.cache[require.resolve(configPath)]
   return require(configPath)
 }
+
+const publicDiscoveryUserAgents = [
+  'Googlebot',
+  'bingbot',
+  'OAI-SearchBot',
+  'ChatGPT-User',
+  'PerplexityBot',
+  'Perplexity-User',
+  'Claude-SearchBot',
+  'Claude-User',
+]
+
+const blockedModelTrainingUserAgents = ['GPTBot', 'ClaudeBot', 'Google-Extended']
 
 describe('next-sitemap config', () => {
   const originalEnv = process.env
@@ -33,11 +46,40 @@ describe('next-sitemap config', () => {
 
     const config = loadConfig()
 
-    expect(config.robotsTxtOptions.policies).toEqual([{ disallow: '/admin/*', userAgent: '*' }])
+    for (const userAgent of publicDiscoveryUserAgents) {
+      expect(config.robotsTxtOptions.policies).toContainEqual({
+        allow: '/',
+        disallow: ['/admin', '/admin/*'],
+        userAgent,
+      })
+    }
+    expect(config.robotsTxtOptions.policies).toContainEqual({
+      allow: '/',
+      disallow: ['/admin', '/admin/*'],
+      userAgent: '*',
+    })
     expect(config.robotsTxtOptions.additionalSitemaps).toEqual([
       'https://findmydoc.eu/pages-sitemap.xml',
       'https://findmydoc.eu/posts-sitemap.xml',
     ])
+  })
+
+  it('blocks model training crawlers outside preview runtime', () => {
+    process.env = {
+      ...originalEnv,
+      DEPLOYMENT_ENV: undefined,
+      NEXT_PUBLIC_SERVER_URL: 'https://findmydoc.eu',
+      VERCEL_ENV: 'production',
+    }
+
+    const config = loadConfig()
+
+    for (const userAgent of blockedModelTrainingUserAgents) {
+      expect(config.robotsTxtOptions.policies).toContainEqual({
+        disallow: '/',
+        userAgent,
+      })
+    }
   })
 
   it('blocks robots and hides sitemap references in Vercel preview runtime', () => {


### PR DESCRIPTION
## Management summary

### Deutsch

findmydoc wird für Suchmaschinen und nutzergesteuerte KI-Assistenten besser auffindbar, ohne die Kontrolle über Trainingsnutzung oder nicht öffentliche Bereiche zu lockern. Öffentliche Inhalte können von ChatGPT, Claude und Perplexity bei konkreten Nutzeranfragen abgerufen und zitiert werden, während Admin-Bereiche und Preview-Oberflächen weiterhin geschützt bleiben.

### English

findmydoc becomes easier for search engines and user-directed AI assistants to discover while keeping control over training access and non-public areas. Public content can be retrieved and cited by ChatGPT, Claude, and Perplexity during user requests, while admin areas and preview surfaces remain protected.

## What changed

- Added explicit production `robots.txt` policy groups for search crawlers, user-directed AI retrieval bots, model-training crawlers, and the general crawler fallback.
- Allowed `ChatGPT-User`, `Perplexity-User`, and `Claude-User` for public pages while keeping `/admin` and `/admin/*` disallowed for every allowed specific bot group.
- Blocked `GPTBot`, `ClaudeBot`, and `Google-Extended` across the site by default.
- Documented the public discovery policy and the separation between automated search, user-directed AI retrieval, and model-training consent.
- Expanded `next-sitemap` config tests to cover the production bot matrix and preview runtime behavior.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P2 | `next-sitemap.config.cjs` | Specific `User-agent` groups can override wildcard crawler rules. | Every allowed bot still blocks `/admin` and `/admin/*`; preview remains fully blocked. | `pnpm vitest tests/unit/config/next-sitemap-config.test.ts`; `pnpm build` generated the expected local `robots.txt`. |
| P2 | `docs/features.md`, `docs/public-discovery-strategy.md` | The crawler policy now expresses a product stance on AI retrieval versus model training. | The wording matches the intended public discovery and training-consent boundary. | `pnpm check`; source docs from OpenAI, Anthropic, Perplexity, and Google were used during planning. |

## Validation

- [x] `pnpm format`: passed
- [x] `pnpm check`: passed; existing test sense-check warnings remain unrelated to this change
- [x] `pnpm build`: passed with `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret}`; local Node is `26.0.0` while repo engines expect `>=24.0.0 <25`
- [x] Focused tests: `pnpm vitest tests/unit/config/next-sitemap-config.test.ts` passed
- [ ] UI/mobile QA: not applicable; no UI or frontend layout changed
- [x] Security/privacy review: policy keeps `/admin` and `/admin/*` disallowed for all allowed specific bots and leaves Preview closed
- [ ] Migration/schema check: not applicable; no Payload schema or migration changed
- [x] Documentation/instructions check: public sitemap and discovery strategy docs updated; no instruction surfaces changed

## Risk and rollout

No data migration or environment change is required. Rollback is limited to reverting the `next-sitemap` policy and documentation updates. WAF/IP crawler controls remain an infrastructure concern outside this repository.

## Development

Closes #1033
