### PR TITLE
feat: add breadcrumbs and clinic discovery links

### DIFF
--- a/src/app/(frontend)/clinics/[slug]/page.tsx
+++ b/src/app/(frontend)/clinics/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 
+import { BreadcrumbJsonLd } from '@/components/molecules/Breadcrumb/BreadcrumbJsonLd'
 import { ClinicDetail } from '@/components/templates/ClinicDetailConcepts'
 import { COOKIE_CONSENT_COOKIE_NAME, resolveCookieConsentContext } from '@/features/cookieConsent'
 import { buildPatientLoginHref } from '@/features/favorites/redirects'
@@ -54,16 +55,19 @@ export default async function ClinicDetailPage({ params: paramsPromise }: Clinic
   const clinicPath = `/clinics/${encodeURIComponent(slug)}`
 
   return (
-    <ClinicDetail
-      data={clinicDetailData}
-      favorite={{
-        isPatient: favoriteAuthContext.isPatient,
-        favoriteId: favoriteStateByClinicId[String(clinicDetailData.clinicId)] ?? null,
-        loginHref: buildPatientLoginHref(clinicPath),
-      }}
-      cookieConsentConfig={cookieConsentContext.config}
-      cookieConsentInitialConsent={cookieConsentContext.initialConsent}
-    />
+    <>
+      <BreadcrumbJsonLd items={clinicDetailData.breadcrumbs} />
+      <ClinicDetail
+        data={clinicDetailData}
+        favorite={{
+          isPatient: favoriteAuthContext.isPatient,
+          favoriteId: favoriteStateByClinicId[String(clinicDetailData.clinicId)] ?? null,
+          loginHref: buildPatientLoginHref(clinicPath),
+        }}
+        cookieConsentConfig={cookieConsentContext.config}
+        cookieConsentInitialConsent={cookieConsentContext.initialConsent}
+      />
+    </>
   )
 }
 

--- a/src/app/(frontend)/listing-comparison/page.tsx
+++ b/src/app/(frontend)/listing-comparison/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 import { headers } from 'next/headers'
 import { getPayload } from 'payload'
 
+import { BreadcrumbJsonLd } from '@/components/molecules/Breadcrumb/BreadcrumbJsonLd'
 import { findFavoriteClinicStateRecord, resolveFavoriteClinicAuthContext } from '@/features/favorites/server'
 import { buildIndexingMetadata, resolveListingComparisonIndexing } from '@/features/searchIndexing'
 import { buildFreshnessMetadata } from '@/utilities/freshness'
@@ -67,42 +68,45 @@ export default async function ListingComparisonPage({ searchParams: searchParams
   ).filter((stat) => stat.value > 0)
 
   return (
-    <ListingComparisonPageClient
-      hero={{
-        title: 'Compare clinic prices',
-        subtitle: `Transparent pricing for medical treatments near you${specialtySuffix ? `\n${specialtySuffix}` : ''}`,
-        features: [
-          `${listingData.metrics.verifiedClinics} ${verifiedClinicLabel}`,
-          'Reviewed prices',
-          'Free comparison',
-        ],
-        bulletStyle: 'circle',
-      }}
-      filterOptions={listingData.filterOptions}
-      priceBounds={listingData.priceBounds}
-      queryState={listingData.queryState}
-      pagination={listingData.pagination}
-      specialtyContext={listingData.specialtyContext}
-      results={listingData.results}
-      favorites={{
-        isPatient: favoriteAuthContext.isPatient,
-        favoriteStateByClinicId,
-      }}
-      trust={{
-        title: 'A clearer way to compare clinics',
-        subtitle:
-          'We make clinic profiles easier to compare by showing key treatment, location, and price fields in one place.',
-        stats: trustStats,
-        badges: ['Verified clinic profiles', 'Treatment types', 'Locations', 'Price fields where available'],
-        disclaimer: {
-          copy: DISCLAIMER_COPY.comparisonPages,
-          routeLabel: 'Comparison pages',
-          variant: 'inline-note',
-          surface: 'muted',
-          size: 'compact',
-          showVariantLabel: false,
-        },
-      }}
-    />
+    <>
+      <BreadcrumbJsonLd items={listingData.specialtyContext.breadcrumbs} />
+      <ListingComparisonPageClient
+        hero={{
+          title: 'Compare clinic prices',
+          subtitle: `Transparent pricing for medical treatments near you${specialtySuffix ? `\n${specialtySuffix}` : ''}`,
+          features: [
+            `${listingData.metrics.verifiedClinics} ${verifiedClinicLabel}`,
+            'Reviewed prices',
+            'Free comparison',
+          ],
+          bulletStyle: 'circle',
+        }}
+        filterOptions={listingData.filterOptions}
+        priceBounds={listingData.priceBounds}
+        queryState={listingData.queryState}
+        pagination={listingData.pagination}
+        specialtyContext={listingData.specialtyContext}
+        results={listingData.results}
+        favorites={{
+          isPatient: favoriteAuthContext.isPatient,
+          favoriteStateByClinicId,
+        }}
+        trust={{
+          title: 'A clearer way to compare clinics',
+          subtitle:
+            'We make clinic profiles easier to compare by showing key treatment, location, and price fields in one place.',
+          stats: trustStats,
+          badges: ['Verified clinic profiles', 'Treatment types', 'Locations', 'Price fields where available'],
+          disclaimer: {
+            copy: DISCLAIMER_COPY.comparisonPages,
+            routeLabel: 'Comparison pages',
+            variant: 'inline-note',
+            surface: 'muted',
+            size: 'compact',
+            showVariantLabel: false,
+          },
+        }}
+      />
+    </>
   )
 }

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { draftMode } from 'next/headers'
 import React, { cache } from 'react'
 import RichText from '@/blocks/_shared/RichText'
 
+import { BreadcrumbJsonLd } from '@/components/molecules/Breadcrumb/BreadcrumbJsonLd'
 import { PostHero } from '@/components/organisms/Heroes/PostHero'
 import { generateMeta } from '@/utilities/generateMeta'
 import PageClient from './page.client'
@@ -21,6 +22,7 @@ import { resolveMediaImage } from '@/utilities/media/resolveMediaImage'
 import { PostShareActionBar } from './PostShareActionBar'
 import { resolveContentLocaleContext, type ContentLocaleContext } from '@/utilities/contentLocalization'
 import { buildPostPath, buildPostsIndexPath } from '@/utilities/content/postPaths'
+import { createBlogBreadcrumb, HOME_BREADCRUMB } from '@/utilities/breadcrumbs'
 
 export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
