### PR TITLE
feat: centralize public structured data

### DIFF
--- a/docs/public-discovery-strategy.md
+++ b/docs/public-discovery-strategy.md
@@ -54,6 +54,12 @@ When a public signal does not have a source field, omit it instead of inventing 
 
 If a signal requires review, moderation, or policy interpretation, define it in the owning trust/review document instead of here.
 
+Structured data is a public facts layer for search engines and AI agents. It should help machines identify the visible page, entity, list, and article facts that patients can already inspect.
+
+Structured data must mirror source-backed public content. It must not introduce hidden ratings, review counts, accreditations, verification claims, medical-quality claims, or recommendation language that is not already visible, moderated, and owned by the relevant trust or medical-content process.
+
+Structured data should stay aligned with the same public-discovery boundaries as canonical URLs, sitemap inclusion, freshness signals, and preview protections. When a page is not a public canonical discovery surface, structured data should not create a parallel discovery signal for it.
+
 ## Non-Goals And Links
 
 Use an ADR when a decision changes the architecture of public discovery, such as localized public URL structure, a dedicated public discovery API, new canonical entity route families, or a new structured-data framework.

--- a/src/app/(frontend)/clinics/[slug]/page.tsx
+++ b/src/app/(frontend)/clinics/[slug]/page.tsx
@@ -4,7 +4,6 @@ import { notFound } from 'next/navigation'
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 
-import { BreadcrumbJsonLd } from '@/components/molecules/Breadcrumb/BreadcrumbJsonLd'
 import { ClinicDetail } from '@/components/templates/ClinicDetailConcepts'
 import { COOKIE_CONSENT_COOKIE_NAME, resolveCookieConsentContext } from '@/features/cookieConsent'
 import { buildPatientLoginHref } from '@/features/favorites/redirects'
@@ -12,6 +11,7 @@ import { findFavoriteClinicStateRecord, resolveFavoriteClinicAuthContext } from 
 import { getClinicDetailServerData } from '@/utilities/clinicDetail/serverData'
 import { createSiteMetadata } from '@/utilities/generateMeta'
 import { getGlobal } from '@/utilities/getGlobals'
