### PR TITLE
test(components): cover breadcrumb jsonld escaping

### DIFF
--- a/tests/unit/components/breadcrumbJsonLd.test.tsx
+++ b/tests/unit/components/breadcrumbJsonLd.test.tsx
@@ -38,8 +38,12 @@ describe('BreadcrumbJsonLd', () => {
     )
 
     const script = container.querySelector('script[type="application/ld+json"]')
-    expect(script?.textContent).toContain('\\u003c/script>')
-    expect(JSON.parse(script?.textContent ?? '').itemListElement[1]).toMatchObject({
+    expect(script).not.toBeNull()
+
+    const scriptText = script?.textContent ?? ''
+    expect(scriptText).toContain('\\u003c/script>')
+    expect(scriptText).not.toContain('</script>')
+    expect(JSON.parse(scriptText).itemListElement[1]).toMatchObject({
       name: '</script><img src=x onerror=alert(1)>',
     })
   })


### PR DESCRIPTION
## Management summary

### Deutsch

Die sichere Breadcrumb-JSON-LD-Einbindung ist auf `main` vorhanden. Dieser PR ergänzt die Regression im Unit-Test, damit ein Script-Tag-Ausbruch über Breadcrumb-Daten nicht wieder unbemerkt möglich wird.

### English

Safe breadcrumb JSON-LD rendering is already present on `main`. This PR adds unit-test regression coverage so script tag breakout input in breadcrumb data cannot silently regress.

## What changed

- Strengthened `tests/unit/components/breadcrumbJsonLd.test.tsx` so the non-happy-path JSON-LD test now asserts the rendered script exists, stores the script text once, confirms `<` is emitted as `\\u003c`, and verifies raw `</script>` is absent from the script text.
- Kept the parsed JSON-LD assertion so the escaped script text still round-trips to the original breadcrumb label.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `tests/unit/components/breadcrumbJsonLd.test.tsx` | Regression coverage should lock the exact script-context escaping behavior | Verify the test fails if raw `</script>` can reappear in the script payload | Focused Vitest run |

## Validation

- [x] `pnpm format`: Passed.
- [ ] `pnpm check`: failed at `tsc --noEmit` because local `.next/dev/types/validator.ts` references missing `src/app/api/auth/register/patient/cleanup/route.js` and `metadata/route.js`; preceding `tests:sense-check`, `lint`, `typegen`, and `check:payload-types` completed.
- [ ] `pnpm build`: Not run locally for this test-only change; PR CI build covers build behavior.
- [x] Focused tests: `pnpm exec vitest run --project unit tests/unit/components/breadcrumbJsonLd.test.tsx` passed, 1 file / 2 tests.
- [ ] UI/mobile QA: Not applicable; no UI rendering change.
- [x] Security/privacy review: Reviewed against React/Next.js frontend security guidance for raw HTML sinks and script-context JSON-LD escaping.
- [x] Migration/schema check: No Payload schema or data migration changes.
- [x] Documentation/instructions check: No instruction files changed; pre-push AI slop check passed.

## Risk and rollout

No data migration, schema migration, runtime code, or runtime configuration change. Risk is limited to focused regression coverage for breadcrumb structured-data rendering.

## Development

Closes #1396