@@ -72,8 +74,9 @@ export default async function Post({ params: paramsPromise, searchParams: search
       : undefined
 
   const breadcrumbs = [
-    { label: 'Home', href: '/' },
-    { label: 'Blog', href: buildPostsIndexPath(contentLocale) },
+    HOME_BREADCRUMB,
+    createBlogBreadcrumb(buildPostsIndexPath(contentLocale)),
+    { label: post.title, href: localizedPostPath },
   ]
   const readTime = calculateReadTime(post.content)
   const hasPostContent = Boolean(post.content?.root?.children?.length)
@@ -81,6 +84,7 @@ export default async function Post({ params: paramsPromise, searchParams: search
   return (
     <article className="pb-16 sm:pb-20">
       <PageClient />
+      <BreadcrumbJsonLd items={breadcrumbs} />
 
       {/* Allows redirects for valid pages too */}
       <PayloadRedirects disableNotFound url={canonicalPostPath} />

--- a/src/app/(frontend)/posts/page.tsx
+++ b/src/app/(frontend)/posts/page.tsx
@@ -4,10 +4,12 @@ import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 import React from 'react'
 import PageClient from './page.client'
+import { BreadcrumbJsonLd } from '@/components/molecules/Breadcrumb/BreadcrumbJsonLd'
 import { Container } from '@/components/molecules/Container'
 import { BlogHero } from '@/components/organisms/Blog/BlogHero'
 import { BlogCard } from '@/components/organisms/Blog/BlogCard'
 import { normalizePost } from '@/utilities/blog/normalizePost'
+import { createBlogBreadcrumb, HOME_BREADCRUMB } from '@/utilities/breadcrumbs'
 import { buildPostsIndexPath, buildPostsPagePath } from '@/utilities/content/postPaths'
 import { findPublishedPostsPage } from '@/utilities/content/serverData'
 import { resolveContentLocaleContext } from '@/utilities/contentLocalization'
@@ -37,13 +39,15 @@ export default async function Page({ searchParams: searchParamsPromise }: Args =
   const normalizedPosts = posts.docs.map((post) => normalizePost(post, { contentLocale }))
   const [featuredPost, ...gridPosts] = normalizedPosts
   const moreArticlesCount = Math.max((posts.totalDocs || 0) - (featuredPost ? 1 : 0), 0)
+  const breadcrumbs = [HOME_BREADCRUMB, createBlogBreadcrumb(buildPostsIndexPath(contentLocale))]
 
   return (
     <div className="pb-20 sm:pb-24">
       <PageClient />
+      <BreadcrumbJsonLd items={breadcrumbs} />
 
       {/* Hero Section */}
-      <BlogHero />
+      <BlogHero breadcrumbs={breadcrumbs} />
 
       {/* Featured Post (Overlay Variant) */}
       {featuredPost && (

--- a/src/app/(frontend)/posts/page/[pageNumber]/page.tsx
+++ b/src/app/(frontend)/posts/page/[pageNumber]/page.tsx
@@ -5,10 +5,13 @@ import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 import React from 'react'
 import PageClient from './page.client'
+import { Breadcrumb, type BreadcrumbItem } from '@/components/molecules/Breadcrumb'
+import { BreadcrumbJsonLd } from '@/components/molecules/Breadcrumb/BreadcrumbJsonLd'
 import { Heading } from '@/components/atoms/Heading'
 import { notFound, redirect } from 'next/navigation'
 import { Container } from '@/components/molecules/Container'
 import { normalizePost } from '@/utilities/blog/normalizePost'
+import { createBlogBreadcrumb, HOME_BREADCRUMB } from '@/utilities/breadcrumbs'
 import { buildPostsIndexPath, buildPostsPagePath } from '@/utilities/content/postPaths'
 import { countPublishedPosts, findPublishedPostsPage } from '@/utilities/content/serverData'
 import { resolveContentLocaleContext } from '@/utilities/contentLocalization'
@@ -51,12 +54,20 @@ export default async function Page({ params: paramsPromise, searchParams: search
 
   const normalizedPosts = posts.docs.map((post) => normalizePost(post, { contentLocale }))
   const remainingArticlesCount = Math.max((posts.totalDocs || 0) - 1, 0)
+  const pagePath = buildPostsPagePath(sanitizedPageNumber, contentLocale)
+  const breadcrumbs: BreadcrumbItem[] = [
+    HOME_BREADCRUMB,
+    createBlogBreadcrumb(buildPostsIndexPath(contentLocale)),
+    { label: `Page ${sanitizedPageNumber}`, href: pagePath },
+  ]
 
   return (
     <div className="pt-16 pb-20 sm:pt-24 sm:pb-24">
       <PageClient />
+      <BreadcrumbJsonLd items={breadcrumbs} />
       <Container className="mb-12 sm:mb-16">
         <div className="prose max-w-none">
+          <Breadcrumb items={breadcrumbs} className="mb-6 [&_ol]:justify-center" />
           <Heading as="h1" align="center">
             Posts
           </Heading>

--- a/src/components/molecules/Breadcrumb/BreadcrumbJsonLd.tsx
+++ b/src/components/molecules/Breadcrumb/BreadcrumbJsonLd.tsx
@@ -1,0 +1,21 @@
+import type { BreadcrumbItem } from '@/components/molecules/Breadcrumb'
+import { buildBreadcrumbListJsonLd } from '@/utilities/structuredData/breadcrumbs'
+
+export type BreadcrumbJsonLdProps = {
+  items: BreadcrumbItem[]
+}
+
+export function BreadcrumbJsonLd({ items }: BreadcrumbJsonLdProps) {
+  const jsonLd = buildBreadcrumbListJsonLd(items)
+
+  if (!jsonLd) return null
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(jsonLd),
+      }}
+    />
+  )
+}

--- a/src/components/molecules/Breadcrumb/index.tsx
+++ b/src/components/molecules/Breadcrumb/index.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/utilities/ui'
 export type BreadcrumbItem = {
   label: string
   href: string
+  current?: boolean
 }
 
 export type BreadcrumbProps = {
@@ -41,11 +42,11 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({ items, separator = '›'
 
   return (
     <nav className={cn('text-sm', variantClasses[variant], className)} aria-label="Breadcrumb">
-      <ol className="flex flex-wrap items-center gap-4">
+      <ol className="flex flex-wrap items-center gap-x-4 gap-y-1">
         {items.map((item, index) => {
-          const isCurrent = index === items.length - 1
+          const isCurrent = item.current ?? index === items.length - 1
 
-          const linkClasses =
+          const itemClasses =
             variant === 'light'
               ? isCurrent
                 ? '!text-white hover:!text-white'
@@ -53,19 +54,21 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({ items, separator = '›'
               : 'text-inherit hover:text-foreground'
 
           return (
-            <li key={index} className="flex items-center gap-4">
-              {index > 0 && (
+            <li key={`${item.href}-${index}`} className="inline-flex max-w-full min-w-0 items-center gap-4">
+              {isCurrent ? (
+                <span aria-current="page" className={cn('max-w-full break-words', itemClasses)} title={item.label}>
+                  {item.label}
+                </span>
+              ) : (
+                <Link href={item.href} className={cn('max-w-full break-words transition-colors', itemClasses)}>
+                  {item.label}
+                </Link>
+              )}
+              {index < items.length - 1 && (
                 <span aria-hidden="true" className={cn(variant === 'light' ? '!text-white/45' : 'text-inherit')}>
                   {separator}
                 </span>
               )}
-              <Link
-                href={item.href}
-                className={cn('transition-colors', linkClasses)}
-                {...(isCurrent && { 'aria-current': 'page' })}
-              >
-                {item.label}
-              </Link>
             </li>
           )
         })}

--- a/src/components/organisms/Blog/BlogHero/index.tsx
+++ b/src/components/organisms/Blog/BlogHero/index.tsx
@@ -29,31 +29,41 @@ export const BlogHero: React.FC<BlogHeroProps> = ({
   className,
 }) => {
   return (
-    <section
-      className={cn(
-        'relative isolate overflow-hidden bg-[#fbf8f4] bg-[url(/images/blog-header-clinic-reception.webp)] bg-cover bg-center bg-no-repeat',
-        className,
-      )}
-    >
-      <div className="absolute inset-0 z-0 bg-white/70" aria-hidden="true" />
-
-      {/* Content */}
-      <Container className="relative z-10 flex flex-col items-center justify-center py-12 text-center sm:py-14 md:min-h-[20rem] md:py-12 lg:min-h-[22rem] lg:items-start lg:py-14 lg:text-left xl:min-h-[24rem]">
-        <div className="mx-auto max-w-2xl text-center lg:mx-0 lg:max-w-xl lg:text-left">
-          {breadcrumbs?.length ? (
-            <Breadcrumb items={breadcrumbs} className="mb-4 [&_ol]:justify-center lg:[&_ol]:justify-start" />
-          ) : null}
-          <Heading as="h1" size="h1" align="center" className="mb-4 text-4xl sm:text-5xl lg:text-left lg:text-6xl">
-            {title}
-          </Heading>
-          {subtitle && (
-            <p className="mx-auto max-w-xl text-base leading-relaxed text-foreground/75 sm:text-lg lg:mx-0">
-              {subtitle}
-            </p>
-          )}
+    <>
+      {breadcrumbs?.length ? (
+        <div className="border-b border-black/5 bg-[#fbf8f4]">
+          <Container className="py-4 sm:py-5">
+            <Breadcrumb
+              items={breadcrumbs}
+              className="text-xs sm:text-sm [&_ol]:justify-center lg:[&_ol]:justify-start"
+            />
+          </Container>
         </div>
-      </Container>
-    </section>
+      ) : null}
+
+      <section
+        className={cn(
+          'relative isolate overflow-hidden bg-[#fbf8f4] bg-[url(/images/blog-header-clinic-reception.webp)] bg-cover bg-center bg-no-repeat',
+          className,
+        )}
+      >
+        <div className="absolute inset-0 z-0 bg-white/70" aria-hidden="true" />
+
+        {/* Content */}
+        <Container className="relative z-10 flex flex-col items-center justify-center py-12 text-center sm:py-14 md:min-h-[20rem] md:py-12 lg:min-h-[22rem] lg:items-start lg:py-14 lg:text-left xl:min-h-[24rem]">
+          <div className="mx-auto max-w-2xl text-center lg:mx-0 lg:max-w-xl lg:text-left">
+            <Heading as="h1" size="h1" align="center" className="mb-4 text-4xl sm:text-5xl lg:text-left lg:text-6xl">
+              {title}
+            </Heading>
+            {subtitle && (
+              <p className="mx-auto max-w-xl text-base leading-relaxed text-foreground/75 sm:text-lg lg:mx-0">
+                {subtitle}
+              </p>
+            )}
+          </div>
+        </Container>
+      </section>
+    </>
   )
 }
 

--- a/src/components/organisms/Blog/BlogHero/index.tsx
+++ b/src/components/organisms/Blog/BlogHero/index.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import { Heading } from '@/components/atoms/Heading'
+import { Breadcrumb, type BreadcrumbItem } from '@/components/molecules/Breadcrumb'
 import { Container } from '@/components/molecules/Container'
 import { cn } from '@/utilities/ui'
 
 export type BlogHeroProps = {
   title?: string
   subtitle?: string
+  breadcrumbs?: BreadcrumbItem[]
   className?: string
 }
 
@@ -23,6 +25,7 @@ export type BlogHeroProps = {
 export const BlogHero: React.FC<BlogHeroProps> = ({
   title = 'Our Blog',
   subtitle = 'Expert insights, practical guidance, and the latest updates in health and medicine.',
+  breadcrumbs,
   className,
 }) => {
   return (
@@ -37,6 +40,9 @@ export const BlogHero: React.FC<BlogHeroProps> = ({
       {/* Content */}
       <Container className="relative z-10 flex flex-col items-center justify-center py-12 text-center sm:py-14 md:min-h-[20rem] md:py-12 lg:min-h-[22rem] lg:items-start lg:py-14 lg:text-left xl:min-h-[24rem]">
         <div className="mx-auto max-w-2xl text-center lg:mx-0 lg:max-w-xl lg:text-left">
+          {breadcrumbs?.length ? (
+            <Breadcrumb items={breadcrumbs} className="mb-4 [&_ol]:justify-center lg:[&_ol]:justify-start" />
+          ) : null}
           <Heading as="h1" size="h1" align="center" className="mb-4 text-4xl sm:text-5xl lg:text-left lg:text-6xl">
             {title}
           </Heading>

--- a/src/components/organisms/ClinicDetail/FurtherTreatmentsSection.tsx
+++ b/src/components/organisms/ClinicDetail/FurtherTreatmentsSection.tsx
@@ -4,6 +4,7 @@ import { Stethoscope } from 'lucide-react'
 import { Heading } from '@/components/atoms/Heading'
 import { Button } from '@/components/atoms/button'
 import { Card, CardContent } from '@/components/atoms/card'
+import { UiLink } from '@/components/molecules/Link'
 import { formatUsd } from '@/components/templates/ClinicDetailConcepts/shared'
 
 import type { ClinicDetailTreatment } from '@/components/templates/ClinicDetailConcepts/types'
@@ -50,9 +51,23 @@ export function FurtherTreatmentsSection({
                 </p>
               </div>
 
-              <Button type="button" variant="secondary" onClick={() => onChooseTreatment(treatment.id)}>
-                Choose Treatment
-              </Button>
+              <div className="flex w-full flex-col items-stretch gap-2 sm:w-auto sm:items-end">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="w-full sm:w-auto"
+                  onClick={() => onChooseTreatment(treatment.id)}
+                >
+                  Choose Treatment
+                </Button>
+                {treatment.comparisonLink ? (
+                  <UiLink
+                    href={treatment.comparisonLink.href}
+                    label={treatment.comparisonLink.label}
+                    className="inline-flex min-h-9 items-center justify-center text-center text-sm font-semibold text-primary underline-offset-4 hover:underline"
+                  />
+                ) : null}
+              </div>
             </article>
           ))}
         </div>

--- a/src/components/organisms/ClinicDetail/HeroOverviewSection.tsx
+++ b/src/components/organisms/ClinicDetail/HeroOverviewSection.tsx
@@ -3,6 +3,7 @@ import { Stethoscope } from 'lucide-react'
 
 import { Heading } from '@/components/atoms/Heading'
 import { Card, CardContent } from '@/components/atoms/card'
+import { Breadcrumb, type BreadcrumbItem } from '@/components/molecules/Breadcrumb'
 import { DoctorPreviewListItem, HeroQualitySummary } from '@/components/molecules/ClinicDetail'
 import { Media } from '@/components/molecules/Media'
 import { formatRatingSummary } from '@/components/templates/ClinicDetailConcepts/shared'
@@ -15,6 +16,7 @@ type HeroOverviewSectionProps = {
   description: string
   heroImage: { src: string; alt: string }
   trust: ClinicDetailTrust
+  breadcrumbs?: BreadcrumbItem[]
   doctors: ClinicDetailDoctor[]
   activeDoctorId: string
   onDoctorSelect: (doctorId: string) => void
@@ -26,6 +28,7 @@ export function HeroOverviewSection({
   description,
   heroImage,
   trust,
+  breadcrumbs,
   doctors,
   activeDoctorId,
   onDoctorSelect,
@@ -39,6 +42,9 @@ export function HeroOverviewSection({
     <section className="grid gap-8 lg:grid-cols-12 lg:items-start">
       <div className="min-w-0 space-y-6 lg:col-span-5 lg:space-y-8 lg:pt-14">
         <div className="space-y-2">
+          {breadcrumbs?.length ? (
+            <Breadcrumb items={breadcrumbs} className="text-xs sm:text-sm [&_li]:gap-2 [&_ol]:gap-2" />
+          ) : null}
           <p className="text-2xl leading-[1.15] font-semibold text-primary sm:text-size-40">CLINIC OVERVIEW</p>
           <Heading
             as="h1"

--- a/src/components/organisms/TreatmentsStrip/index.tsx
+++ b/src/components/organisms/TreatmentsStrip/index.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/atoms/button'
 import { Card, CardContent } from '@/components/atoms/card'
 import { Heading } from '@/components/atoms/Heading'
 import { Container } from '@/components/molecules/Container'
+import { UiLink } from '@/components/molecules/Link'
 import { cn } from '@/utilities/ui'
 
 export type TreatmentsStripItem = {
@@ -16,6 +17,10 @@ export type TreatmentsStripItem = {
   cta?: {
     label: string
     onClick: () => void
+  }
+  comparisonLink?: {
+    href: string
+    label: string
   }
 }
 
@@ -113,7 +118,7 @@ export const TreatmentsStrip: React.FC<TreatmentsStripProps> = ({
                         title={item.title}
                         description={item.description}
                         icon={item.icon}
-                        hasCta={Boolean(item.cta)}
+                        hasActions={Boolean(item.cta || item.comparisonLink)}
                         isInteractive={isInteractive}
                         onSelect={onActiveIndexChange}
                         index={index}
@@ -143,7 +148,7 @@ export const TreatmentsStrip: React.FC<TreatmentsStripProps> = ({
                     title={item.title}
                     description={item.description}
                     icon={item.icon}
-                    hasCta={Boolean(item.cta)}
+                    hasActions={Boolean(item.cta || item.comparisonLink)}
                     isInteractive={isInteractive}
                     onSelect={onActiveIndexChange}
                     index={index}
@@ -165,7 +170,7 @@ function Tile({
   title,
   description,
   icon,
-  hasCta = false,
+  hasActions = false,
   isInteractive,
   onSelect,
   index,
@@ -176,7 +181,7 @@ function Tile({
   title: string
   description: string
   icon?: React.ReactNode
-  hasCta?: boolean
+  hasActions?: boolean
   isInteractive: boolean
   onSelect?: (idx: number) => void
   index: number
@@ -208,8 +213,8 @@ function Tile({
             {title}
           </Heading>
           <p className="text-normal mt-3 line-clamp-3 text-primary-foreground/85">{description}</p>
-          {hasCta ? (
-            <div className="mt-5 inline-flex h-10 w-[172px] rounded-full border border-primary-foreground/20" />
+          {hasActions ? (
+            <div className="mt-5 inline-flex h-[72px] w-[220px] rounded-full border border-primary-foreground/20" />
           ) : null}
         </div>
       ) : (
@@ -257,10 +262,21 @@ function ActiveCard({ item, lifted = false }: { item: TreatmentsStripItem; lifte
         <p className="text-normal mt-3 line-clamp-3 self-start text-secondary/90" title={item.description}>
           {item.description}
         </p>
-        {item.cta ? (
-          <Button type="button" className="mt-5 rounded-full px-6" onClick={item.cta.onClick}>
-            {item.cta.label}
-          </Button>
+        {item.cta || item.comparisonLink ? (
+          <div className="mt-5 flex flex-col items-center gap-2">
+            {item.cta ? (
+              <Button type="button" className="rounded-full px-6" onClick={item.cta.onClick}>
+                {item.cta.label}
+              </Button>
+            ) : null}
+            {item.comparisonLink ? (
+              <UiLink
+                href={item.comparisonLink.href}
+                label={item.comparisonLink.label}
+                className="inline-flex min-h-9 items-center text-sm font-semibold text-primary underline-offset-4 hover:underline"
+              />
+            ) : null}
+          </div>
         ) : null}
       </CardContent>
     </Card>

--- a/src/components/templates/ClinicDetailConcepts/ClinicDetail.tsx
+++ b/src/components/templates/ClinicDetailConcepts/ClinicDetail.tsx
@@ -176,6 +176,7 @@ export function ClinicDetail({
             priceFromUsd: treatment.priceFromUsd,
           }),
           icon: <Icon className="size-7" aria-hidden={true} />,
+          comparisonLink: treatment.comparisonLink,
           cta: {
             label: 'Choose Treatment',
             onClick: () => handleCuratedTreatmentClick(treatment.id),
@@ -235,6 +236,7 @@ export function ClinicDetail({
           description={data.description}
           heroImage={data.heroImage}
           trust={data.trust}
+          breadcrumbs={data.breadcrumbs}
           doctors={heroDoctors}
           activeDoctorId={interaction.activeHeroDoctorId}
           onDoctorSelect={interaction.toggleDoctorSelection}

--- a/src/components/templates/ClinicDetailConcepts/types.ts
+++ b/src/components/templates/ClinicDetailConcepts/types.ts
@@ -1,3 +1,4 @@
+import type { BreadcrumbItem } from '@/components/molecules/Breadcrumb'
 import type { CookieConsentConfig, CookieConsentState } from '@/features/cookieConsent'
 import type { FreshnessSignals } from '@/utilities/freshness'
 
@@ -29,6 +30,10 @@ export type ClinicDetailTreatment = {
   name: string
   priceFromUsd?: number
   category?: string
+  comparisonLink?: {
+    href: string
+    label: string
+  }
 }
 
 export type ClinicBeforeAfterEntry = {
@@ -79,6 +84,7 @@ export type ClinicDetailData = {
   clinicId: number
   clinicSlug: string
   clinicName: string
+  breadcrumbs: BreadcrumbItem[]
   heroImage: { src: string; alt: string }
   description: string
   trust: ClinicDetailTrust

--- a/src/stories/fixtures/clinicDetail.ts
+++ b/src/stories/fixtures/clinicDetail.ts
@@ -5,6 +5,13 @@ import { getStoryImageSrc, storyClinicImages, storyPortraits } from './assets'
 const clinicSlug = 'berlin-health-clinic'
 const clinicContactHref = `/contact?clinic=${clinicSlug}&source=clinic-detail`
 
+function buildTreatmentComparisonLink(id: string, treatmentName: string) {
+  return {
+    href: `/listing-comparison?treatment=${encodeURIComponent(id)}`,
+    label: `Compare clinics for ${treatmentName}`,
+  }
+}
+
 const doctorBlueprints = [
   { name: 'Dr. Amelia Carter', specialty: 'Pediatric Cardiology' },
   { name: 'Dr. Jonas Meyer', specialty: 'General Pediatrics' },
@@ -78,6 +85,11 @@ export const clinicDetailFixture: ClinicDetailData = {
   clinicId: 1001,
   clinicSlug,
   clinicName: 'Berlin Health Clinic',
+  breadcrumbs: [
+    { label: 'Home', href: '/' },
+    { label: 'Clinics', href: '/listing-comparison' },
+    { label: 'Berlin Health Clinic', href: `/clinics/${clinicSlug}` },
+  ],
   heroImage: {
     src: getStoryImageSrc(storyClinicImages.clinicDetail.exterior),
     alt: 'Berlin Health Clinic exterior',
@@ -139,14 +151,61 @@ export const clinicDetailFixture: ClinicDetailData = {
     sourceCollections: ['clinics', 'reviews'],
   },
   treatments: [
-    { id: 'treatment-1', name: 'Routine Checkup', category: 'Preventive Care', priceFromUsd: 120 },
-    { id: 'treatment-2', name: 'Developmental Screening', category: 'Diagnostics', priceFromUsd: 180 },
-    { id: 'treatment-3', name: 'Vaccination Package', category: 'Preventive Care', priceFromUsd: 230 },
-    { id: 'treatment-4', name: 'Asthma Management Plan', category: 'Chronic Care', priceFromUsd: 310 },
-    { id: 'treatment-5', name: 'Neurology Consultation', category: 'Specialist Care', priceFromUsd: 380 },
-    { id: 'treatment-6', name: 'Pediatric Cardiology Review', category: 'Specialist Care', priceFromUsd: 460 },
-    { id: 'treatment-7', name: 'Genetic Counseling', category: 'Specialist Care' },
-    { id: 'treatment-8', name: 'Family Nutrition Coaching', category: 'Supportive Care', priceFromUsd: 150 },
+    {
+      id: 'treatment-1',
+      name: 'Routine Checkup',
+      category: 'Preventive Care',
+      priceFromUsd: 120,
+      comparisonLink: buildTreatmentComparisonLink('treatment-1', 'Routine Checkup'),
+    },
+    {
+      id: 'treatment-2',
+      name: 'Developmental Screening',
+      category: 'Diagnostics',
+      priceFromUsd: 180,
+      comparisonLink: buildTreatmentComparisonLink('treatment-2', 'Developmental Screening'),
+    },
+    {
+      id: 'treatment-3',
+      name: 'Vaccination Package',
+      category: 'Preventive Care',
+      priceFromUsd: 230,
+      comparisonLink: buildTreatmentComparisonLink('treatment-3', 'Vaccination Package'),
+    },
+    {
+      id: 'treatment-4',
+      name: 'Asthma Management Plan',
+      category: 'Chronic Care',
+      priceFromUsd: 310,
+      comparisonLink: buildTreatmentComparisonLink('treatment-4', 'Asthma Management Plan'),
+    },
+    {
+      id: 'treatment-5',
+      name: 'Neurology Consultation',
+      category: 'Specialist Care',
+      priceFromUsd: 380,
+      comparisonLink: buildTreatmentComparisonLink('treatment-5', 'Neurology Consultation'),
+    },
+    {
+      id: 'treatment-6',
+      name: 'Pediatric Cardiology Review',
+      category: 'Specialist Care',
+      priceFromUsd: 460,
+      comparisonLink: buildTreatmentComparisonLink('treatment-6', 'Pediatric Cardiology Review'),
+    },
+    {
+      id: 'treatment-7',
+      name: 'Genetic Counseling',
+      category: 'Specialist Care',
+      comparisonLink: buildTreatmentComparisonLink('treatment-7', 'Genetic Counseling'),
+    },
+    {
+      id: 'treatment-8',
+      name: 'Family Nutrition Coaching',
+      category: 'Supportive Care',
+      priceFromUsd: 150,
+      comparisonLink: buildTreatmentComparisonLink('treatment-8', 'Family Nutrition Coaching'),
+    },
   ],
   doctors,
   beforeAfterEntries: [

--- a/src/stories/molecules/Breadcrumb.stories.tsx
+++ b/src/stories/molecules/Breadcrumb.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Breadcrumb } from '@/components/molecules/Breadcrumb'
 import { userEvent, within, expect } from 'storybook/test'
 import { ChevronRight } from 'lucide-react'
+import { withViewportStory } from '../utils/viewportMatrix'
 
 const meta = {
   title: 'Shared/Molecules/Breadcrumb',
@@ -104,7 +105,24 @@ export const LongLabels: Story = {
       { label: 'Orthopädische Rehabilitation nach Sportverletzungen', href: '/posts/ortho' },
     ],
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    expect(canvas.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/')
+    expect(
+      canvas.getByText('Orthopädische Rehabilitation nach Sportverletzungen', {
+        selector: '[aria-current="page"]',
+      }),
+    ).toBeInTheDocument()
+  },
 }
+
+export const LongLabels320: Story = withViewportStory(LongLabels, 'public320', 'Long labels / 320')
+export const LongLabels375: Story = withViewportStory(LongLabels, 'public375', 'Long labels / 375')
+export const LongLabels640: Story = withViewportStory(LongLabels, 'public640', 'Long labels / 640')
+export const LongLabels768: Story = withViewportStory(LongLabels, 'public768', 'Long labels / 768')
+export const LongLabels1024: Story = withViewportStory(LongLabels, 'public1024', 'Long labels / 1024')
+export const LongLabels1280: Story = withViewportStory(LongLabels, 'public1280', 'Long labels / 1280')
 
 export const Interactive: Story = {
   name: 'Interactive (Hover Test)',

--- a/src/stories/organisms/BlogHero.stories.tsx
+++ b/src/stories/organisms/BlogHero.stories.tsx
@@ -4,6 +4,11 @@ import { expect, within } from 'storybook/test'
 import { BlogHero } from '@/components/organisms/Blog/BlogHero'
 import { withViewportStory } from '../utils/viewportMatrix'
 
+const blogBreadcrumbs = [
+  { label: 'Home', href: '/' },
+  { label: 'Blog', href: '/posts' },
+]
+
 /**
  * BlogHero Component
  *
@@ -79,6 +84,18 @@ export const CustomContent: Story = {
   },
 }
 
+export const WithBreadcrumbs: Story = {
+  args: {
+    breadcrumbs: blogBreadcrumbs,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getByRole('navigation', { name: 'Breadcrumb' })).toBeInTheDocument()
+    await expect(canvas.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/')
+    await expect(canvas.getByText('Blog', { selector: '[aria-current="page"]' })).toBeInTheDocument()
+  },
+}
+
 const denseCopyBase: Story = {
   args: {
     title: 'Insights for medical travel',
@@ -146,5 +163,11 @@ export const DenseCopy640: Story = withViewportStory(denseCopyBase, 'public640',
 export const DenseCopy768: Story = withViewportStory(denseCopyBase, 'public768', 'Dense copy / 768')
 export const DenseCopy1024: Story = withViewportStory(denseCopyBase, 'public1024', 'Dense copy / 1024')
 export const DenseCopy1280: Story = withViewportStory(denseCopyBase, 'public1280', 'Dense copy / 1280')
+export const WithBreadcrumbs320: Story = withViewportStory(WithBreadcrumbs, 'public320', 'With breadcrumbs / 320')
+export const WithBreadcrumbs375: Story = withViewportStory(WithBreadcrumbs, 'public375', 'With breadcrumbs / 375')
+export const WithBreadcrumbs640: Story = withViewportStory(WithBreadcrumbs, 'public640', 'With breadcrumbs / 640')
+export const WithBreadcrumbs768: Story = withViewportStory(WithBreadcrumbs, 'public768', 'With breadcrumbs / 768')
+export const WithBreadcrumbs1024: Story = withViewportStory(WithBreadcrumbs, 'public1024', 'With breadcrumbs / 1024')
+export const WithBreadcrumbs1280: Story = withViewportStory(WithBreadcrumbs, 'public1280', 'With breadcrumbs / 1280')
 export const TabletCentered768: Story = withViewportStory(tabletCenteredBase, 'public768', 'Tablet centered / 768')
 export const DesktopLeft1024: Story = withViewportStory(desktopLeftBase, 'public1024', 'Desktop left / 1024')

--- a/src/stories/organisms/BlogHero.stories.tsx
+++ b/src/stories/organisms/BlogHero.stories.tsx
@@ -90,9 +90,14 @@ export const WithBreadcrumbs: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
-    await expect(canvas.getByRole('navigation', { name: 'Breadcrumb' })).toBeInTheDocument()
+    const breadcrumb = canvas.getByRole('navigation', { name: 'Breadcrumb' })
+    const heading = canvas.getByRole('heading', { name: 'Our Blog' })
+    const hero = heading.closest('section')
+
+    await expect(breadcrumb).toBeInTheDocument()
     await expect(canvas.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/')
     await expect(canvas.getByText('Blog', { selector: '[aria-current="page"]' })).toBeInTheDocument()
+    expect(hero?.contains(breadcrumb)).toBe(false)
   },
 }
 

--- a/src/stories/organisms/ClinicDetail/FurtherTreatmentsSection.stories.tsx
+++ b/src/stories/organisms/ClinicDetail/FurtherTreatmentsSection.stories.tsx
@@ -4,13 +4,49 @@ import { expect, fn, userEvent, within } from 'storybook/test'
 
 import { FurtherTreatmentsSection } from '@/components/organisms/ClinicDetail'
 import type { ClinicDetailTreatment } from '@/components/templates/ClinicDetailConcepts/types'
+import { withViewportStory } from '../../utils/viewportMatrix'
 
 const treatments: ClinicDetailTreatment[] = [
-  { id: 't-1', name: 'Neurology Consultation', category: 'Specialist Care', priceFromUsd: 380 },
-  { id: 't-2', name: 'Pediatric Cardiology Review', category: 'Specialist Care', priceFromUsd: 460 },
-  { id: 't-3', name: 'Genetic Counseling', category: 'Specialist Care' },
-  { id: 't-4', name: 'Family Nutrition Coaching', category: 'Supportive Care', priceFromUsd: 150 },
-  { id: 't-5', name: 'Asthma Management Plan', category: 'Chronic Care', priceFromUsd: 310 },
+  {
+    id: 't-1',
+    name: 'Neurology Consultation',
+    category: 'Specialist Care',
+    priceFromUsd: 380,
+    comparisonLink: { href: '/listing-comparison?treatment=t-1', label: 'Compare clinics for Neurology Consultation' },
+  },
+  {
+    id: 't-2',
+    name: 'Pediatric Cardiology Review',
+    category: 'Specialist Care',
+    priceFromUsd: 460,
+    comparisonLink: {
+      href: '/listing-comparison?treatment=t-2',
+      label: 'Compare clinics for Pediatric Cardiology Review',
+    },
+  },
+  {
+    id: 't-3',
+    name: 'Genetic Counseling',
+    category: 'Specialist Care',
+    comparisonLink: { href: '/listing-comparison?treatment=t-3', label: 'Compare clinics for Genetic Counseling' },
+  },
+  {
+    id: 't-4',
+    name: 'Family Nutrition Coaching',
+    category: 'Supportive Care',
+    priceFromUsd: 150,
+    comparisonLink: {
+      href: '/listing-comparison?treatment=t-4',
+      label: 'Compare clinics for Family Nutrition Coaching',
+    },
+  },
+  {
+    id: 't-5',
+    name: 'Asthma Management Plan',
+    category: 'Chronic Care',
+    priceFromUsd: 310,
+    comparisonLink: { href: '/listing-comparison?treatment=t-5', label: 'Compare clinics for Asthma Management Plan' },
+  },
 ]
 
 const meta = {
@@ -68,6 +104,10 @@ export const PaginatedSelection: Story = {
     await expect(canvas.getByRole('heading', { name: 'Further Treatments' })).toBeInTheDocument()
 
     const chooseButtons = canvas.getAllByRole('button', { name: 'Choose Treatment' })
+    await expect(canvas.getByRole('link', { name: 'Compare clinics for Neurology Consultation' })).toHaveAttribute(
+      'href',
+      '/listing-comparison?treatment=t-1',
+    )
     await userEvent.click(chooseButtons[0] as HTMLElement)
     await expect(canvas.getByTestId('selected-treatment-output')).toHaveTextContent('Selected treatment: t-1')
 
@@ -75,3 +115,34 @@ export const PaginatedSelection: Story = {
     await expect(canvas.getByText('Genetic Counseling')).toBeInTheDocument()
   },
 }
+
+export const PaginatedSelection320: Story = withViewportStory(
+  PaginatedSelection,
+  'public320',
+  'Paginated selection / 320',
+)
+export const PaginatedSelection375: Story = withViewportStory(
+  PaginatedSelection,
+  'public375',
+  'Paginated selection / 375',
+)
+export const PaginatedSelection640: Story = withViewportStory(
+  PaginatedSelection,
+  'public640',
+  'Paginated selection / 640',
+)
+export const PaginatedSelection768: Story = withViewportStory(
+  PaginatedSelection,
+  'public768',
+  'Paginated selection / 768',
+)
+export const PaginatedSelection1024: Story = withViewportStory(
+  PaginatedSelection,
+  'public1024',
+  'Paginated selection / 1024',
+)
+export const PaginatedSelection1280: Story = withViewportStory(
+  PaginatedSelection,
+  'public1280',
+  'Paginated selection / 1280',
+)

--- a/src/stories/organisms/ClinicDetail/HeroOverviewSection.stories.tsx
+++ b/src/stories/organisms/ClinicDetail/HeroOverviewSection.stories.tsx
@@ -14,6 +14,7 @@ const meta = {
   component: HeroOverviewSection,
   args: {
     clinicName: clinicDetailFixture.clinicName,
+    breadcrumbs: clinicDetailFixture.breadcrumbs,
     description: clinicDetailFixture.description,
     heroImage: clinicDetailFixture.heroImage,
     trust: clinicDetailFixture.trust,
@@ -48,6 +49,7 @@ function HeroOverviewSectionStoryHarness() {
         </p>
         <HeroOverviewSection
           clinicName={clinicDetailFixture.clinicName}
+          breadcrumbs={clinicDetailFixture.breadcrumbs}
           description={clinicDetailFixture.description}
           heroImage={clinicDetailFixture.heroImage}
           trust={clinicDetailFixture.trust}
@@ -66,6 +68,7 @@ export const InteractiveDoctorSelection: Story = {
     const canvas = within(canvasElement)
 
     await expect(canvas.getByRole('heading', { name: 'Berlin Health Clinic' })).toBeInTheDocument()
+    await expect(canvas.getByRole('navigation', { name: 'Breadcrumb' })).toBeInTheDocument()
     const doctorButton = canvas.getByRole('button', { name: `Select ${heroDoctors[1]?.name}` })
 
     await userEvent.click(doctorButton)

--- a/src/stories/templates/ClinicDetailConcepts.stories.tsx
+++ b/src/stories/templates/ClinicDetailConcepts.stories.tsx
@@ -81,8 +81,9 @@ export const Main_InitialReviewSummary: Story = {
     await expect(canvas.getByText('Latest review')).toBeInTheDocument()
     await expect(canvas.getByText('5 verified reviews')).toBeInTheDocument()
     await expect(canvas.getByRole('button', { name: 'What verified reviews mean' })).toBeInTheDocument()
+    const reviewsRegion = canvas.getByRole('region', { name: 'Patient Reviews' })
     await expect(
-      within(canvas.getByRole('list')).queryByRole('article', {
+      within(reviewsRegion).queryByRole('article', {
         name: 'Maya K. verified review from Jan 12, 2026',
       }),
     ).not.toBeInTheDocument()

--- a/src/utilities/breadcrumbs.ts
+++ b/src/utilities/breadcrumbs.ts
@@ -1,0 +1,16 @@
+import type { BreadcrumbItem } from '@/components/molecules/Breadcrumb'
+
+export const HOME_BREADCRUMB: BreadcrumbItem = {
+  label: 'Home',
+  href: '/',
+}
+
+export const CLINICS_BREADCRUMB: BreadcrumbItem = {
+  label: 'Clinics',
+  href: '/listing-comparison',
+}
+
+export const createBlogBreadcrumb = (href = '/posts'): BreadcrumbItem => ({
+  label: 'Blog',
+  href,
+})

--- a/src/utilities/clinicDetail/serverData/mappers.ts
+++ b/src/utilities/clinicDetail/serverData/mappers.ts
@@ -22,10 +22,16 @@ import type {
   ClinicDetailTrust,
   ClinicVerificationTier,
 } from '@/components/templates/ClinicDetailConcepts/types'
+import { CLINICS_BREADCRUMB, HOME_BREADCRUMB } from '@/utilities/breadcrumbs'
 import { resolveMediaDescriptorFromLoadedRelation } from '@/utilities/media/relationMedia'
 import { resolveAvatarPlaceholder } from '@/utilities/placeholders/avatar'
 import { buildFreshnessSignals } from '@/utilities/freshness'
 import { findLatestIsoTimestampString } from '@/utilities/timestamps'
+import {
+  LISTING_COMPARISON_PRICE_MAX_DEFAULT,
+  LISTING_COMPARISON_PRICE_MIN_DEFAULT,
+  buildListingComparisonHref,
+} from '@/utilities/listingComparison/queryState'
 
 import type { ClinicDetailMappingArgs } from './types'
 
@@ -169,6 +175,25 @@ function resolveTreatmentCategory(value: unknown): string | undefined {
   return resolveMedicalSpecialtyName(treatment.medicalSpecialty) ?? undefined
 }
 
+function buildTreatmentComparisonLink(
+  treatmentId: number,
+  treatmentName: string,
+): NonNullable<ClinicDetailTreatment['comparisonLink']> {
+  return {
+    href: buildListingComparisonHref({
+      page: 1,
+      sort: 'rank',
+      cities: [],
+      treatments: [String(treatmentId)],
+      specialties: [],
+      ratingMin: null,
+      priceMin: LISTING_COMPARISON_PRICE_MIN_DEFAULT,
+      priceMax: LISTING_COMPARISON_PRICE_MAX_DEFAULT,
+    }),
+    label: `Compare clinics for ${treatmentName}`,
+  }
+}
+
 function resolveDoctorName(doctor: Doctor): string {
   if (typeof doctor.fullName === 'string' && doctor.fullName.trim().length > 0) {
     return doctor.fullName
@@ -220,7 +245,8 @@ function buildLocation(clinic: Clinic, cityNameById: Map<number, string>): Clini
 function mapTreatments(treatments: Clinictreatment[]): ClinicDetailTreatment[] {
   return treatments.map((entry) => {
     const treatment = entry.treatment as number | Treatment
-    const treatmentId = extractRelationId(treatment) ?? entry.id
+    const treatmentRelationId = extractRelationId(treatment)
+    const treatmentId = treatmentRelationId ?? entry.id
 
     const treatmentName =
       treatment && typeof treatment === 'object' && 'name' in treatment && typeof treatment.name === 'string'
@@ -232,6 +258,10 @@ function mapTreatments(treatments: Clinictreatment[]): ClinicDetailTreatment[] {
       name: treatmentName,
       priceFromUsd: Number.isFinite(entry.price) ? entry.price : undefined,
       category: resolveTreatmentCategory(treatment),
+      comparisonLink:
+        typeof treatmentRelationId === 'number'
+          ? buildTreatmentComparisonLink(treatmentRelationId, treatmentName)
+          : undefined,
     }
   })
 }
@@ -508,6 +538,11 @@ export function mapClinicToClinicDetailData({
     clinicId: clinic.id,
     clinicSlug: clinic.slug,
     clinicName: clinic.name,
+    breadcrumbs: [
+      HOME_BREADCRUMB,
+      CLINICS_BREADCRUMB,
+      { label: clinic.name, href: `/clinics/${encodeURIComponent(clinic.slug)}` },
+    ],
     heroImage: toClinicImage(clinic),
     description: extractLexicalPlainText(clinic.description) || 'Clinic profile information currently being updated.',
     trust: mapTrust({

--- a/src/utilities/listingComparison/serverData/getListingComparisonServerData.ts
+++ b/src/utilities/listingComparison/serverData/getListingComparisonServerData.ts
@@ -1,6 +1,7 @@
 import type { Payload } from 'payload'
 
 import type { Clinic } from '@/payload-types'
+import { CLINICS_BREADCRUMB, HOME_BREADCRUMB } from '@/utilities/breadcrumbs'
 import { buildFreshnessSignals } from '@/utilities/freshness'
 import { findLatestIsoTimestampString } from '@/utilities/timestamps'
 import { slugify } from '@/utilities/slugify'
@@ -329,24 +330,21 @@ export async function getListingComparisonServerData(
   const selectedSpecialtyPath = buildSpecialtyPath(selectedSpecialtyIds[0] ?? null, specialtyById)
   const specialtyContext = {
     selected: selectedSpecialties,
-    breadcrumbs:
-      selectedSpecialtyPath.length > 0
-        ? [
-            { label: 'Home', href: '/' },
-            { label: 'Clinics', href: '/listing-comparison' },
-            ...selectedSpecialtyPath.map((specialty) => ({
-              label: specialty.name,
-              href: buildListingComparisonHref(
-                {
-                  ...queryState,
-                  page: 1,
-                  specialties: [String(specialty.id)],
-                },
-                { priceMax: priceBounds.max },
-              ),
-            })),
-          ]
-        : [],
+    breadcrumbs: [
+      HOME_BREADCRUMB,
+      CLINICS_BREADCRUMB,
+      ...selectedSpecialtyPath.map((specialty) => ({
+        label: specialty.name,
+        href: buildListingComparisonHref(
+          {
+            ...queryState,
+            page: 1,
+            specialties: [String(specialty.id)],
+          },
+          { priceMax: priceBounds.max },
+        ),
+      })),
+    ],
   }
 
   return {

--- a/src/utilities/structuredData/breadcrumbs.ts
+++ b/src/utilities/structuredData/breadcrumbs.ts
@@ -1,0 +1,35 @@
+import type { BreadcrumbItem } from '@/components/molecules/Breadcrumb'
+import { getAbsoluteSiteURL } from '@/utilities/socialPreview'
+
+export type BreadcrumbListJsonLd = {
+  '@context': 'https://schema.org'
+  '@type': 'BreadcrumbList'
+  itemListElement: Array<{
+    '@type': 'ListItem'
+    position: number
+    name: string
+    item: string
+  }>
+}
+
+export function buildBreadcrumbListJsonLd(items: BreadcrumbItem[]): BreadcrumbListJsonLd | null {
+  const normalizedItems = items
+    .map((item) => ({
+      label: item.label.trim(),
+      href: item.href.trim(),
+    }))
+    .filter((item) => item.label.length > 0 && item.href.length > 0)
+
+  if (normalizedItems.length < 2) return null
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: normalizedItems.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.label,
+      item: getAbsoluteSiteURL(item.href),
+    })),
+  }
+}

--- a/tests/e2e/public/blog.public-smoke.spec.ts
+++ b/tests/e2e/public/blog.public-smoke.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test'
+
+import { createBrowserIssueCollector, expectNoBrowserIssues } from '../helpers/browserIssues'
+import { setCookieConsent } from '../helpers/cookieConsent'
+
+test.beforeEach(async ({ context }) => {
+  await context.clearCookies()
+  await setCookieConsent(context)
+})
+
+test('blog index shows visible breadcrumbs @smoke', async ({ page }) => {
+  const issues = createBrowserIssueCollector(page)
+
+  await page.goto('/posts', { waitUntil: 'domcontentloaded' })
+  await expect(page.getByRole('heading', { name: 'Our Blog' })).toBeVisible()
+
+  const breadcrumb = page.getByRole('navigation', { name: 'Breadcrumb' })
+  await expect(breadcrumb.getByRole('link', { name: 'Home' })).toBeVisible()
+  await expect(breadcrumb.getByText('Blog')).toHaveAttribute('aria-current', 'page')
+
+  await expectNoBrowserIssues(issues)
+})

--- a/tests/e2e/public/clinic-detail.public-smoke.spec.ts
+++ b/tests/e2e/public/clinic-detail.public-smoke.spec.ts
@@ -83,6 +83,10 @@ test.describe('clinic detail map dialog', () => {
 
     await page.goto(`/clinics/${clinicSlug}`, { waitUntil: 'domcontentloaded' })
     await page.waitForLoadState('networkidle')
+    const breadcrumb = page.getByRole('navigation', { name: 'Breadcrumb' })
+    await expect(breadcrumb.getByRole('link', { name: 'Home' })).toBeVisible()
+    await expect(breadcrumb.getByRole('link', { name: 'Clinics' })).toBeVisible()
+    await expect(breadcrumb.locator('[aria-current="page"]')).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Clinic Location' })).toBeVisible()
 
     const previewMap = page.getByTitle(/Map preview of/)

--- a/tests/e2e/public/listing-comparison.public-smoke.spec.ts
+++ b/tests/e2e/public/listing-comparison.public-smoke.spec.ts
@@ -26,11 +26,17 @@ test('listing filters preserve the selected specialty when rating changes @smoke
 
   await page.goto('/listing-comparison', { waitUntil: 'domcontentloaded' })
   await expect(page.getByRole('heading', { name: 'Compare clinic prices' })).toBeVisible()
+  const breadcrumb = page.getByRole('navigation', { name: 'Breadcrumb' })
+  await expect(breadcrumb.getByRole('link', { name: 'Home' })).toBeVisible()
+  await expect(breadcrumb.getByText('Clinics')).toHaveAttribute('aria-current', 'page')
+
   const medicalSpecialtyToggle = page.getByRole('button', { name: /^Medical Specialty/ })
   await medicalSpecialtyToggle.click()
   await expect(medicalSpecialtyToggle).toHaveAttribute('aria-expanded', 'true')
   await page.getByRole('radiogroup', { name: 'Medical Specialty' }).getByText('Dental', { exact: true }).click()
   await waitForSearchParam(page, 'specialty', '1')
+  await expect(breadcrumb.getByRole('link', { name: 'Clinics' })).toBeVisible()
+  await expect(breadcrumb.getByText('Dental')).toHaveAttribute('aria-current', 'page')
 
   const fourStarButton = page.getByRole('button', { name: '4+ ★' })
   await fourStarButton.click()

--- a/tests/unit/app/frontend/clinic-detail.page.test.tsx
+++ b/tests/unit/app/frontend/clinic-detail.page.test.tsx
@@ -1,0 +1,166 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const routeMocks = vi.hoisted(() => ({
+  breadcrumbJsonLdComponent: vi.fn(() => null),
+  clinicDetailComponent: vi.fn(() => null),
+  cookies: vi.fn(),
+  draftMode: vi.fn(),
+  findFavoriteClinicStateRecord: vi.fn(),
+  getClinicDetailServerData: vi.fn(),
+  getGlobal: vi.fn(),
+  getPayload: vi.fn(),
+  headers: vi.fn(),
+  notFound: vi.fn(),
+  resolveCookieConsentContext: vi.fn(),
+  resolveFavoriteClinicAuthContext: vi.fn(),
+}))
+
+vi.mock('@payload-config', () => ({
+  default: {},
+}))
+
+vi.mock('payload', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('payload')>()
+  return {
+    ...actual,
+    getPayload: routeMocks.getPayload,
+  }
+})
+
+vi.mock('next/headers', () => ({
+  cookies: routeMocks.cookies,
+  draftMode: routeMocks.draftMode,
+  headers: routeMocks.headers,
+}))
+
+vi.mock('next/navigation', () => ({
+  notFound: routeMocks.notFound,
+}))
+
+vi.mock('@/components/templates/ClinicDetailConcepts', () => ({
+  ClinicDetail: routeMocks.clinicDetailComponent,
+}))
+
+vi.mock('@/components/molecules/Breadcrumb/BreadcrumbJsonLd', () => ({
+  BreadcrumbJsonLd: routeMocks.breadcrumbJsonLdComponent,
+}))
+
+vi.mock('@/features/cookieConsent', () => ({
+  COOKIE_CONSENT_COOKIE_NAME: 'cookie-consent',
+  resolveCookieConsentContext: routeMocks.resolveCookieConsentContext,
+}))
+
+vi.mock('@/features/favorites/server', () => ({
+  findFavoriteClinicStateRecord: routeMocks.findFavoriteClinicStateRecord,
+  resolveFavoriteClinicAuthContext: routeMocks.resolveFavoriteClinicAuthContext,
+}))
+
+vi.mock('@/utilities/clinicDetail/serverData', () => ({
+  getClinicDetailServerData: routeMocks.getClinicDetailServerData,
+}))
+
+vi.mock('@/utilities/getGlobals', () => ({
+  getGlobal: routeMocks.getGlobal,
+}))
+
+type ReactNodeLike = React.ReactNode
+
+const findElementByType = (node: ReactNodeLike, type: unknown): React.ReactElement<Record<string, unknown>> | null => {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const match = findElementByType(child, type)
+      if (match) {
+        return match
+      }
+    }
+
+    return null
+  }
+
+  if (!React.isValidElement(node)) {
+    return null
+  }
+
+  const element = node as React.ReactElement<{ children?: ReactNodeLike }>
+
+  if (element.type === type) {
+    return element as React.ReactElement<Record<string, unknown>>
+  }
+
+  return findElementByType(element.props.children, type)
+}
+
+const clinicDetailData = {
+  clinicId: 42,
+  clinicSlug: 'berlin-health',
+  clinicName: 'Berlin Health',
+  breadcrumbs: [
+    { label: 'Home', href: '/' },
+    { label: 'Clinics', href: '/listing-comparison' },
+    { label: 'Berlin Health', href: '/clinics/berlin-health' },
+  ],
+  heroImage: { src: '/hero.jpg', alt: 'Berlin Health' },
+  description: 'Clinic description.',
+  trust: {
+    ratingValue: null,
+    reviewCount: 0,
+    verification: 'gold' as const,
+    accreditations: [],
+    languages: [],
+  },
+  reviews: {
+    totalCount: 0,
+    items: [],
+  },
+  treatments: [],
+  doctors: [],
+  beforeAfterEntries: [],
+  location: {},
+  freshness: {
+    sourceCollections: ['clinics'],
+  },
+  contactHref: '/contact?clinic=berlin-health&source=clinic-detail',
+}
+
+describe('frontend clinic detail route', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    routeMocks.cookies.mockResolvedValue({ get: vi.fn(() => null) })
+    routeMocks.draftMode.mockResolvedValue({ isEnabled: false })
+    routeMocks.getClinicDetailServerData.mockResolvedValue(clinicDetailData)
+    routeMocks.getGlobal.mockResolvedValue(null)
+    routeMocks.getPayload.mockResolvedValue({})
+    routeMocks.headers.mockResolvedValue(new Headers())
+    routeMocks.resolveCookieConsentContext.mockReturnValue({
+      config: null,
+      initialConsent: null,
+    })
+    routeMocks.resolveFavoriteClinicAuthContext.mockResolvedValue({
+      isPatient: false,
+      patient: null,
+    })
+  })
+
+  it('renders BreadcrumbList JSON-LD from clinic detail server data', async () => {
+    const pageModule = await import('@/app/(frontend)/clinics/[slug]/page')
+    const result = await pageModule.default({
+      params: Promise.resolve({ slug: 'berlin-health' }),
+    })
+
+    const breadcrumbJsonLdElement = findElementByType(
+      result,
+      routeMocks.breadcrumbJsonLdComponent,
+    ) as React.ReactElement<{
+      items: Array<{ href: string; label: string }>
+    }> | null
+    expect(breadcrumbJsonLdElement?.props.items).toEqual(clinicDetailData.breadcrumbs)
+
+    const clinicDetailElement = findElementByType(result, routeMocks.clinicDetailComponent) as React.ReactElement<{
+      data: unknown
+    }> | null
+    expect(clinicDetailElement?.props.data).toBe(clinicDetailData)
+  })
+})

--- a/tests/unit/app/frontend/listing-comparison.page.test.ts
+++ b/tests/unit/app/frontend/listing-comparison.page.test.ts
@@ -1,6 +1,8 @@
+import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const routeMocks = vi.hoisted(() => ({
+  breadcrumbJsonLdComponent: vi.fn(() => null),
   findFavoriteClinicStateRecord: vi.fn(),
   getListingComparisonServerData: vi.fn(),
   getPayload: vi.fn(),
@@ -34,19 +36,97 @@ vi.mock('@/utilities/listingComparison/serverData', () => ({
   getListingComparisonServerData: routeMocks.getListingComparisonServerData,
 }))
 
+vi.mock('@/components/molecules/Breadcrumb/BreadcrumbJsonLd', () => ({
+  BreadcrumbJsonLd: routeMocks.breadcrumbJsonLdComponent,
+}))
+
 vi.mock('@/app/(frontend)/listing-comparison/ListingComparisonPage.client', () => ({
   ListingComparisonPageClient: routeMocks.listingComparisonPageClient,
 }))
+
+type ReactNodeLike = React.ReactNode
+
+const findElementByType = (node: ReactNodeLike, type: unknown): React.ReactElement<Record<string, unknown>> | null => {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const match = findElementByType(child, type)
+      if (match) {
+        return match
+      }
+    }
+
+    return null
+  }
+
+  if (!React.isValidElement(node)) {
+    return null
+  }
+
+  const element = node as React.ReactElement<{ children?: ReactNodeLike }>
+
+  if (element.type === type) {
+    return element as React.ReactElement<Record<string, unknown>>
+  }
+
+  return findElementByType(element.props.children, type)
+}
+
+function buildListingData() {
+  return {
+    freshness: {
+      sourceCollections: [],
+    },
+    filterOptions: {
+      cities: [],
+      waitTimes: [],
+      specialties: [],
+      treatments: [],
+    },
+    priceBounds: { min: 0, max: 20000 },
+    queryState: {
+      page: 1,
+      sort: 'rank',
+      cities: [],
+      treatments: [],
+      specialties: [],
+      ratingMin: null,
+      priceMin: 0,
+      priceMax: 20000,
+    },
+    pagination: {
+      page: 1,
+      perPage: 24,
+      totalPages: 1,
+      totalResults: 0,
+      totalAvailableResults: 0,
+    },
+    specialtyContext: {
+      selected: [],
+      breadcrumbs: [
+        { label: 'Home', href: '/' },
+        { label: 'Clinics', href: '/listing-comparison' },
+      ],
+    },
+    results: [],
+    metrics: {
+      verifiedClinics: 0,
+      treatmentTypes: 0,
+      cities: 0,
+      priceEntries: 0,
+    },
+  }
+}
 
 describe('listing comparison page route metadata', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
     routeMocks.getPayload.mockResolvedValue({})
-    routeMocks.getListingComparisonServerData.mockResolvedValue({
-      freshness: {
-        sourceCollections: [],
-      },
+    routeMocks.getListingComparisonServerData.mockResolvedValue(buildListingData())
+    routeMocks.headers.mockResolvedValue(new Headers())
+    routeMocks.resolveFavoriteClinicAuthContext.mockResolvedValue({
+      isPatient: false,
+      patient: null,
     })
   })
 
@@ -82,5 +162,23 @@ describe('listing comparison page route metadata', () => {
         follow: true,
       },
     })
+  })
+
+  it('renders BreadcrumbList JSON-LD from listing server breadcrumbs', async () => {
+    const pageModule = await import('@/app/(frontend)/listing-comparison/page')
+    const result = await pageModule.default({
+      searchParams: Promise.resolve({}),
+    })
+
+    const breadcrumbJsonLdElement = findElementByType(
+      result,
+      routeMocks.breadcrumbJsonLdComponent,
+    ) as React.ReactElement<{
+      items: Array<{ href: string; label: string }>
+    }> | null
+    expect(breadcrumbJsonLdElement?.props.items).toEqual([
+      { label: 'Home', href: '/' },
+      { label: 'Clinics', href: '/listing-comparison' },
+    ])
   })
 })

--- a/tests/unit/app/frontend/post.page.test.tsx
+++ b/tests/unit/app/frontend/post.page.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
+  breadcrumbJsonLdComponent: vi.fn(() => null),
   calculateReadTimeMock: vi.fn(() => '5 min read'),
   draftModeMock: vi.fn(),
   findPostBySlugMock: vi.fn(),
@@ -35,6 +36,10 @@ vi.mock('payload', async (importOriginal) => {
 
 vi.mock('@/app/(frontend)/_components/PayloadRedirects', () => ({
   PayloadRedirects: mocks.payloadRedirectsComponent,
+}))
+
+vi.mock('@/components/molecules/Breadcrumb/BreadcrumbJsonLd', () => ({
+  BreadcrumbJsonLd: mocks.breadcrumbJsonLdComponent,
 }))
 
 vi.mock('@/components/organisms/Heroes/PostHero', () => ({
@@ -181,6 +186,7 @@ describe('frontend post detail route', () => {
     expect(heroElement?.props.breadcrumbs).toEqual([
       { label: 'Home', href: '/' },
       { label: 'Blog', href: '/posts?locale=de' },
+      { label: 'Hallo Welt', href: '/posts/hello-world?locale=de' },
     ])
     expect(heroElement?.props.image).toEqual({
       src: '/api/platformContentMedia/file/post-hero.webp',
@@ -188,6 +194,11 @@ describe('frontend post detail route', () => {
       sizes: '100vw',
       quality: 75,
     })
+
+    const breadcrumbJsonLdElement = findElementByType(result, mocks.breadcrumbJsonLdComponent) as React.ReactElement<{
+      items: Array<{ href: string; label: string }>
+    }> | null
+    expect(breadcrumbJsonLdElement?.props.items).toEqual(heroElement?.props.breadcrumbs)
 
     const shareElement = findElementByType(result, mocks.postShareActionBarComponent) as React.ReactElement<{
       backLink: { href: string; label: string }

--- a/tests/unit/app/frontend/posts.page-number.page.test.tsx
+++ b/tests/unit/app/frontend/posts.page-number.page.test.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
+  breadcrumbComponent: vi.fn(() => null),
+  breadcrumbJsonLdComponent: vi.fn(() => null),
   countPublishedPostsMock: vi.fn(),
   createSiteMetadataMock: vi.fn((args: unknown) => args),
   findPublishedPostsPageMock: vi.fn(),
@@ -40,6 +42,14 @@ vi.mock('@/utilities/blog/normalizePost', () => ({
 
 vi.mock('@/utilities/generateMeta', () => ({
   createSiteMetadata: mocks.createSiteMetadataMock,
+}))
+
+vi.mock('@/components/molecules/Breadcrumb', () => ({
+  Breadcrumb: mocks.breadcrumbComponent,
+}))
+
+vi.mock('@/components/molecules/Breadcrumb/BreadcrumbJsonLd', () => ({
+  BreadcrumbJsonLd: mocks.breadcrumbJsonLdComponent,
 }))
 
 vi.mock('@/app/(frontend)/posts/_components/PostsPagination', () => ({
@@ -143,6 +153,21 @@ describe('frontend paginated posts route', () => {
     expect(paginationElement).not.toBeNull()
     expect(paginationElement?.props.getPathForPage(1)).toBe('/posts?locale=de')
     expect(paginationElement?.props.getPathForPage(2)).toBe('/posts/page/2?locale=de')
+
+    const expectedBreadcrumbs = [
+      { label: 'Home', href: '/' },
+      { label: 'Blog', href: '/posts?locale=de' },
+      { label: 'Page 2', href: '/posts/page/2?locale=de' },
+    ]
+    const breadcrumbElement = findElementByType(result, mocks.breadcrumbComponent) as React.ReactElement<{
+      items: Array<{ href: string; label: string }>
+    }> | null
+    expect(breadcrumbElement?.props.items).toEqual(expectedBreadcrumbs)
+
+    const breadcrumbJsonLdElement = findElementByType(result, mocks.breadcrumbJsonLdComponent) as React.ReactElement<{
+      items: Array<{ href: string; label: string }>
+    }> | null
+    expect(breadcrumbJsonLdElement?.props.items).toEqual(expectedBreadcrumbs)
   })
 
   it('uses the requested content locale in metadata paths', async () => {

--- a/tests/unit/app/frontend/posts.page.test.tsx
+++ b/tests/unit/app/frontend/posts.page.test.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
+  blogHeroComponent: vi.fn(() => null),
+  breadcrumbJsonLdComponent: vi.fn(() => null),
   createSiteMetadataMock: vi.fn((args: unknown) => args),
   findPublishedPostsPageMock: vi.fn(),
   getPayloadMock: vi.fn(),
@@ -31,6 +33,14 @@ vi.mock('@/utilities/blog/normalizePost', () => ({
 
 vi.mock('@/utilities/generateMeta', () => ({
   createSiteMetadata: mocks.createSiteMetadataMock,
+}))
+
+vi.mock('@/components/molecules/Breadcrumb/BreadcrumbJsonLd', () => ({
+  BreadcrumbJsonLd: mocks.breadcrumbJsonLdComponent,
+}))
+
+vi.mock('@/components/organisms/Blog/BlogHero', () => ({
+  BlogHero: mocks.blogHeroComponent,
 }))
 
 vi.mock('@/app/(frontend)/posts/_components/PostsPagination', () => ({
@@ -114,6 +124,20 @@ describe('frontend posts index route', () => {
     expect(paginationElement).not.toBeNull()
     expect(paginationElement?.props.getPathForPage(1)).toBe('/posts?locale=de')
     expect(paginationElement?.props.getPathForPage(2)).toBe('/posts/page/2?locale=de')
+
+    const expectedBreadcrumbs = [
+      { label: 'Home', href: '/' },
+      { label: 'Blog', href: '/posts?locale=de' },
+    ]
+    const heroElement = findElementByType(result, mocks.blogHeroComponent) as React.ReactElement<{
+      breadcrumbs: Array<{ href: string; label: string }>
+    }> | null
+    expect(heroElement?.props.breadcrumbs).toEqual(expectedBreadcrumbs)
+
+    const breadcrumbJsonLdElement = findElementByType(result, mocks.breadcrumbJsonLdComponent) as React.ReactElement<{
+      items: Array<{ href: string; label: string }>
+    }> | null
+    expect(breadcrumbJsonLdElement?.props.items).toEqual(expectedBreadcrumbs)
   })
 
   it('uses the requested content locale in metadata paths', async () => {

--- a/tests/unit/components/breadcrumbJsonLd.test.tsx
+++ b/tests/unit/components/breadcrumbJsonLd.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { BreadcrumbJsonLd } from '@/components/molecules/Breadcrumb/BreadcrumbJsonLd'
+
+describe('BreadcrumbJsonLd', () => {
+  it('renders a BreadcrumbList script from breadcrumb items', () => {
+    const { container } = render(
+      <BreadcrumbJsonLd
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Clinics', href: '/listing-comparison' },
+        ]}
+      />,
+    )
+
+    const script = container.querySelector('script[type="application/ld+json"]')
+    expect(script).not.toBeNull()
+    expect(JSON.parse(script?.textContent ?? '')).toMatchObject({
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        expect.objectContaining({ name: 'Home', position: 1 }),
+        expect.objectContaining({ name: 'Clinics', position: 2 }),
+      ],
+    })
+  })
+})

--- a/tests/unit/components/clinicDetailConcepts.test.tsx
+++ b/tests/unit/components/clinicDetailConcepts.test.tsx
@@ -108,6 +108,11 @@ const baseData = {
   clinicId: 1,
   clinicSlug: 'template-test',
   clinicName: 'Template Test Clinic',
+  breadcrumbs: [
+    { label: 'Home', href: '/' },
+    { label: 'Clinics', href: '/listing-comparison' },
+    { label: 'Template Test Clinic', href: '/clinics/template-test' },
+  ],
   heroImage: { src: '/hero.jpg', alt: 'Hero' },
   description: 'Clinic description',
   trust: {
@@ -125,7 +130,17 @@ const baseData = {
     updatedAt: '2026-01-01T00:00:00.000Z',
     sourceCollections: ['clinics'],
   },
-  treatments: [{ id: 't1', name: 'Treatment 1', priceFromUsd: 1200 }],
+  treatments: [
+    {
+      id: 't1',
+      name: 'Treatment 1',
+      priceFromUsd: 1200,
+      comparisonLink: {
+        href: '/listing-comparison?treatment=t1',
+        label: 'Compare clinics for Treatment 1',
+      },
+    },
+  ],
   doctors: [
     {
       id: 'd1',
@@ -165,5 +180,13 @@ describe('ClinicDetail concept', () => {
         showVariantLabel: false,
       }),
     )
+
+    const heroCall = mocks.heroOverviewSection.mock.calls.at(0) as unknown as Array<unknown> | undefined
+    const heroProps = heroCall?.[0] as { breadcrumbs?: unknown } | undefined
+    expect(heroProps?.breadcrumbs).toEqual(baseData.breadcrumbs)
+
+    const stripCall = mocks.treatmentsStrip.mock.calls.at(0) as unknown as Array<unknown> | undefined
+    const stripProps = stripCall?.[0] as { items?: Array<{ comparisonLink?: unknown }> } | undefined
+    expect(stripProps?.items?.[0]?.comparisonLink).toEqual(baseData.treatments[0]?.comparisonLink)
   })
 })

--- a/tests/unit/components/treatmentsStrip.test.tsx
+++ b/tests/unit/components/treatmentsStrip.test.tsx
@@ -60,4 +60,27 @@ describe('TreatmentsStrip', () => {
     expect(matches.length).toBeGreaterThan(0)
     expect(matches[0]).toHaveClass('line-clamp-3')
   })
+
+  it('renders optional comparison links on active treatment cards', () => {
+    render(
+      <TreatmentsStrip
+        heading="Treatments"
+        items={[
+          {
+            ...items[0]!,
+            comparisonLink: {
+              href: '/listing-comparison?treatment=101',
+              label: 'Compare clinics for Cardiology Consultation',
+            },
+          },
+        ]}
+        activeIndex={0}
+      />,
+    )
+
+    expect(screen.getAllByRole('link', { name: 'Compare clinics for Cardiology Consultation' })[0]).toHaveAttribute(
+      'href',
+      '/listing-comparison?treatment=101',
+    )
+  })
 })

--- a/tests/unit/utilities/breadcrumbStructuredData.test.ts
+++ b/tests/unit/utilities/breadcrumbStructuredData.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { buildBreadcrumbListJsonLd } from '@/utilities/structuredData/breadcrumbs'
+
+vi.mock('@/utilities/getURL', () => ({
+  getServerSideURL: vi.fn(() => 'https://findmydoc.eu/'),
+}))
+
+describe('breadcrumb structured data', () => {
+  it('builds BreadcrumbList JSON-LD from shared breadcrumb items', () => {
+    const result = buildBreadcrumbListJsonLd([
+      { label: 'Home', href: '/' },
+      { label: 'Blog', href: '/posts' },
+      { label: 'Article', href: '/posts/article' },
+    ])
+
+    expect(result).toEqual({
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Home',
+          item: 'https://findmydoc.eu/',
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'Blog',
+          item: 'https://findmydoc.eu/posts',
+        },
+        {
+          '@type': 'ListItem',
+          position: 3,
+          name: 'Article',
+          item: 'https://findmydoc.eu/posts/article',
+        },
+      ],
+    })
+  })
+
+  it('skips invalid one-item trails instead of emitting partial JSON-LD', () => {
+    expect(buildBreadcrumbListJsonLd([{ label: 'Home', href: '/' }])).toBeNull()
+  })
+})

--- a/tests/unit/utilities/clinicDetailServerData.contract.test.ts
+++ b/tests/unit/utilities/clinicDetailServerData.contract.test.ts
@@ -352,6 +352,11 @@ describe('getClinicDetailServerData (contract)', () => {
     expect(result).not.toBeNull()
     expect(result?.clinicName).toBe('Berlin Health Clinic')
     expect(result?.contactHref).toBe('/contact?clinic=berlin-health-clinic&source=clinic-detail')
+    expect(result?.breadcrumbs).toEqual([
+      { label: 'Home', href: '/' },
+      { label: 'Clinics', href: '/listing-comparison' },
+      { label: 'Berlin Health Clinic', href: '/clinics/berlin-health-clinic' },
+    ])
 
     expect(result?.trust.reviewCount).toBe(3)
     expect(result?.trust.ratingValue).toBe(4.8)
@@ -386,6 +391,10 @@ describe('getClinicDetailServerData (contract)', () => {
     expect(result?.doctors[1]?.specialty).toBe('General Practice')
     expect(result?.doctors[0]?.reviewCount).toBe(2)
     expect(result?.doctors[1]?.image.src).toBe('/images/avatar-doctor-male-placeholder.svg')
+    expect(result?.treatments[0]?.comparisonLink).toEqual({
+      href: '/listing-comparison?treatment=301',
+      label: 'Compare clinics for Routine Checkup',
+    })
 
     expect(result?.beforeAfterEntries).toHaveLength(1)
     expect(result?.beforeAfterEntries[0]?.title).toBe('Orthopedic recovery case')

--- a/tests/unit/utilities/listingComparisonServerData.contract.test.ts
+++ b/tests/unit/utilities/listingComparisonServerData.contract.test.ts
@@ -275,6 +275,7 @@ describe('getListingComparisonServerData (contract)', () => {
 
     expect(result.metrics.priceEntries).toBe(5)
     expect(result.metrics.cities).toBe(2)
+    expect(result.specialtyContext.breadcrumbs.map((item) => item.label)).toEqual(['Home', 'Clinics'])
   })
 
   it('reuses the public listing catalog for repeated requests on the same payload instance', async () => {


### PR DESCRIPTION
## Management summary

### Deutsch

Patienten und Suchmaschinen erhalten eine klarere Orientierung zwischen Blog, Klinikvergleich und Klinikprofilen. Die öffentlichen Seiten zeigen jetzt konsistente Pfade und passende Weiterleitungen zu relevanten Vergleichsansichten, ohne neue Detailseiten oder private Daten sichtbar zu machen.

### English

Patients and search engines now get clearer orientation across the blog, clinic comparison, and clinic profile pages. Public pages show consistent paths and relevant comparison entry points without introducing new detail pages or exposing private data.

## What changed

- Added shared breadcrumb route constants and a small BreadcrumbList JSON-LD helper so visible breadcrumbs and structured data use the same source items.
- Added visible and structured-data breadcrumbs for blog index, paginated blog pages, post detail, listing comparison, and clinic detail pages.
- Kept listing breadcrumbs tied to existing listing context, including specialty hierarchy when an active specialty filter is present.
- Added clinic detail breadcrumbs from server-mapped clinic data and kept entity labels data-driven.
- Added optional treatment comparison links only when a real treatment relation id exists in published clinic treatment data.
- Moved the blog breadcrumb above the hero image so it remains readable while reusing the existing Breadcrumb component.
- Hardened accessibility and mobile behavior: current breadcrumbs are not self-links, long labels wrap without leading separators, and treatment comparison links include the treatment name.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P2 | `src/components/molecules/Breadcrumb/**`, `src/utilities/structuredData/breadcrumbs.ts` | Shared UI and JSON-LD behavior now depend on one breadcrumb item shape. | Current-page crumbs should render as text with `aria-current`, while JSON-LD still contains complete route items. | Unit tests for Breadcrumb JSON-LD and structured-data helper. |
| P2 | `src/app/(frontend)/posts/**`, `src/app/(frontend)/listing-comparison/page.tsx`, `src/app/(frontend)/clinics/[slug]/page.tsx` | Public route integration affects crawlable links and visible page orientation. | Breadcrumb trails should match page hierarchy and avoid invented entity routes. | Route tests and public E2E smoke tests. |
| P2 | `src/utilities/clinicDetail/serverData/mappers.ts`, `src/components/organisms/ClinicDetail/**`, `src/components/organisms/TreatmentsStrip/index.tsx` | Treatment discovery links must stay data-derived and accessible. | Links should appear only for reliable treatment relation ids and names should be distinguishable to assistive tech. | Clinic detail contract tests, component tests, accessibility reviewer fix. |
| P3 | `src/stories/**BlogHero**`, `src/stories/**Breadcrumb**`, `src/stories/organisms/ClinicDetail/**` | Story coverage documents the new responsive states. | Mobile breadcrumb and treatment-link states should remain deterministic in Storybook. | Storybook Vitest and story governance check. |

## Validation

- [x] `pnpm format`: Passed.
- [x] `pnpm check`: Passed; existing sense-check warnings remain unrelated to this scope.
- [x] `pnpm build`: Passed with `PAYLOAD_SECRET=dev-secret`.
- [x] Focused tests: Passed targeted unit route/component/contract tests, full Storybook Vitest, Storybook governance, and public smoke tests for blog, listing comparison, and clinic detail.
- [x] UI/mobile QA: Checked mobile and desktop Playwright screenshots for blog, listing, and clinic breadcrumb states. Blog breadcrumb was moved above the hero after review because the overlay variant was too weak on the image.
  <!-- gh-ui-screenshots:start -->
  ### Blog Breadcrumbs Mobile
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":2.164102564102564,"capturedAt":"2026-06-22T18:25:56.439Z","contentType":"image/png","focus":"blog-breadcrumbs-mobile","focusLabel":"Blog Breadcrumbs Mobile","formFactor":"mobile","gitSha":"0d2d7fa6","height":844,"releaseEligible":false,"releaseRole":"qa","size":108136,"sizeKb":106,"uploadName":"blog-breadcrumbs-mobile__mobile__390x844__20260622T182556Z__0d2d7fa6__390x844__106kb.png","viewport":"390x844","warnings":["not_release_marked"],"width":390,"url":"https://github.com/user-attachments/assets/7f7626c8-787c-4689-9a22-f9fc92f51a99"} -->
  ![Blog Breadcrumbs Mobile](https://github.com/user-attachments/assets/7f7626c8-787c-4689-9a22-f9fc92f51a99)
  
  
  > Screenshot warning: not_release_marked
  
  ### Blog Breadcrumbs Desktop
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":0.703125,"capturedAt":"2026-06-22T18:25:57.648Z","contentType":"image/png","focus":"blog-breadcrumbs-desktop","focusLabel":"Blog Breadcrumbs Desktop","formFactor":"desktop","gitSha":"0d2d7fa6","height":900,"releaseEligible":false,"releaseRole":"qa","size":359095,"sizeKb":351,"uploadName":"blog-breadcrumbs-desktop__desktop__1280x900__20260622T182557Z__0d2d7fa6__1280x900__351kb.png","viewport":"1280x900","warnings":["not_release_marked"],"width":1280,"url":"https://github.com/user-attachments/assets/809be5fd-4687-4077-a369-b05f46be1366"} -->
  ![Blog Breadcrumbs Desktop](https://github.com/user-attachments/assets/809be5fd-4687-4077-a369-b05f46be1366)
  
  
  > Screenshot warning: not_release_marked
  
  ### Clinic Breadcrumbs Mobile
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":2.164102564102564,"capturedAt":"2026-06-22T15:56:42.232Z","contentType":"image/png","focus":"clinic-breadcrumbs-mobile","focusLabel":"Clinic Breadcrumbs Mobile","formFactor":"mobile","gitSha":"0d2d7fa6","height":844,"releaseEligible":false,"releaseRole":"qa","size":62542,"sizeKb":62,"uploadName":"clinic-breadcrumbs-mobile__mobile__390x844__20260622T155642Z__0d2d7fa6__390x844__62kb.png","viewport":"390x844","warnings":["not_release_marked"],"width":390,"url":"https://github.com/user-attachments/assets/1c91a8ca-1c82-46bd-b944-7affb7af2036"} -->
  ![Clinic Breadcrumbs Mobile](https://github.com/user-attachments/assets/1c91a8ca-1c82-46bd-b944-7affb7af2036)
  
  
  > Screenshot warning: not_release_marked
  
  ### Listing Breadcrumbs Desktop
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":0.703125,"capturedAt":"2026-06-22T15:56:01.049Z","contentType":"image/png","focus":"listing-breadcrumbs-desktop","focusLabel":"Listing Breadcrumbs Desktop","formFactor":"desktop","gitSha":"0d2d7fa6","height":900,"releaseEligible":false,"releaseRole":"qa","size":95854,"sizeKb":94,"uploadName":"listing-breadcrumbs-desktop__desktop__1280x900__20260622T155601Z__0d2d7fa6__1280x900__94kb.png","viewport":"1280x900","warnings":["not_release_marked"],"width":1280,"url":"https://github.com/user-attachments/assets/119fff27-240d-4e46-ba19-021a51d13efb"} -->
  ![Listing Breadcrumbs Desktop](https://github.com/user-attachments/assets/119fff27-240d-4e46-ba19-021a51d13efb)
  
  
  > Screenshot warning: not_release_marked
  <!-- gh-ui-screenshots:end -->
- [x] Security/privacy review: Scope reviewed for public data exposure; no private, admin-only, draft, or unpublished routes are linked. No auth, secrets, access-control, or API trust boundary changes.
- [x] Migration/schema check: No Payload schema or data migration changes.
- [x] Documentation/instructions check: No instruction files changed; Storybook governance passed.

## Risk and rollout

No schema, migration, or environment changes. Rollout risk is limited to public UI/SEO presentation on blog, listing comparison, post detail, and clinic detail pages. Rollback is a standard revert of the route/component changes.

## Development

Closes #1040
