### PR TITLE
fix: refine disclaimer note presentation

### DIFF
--- a/src/components/molecules/DisclaimerNotice/index.tsx
+++ b/src/components/molecules/DisclaimerNotice/index.tsx
@@ -4,7 +4,6 @@ import * as React from 'react'
 import { ChevronDown, Info } from 'lucide-react'
 
 import { Button } from '@/components/atoms/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/atoms/card'
 import { cn } from '@/utilities/ui'
 
 export type DisclaimerNoticeVariant = 'inline-note' | 'slim-notice-bar' | 'collapsible-disclosure'
@@ -35,11 +34,38 @@ function variantLabel(variant: DisclaimerNoticeVariant): string {
 }
 
 function surfaceClasses(surface: DisclaimerNoticeSurface): string {
-  return surface === 'muted' ? 'bg-muted/50' : 'bg-background'
+  return surface === 'muted' ? 'bg-muted/45' : 'bg-card'
 }
 
-function routeCardClasses(size: DisclaimerNoticeSize): string {
-  return size === 'compact' ? 'p-4' : 'p-6'
+function noticePaddingClasses(size: DisclaimerNoticeSize, standalone: boolean): string {
+  if (standalone) {
+    return size === 'compact' ? 'py-2.5' : 'py-3'
+  }
+
+  return size === 'compact' ? 'px-3.5 py-3' : 'px-4 py-3.5'
+}
+
+function noticeVariantClasses(variant: DisclaimerNoticeVariant, standalone: boolean): string {
+  if (standalone && variant !== 'collapsible-disclosure') {
+    return 'rounded-none border-0 bg-transparent shadow-none'
+  }
+
+  switch (variant) {
+    case 'inline-note':
+      return 'border-l-2 border-l-primary/30'
+    case 'slim-notice-bar':
+      return 'border-border/60'
+    case 'collapsible-disclosure':
+      return 'border-border/60'
+  }
+}
+
+function iconClasses(size: DisclaimerNoticeSize, standalone: boolean): string {
+  if (standalone) {
+    return size === 'compact' ? 'size-5' : 'size-6'
+  }
+
+  return size === 'compact' ? 'size-6' : 'size-7'
 }
 
 export function DisclaimerNotice({
@@ -49,7 +75,7 @@ export function DisclaimerNotice({
   size = 'default',
   routeLabel,
   title,
-  showVariantLabel = true,
+  showVariantLabel = false,
   standalone = false,
   className,
 }: DisclaimerNoticeProps) {
@@ -58,29 +84,17 @@ export function DisclaimerNotice({
   const showBadge = typeof routeLabel === 'string' && routeLabel.trim().length > 0
   const showTitle = typeof title === 'string' && title.trim().length > 0
 
-  if (standalone) {
+  if (variant === 'collapsible-disclosure') {
     return (
-      <aside
-        aria-label={routeLabel ? `${routeLabel} disclaimer` : 'Disclaimer'}
+      <div
         className={cn(
-          'flex items-start gap-3 rounded-2xl border border-border/60 bg-card px-4 py-3',
-          variant === 'inline-note' ? 'border-l-2 border-l-primary/20' : null,
+          'rounded-xl border shadow-xs',
+          surfaceClasses(surface),
+          noticeVariantClasses(variant, standalone),
+          noticePaddingClasses(size, standalone),
           className,
         )}
       >
-        <span className="mt-0.5 inline-flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/8 text-primary">
-          <Info className="size-4" aria-hidden={true} />
-        </span>
-        <div className="min-w-0 space-y-1">
-          <p className="text-sm leading-6 text-foreground">{copy}</p>
-        </div>
-      </aside>
-    )
-  }
-
-  if (variant === 'collapsible-disclosure') {
-    return (
-      <div className={cn('rounded-2xl border border-border/60 bg-card px-4 py-3', className)}>
         <Button
           type="button"
           variant="ghost"
@@ -92,11 +106,11 @@ export function DisclaimerNotice({
         >
           <span className="flex items-center gap-2">
             <Info className="size-4 text-primary/80" aria-hidden={true} />
-            <span>{title ?? 'Why this note appears'}</span>
+            <span>{title ?? routeLabel ?? 'Information note'}</span>
           </span>
           <ChevronDown className={cn('size-4 shrink-0 transition-transform', open ? 'rotate-180' : 'rotate-0')} />
         </Button>
-        {showBadge || showVariantLabel || showTitle ? (
+        {!standalone && (showBadge || showVariantLabel) ? (
           <div className="mt-2 flex flex-wrap items-center gap-2">
             {showBadge ? (
               <span className="rounded-full border border-border/70 bg-background px-2.5 py-1 text-[11px] font-medium text-muted-foreground">
@@ -110,9 +124,6 @@ export function DisclaimerNotice({
             ) : null}
           </div>
         ) : null}
-        <p className="mt-2 text-sm leading-6 text-muted-foreground">
-          Short legal text stays available without taking over the page.
-        </p>
         {open ? (
           <div id={disclosureId} className="mt-3 border-t border-border/60 pt-3 text-sm leading-6 text-foreground">
             {copy}
@@ -123,10 +134,27 @@ export function DisclaimerNotice({
   }
 
   return (
-    <Card className={cn('border-border/70 shadow-xs', surfaceClasses(surface), className)}>
-      <CardHeader className={routeCardClasses(size)}>
-        {showBadge || showVariantLabel ? (
-          <div className="flex items-center gap-2">
+    <aside
+      aria-label={routeLabel ? `${routeLabel} disclaimer` : 'Disclaimer'}
+      className={cn(
+        'flex items-start gap-3 rounded-xl border border-border/60 shadow-xs',
+        surfaceClasses(surface),
+        noticePaddingClasses(size, standalone),
+        noticeVariantClasses(variant, standalone),
+        className,
+      )}
+    >
+      <span
+        className={cn(
+          'mt-0.5 inline-flex shrink-0 items-center justify-center rounded-full bg-primary/8 text-primary',
+          iconClasses(size, standalone),
+        )}
+      >
+        <Info className={cn(size === 'compact' || standalone ? 'size-3.5' : 'size-4')} aria-hidden={true} />
+      </span>
+      <div className="min-w-0 space-y-1">
+        {!standalone && (showBadge || showVariantLabel || showTitle) ? (
+          <div className="flex flex-wrap items-center gap-2">
             {showBadge ? (
               <span className="rounded-full border border-border/70 bg-background px-2.5 py-1 text-[11px] font-medium text-muted-foreground">
                 {routeLabel}
@@ -137,31 +165,11 @@ export function DisclaimerNotice({
                 {variantLabel(variant)}
               </span>
             ) : null}
+            {showTitle ? <span className="text-xs font-semibold text-foreground">{title}</span> : null}
           </div>
         ) : null}
-        {showTitle ? <CardTitle className={cn(size === 'compact' ? 'text-base' : 'text-lg')}>{title}</CardTitle> : null}
-        <CardDescription>
-          {variant === 'slim-notice-bar'
-            ? 'Still visible, but visually closer to a page utility than a prominent alert.'
-            : 'Visible in flow, low-noise in tone, and short enough to keep the page feeling like content rather than a warning.'}
-        </CardDescription>
-      </CardHeader>
-      <CardContent className={cn(routeCardClasses(size), 'pt-0')}>
-        <aside
-          aria-label={routeLabel ? `${routeLabel} disclaimer` : 'Disclaimer'}
-          className={cn(
-            'flex items-start gap-3 rounded-2xl border border-border/60 bg-card px-4 py-3',
-            variant === 'inline-note' ? 'border-l-2 border-l-primary/20' : null,
-          )}
-        >
-          <span className="mt-0.5 inline-flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/8 text-primary">
-            <Info className="size-4" aria-hidden={true} />
-          </span>
-          <div className="min-w-0 space-y-1">
-            <p className="text-sm leading-6 text-foreground">{copy}</p>
-          </div>
-        </aside>
-      </CardContent>
-    </Card>
+        <p className={cn('text-sm leading-6', standalone ? 'text-muted-foreground' : 'text-foreground')}>{copy}</p>
+      </div>
+    </aside>
   )
 }

--- a/src/components/templates/ClinicDetailConcepts/ClinicDetail.tsx
+++ b/src/components/templates/ClinicDetailConcepts/ClinicDetail.tsx
@@ -260,6 +260,7 @@ export function ClinicDetail({
           variant="inline-note"
           size="compact"
           showVariantLabel={false}
+          standalone={true}
         />
       </Container>
 

--- a/src/stories/templates/DisclaimerOptions.stories.tsx
+++ b/src/stories/templates/DisclaimerOptions.stories.tsx
@@ -65,18 +65,22 @@ function DisclaimerComparisonBoard() {
                   copy={legalPreviewCopy}
                   variant="inline-note"
                   surface="light"
+                  showVariantLabel={true}
                 />
                 <DisclaimerNotice
                   routeLabel="Comparison pages"
                   copy={legalPreviewCopy}
                   variant="slim-notice-bar"
                   surface="light"
+                  showVariantLabel={true}
                 />
                 <DisclaimerNotice
                   routeLabel="Comparison pages"
                   copy={legalPreviewCopy}
                   variant="collapsible-disclosure"
                   surface="light"
+                  title="Why this note appears"
+                  showVariantLabel={true}
                 />
               </div>
             </div>
@@ -102,18 +106,22 @@ function DisclaimerComparisonBoard() {
                   copy={legalPreviewCopy}
                   variant="inline-note"
                   surface="muted"
+                  showVariantLabel={true}
                 />
                 <DisclaimerNotice
                   routeLabel="Comparison pages"
                   copy={legalPreviewCopy}
                   variant="slim-notice-bar"
                   surface="muted"
+                  showVariantLabel={true}
                 />
                 <DisclaimerNotice
                   routeLabel="Comparison pages"
                   copy={legalPreviewCopy}
                   variant="collapsible-disclosure"
                   surface="muted"
+                  title="Why this note appears"
+                  showVariantLabel={true}
                 />
               </div>
             </div>
@@ -252,6 +260,7 @@ export const CollapsibleDisclosure: Story = {
     copy: routeDisclaimerExamples[2].copy,
     variant: 'collapsible-disclosure',
     surface: 'light',
+    title: 'Why this note appears',
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)

--- a/src/stories/templates/ListingComparison.stories.tsx
+++ b/src/stories/templates/ListingComparison.stories.tsx
@@ -231,6 +231,7 @@ export const Default: Story = {
     // Results render
     expect(canvas.getByLabelText(/clinic results/i)).toBeInTheDocument()
     expect(canvas.getByText('Ring Clinic')).toBeInTheDocument()
+    expect(canvas.getByText(DISCLAIMER_COPY.comparisonPages)).toBeInTheDocument()
 
     // Filters interaction narrows results (city filter)
     await userEvent.click(canvas.getByRole('checkbox', { name: 'Berlin' }))

--- a/src/stories/templates/ListingComparison.stories.tsx
+++ b/src/stories/templates/ListingComparison.stories.tsx
@@ -7,6 +7,7 @@ import { ListingComparison } from '@/components/templates/ListingComparison/Comp
 import { ListingComparisonFilters } from '@/app/(frontend)/listing-comparison/ListingComparisonFilters.client'
 import { sortListingComparison, SORT_OPTIONS, type SortOption } from '@/utilities/listingComparison/sort'
 import { SortControl } from '@/components/molecules/SortControl'
+import { DISCLAIMER_COPY } from '@/utilities/legal/disclaimers'
 import { withViewportStory } from '../utils/viewportMatrix'
 import {
   applyListingComparisonLocalFilters,
@@ -195,6 +196,17 @@ const FilterHarness: React.FC<TemplateArgs> = ({ hero, trust, results = [], empt
 }
 
 const sampleResults: ListingCardData[] = clinicResults
+const comparisonTrust = {
+  ...clinicTrust,
+  disclaimer: {
+    copy: DISCLAIMER_COPY.comparisonPages,
+    routeLabel: 'Comparison pages',
+    variant: 'inline-note' as const,
+    surface: 'muted' as const,
+    size: 'compact' as const,
+    showVariantLabel: false,
+  },
+}
 
 export const Default: Story = {
   args: {
@@ -207,7 +219,7 @@ export const Default: Story = {
     },
     filters: undefined,
     results: sampleResults,
-    trust: clinicTrust,
+    trust: comparisonTrust,
   },
   render: (args) => <FilterHarness {...args} />,
   play: async ({ canvasElement }) => {
@@ -235,7 +247,7 @@ export const EmptyResults: Story = {
     hero: baseHero,
     filters: undefined,
     results: [],
-    trust: clinicTrust,
+    trust: comparisonTrust,
     emptyState: (
       <div className="rounded-2xl border border-border bg-card p-6 text-sm text-muted-foreground">
         No results yet. Adjust filters or connect the search API.
@@ -258,7 +270,7 @@ export const NoHeroMedia: Story = {
     },
     filters: undefined,
     results: sampleResults,
-    trust: clinicTrust,
+    trust: comparisonTrust,
   },
   render: (args) => <FilterHarness {...args} />,
 }
@@ -276,7 +288,7 @@ export const LongResultsList: Story = {
     },
     filters: undefined,
     results: makeClinicList(18),
-    trust: clinicTrust,
+    trust: comparisonTrust,
   },
   render: (args) => <FilterHarness {...args} />,
   play: async ({ canvasElement }) => {
@@ -294,7 +306,7 @@ export const NoFiltersPanel: Story = {
     },
     filters: null,
     results: sampleResults,
-    trust: clinicTrust,
+    trust: comparisonTrust,
   },
 }
 
@@ -309,7 +321,7 @@ export const FilterByHighRating: Story = {
     },
     filters: undefined,
     results: sampleResults,
-    trust: clinicTrust,
+    trust: comparisonTrust,
   },
   render: (args) => <FilterHarness {...args} />,
   play: async ({ canvasElement }) => {
@@ -328,7 +340,7 @@ export const FilterByShortWaitTime: Story = {
     hero: baseHero,
     filters: undefined,
     results: sampleResults,
-    trust: clinicTrust,
+    trust: comparisonTrust,
   },
   render: (args) => <FilterHarness {...args} />,
   play: async ({ canvasElement }) => {
@@ -349,7 +361,7 @@ export const FilterByTreatmentHipReplacement: Story = {
     hero: baseHero,
     filters: undefined,
     results: sampleResults,
-    trust: clinicTrust,
+    trust: comparisonTrust,
   },
   render: (args) => <FilterHarness {...args} />,
   play: async ({ canvasElement }) => {
@@ -377,7 +389,7 @@ export const SortByPrice: Story = {
     },
     filters: undefined,
     results: sampleResults,
-    trust: clinicTrust,
+    trust: comparisonTrust,
   },
   render: (args) => <FilterHarness {...args} />,
   play: async ({ canvasElement }) => {
@@ -418,7 +430,7 @@ export const SortByRating: Story = {
     },
     filters: undefined,
     results: sampleResults,
-    trust: clinicTrust,
+    trust: comparisonTrust,
   },
   render: (args) => <FilterHarness {...args} />,
   play: async ({ canvasElement }) => {

--- a/tests/unit/components/clinicDetailConcepts.test.tsx
+++ b/tests/unit/components/clinicDetailConcepts.test.tsx
@@ -163,6 +163,7 @@ describe('ClinicDetail concept', () => {
         variant: 'inline-note',
         size: 'compact',
         showVariantLabel: false,
+        standalone: true,
       }),
     )
   })

--- a/tests/unit/components/disclaimerNotice.test.tsx
+++ b/tests/unit/components/disclaimerNotice.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { DisclaimerNotice } from '@/components/molecules/DisclaimerNotice'
+
+describe('DisclaimerNotice', () => {
+  const copy = 'Clinic profile details are provided by the clinic unless otherwise noted.'
+
+  it('renders route note copy without internal design guidance by default', () => {
+    render(<DisclaimerNotice routeLabel="Clinic profiles" copy={copy} variant="inline-note" size="compact" />)
+
+    expect(screen.getByText(copy)).toBeInTheDocument()
+    expect(screen.getByText('Clinic profiles')).toBeInTheDocument()
+    expect(screen.queryByText('Inline note')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Visible in flow/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Still visible/i)).not.toBeInTheDocument()
+  })
+
+  it('keeps standalone route notes to icon and copy only', () => {
+    render(<DisclaimerNotice routeLabel="Clinic profiles" copy={copy} variant="inline-note" standalone={true} />)
+
+    expect(screen.getByText(copy)).toBeInTheDocument()
+    expect(screen.queryByText('Clinic profiles')).not.toBeInTheDocument()
+  })
+
+  it('keeps collapsible disclosure text hidden until expanded', () => {
+    render(<DisclaimerNotice routeLabel="Clinic profiles" copy={copy} variant="collapsible-disclosure" />)
+
+    expect(screen.queryByText(copy)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Short legal text/i)).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clinic profiles' }))
+
+    expect(screen.getByText(copy)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Management summary

### Deutsch

Die Hinweiszeilen auf Klinikprofilen und Vergleichsseiten sind jetzt ruhiger eingebunden und lenken weniger von den eigentlichen Klinik-, Ergebnis- und Bewertungsinhalten ab. Vergleichsspezifische Hinweise bleiben auf den Vergleichskontext begrenzt, sodass Nutzer klarer erkennen, welche Aussage zu welchem Seitenbereich gehört.

### English

The note rows on clinic profiles and comparison pages are now quieter and less distracting from the primary clinic, result, and review content. Comparison-specific guidance stays limited to the comparison context, making it clearer which message belongs to which part of the experience.

## What changed

- Reworked `DisclaimerNotice` so production notes no longer render as card-like demo blocks with internal variant copy.
- Kept standalone notes to icon plus subdued copy, without card chrome, labels, or vertical accent line.
- Set the clinic profile source note to standalone mode between the profile overview and patient reviews.
- Scoped comparison disclaimer story data to the listing comparison stories instead of the shared trust-section fixture.
- Added unit coverage for default, standalone, and collapsible disclaimer behavior.

## Points to review

| Priority | Files / paths                                             | Why focus here                                         | Reviewer should verify                                                        | Evidence                                                 |
| -------- | --------------------------------------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------- | -------------------------------------------------------- |
| P2       | `src/components/molecules/DisclaimerNotice/index.tsx`     | Shared note component used across public UI contexts.  | Standalone notes stay visually quiet while demo/collapsible variants remain usable. | Focused tests, Storybook/Playwright screenshots.         |
| P2       | `src/stories/templates/ListingComparison.stories.tsx`     | Comparison disclaimer scope is represented in stories. | Comparison-page copy appears in listing comparison stories, not generic trust stories. | Playwright text-count check and mobile screenshot.       |
| P3       | `src/components/templates/ClinicDetailConcepts/ClinicDetail.tsx` | Clinic source note sits between profile and reviews.   | The note supports the transition into reviews without competing with content. | Clinic mobile screenshot and component unit assertion.   |

## UI/UX

Screenshot evidence is recorded under the `UI/mobile QA` validation item.

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed; existing test-sense warnings were reported and did not block the command.
- [x] `pnpm build`: passed with the existing local Node engine warning (`v26.0.0` while the repo expects `>=24.0.0 <25`).
- [x] Focused tests: `pnpm vitest tests/unit/components/disclaimerNotice.test.tsx tests/unit/components/clinicDetailConcepts.test.tsx tests/unit/components/listingComparisonTemplate.test.tsx`.
- [x] UI/mobile QA: Storybook/Playwright checked clinic mobile note without card chrome or vertical line, listing comparison mobile note, and text-scope counts for clinic/listing/trust stories.
  <!-- gh-ui-screenshots:start -->
  ### Clinic Profile Mobile Note
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":2.4,"capturedAt":"2026-06-22T15:15:35.854Z","contentType":"image/png","focus":"clinic-profile-mobile-note","focusLabel":"Clinic Profile Mobile Note","formFactor":"mobile","gitSha":"eb2f09f4","height":900,"releaseEligible":false,"releaseRole":"qa","size":74187,"sizeKb":73,"uploadName":"clinic-profile-mobile-note__mobile__375x900__20260622T151535Z__eb2f09f4__375x900__73kb.png","viewport":"375x900","warnings":["not_release_marked"],"width":375,"url":"https://github.com/user-attachments/assets/ce11b8b5-d0f1-4324-b334-0b43b3e4fa9f"} -->
  ![Clinic Profile Mobile Note](https://github.com/user-attachments/assets/ce11b8b5-d0f1-4324-b334-0b43b3e4fa9f)
  
  
  > Screenshot warning: not_release_marked
  
  ### Listing Comparison Mobile Note
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":2.4,"capturedAt":"2026-06-22T15:15:37.528Z","contentType":"image/png","focus":"listing-comparison-mobile-note","focusLabel":"Listing Comparison Mobile Note","formFactor":"mobile","gitSha":"eb2f09f4","height":900,"releaseEligible":false,"releaseRole":"qa","size":53428,"sizeKb":53,"uploadName":"listing-comparison-mobile-note__mobile__375x900__20260622T151537Z__eb2f09f4__375x900__53kb.png","viewport":"375x900","warnings":["not_release_marked"],"width":375,"url":"https://github.com/user-attachments/assets/f2feca41-7cac-4bc1-9a57-72199009c500"} -->
  ![Listing Comparison Mobile Note](https://github.com/user-attachments/assets/f2feca41-7cac-4bc1-9a57-72199009c500)
  
  
  > Screenshot warning: not_release_marked
  <!-- gh-ui-screenshots:end -->
- [ ] Security/privacy review: Not run; the change is scoped to public UI presentation, story fixtures, and tests with no auth, secret, API, logging, or data-boundary changes.
- [ ] Migration/schema check: Not applicable; no Payload schema, migration, or data-model changes.
- [ ] Documentation/instructions check: Not applicable; no docs or instruction surfaces changed.

## Risk and rollout

Low UI risk. The shared note component changes presentation for standalone public notes, while non-standalone demo and collapsible variants remain covered by focused tests. Rollback is a normal revert of this PR.

## Development

Closes #1384