+import { JsonLdScript, buildClinicDetailPageJsonLd } from '@/utilities/structuredData'
 import type { CookieConsent as CookieConsentType } from '@/payload-types'
 
 type ClinicDetailPageArgs = {
@@ -56,7 +56,7 @@ export default async function ClinicDetailPage({ params: paramsPromise }: Clinic
 
   return (
     <>
-      <BreadcrumbJsonLd items={clinicDetailData.breadcrumbs} />
+      <JsonLdScript data={draft ? null : buildClinicDetailPageJsonLd(clinicDetailData)} />
       <ClinicDetail
         data={clinicDetailData}
         favorite={{

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -28,6 +28,7 @@ import {
   shouldBlockSearchIndexing,
   shouldBlockSearchIndexingForRequest,
 } from '@/features/searchIndexing'
+import { JsonLdScript, buildSiteBaseJsonLd } from '@/utilities/structuredData'
 import type { Footer as FooterType, Header as HeaderType } from '@/payload-types'
 import type { CookieConsent as CookieConsentType } from '@/payload-types'
 
@@ -101,6 +102,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         ) : null}
       </head>
       <body className="min-h-screen bg-site-canvas text-foreground antialiased">
+        {!blockSearchIndexing ? <JsonLdScript data={buildSiteBaseJsonLd()} /> : null}
         <div className="flex min-h-screen min-h-svh flex-col">
           <AdminBar adminBarProps={{ preview: isEnabled }} />
 

--- a/src/app/(frontend)/listing-comparison/page.tsx
+++ b/src/app/(frontend)/listing-comparison/page.tsx
@@ -3,12 +3,12 @@ import type { Metadata } from 'next'
 import { headers } from 'next/headers'
 import { getPayload } from 'payload'
 
-import { BreadcrumbJsonLd } from '@/components/molecules/Breadcrumb/BreadcrumbJsonLd'
 import { findFavoriteClinicStateRecord, resolveFavoriteClinicAuthContext } from '@/features/favorites/server'
 import { buildIndexingMetadata, resolveListingComparisonIndexing } from '@/features/searchIndexing'
 import { buildFreshnessMetadata } from '@/utilities/freshness'
 import { getListingComparisonServerData } from '@/utilities/listingComparison/serverData'
 import { DISCLAIMER_COPY } from '@/utilities/legal/disclaimers'
+import { JsonLdScript, buildListingComparisonJsonLd } from '@/utilities/structuredData'
 
 import type { ListingComparisonTrust } from './ListingComparisonPage.client'
 import { ListingComparisonPageClient } from './ListingComparisonPage.client'
@@ -25,9 +25,10 @@ export async function generateMetadata({
   const searchParams = (await searchParamsPromise) ?? {}
   const payload = await getPayload({ config: configPromise })
   const listingData = await getListingComparisonServerData(payload, searchParams)
+  const indexingPolicy = resolveListingComparisonIndexing(searchParams)
 
   return {
-    ...buildIndexingMetadata(resolveListingComparisonIndexing(searchParams)),
+    ...buildIndexingMetadata(indexingPolicy),
     ...buildFreshnessMetadata(listingData.freshness),
   }
 }
@@ -37,6 +38,7 @@ export default async function ListingComparisonPage({ searchParams: searchParams
   const requestHeaders = await headers()
   const payload = await getPayload({ config: configPromise })
   const listingData = await getListingComparisonServerData(payload, searchParams)
+  const indexingPolicy = resolveListingComparisonIndexing(searchParams)
   const favoriteAuthContext = await resolveFavoriteClinicAuthContext({
     payload,
     headers: requestHeaders,
@@ -69,7 +71,13 @@ export default async function ListingComparisonPage({ searchParams: searchParams
 
   return (
     <>
-      <BreadcrumbJsonLd items={listingData.specialtyContext.breadcrumbs} />
+      <JsonLdScript
+        data={buildListingComparisonJsonLd({
+          breadcrumbs: listingData.specialtyContext.breadcrumbs,
+          clinics: listingData.results,
+          isCanonicalRoute: indexingPolicy.reason === 'canonical-route',
+        })}
+      />
       <ListingComparisonPageClient
         hero={{
           title: 'Compare clinic prices',

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -8,7 +8,6 @@ import { draftMode } from 'next/headers'
 import React, { cache } from 'react'
 import RichText from '@/blocks/_shared/RichText'
 
-import { BreadcrumbJsonLd } from '@/components/molecules/Breadcrumb/BreadcrumbJsonLd'
 import { PostHero } from '@/components/organisms/Heroes/PostHero'
 import { generateMeta } from '@/utilities/generateMeta'
 import PageClient from './page.client'
@@ -23,6 +22,7 @@ import { PostShareActionBar } from './PostShareActionBar'
 import { resolveContentLocaleContext, type ContentLocaleContext } from '@/utilities/contentLocalization'
 import { buildPostPath, buildPostsIndexPath } from '@/utilities/content/postPaths'
 import { createBlogBreadcrumb, HOME_BREADCRUMB } from '@/utilities/breadcrumbs'
+import { JsonLdScript, buildArticlePageJsonLd } from '@/utilities/structuredData'
 
 export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
@@ -84,7 +84,22 @@ export default async function Post({ params: paramsPromise, searchParams: search
   return (
     <article className="pb-16 sm:pb-20">
       <PageClient />
-      <BreadcrumbJsonLd items={breadcrumbs} />
+      <JsonLdScript
+        data={
+          draft
+            ? null
+            : buildArticlePageJsonLd({
+                authorName: authorData?.name,
+                breadcrumbs,
+                description: post.excerpt,
+                imageUrl: heroImage?.src,
+                path: localizedPostPath,
+                publishedAt: post.publishedAt,
+                title: post.title,
+                updatedAt: post.updatedAt,
+              })
+        }
+      />
 
       {/* Allows redirects for valid pages too */}
       <PayloadRedirects disableNotFound url={canonicalPostPath} />

--- a/src/app/(frontend)/posts/page.tsx
+++ b/src/app/(frontend)/posts/page.tsx
@@ -4,7 +4,6 @@ import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 import React from 'react'
 import PageClient from './page.client'
-import { BreadcrumbJsonLd } from '@/components/molecules/Breadcrumb/BreadcrumbJsonLd'
 import { Container } from '@/components/molecules/Container'
 import { BlogHero } from '@/components/organisms/Blog/BlogHero'
 import { BlogCard } from '@/components/organisms/Blog/BlogCard'
@@ -14,6 +13,7 @@ import { buildPostsIndexPath, buildPostsPagePath } from '@/utilities/content/pos
 import { findPublishedPostsPage } from '@/utilities/content/serverData'
 import { resolveContentLocaleContext } from '@/utilities/contentLocalization'
 import { createSiteMetadata } from '@/utilities/generateMeta'
+import { JsonLdScript, buildPostsIndexJsonLd } from '@/utilities/structuredData'
 import { Heading } from '@/components/atoms/Heading'
 import { PostsPagination } from './_components/PostsPagination'
 
@@ -44,7 +44,7 @@ export default async function Page({ searchParams: searchParamsPromise }: Args =
   return (
     <div className="pb-20 sm:pb-24">
       <PageClient />
-      <BreadcrumbJsonLd items={breadcrumbs} />
+      <JsonLdScript data={buildPostsIndexJsonLd({ breadcrumbs, posts: normalizedPosts })} />
 
       {/* Hero Section */}
       <BlogHero breadcrumbs={breadcrumbs} />

--- a/src/app/(frontend)/posts/page/[pageNumber]/page.tsx
+++ b/src/app/(frontend)/posts/page/[pageNumber]/page.tsx
@@ -6,7 +6,6 @@ import { getPayload } from 'payload'
 import React from 'react'
 import PageClient from './page.client'
 import { Breadcrumb, type BreadcrumbItem } from '@/components/molecules/Breadcrumb'
-import { BreadcrumbJsonLd } from '@/components/molecules/Breadcrumb/BreadcrumbJsonLd'
 import { Heading } from '@/components/atoms/Heading'
 import { notFound, redirect } from 'next/navigation'
 import { Container } from '@/components/molecules/Container'
@@ -16,6 +15,7 @@ import { buildPostsIndexPath, buildPostsPagePath } from '@/utilities/content/pos
 import { countPublishedPosts, findPublishedPostsPage } from '@/utilities/content/serverData'
 import { resolveContentLocaleContext } from '@/utilities/contentLocalization'
 import { createSiteMetadata } from '@/utilities/generateMeta'
+import { JsonLdScript, buildPostsIndexJsonLd } from '@/utilities/structuredData'
 import { PostsPagination } from '../../_components/PostsPagination'
 
 export const revalidate = 600
@@ -64,7 +64,7 @@ export default async function Page({ params: paramsPromise, searchParams: search
   return (
     <div className="pt-16 pb-20 sm:pt-24 sm:pb-24">
       <PageClient />
-      <BreadcrumbJsonLd items={breadcrumbs} />
+      <JsonLdScript data={buildPostsIndexJsonLd({ breadcrumbs, posts: normalizedPosts })} />
       <Container className="mb-12 sm:mb-16">
         <div className="prose max-w-none">
           <Breadcrumb items={breadcrumbs} className="mb-6 [&_ol]:justify-center" />

--- a/src/components/molecules/Breadcrumb/BreadcrumbJsonLd.tsx
+++ b/src/components/molecules/Breadcrumb/BreadcrumbJsonLd.tsx
@@ -1,18 +1,12 @@
 import type { BreadcrumbItem } from '@/components/molecules/Breadcrumb'
-import { buildBreadcrumbListJsonLd, type BreadcrumbListJsonLd } from '@/utilities/structuredData/breadcrumbs'
+import { JsonLdScript, buildBreadcrumbListJsonLd } from '@/utilities/structuredData'
 
 export type BreadcrumbJsonLdProps = {
   items: BreadcrumbItem[]
 }
 
-function serializeBreadcrumbJsonLd(jsonLd: BreadcrumbListJsonLd): string {
-  return JSON.stringify(jsonLd).replace(/</g, '\\u003c')
-}
-
 export function BreadcrumbJsonLd({ items }: BreadcrumbJsonLdProps) {
   const jsonLd = buildBreadcrumbListJsonLd(items)
 
-  if (!jsonLd) return null
-
-  return <script type="application/ld+json">{serializeBreadcrumbJsonLd(jsonLd)}</script>
+  return <JsonLdScript data={jsonLd} />
 }

--- a/src/utilities/structuredData/JsonLdScript.tsx
+++ b/src/utilities/structuredData/JsonLdScript.tsx
@@ -1,0 +1,16 @@
+import type { JsonLdNode } from './types'
+import { cleanJsonLdNode, cleanJsonLdNodes } from './internal'
+
+export type JsonLdScriptProps = {
+  data: JsonLdNode | JsonLdNode[] | null | undefined
+}
+
+const serializeJsonLd = (data: JsonLdNode | JsonLdNode[]): string => JSON.stringify(data).replace(/</g, '\\u003c')
+
+export function JsonLdScript({ data }: JsonLdScriptProps) {
+  const jsonLd = Array.isArray(data) ? cleanJsonLdNodes(data) : cleanJsonLdNode(data)
+
+  if (!jsonLd || (Array.isArray(jsonLd) && jsonLd.length === 0)) return null
+
+  return <script type="application/ld+json">{serializeJsonLd(jsonLd)}</script>
+}

--- a/src/utilities/structuredData/articles.ts
+++ b/src/utilities/structuredData/articles.ts
@@ -1,0 +1,57 @@
+import type { BreadcrumbItem } from '@/components/molecules/Breadcrumb'
+
+import { buildBreadcrumbListJsonLd } from './breadcrumbs'
+import { absoluteUrl, buildNodeId, cleanJsonLdNodes, organizationId } from './internal'
+import type { JsonLdNode } from './types'
+
+export type ArticlePageJsonLdInput = {
+  authorName?: string | null
+  breadcrumbs: BreadcrumbItem[]
+  description?: string | null
+  imageUrl?: string | null
+  path: string
+  publishedAt?: string | null
+  title: string
+  updatedAt?: string | null
+}
+
+export function buildArticlePageJsonLd({
+  authorName,
+  breadcrumbs,
+  description,
+  imageUrl,
+  path,
+  publishedAt,
+  title,
+  updatedAt,
+}: ArticlePageJsonLdInput): JsonLdNode[] {
+  const pageUrl = absoluteUrl(path)
+
+  return cleanJsonLdNodes([
+    buildBreadcrumbListJsonLd(breadcrumbs),
+    {
+      '@context': 'https://schema.org',
+      '@id': buildNodeId(path, 'article'),
+      '@type': 'Article',
+      author: authorName
+        ? {
+            '@type': 'Person',
+            name: authorName,
+          }
+        : undefined,
+      dateModified: updatedAt ?? publishedAt,
+      datePublished: publishedAt,
+      description,
+      headline: title,
+      image: imageUrl ? [absoluteUrl(imageUrl)] : undefined,
+      mainEntityOfPage: {
+        '@id': pageUrl,
+        '@type': 'WebPage',
+      },
+      publisher: {
+        '@id': organizationId(),
+      },
+      url: pageUrl,
+    },
+  ])
+}

--- a/src/utilities/structuredData/clinics.ts
+++ b/src/utilities/structuredData/clinics.ts
@@ -1,0 +1,61 @@
+import type { BreadcrumbItem } from '@/components/molecules/Breadcrumb'
+
+import { buildBreadcrumbListJsonLd } from './breadcrumbs'
+import { absoluteUrl, buildNodeId, cleanJsonLdNodes } from './internal'
+import type { JsonLdNode } from './types'
+
+export type ClinicDetailPageJsonLdInput = {
+  breadcrumbs: BreadcrumbItem[]
+  clinicName: string
+  clinicSlug: string
+  description?: string | null
+  doctors: Array<{
+    image: {
+      src?: string | null
+    }
+    name: string
+    specialty: string
+  }>
+  heroImage: {
+    src?: string | null
+  }
+  location: {
+    fullAddress?: string | null
+  }
+  treatments: Array<{
+    name: string
+  }>
+}
+
+export function buildClinicDetailPageJsonLd(data: ClinicDetailPageJsonLdInput): JsonLdNode[] {
+  const path = `/clinics/${encodeURIComponent(data.clinicSlug)}`
+
+  return cleanJsonLdNodes([
+    buildBreadcrumbListJsonLd(data.breadcrumbs),
+    {
+      '@context': 'https://schema.org',
+      '@id': buildNodeId(path, 'clinic'),
+      '@type': 'MedicalClinic',
+      address: data.location.fullAddress
+        ? {
+            '@type': 'PostalAddress',
+            streetAddress: data.location.fullAddress,
+          }
+        : undefined,
+      description: data.description,
+      employee: data.doctors.map((doctor) => ({
+        '@type': 'Physician',
+        image: doctor.image.src ? absoluteUrl(doctor.image.src) : undefined,
+        medicalSpecialty: doctor.specialty,
+        name: doctor.name,
+      })),
+      image: data.heroImage.src ? absoluteUrl(data.heroImage.src) : undefined,
+      name: data.clinicName,
+      availableService: data.treatments.map((treatment) => ({
+        '@type': 'MedicalProcedure',
+        name: treatment.name,
+      })),
+      url: absoluteUrl(path),
+    },
+  ])
+}

--- a/src/utilities/structuredData/index.ts
+++ b/src/utilities/structuredData/index.ts
@@ -1,0 +1,12 @@
+export { JsonLdScript, type JsonLdScriptProps } from './JsonLdScript'
+export { buildArticlePageJsonLd, type ArticlePageJsonLdInput } from './articles'
+export { buildBreadcrumbListJsonLd, type BreadcrumbListJsonLd } from './breadcrumbs'
+export { buildClinicDetailPageJsonLd, type ClinicDetailPageJsonLdInput } from './clinics'
+export {
+  buildListingComparisonJsonLd,
+  buildPostsIndexJsonLd,
+  type ListingComparisonJsonLdInput,
+  type PostsIndexJsonLdInput,
+} from './itemLists'
+export { buildSiteBaseJsonLd } from './site'
+export type { JsonLdNode } from './types'

--- a/src/utilities/structuredData/internal.ts
+++ b/src/utilities/structuredData/internal.ts
@@ -1,0 +1,41 @@
+import { getAbsoluteSiteURL } from '@/utilities/socialPreview'
+
+import type { JsonLdNode, JsonLdObject, JsonLdValue } from './types'
+
+const isJsonLdObject = (value: JsonLdValue): value is JsonLdObject =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
+const cleanJsonLdValue = (value: JsonLdValue): JsonLdValue => {
+  if (value === null || value === undefined || value === '') return undefined
+
+  if (Array.isArray(value)) {
+    const nextValue = value.map(cleanJsonLdValue).filter((item) => item !== undefined && item !== null && item !== '')
+    return nextValue.length > 0 ? nextValue : undefined
+  }
+
+  if (isJsonLdObject(value)) {
+    const entries = Object.entries(value)
+      .map(([key, entryValue]) => [key, cleanJsonLdValue(entryValue)] as const)
+      .filter(([, entryValue]) => entryValue !== undefined && entryValue !== null && entryValue !== '')
+
+    return entries.length > 0 ? Object.fromEntries(entries) : undefined
+  }
+
+  return value
+}
+
+export const cleanJsonLdNode = (node: JsonLdNode | null | undefined): JsonLdNode | null => {
+  const cleaned = cleanJsonLdValue(node)
+  return isJsonLdObject(cleaned) ? cleaned : null
+}
+
+export const cleanJsonLdNodes = (nodes: Array<JsonLdNode | null | undefined>): JsonLdNode[] =>
+  nodes.map(cleanJsonLdNode).filter((node): node is JsonLdNode => Boolean(node))
+
+export const absoluteUrl = (pathOrURL: string) => getAbsoluteSiteURL(pathOrURL)
+
+export const buildNodeId = (pathOrURL: string, fragment: string) => `${absoluteUrl(pathOrURL)}#${fragment}`
+
+export const organizationId = () => buildNodeId('/', 'organization')
+
+export const websiteId = () => buildNodeId('/', 'website')

--- a/src/utilities/structuredData/itemLists.ts
+++ b/src/utilities/structuredData/itemLists.ts
@@ -1,0 +1,118 @@
+import type { BreadcrumbItem } from '@/components/molecules/Breadcrumb'
+
+import { buildBreadcrumbListJsonLd } from './breadcrumbs'
+import { absoluteUrl, buildNodeId, cleanJsonLdNodes } from './internal'
+import type { JsonLdNode } from './types'
+
+type ItemListEntryType = 'Article' | 'MedicalClinic' | 'Thing'
+
+type ItemListEntry = {
+  imageUrl?: string | null
+  name: string
+  type?: ItemListEntryType
+  url: string
+}
+
+type BuildItemListJsonLdInput = {
+  idPath: string
+  items: ItemListEntry[]
+  name: string
+}
+
+export type PostsIndexJsonLdInput = {
+  breadcrumbs: BreadcrumbItem[]
+  posts: Array<{
+    href: string
+    image?: {
+      src?: string | null
+    }
+    title: string
+  }>
+}
+
+export type ListingComparisonJsonLdInput = {
+  breadcrumbs: BreadcrumbItem[]
+  clinics: Array<{
+    actions: {
+      details: {
+        href: string
+      }
+    }
+    media: {
+      src?: string | null
+    }
+    name: string
+  }>
+  isCanonicalRoute: boolean
+}
+
+const buildItemListJsonLd = ({ idPath, items, name }: BuildItemListJsonLdInput): JsonLdNode | null => {
+  const normalizedItems = items
+    .map((item) => ({
+      ...item,
+      name: item.name.trim(),
+      url: item.url.trim(),
+    }))
+    .filter((item) => item.name.length > 0 && item.url.length > 0)
+
+  if (normalizedItems.length === 0) return null
+
+  return {
+    '@context': 'https://schema.org',
+    '@id': buildNodeId(idPath, 'item-list'),
+    '@type': 'ItemList',
+    itemListElement: normalizedItems.map((item, index) => ({
+      '@type': 'ListItem',
+      item: {
+        '@type': item.type ?? 'Thing',
+        image: item.imageUrl ? absoluteUrl(item.imageUrl) : undefined,
+        name: item.name,
+        url: absoluteUrl(item.url),
+      },
+      name: item.name,
+      position: index + 1,
+      url: absoluteUrl(item.url),
+    })),
+    name,
+  }
+}
+
+export function buildPostsIndexJsonLd({ breadcrumbs, posts }: PostsIndexJsonLdInput): JsonLdNode[] {
+  const path = breadcrumbs.at(-1)?.href ?? '/posts'
+
+  return cleanJsonLdNodes([
+    buildBreadcrumbListJsonLd(breadcrumbs),
+    buildItemListJsonLd({
+      idPath: path,
+      items: posts.map((post) => ({
+        imageUrl: post.image?.src,
+        name: post.title,
+        type: 'Article',
+        url: post.href,
+      })),
+      name: 'findmydoc articles',
+    }),
+  ])
+}
+
+export function buildListingComparisonJsonLd({
+  breadcrumbs,
+  clinics,
+  isCanonicalRoute,
+}: ListingComparisonJsonLdInput): JsonLdNode[] {
+  return cleanJsonLdNodes([
+    buildBreadcrumbListJsonLd(breadcrumbs),
+    isCanonicalRoute
+      ? buildItemListJsonLd({
+          idPath: '/listing-comparison',
+          items: clinics.map((clinic) => ({
+            imageUrl: clinic.media.src,
+            name: clinic.name,
+            type: 'MedicalClinic',
+            url: clinic.actions.details.href,
+          })),
+          name: 'findmydoc clinic comparison',
+        })
+      : null,
+  ])
+}

--- a/src/utilities/structuredData/site.ts
+++ b/src/utilities/structuredData/site.ts
@@ -1,0 +1,29 @@
+import { DEFAULT_SITE_DESCRIPTION, SITE_NAME } from '@/utilities/socialPreview'
+
+import { absoluteUrl, organizationId, websiteId } from './internal'
+import type { JsonLdNode } from './types'
+
+export function buildSiteBaseJsonLd(): JsonLdNode[] {
+  const homeUrl = absoluteUrl('/')
+
+  return [
+    {
+      '@context': 'https://schema.org',
+      '@id': organizationId(),
+      '@type': 'Organization',
+      name: SITE_NAME,
+      url: homeUrl,
+    },
+    {
+      '@context': 'https://schema.org',
+      '@id': websiteId(),
+      '@type': 'WebSite',
+      description: DEFAULT_SITE_DESCRIPTION,
+      name: SITE_NAME,
+      publisher: {
+        '@id': organizationId(),
+      },
+      url: homeUrl,
+    },
+  ]
+}

--- a/src/utilities/structuredData/types.ts
+++ b/src/utilities/structuredData/types.ts
@@ -1,0 +1,9 @@
+export type JsonLdPrimitive = string | number | boolean
+
+export type JsonLdValue = JsonLdPrimitive | JsonLdObject | JsonLdValue[] | null | undefined
+
+export type JsonLdObject = {
+  [key: string]: JsonLdValue
+}
+
+export type JsonLdNode = JsonLdObject

--- a/tests/unit/app/frontend/clinic-detail.page.test.tsx
+++ b/tests/unit/app/frontend/clinic-detail.page.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const routeMocks = vi.hoisted(() => ({
-  breadcrumbJsonLdComponent: vi.fn(() => null),
+  buildClinicDetailPageJsonLd: vi.fn(() => [{ '@type': 'MedicalClinic' }]),
   clinicDetailComponent: vi.fn(() => null),
   cookies: vi.fn(),
   draftMode: vi.fn(),
@@ -11,6 +11,7 @@ const routeMocks = vi.hoisted(() => ({
   getGlobal: vi.fn(),
   getPayload: vi.fn(),
   headers: vi.fn(),
+  jsonLdScriptComponent: vi.fn(() => null),
   notFound: vi.fn(),
   resolveCookieConsentContext: vi.fn(),
   resolveFavoriteClinicAuthContext: vi.fn(),
@@ -42,10 +43,6 @@ vi.mock('@/components/templates/ClinicDetailConcepts', () => ({
   ClinicDetail: routeMocks.clinicDetailComponent,
 }))
 
-vi.mock('@/components/molecules/Breadcrumb/BreadcrumbJsonLd', () => ({
-  BreadcrumbJsonLd: routeMocks.breadcrumbJsonLdComponent,
-}))
-
 vi.mock('@/features/cookieConsent', () => ({
   COOKIE_CONSENT_COOKIE_NAME: 'cookie-consent',
   resolveCookieConsentContext: routeMocks.resolveCookieConsentContext,
@@ -62,6 +59,11 @@ vi.mock('@/utilities/clinicDetail/serverData', () => ({
 
 vi.mock('@/utilities/getGlobals', () => ({
   getGlobal: routeMocks.getGlobal,
+}))
+
+vi.mock('@/utilities/structuredData', () => ({
+  buildClinicDetailPageJsonLd: routeMocks.buildClinicDetailPageJsonLd,
+  JsonLdScript: routeMocks.jsonLdScriptComponent,
 }))
 
 type ReactNodeLike = React.ReactNode
@@ -144,19 +146,17 @@ describe('frontend clinic detail route', () => {
     })
   })
 
-  it('renders BreadcrumbList JSON-LD from clinic detail server data', async () => {
+  it('renders clinic detail JSON-LD from clinic detail server data', async () => {
     const pageModule = await import('@/app/(frontend)/clinics/[slug]/page')
     const result = await pageModule.default({
       params: Promise.resolve({ slug: 'berlin-health' }),
     })
 
-    const breadcrumbJsonLdElement = findElementByType(
-      result,
-      routeMocks.breadcrumbJsonLdComponent,
-    ) as React.ReactElement<{
-      items: Array<{ href: string; label: string }>
+    expect(routeMocks.buildClinicDetailPageJsonLd).toHaveBeenCalledWith(clinicDetailData)
+    const jsonLdElement = findElementByType(result, routeMocks.jsonLdScriptComponent) as React.ReactElement<{
+      data: unknown
     }> | null
-    expect(breadcrumbJsonLdElement?.props.items).toEqual(clinicDetailData.breadcrumbs)
+    expect(jsonLdElement?.props.data).toEqual([{ '@type': 'MedicalClinic' }])
 
     const clinicDetailElement = findElementByType(result, routeMocks.clinicDetailComponent) as React.ReactElement<{
       data: unknown

--- a/tests/unit/app/frontend/listing-comparison.page.test.ts
+++ b/tests/unit/app/frontend/listing-comparison.page.test.ts
@@ -2,11 +2,12 @@ import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const routeMocks = vi.hoisted(() => ({
-  breadcrumbJsonLdComponent: vi.fn(() => null),
+  buildListingComparisonJsonLd: vi.fn(() => [{ '@type': 'ItemList' }]),
   findFavoriteClinicStateRecord: vi.fn(),
   getListingComparisonServerData: vi.fn(),
   getPayload: vi.fn(),
   headers: vi.fn(),
+  jsonLdScriptComponent: vi.fn(() => null),
   listingComparisonPageClient: vi.fn(() => null),
   resolveFavoriteClinicAuthContext: vi.fn(),
 }))
@@ -36,12 +37,13 @@ vi.mock('@/utilities/listingComparison/serverData', () => ({
   getListingComparisonServerData: routeMocks.getListingComparisonServerData,
 }))
 
-vi.mock('@/components/molecules/Breadcrumb/BreadcrumbJsonLd', () => ({
-  BreadcrumbJsonLd: routeMocks.breadcrumbJsonLdComponent,
-}))
-
 vi.mock('@/app/(frontend)/listing-comparison/ListingComparisonPage.client', () => ({
   ListingComparisonPageClient: routeMocks.listingComparisonPageClient,
+}))
+
+vi.mock('@/utilities/structuredData', () => ({
+  buildListingComparisonJsonLd: routeMocks.buildListingComparisonJsonLd,
+  JsonLdScript: routeMocks.jsonLdScriptComponent,
 }))
 
 type ReactNodeLike = React.ReactNode
@@ -164,21 +166,37 @@ describe('listing comparison page route metadata', () => {
     })
   })
 
-  it('renders BreadcrumbList JSON-LD from listing server breadcrumbs', async () => {
+  it('renders canonical listing comparison JSON-LD from listing server data', async () => {
     const pageModule = await import('@/app/(frontend)/listing-comparison/page')
     const result = await pageModule.default({
       searchParams: Promise.resolve({}),
     })
 
-    const breadcrumbJsonLdElement = findElementByType(
-      result,
-      routeMocks.breadcrumbJsonLdComponent,
-    ) as React.ReactElement<{
-      items: Array<{ href: string; label: string }>
+    expect(routeMocks.buildListingComparisonJsonLd).toHaveBeenCalledWith({
+      breadcrumbs: [
+        { label: 'Home', href: '/' },
+        { label: 'Clinics', href: '/listing-comparison' },
+      ],
+      clinics: [],
+      isCanonicalRoute: true,
+    })
+    const jsonLdElement = findElementByType(result, routeMocks.jsonLdScriptComponent) as React.ReactElement<{
+      data: unknown
     }> | null
-    expect(breadcrumbJsonLdElement?.props.items).toEqual([
-      { label: 'Home', href: '/' },
-      { label: 'Clinics', href: '/listing-comparison' },
-    ])
+    expect(jsonLdElement?.props.data).toEqual([{ '@type': 'ItemList' }])
+  })
+
+  it('keeps query variant JSON-LD from emitting a discovery ItemList', async () => {
+    const pageModule = await import('@/app/(frontend)/listing-comparison/page')
+
+    await pageModule.default({
+      searchParams: Promise.resolve({ city: 'berlin' }),
+    })
+
+    expect(routeMocks.buildListingComparisonJsonLd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isCanonicalRoute: false,
+      }),
+    )
   })
 })

--- a/tests/unit/app/frontend/post.page.test.tsx
+++ b/tests/unit/app/frontend/post.page.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  breadcrumbJsonLdComponent: vi.fn(() => null),
+  buildArticlePageJsonLdMock: vi.fn(() => [{ '@type': 'Article' }]),
   calculateReadTimeMock: vi.fn(() => '5 min read'),
   draftModeMock: vi.fn(),
   findPostBySlugMock: vi.fn(),
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   relatedPostsComponent: vi.fn(() => null),
   richTextComponent: vi.fn(() => null),
   disclaimerNoticeComponent: vi.fn(() => null),
+  jsonLdScriptComponent: vi.fn(() => null),
   resolveMediaImageMock: vi.fn<() => unknown>(() => undefined),
 }))
 
@@ -36,10 +37,6 @@ vi.mock('payload', async (importOriginal) => {
 
 vi.mock('@/app/(frontend)/_components/PayloadRedirects', () => ({
   PayloadRedirects: mocks.payloadRedirectsComponent,
-}))
-
-vi.mock('@/components/molecules/Breadcrumb/BreadcrumbJsonLd', () => ({
-  BreadcrumbJsonLd: mocks.breadcrumbJsonLdComponent,
 }))
 
 vi.mock('@/components/organisms/Heroes/PostHero', () => ({
@@ -77,6 +74,11 @@ vi.mock('@/utilities/generateMeta', () => ({
 vi.mock('@/utilities/content/serverData', () => ({
   findPostBySlug: mocks.findPostBySlugMock,
   findPostSlugs: mocks.findPostSlugsMock,
+}))
+
+vi.mock('@/utilities/structuredData', () => ({
+  buildArticlePageJsonLd: mocks.buildArticlePageJsonLdMock,
+  JsonLdScript: mocks.jsonLdScriptComponent,
 }))
 
 type ReactNodeLike = React.ReactNode
@@ -195,10 +197,21 @@ describe('frontend post detail route', () => {
       quality: 75,
     })
 
-    const breadcrumbJsonLdElement = findElementByType(result, mocks.breadcrumbJsonLdComponent) as React.ReactElement<{
-      items: Array<{ href: string; label: string }>
+    expect(mocks.buildArticlePageJsonLdMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorName: 'Ada',
+        breadcrumbs: heroElement?.props.breadcrumbs,
+        description: 'Deutscher Auszug.',
+        imageUrl: '/api/platformContentMedia/file/post-hero.webp',
+        path: '/posts/hello-world?locale=de',
+        publishedAt: '2026-01-01T00:00:00.000Z',
+        title: 'Hallo Welt',
+      }),
+    )
+    const jsonLdElement = findElementByType(result, mocks.jsonLdScriptComponent) as React.ReactElement<{
+      data: unknown
     }> | null
-    expect(breadcrumbJsonLdElement?.props.items).toEqual(heroElement?.props.breadcrumbs)
+    expect(jsonLdElement?.props.data).toEqual([{ '@type': 'Article' }])
 
     const shareElement = findElementByType(result, mocks.postShareActionBarComponent) as React.ReactElement<{
       backLink: { href: string; label: string }

--- a/tests/unit/app/frontend/posts.page-number.page.test.tsx
+++ b/tests/unit/app/frontend/posts.page-number.page.test.tsx
@@ -3,11 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   breadcrumbComponent: vi.fn(() => null),
-  breadcrumbJsonLdComponent: vi.fn(() => null),
+  buildPostsIndexJsonLdMock: vi.fn(() => [{ '@type': 'ItemList' }]),
   countPublishedPostsMock: vi.fn(),
   createSiteMetadataMock: vi.fn((args: unknown) => args),
   findPublishedPostsPageMock: vi.fn(),
   getPayloadMock: vi.fn(),
+  jsonLdScriptComponent: vi.fn(() => null),
   normalizePostMock: vi.fn(),
   notFoundMock: vi.fn(),
   postsPaginationComponent: vi.fn(() => null),
@@ -48,12 +49,13 @@ vi.mock('@/components/molecules/Breadcrumb', () => ({
   Breadcrumb: mocks.breadcrumbComponent,
 }))
 
-vi.mock('@/components/molecules/Breadcrumb/BreadcrumbJsonLd', () => ({
-  BreadcrumbJsonLd: mocks.breadcrumbJsonLdComponent,
-}))
-
 vi.mock('@/app/(frontend)/posts/_components/PostsPagination', () => ({
   PostsPagination: mocks.postsPaginationComponent,
+}))
+
+vi.mock('@/utilities/structuredData', () => ({
+  buildPostsIndexJsonLd: mocks.buildPostsIndexJsonLdMock,
+  JsonLdScript: mocks.jsonLdScriptComponent,
 }))
 
 type ReactNodeLike = React.ReactNode
@@ -164,10 +166,14 @@ describe('frontend paginated posts route', () => {
     }> | null
     expect(breadcrumbElement?.props.items).toEqual(expectedBreadcrumbs)
 
-    const breadcrumbJsonLdElement = findElementByType(result, mocks.breadcrumbJsonLdComponent) as React.ReactElement<{
-      items: Array<{ href: string; label: string }>
+    expect(mocks.buildPostsIndexJsonLdMock).toHaveBeenCalledWith({
+      breadcrumbs: expectedBreadcrumbs,
+      posts: [{ title: 'Seite zwei', href: '/posts/page-2-post?locale=de' }],
+    })
+    const jsonLdElement = findElementByType(result, mocks.jsonLdScriptComponent) as React.ReactElement<{
+      data: unknown
     }> | null
-    expect(breadcrumbJsonLdElement?.props.items).toEqual(expectedBreadcrumbs)
+    expect(jsonLdElement?.props.data).toEqual([{ '@type': 'ItemList' }])
   })
 
   it('uses the requested content locale in metadata paths', async () => {

--- a/tests/unit/app/frontend/posts.page.test.tsx
+++ b/tests/unit/app/frontend/posts.page.test.tsx
@@ -3,10 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   blogHeroComponent: vi.fn(() => null),
-  breadcrumbJsonLdComponent: vi.fn(() => null),
+  buildPostsIndexJsonLdMock: vi.fn(() => [{ '@type': 'ItemList' }]),
   createSiteMetadataMock: vi.fn((args: unknown) => args),
   findPublishedPostsPageMock: vi.fn(),
   getPayloadMock: vi.fn(),
+  jsonLdScriptComponent: vi.fn(() => null),
   normalizePostMock: vi.fn(),
   postsPaginationComponent: vi.fn(() => null),
 }))
@@ -35,16 +36,17 @@ vi.mock('@/utilities/generateMeta', () => ({
   createSiteMetadata: mocks.createSiteMetadataMock,
 }))
 
-vi.mock('@/components/molecules/Breadcrumb/BreadcrumbJsonLd', () => ({
-  BreadcrumbJsonLd: mocks.breadcrumbJsonLdComponent,
-}))
-
 vi.mock('@/components/organisms/Blog/BlogHero', () => ({
   BlogHero: mocks.blogHeroComponent,
 }))
 
 vi.mock('@/app/(frontend)/posts/_components/PostsPagination', () => ({
   PostsPagination: mocks.postsPaginationComponent,
+}))
+
+vi.mock('@/utilities/structuredData', () => ({
+  buildPostsIndexJsonLd: mocks.buildPostsIndexJsonLdMock,
+  JsonLdScript: mocks.jsonLdScriptComponent,
 }))
 
 type ReactNodeLike = React.ReactNode
@@ -134,10 +136,14 @@ describe('frontend posts index route', () => {
     }> | null
     expect(heroElement?.props.breadcrumbs).toEqual(expectedBreadcrumbs)
 
-    const breadcrumbJsonLdElement = findElementByType(result, mocks.breadcrumbJsonLdComponent) as React.ReactElement<{
-      items: Array<{ href: string; label: string }>
+    expect(mocks.buildPostsIndexJsonLdMock).toHaveBeenCalledWith({
+      breadcrumbs: expectedBreadcrumbs,
+      posts: [{ title: 'Hallo Welt', href: '/posts/hello-world?locale=de' }],
+    })
+    const jsonLdElement = findElementByType(result, mocks.jsonLdScriptComponent) as React.ReactElement<{
+      data: unknown
     }> | null
-    expect(breadcrumbJsonLdElement?.props.items).toEqual(expectedBreadcrumbs)
+    expect(jsonLdElement?.props.data).toEqual([{ '@type': 'ItemList' }])
   })
 
   it('uses the requested content locale in metadata paths', async () => {

--- a/tests/unit/utilities/jsonLdScript.test.tsx
+++ b/tests/unit/utilities/jsonLdScript.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { JsonLdScript } from '@/utilities/structuredData'
+
+describe('JsonLdScript', () => {
+  it('renders a single JSON-LD script', () => {
+    const { container } = render(<JsonLdScript data={{ '@context': 'https://schema.org', '@type': 'WebSite' }} />)
+
+    const script = container.querySelector('script[type="application/ld+json"]')
+    expect(script).not.toBeNull()
+    expect(JSON.parse(script?.textContent ?? '')).toEqual({
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+    })
+  })
+
+  it('renders a list of JSON-LD nodes and removes empty fields', () => {
+    const { container } = render(
+      <JsonLdScript
+        data={[
+          {
+            '@context': 'https://schema.org',
+            '@type': 'Organization',
+            name: 'findmydoc',
+            description: '',
+            image: undefined,
+          },
+          { '@context': 'https://schema.org', '@type': 'WebSite', name: 'findmydoc' },
+        ]}
+      />,
+    )
+
+    const script = container.querySelector('script[type="application/ld+json"]')
+    expect(JSON.parse(script?.textContent ?? '')).toEqual([
+      {
+        '@context': 'https://schema.org',
+        '@type': 'Organization',
+        name: 'findmydoc',
+      },
+      {
+        '@context': 'https://schema.org',
+        '@type': 'WebSite',
+        name: 'findmydoc',
+      },
+    ])
+  })
+
+  it('escapes less-than characters before rendering script text', () => {
+    const { container } = render(
+      <JsonLdScript data={{ '@context': 'https://schema.org', '@type': 'Thing', name: '</script><img>' }} />,
+    )
+
+    const scriptText = container.querySelector('script[type="application/ld+json"]')?.textContent ?? ''
+    expect(scriptText).toContain('\\u003c/script>')
+    expect(scriptText).not.toContain('</script>')
+    expect(JSON.parse(scriptText).name).toBe('</script><img>')
+  })
+
+  it('renders nothing for empty input', () => {
+    const { container } = render(<JsonLdScript data={null} />)
+
+    expect(container.querySelector('script[type="application/ld+json"]')).toBeNull()
+  })
+})

--- a/tests/unit/utilities/structuredDataBuilders.test.ts
+++ b/tests/unit/utilities/structuredDataBuilders.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  buildArticlePageJsonLd,
+  buildClinicDetailPageJsonLd,
+  buildListingComparisonJsonLd,
+  buildPostsIndexJsonLd,
+  buildSiteBaseJsonLd,
+} from '@/utilities/structuredData'
+
+vi.mock('@/utilities/getURL', () => ({
+  getServerSideURL: vi.fn(() => 'https://findmydoc.eu'),
+}))
+
+describe('structured data builders', () => {
+  it('builds stable site base Organization and WebSite nodes', () => {
+    expect(buildSiteBaseJsonLd()).toEqual([
+      expect.objectContaining({
+        '@id': 'https://findmydoc.eu/#organization',
+        '@type': 'Organization',
+        name: 'findmydoc',
+        url: 'https://findmydoc.eu/',
+      }),
+      expect.objectContaining({
+        '@id': 'https://findmydoc.eu/#website',
+        '@type': 'WebSite',
+        publisher: {
+          '@id': 'https://findmydoc.eu/#organization',
+        },
+      }),
+    ])
+  })
+
+  it('builds Article and BreadcrumbList data from visible post fields', () => {
+    const result = buildArticlePageJsonLd({
+      authorName: 'Ada Lovelace',
+      breadcrumbs: [
+        { label: 'Home', href: '/' },
+        { label: 'Blog', href: '/posts' },
+        { label: 'Article', href: '/posts/article' },
+      ],
+      description: 'Public article summary.',
+      imageUrl: '/media/article.webp',
+      path: '/posts/article',
+      publishedAt: '2026-01-01T00:00:00.000Z',
+      title: 'Public Article',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    })
+
+    expect(result).toEqual([
+      expect.objectContaining({ '@type': 'BreadcrumbList' }),
+      expect.objectContaining({
+        '@id': 'https://findmydoc.eu/posts/article#article',
+        '@type': 'Article',
+        author: {
+          '@type': 'Person',
+          name: 'Ada Lovelace',
+        },
+        dateModified: '2026-01-02T00:00:00.000Z',
+        datePublished: '2026-01-01T00:00:00.000Z',
+        headline: 'Public Article',
+        image: ['https://findmydoc.eu/media/article.webp'],
+        url: 'https://findmydoc.eu/posts/article',
+      }),
+    ])
+  })
+
+  it('builds ItemList data from visible post cards', () => {
+    const result = buildPostsIndexJsonLd({
+      breadcrumbs: [
+        { label: 'Home', href: '/' },
+        { label: 'Blog', href: '/posts' },
+      ],
+      posts: [
+        {
+          href: '/posts/article',
+          title: 'Public Article',
+        },
+      ],
+    })
+
+    expect(result).toEqual([
+      expect.objectContaining({ '@type': 'BreadcrumbList' }),
+      expect.objectContaining({
+        '@id': 'https://findmydoc.eu/posts#item-list',
+        '@type': 'ItemList',
+        itemListElement: [
+          expect.objectContaining({
+            item: expect.objectContaining({
+              '@type': 'Article',
+              name: 'Public Article',
+              url: 'https://findmydoc.eu/posts/article',
+            }),
+            position: 1,
+          }),
+        ],
+      }),
+    ])
+  })
+
+  it('omits listing discovery ItemList data for query variants', () => {
+    const breadcrumbs = [
+      { label: 'Home', href: '/' },
+      { label: 'Clinics', href: '/listing-comparison' },
+    ]
+    const clinics = [
+      {
+        actions: { details: { href: '/clinics/berlin-health', label: 'View profile' } },
+        id: '42',
+        location: 'Berlin',
+        media: { src: '/clinic.webp', alt: 'Berlin Health' },
+        name: 'Berlin Health',
+        rating: { value: 0, count: 0 },
+        tags: [],
+        verification: { variant: 'gold' },
+      },
+    ]
+
+    expect(buildListingComparisonJsonLd({ breadcrumbs, clinics, isCanonicalRoute: false })).toEqual([
+      expect.objectContaining({ '@type': 'BreadcrumbList' }),
+    ])
+    expect(buildListingComparisonJsonLd({ breadcrumbs, clinics, isCanonicalRoute: true })).toEqual([
+      expect.objectContaining({ '@type': 'BreadcrumbList' }),
+      expect.objectContaining({ '@type': 'ItemList' }),
+    ])
+  })
+
+  it('builds conservative MedicalClinic data without ratings or trust claims', () => {
+    const clinicDetailData = {
+      beforeAfterEntries: [],
+      breadcrumbs: [
+        { label: 'Home', href: '/' },
+        { label: 'Clinics', href: '/listing-comparison' },
+        { label: 'Berlin Health', href: '/clinics/berlin-health' },
+      ],
+      clinicId: 42,
+      clinicName: 'Berlin Health',
+      clinicSlug: 'berlin-health',
+      contactHref: '/contact?clinic=berlin-health',
+      description: 'Public clinic description.',
+      doctors: [
+        {
+          id: '1',
+          image: { src: '/doctor.webp', alt: 'Doctor' },
+          name: 'Dr Ada',
+          specialty: 'Dentistry',
+          contactHref: '#',
+        },
+      ],
+      freshness: { sourceCollections: ['clinics'] },
+      heroImage: { src: '/clinic.webp', alt: 'Berlin Health' },
+      location: { fullAddress: 'Example Street 1, Berlin' },
+      reviews: { items: [], totalCount: 25 },
+      treatments: [{ id: 'dental-implant', name: 'Dental implant', priceFromUsd: 1000 }],
+      trust: {
+        accreditations: ['Visible badge'],
+        languages: ['English'],
+        ratingValue: 4.8,
+        reviewCount: 25,
+        verification: 'gold',
+      },
+    }
+
+    const result = buildClinicDetailPageJsonLd(clinicDetailData)
+
+    const clinicNode = result.find((node) => node['@type'] === 'MedicalClinic')
+    expect(clinicNode).toMatchObject({
+      '@id': 'https://findmydoc.eu/clinics/berlin-health#clinic',
+      '@type': 'MedicalClinic',
+      availableService: [{ '@type': 'MedicalProcedure', name: 'Dental implant' }],
+      employee: [{ '@type': 'Physician', medicalSpecialty: 'Dentistry', name: 'Dr Ada' }],
+      name: 'Berlin Health',
+      url: 'https://findmydoc.eu/clinics/berlin-health',
+    })
+    expect(clinicNode).not.toHaveProperty('aggregateRating')
+    expect(clinicNode).not.toHaveProperty('reviewCount')
+    expect(clinicNode).not.toHaveProperty('accreditation')
+    expect(clinicNode).not.toHaveProperty('verification')
+  })
+})


### PR DESCRIPTION
## Management summary

### Deutsch

findmydoc stellt öffentliche Inhalte künftig maschinenlesbarer bereit, damit Suchmaschinen und AI Agents veröffentlichte Artikel, Klinikprofile und Vergleichsseiten konsistenter verstehen können. Die sichtbaren öffentlichen Fakten bleiben die Quelle; nicht sichtbare Bewertungen, Trust-Signale oder medizinische Qualitätsaussagen werden nicht ergänzt.

### English

findmydoc now exposes public content in a more machine-readable way, helping search engines and AI agents understand published articles, clinic profiles, and comparison pages more consistently. Visible public facts remain the source of truth; hidden ratings, trust signals, or medical-quality claims are not added.

## What changed

- Added a central structured-data layer for JSON-LD rendering, cleanup, URL IDs, and route-focused builders.
- Folded the existing Breadcrumb JSON-LD rendering into the shared renderer.
- Added site-level Organization/WebSite JSON-LD to the public frontend layout when indexing is allowed.
- Added route-level JSON-LD for post detail, post listing pages, clinic detail pages, and the canonical listing comparison surface.
- Kept listing query variants aligned with noindex behavior by omitting a discovery ItemList for non-canonical query states.
- Updated the public discovery strategy with the strategic boundary for structured data as a visible, source-backed public facts layer.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P2 | `src/utilities/structuredData/**` | New shared JSON-LD boundary controls route output and serialization. | Builder inputs stay public, conservative, and route-oriented; internal helpers are not exposed as a broad API. | Focused Vitest suite and `seo_reviewer` returned no credible technical SEO findings. |
| P2 | `src/app/(frontend)/**` touched routes | Route-level indexation behavior controls whether JSON-LD should be emitted. | Draft/noindex/query-variant behavior stays aligned with public discovery boundaries. | `pnpm check`, focused route tests, and production build passed. |

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed; existing test sense-check warnings remain unrelated to this change.
- [x] `pnpm build`: passed via `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} pnpm build`; local Node emitted the existing engine warning because the shell used Node v26 while the project expects `>=24 <25`.
- [x] Focused tests: `pnpm vitest run tests/unit/utilities/jsonLdScript.test.tsx tests/unit/utilities/structuredDataBuilders.test.ts tests/unit/utilities/breadcrumbStructuredData.test.ts tests/unit/components/breadcrumbJsonLd.test.tsx tests/unit/app/frontend/post.page.test.tsx tests/unit/app/frontend/posts.page.test.tsx tests/unit/app/frontend/posts.page-number.page.test.tsx tests/unit/app/frontend/clinic-detail.page.test.tsx tests/unit/app/frontend/listing-comparison.page.test.ts` passed.
- [x] UI/mobile QA: no visual UI changes; not applicable.
- [x] Security/privacy review: not run; no auth, access-control, private data, API trust boundary, or secrets changes.
- [x] SEO reviewer: `seo_reviewer` returned no credible technical SEO findings in the staged diff.
- [x] Migration/schema check: not applicable; no Payload schema changes or migrations.
- [x] Documentation/instructions check: `pnpm docs:check` passed; no instruction files changed.

## Risk and rollout

Structured data is generated from existing public route data and can be removed by reverting this PR. No database migration, CMS field, environment variable, or manual editor workflow is introduced.

## Development

Closes #1036
