### PR TITLE
fix: prevent clinic partner nav from scrolling to funnel

### DIFF
--- a/src/components/templates/ClinicRegistrationFunnel/ClinicRegistrationFunnel.tsx
+++ b/src/components/templates/ClinicRegistrationFunnel/ClinicRegistrationFunnel.tsx
@@ -119,7 +119,7 @@ export function ClinicRegistrationFunnel({
     messages: validationMessages,
   })
   const stepHeadingRef = React.useRef<HTMLHeadingElement>(null)
-  const didMountRef = React.useRef(false)
+  const previousStepRef = React.useRef(step)
 
   const selectedCategoryLabels = treatmentCategories
     .filter((category) => selectedTreatmentCategories.includes(category.id))
@@ -226,11 +226,11 @@ export function ClinicRegistrationFunnel({
   }, [])
 
   React.useEffect(() => {
-    if (!didMountRef.current) {
-      didMountRef.current = true
+    if (previousStepRef.current === step) {
       return
     }
 
+    previousStepRef.current = step
     stepHeadingRef.current?.focus()
   }, [step])
 

--- a/tests/unit/components/clinicRegistrationFunnel.test.tsx
+++ b/tests/unit/components/clinicRegistrationFunnel.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { StrictMode } from 'react'
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ClinicRegistrationFunnel } from '@/components/templates/ClinicRegistrationFunnel'
+
+vi.mock('@/auth/utilities/clinicRegistrationSubmission', () => ({
+  submitClinicRegistration: vi.fn(),
+}))
+
+describe('ClinicRegistrationFunnel focus management', () => {
+  it('does not focus the first step heading during the initial StrictMode render', () => {
+    render(
+      <StrictMode>
+        <ClinicRegistrationFunnel variant="landing" />
+      </StrictMode>,
+    )
+
+    expect(document.activeElement).not.toBe(screen.getByRole('heading', { name: 'Register your clinic' }))
+  })
+
+  it('focuses the active step heading after an explicit step change', async () => {
+    render(
+      <StrictMode>
+        <ClinicRegistrationFunnel
+          initialValues={{
+            clinicName: 'Demo Clinic',
+            clinicWebsite: 'https://clinic.example',
+          }}
+          variant="landing"
+        />
+      </StrictMode>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    const nextHeading = await screen.findByRole('heading', { name: 'Choose focus areas' })
+    await waitFor(() => expect(document.activeElement).toBe(nextHeading))
+  })
+})


### PR DESCRIPTION
## Management summary

### Deutsch

Die Klinikpartner-Seite bleibt bei normaler Navigation wieder am Seitenanfang, statt Besucherinnen und Besucher direkt in den Registrierungsbereich zu springen. Dadurch sehen Klinikinteressenten zuerst die eigentliche Landingpage-Einordnung und können die Registrierung bewusst starten.

### English

The clinic partner page now stays at the top during normal navigation instead of sending visitors directly into the registration area. This lets clinic prospects see the landing-page context first and start registration intentionally.

## What changed

- Updated the clinic registration funnel focus guard so the first step heading is not focused during the initial StrictMode mount.
- Preserved focus management for explicit step changes inside the funnel.
- Added focused unit coverage for initial StrictMode render behavior and step-change focus behavior.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P2 | `src/components/templates/ClinicRegistrationFunnel/ClinicRegistrationFunnel.tsx` | Focus management directly affected the route scroll position. | Initial render does not steal focus, while explicit step navigation remains accessible. | Focused unit test and browser QA |
| P2 | `tests/unit/components/clinicRegistrationFunnel.test.tsx` | Regression coverage locks the StrictMode behavior. | The test asserts the bug condition and the intended focus behavior, not only rendering. | `pnpm tests:unit tests/unit/components/clinicRegistrationFunnel.test.tsx` |

## Validation

- [x] `pnpm format`: passed locally.
- [x] `pnpm check`: passed locally. Existing test-sense warnings are unrelated repository-wide warnings.
- [x] `pnpm build`: passed locally. Next reported compile warnings without detailed warning text in the captured output.
- [x] Focused tests: `pnpm tests:unit tests/unit/components/clinicRegistrationFunnel.test.tsx` passed.
- [x] UI/mobile QA: Browser QA confirmed `/` -> `Compare Clinics` -> `For Clinics` opens `/partners/clinics` at `scrollY=0` with an empty hash and no relevant console errors at 320, 375, 640, 768, 1024, plus 375x560 short-height. Existing 1024px horizontal overflow of about 7px comes from the testimonials carousel and is unrelated to this focus fix.
  <!-- gh-ui-screenshots:start -->
  ### Mobile
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":2,"capturedAt":"2026-06-24T11:38:07.645Z","contentType":"image/png","focus":"mobile","focusLabel":"Mobile","formFactor":"mobile","gitSha":"4a9ba642","height":720,"releaseEligible":false,"releaseRole":"qa","size":43524,"sizeKb":43,"uploadName":"mobile__mobile__360x720__20260624T113807Z__4a9ba642__360x720__43kb.png","viewport":"360x720","warnings":["not_release_marked"],"width":360,"url":"https://github.com/user-attachments/assets/60b22ea0-3756-4a33-86ff-0243a7078730"} -->
  ![Mobile](https://github.com/user-attachments/assets/60b22ea0-3756-4a33-86ff-0243a7078730)
  
  
  > Screenshot warning: not_release_marked
  
  ### Desktop
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":0.6987115956392468,"capturedAt":"2026-06-24T11:38:09.463Z","contentType":"image/png","focus":"desktop","focusLabel":"Desktop","formFactor":"desktop","gitSha":"4a9ba642","height":705,"releaseEligible":false,"releaseRole":"qa","size":87601,"sizeKb":86,"uploadName":"desktop__desktop__1009x705__20260624T113809Z__4a9ba642__1009x705__86kb.png","viewport":"1009x705","warnings":["not_release_marked"],"width":1009,"url":"https://github.com/user-attachments/assets/7a6b35e8-0d6a-467f-849c-466c551352dd"} -->
  ![Desktop](https://github.com/user-attachments/assets/7a6b35e8-0d6a-467f-849c-466c551352dd)
  
  
  > Screenshot warning: not_release_marked
  <!-- gh-ui-screenshots:end -->
- [ ] Security/privacy review: Not run; this change only adjusts local focus behavior in a public UI component and does not touch auth, access, secrets, logging, or data boundaries.
- [ ] Migration/schema check: Not applicable; no Payload schema, migration, or data-model changes.
- [ ] Documentation/instructions check: Not applicable; no documentation or instruction files changed.

## Risk and rollout

Low risk. The change is limited to client-side focus timing in the existing clinic registration funnel. Rollback restores the previous focus guard if unexpected funnel keyboard behavior appears.

## Development

Closes #1409
