### PR TITLE
feat: add llms public discovery policy

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -149,7 +149,7 @@ Priority behavior:
 
 Preview deployments use runtime policy for auth recovery and search-index protection, and PostHog for the optional preview access guard.
 
-- Runtime resolves to `preview` from `VERCEL_ENV` first, then `DEPLOYMENT_ENV`
+- Runtime resolves to the boolean preview signal from `VERCEL_ENV` first, then `DEPLOYMENT_ENV`; request hostnames are not preview or production signals
 - `NODE_ENV` is not used as a preview or production deployment signal
 - Non-Vercel preview/production runtimes must set `DEPLOYMENT_ENV` explicitly
 - Preview Guard login redirects are controlled by the server-side PostHog feature flag `preview-guard-enabled`
@@ -179,6 +179,8 @@ The public sitemap surface is split between the generated `robots.txt` file and 
 - `/pages-sitemap.xml` lists `/`, `/posts`, `/contact`, `/about`, `/listing-comparison`, and published CMS pages. It does not list `/search` because there is no dedicated public search route.
 - `/posts-sitemap.xml` lists published post detail URLs with valid single-segment slugs.
 - Preview runtime and Temporary Landing Mode keep deeper public content out of sitemap discovery through preview robots policy and empty guarded sitemap responses.
+- `/llms.txt` provides a curated public agent-context file for findmydoc. `/.well-known/llms.txt` serves the same content as an optional discovery alias. The file uses canonical production URLs only and does not publish a full content dump, private routes, admin routes, authenticated endpoints, draft content, or unpublished data.
+- Preview runtime and Temporary Landing Mode do not expose `llms.txt` as a public discovery surface; guarded responses include `X-Robots-Tag: noindex, nofollow, noarchive`.
 
 Production `robots.txt` treats automated search discovery, user-directed AI retrieval, and model training as separate access classes:
 
@@ -196,6 +198,15 @@ Run the sitemap status check against local development or production when Tempor
 ```bash
 BASE_URL="${BASE_URL:-http://localhost:3000}"
 for path in /robots.txt /pages-sitemap.xml /posts-sitemap.xml / /posts /contact /about /listing-comparison; do
+  curl --fail --location --silent --show-error --output /dev/null --write-out "%{http_code} ${path}\n" "${BASE_URL}${path}"
+done
+```
+
+Run the agent-context status check against production or local development when Temporary Landing Mode is disabled:
+
+```bash
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+for path in /llms.txt /.well-known/llms.txt; do
   curl --fail --location --silent --show-error --output /dev/null --write-out "%{http_code} ${path}\n" "${BASE_URL}${path}"
 done
 ```

--- a/docs/public-discovery-strategy.md
+++ b/docs/public-discovery-strategy.md
@@ -8,6 +8,8 @@ findmydoc public content should be easy for search engines and AI agents to craw
 
 Public discovery includes both automated search indexing and user-directed AI retrieval; model training access is a separate consent choice.
 
+`/llms.txt` is a curated agent-context file for public findmydoc orientation. It points agents to canonical public URLs and citation boundaries; it is not a content export, crawler policy, private capability registry, or substitute for public page citations.
+
 Public discovery work supports three outcomes:
 
 - Search engines can discover stable, crawlable, canonical URLs.

--- a/next-sitemap.config.cjs
+++ b/next-sitemap.config.cjs
@@ -1,16 +1,10 @@
+/* eslint-disable @typescript-eslint/no-require-imports -- next-sitemap loads this config as CommonJS. */
+const { isPreviewRuntime } = require('./src/features/runtimePolicy/core.cjs')
+
 const SITE_URL =
   process.env.NEXT_PUBLIC_SERVER_URL || process.env.VERCEL_PROJECT_PRODUCTION_URL || 'https://example.com'
 
-const normalizeEnvValue = (value) => {
-  if (!value) return null
-
-  const normalized = value.trim().toLowerCase()
-  return normalized.length > 0 ? normalized : null
-}
-
-const isPreviewRuntime =
-  (normalizeEnvValue(process.env.VERCEL_ENV) ?? normalizeEnvValue(process.env.DEPLOYMENT_ENV)) === 'preview'
-const blockSearchIndexing = isPreviewRuntime
+const blockSearchIndexing = isPreviewRuntime(process.env)
 
 const PUBLIC_DISCOVERY_USER_AGENTS = [
   'Googlebot',

--- a/src/app/(frontend)/.well-known/llms.txt/route.ts
+++ b/src/app/(frontend)/.well-known/llms.txt/route.ts
@@ -1,0 +1,7 @@
+import { resolvePublicDiscoveryAccessForRequest } from '@/features/publicDiscovery/access'
+import { buildLlmsTxtResponse } from '@/features/publicDiscovery/llmsTxt'
+
+export async function GET(request: Request): Promise<Response> {
+  const access = await resolvePublicDiscoveryAccessForRequest(request)
+  return buildLlmsTxtResponse(access)
+}

--- a/src/app/(frontend)/llms.txt/route.ts
+++ b/src/app/(frontend)/llms.txt/route.ts
@@ -1,0 +1,7 @@
+import { resolvePublicDiscoveryAccessForRequest } from '@/features/publicDiscovery/access'
+import { buildLlmsTxtResponse } from '@/features/publicDiscovery/llmsTxt'
+
+export async function GET(request: Request): Promise<Response> {
+  const access = await resolvePublicDiscoveryAccessForRequest(request)
+  return buildLlmsTxtResponse(access)
+}

--- a/src/auth/utilities/firstAdminCheck.ts
+++ b/src/auth/utilities/firstAdminCheck.ts
@@ -2,7 +2,7 @@ import type { Payload } from 'payload'
 import type { User } from '@supabase/supabase-js'
 import { getLoggedSupabaseAdminClient, getSupabaseLogger } from './supabaseLogger'
 import { hashLogValue, toLoggedError } from '@/utilities/logging/shared'
-import { resolveRuntimeClass } from '@/features/runtimePolicy'
+import { isPreviewRuntime } from '@/features/runtimePolicy'
 
 type PayloadForAdminCheck = Pick<Payload, 'find'>
 type PayloadAdminCandidate = {
@@ -51,8 +51,6 @@ const toRelationshipId = (value: unknown): number | string | null => {
   const id = (value as { id?: unknown }).id
   return typeof id === 'number' || typeof id === 'string' ? id : null
 }
-
-const isPreviewRuntime = (env: NodeJS.ProcessEnv = process.env): boolean => resolveRuntimeClass(env) === 'preview'
 
 const isMissingSupabaseUserError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') return false

--- a/src/features/previewGuard/index.ts
+++ b/src/features/previewGuard/index.ts
@@ -1,5 +1,5 @@
 import type { User } from '@supabase/supabase-js'
-import { resolveRuntimeClass, resolveServerRuntimeEnvironment } from '@/features/runtimePolicy'
+import { isPreviewRuntime, resolveServerRuntimeEnvironment } from '@/features/runtimePolicy'
 import { sanitizeInternalRedirectPath } from '@/utilities/routing/sanitizeInternalRedirectPath'
 
 export const PREVIEW_GUARD_LOCK_REQUEST_HEADER = 'x-preview-guard-lock'
@@ -24,8 +24,7 @@ export const resolveDeploymentEnvironment = (env: DeploymentEnvInput = process.e
   return resolveServerRuntimeEnvironment(env)
 }
 
-export const isPreviewDeployment = (env: DeploymentEnvInput = process.env): boolean =>
-  resolveRuntimeClass(env) === 'preview'
+export const isPreviewDeployment = (env: DeploymentEnvInput = process.env): boolean => isPreviewRuntime(env)
 
 export const isNonProductionDeployment = (env: DeploymentEnvInput = process.env): boolean =>
   resolveDeploymentEnvironment(env) !== 'production'

--- a/src/features/publicDiscovery/access.ts
+++ b/src/features/publicDiscovery/access.ts
@@ -1,0 +1,75 @@
+import { createPostHogFlagEvaluationContext, evaluatePostHogFlags, resolvePostHogSiteFlagActor } from '@/posthog/api'
+import {
+  SEARCH_ROBOTS_HEADER,
+  SEARCH_ROBOTS_HEADER_VALUE,
+  shouldBlockSearchIndexing,
+  type SearchIndexingEnvInput,
+} from '@/features/searchIndexing'
+
+export type PublicDiscoveryBlockReason = 'preview-runtime' | 'temporary-landing-mode'
+
+export type PublicDiscoveryAccess =
+  | {
+      allowed: true
+    }
+  | {
+      allowed: false
+      reason: PublicDiscoveryBlockReason
+    }
+
+export const PUBLIC_DISCOVERY_BLOCK_HEADERS = {
+  [SEARCH_ROBOTS_HEADER]: SEARCH_ROBOTS_HEADER_VALUE,
+} as const
+
+export const resolvePublicDiscoveryAccessForRuntime = (
+  env: SearchIndexingEnvInput = process.env,
+): PublicDiscoveryAccess => {
+  if (shouldBlockSearchIndexing(env)) {
+    return {
+      allowed: false,
+      reason: 'preview-runtime',
+    }
+  }
+
+  return {
+    allowed: true,
+  }
+}
+
+export const resolvePublicDiscoveryAccessForRequest = async (
+  request: Request,
+  env: SearchIndexingEnvInput = process.env,
+): Promise<PublicDiscoveryAccess> => {
+  const runtimeAccess = resolvePublicDiscoveryAccessForRuntime(env)
+  if (!runtimeAccess.allowed) return runtimeAccess
+
+  const context = createPostHogFlagEvaluationContext({
+    url: new URL(request.url),
+  })
+  const actor = resolvePostHogSiteFlagActor(context)
+  const flags = await evaluatePostHogFlags(actor, ['temporary-landing-mode'], {
+    context,
+  })
+
+  if (flags.isEnabled('temporary-landing-mode')) {
+    return {
+      allowed: false,
+      reason: 'temporary-landing-mode',
+    }
+  }
+
+  return {
+    allowed: true,
+  }
+}
+
+export const buildPublicDiscoveryBlockedResponse = (init: ResponseInit = {}): Response => {
+  const headers = new Headers(init.headers)
+  headers.set(SEARCH_ROBOTS_HEADER, SEARCH_ROBOTS_HEADER_VALUE)
+
+  return new Response(null, {
+    ...init,
+    headers,
+    status: init.status ?? 404,
+  })
+}

--- a/src/features/publicDiscovery/llmsTxt.ts
+++ b/src/features/publicDiscovery/llmsTxt.ts
@@ -1,0 +1,158 @@
+import { buildPublicDiscoveryBlockedResponse, type PublicDiscoveryAccess } from './access'
+import { PUBLIC_CANONICAL_SITE_URL, toPublicCanonicalUrl } from './site'
+
+export const LLMS_TXT_CONTENT_TYPE = 'text/markdown; charset=utf-8'
+export const LLMS_TXT_CACHE_CONTROL = 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800'
+
+type LlmsTxtLink = {
+  description: string
+  href: string
+  label: string
+}
+
+type LlmsTxtSection = {
+  heading: string
+  items: string[]
+}
+
+type LlmsTxtDocument = {
+  intro: string[]
+  sections: LlmsTxtSection[]
+  summary: string
+  title: string
+}
+
+const renderLinkItem = ({ description, href, label }: LlmsTxtLink): string => {
+  return `[${label}](${href}): ${description}`
+}
+
+const keyUrlLinks = [
+  {
+    description: 'Public entry point for findmydoc.',
+    href: toPublicCanonicalUrl('/'),
+    label: 'Home',
+  },
+  {
+    description: 'Canonical public clinic comparison entry point.',
+    href: toPublicCanonicalUrl('/listing-comparison'),
+    label: 'Clinic comparison',
+  },
+  {
+    description: 'Approved public clinic detail pages use readable clinic slugs.',
+    href: toPublicCanonicalUrl('/clinics/{clinic-slug}'),
+    label: 'Clinic profile pattern',
+  },
+  {
+    description: 'Public article index.',
+    href: toPublicCanonicalUrl('/posts'),
+    label: 'Posts',
+  },
+  {
+    description: 'Public company and platform context.',
+    href: toPublicCanonicalUrl('/about'),
+    label: 'About',
+  },
+  {
+    description: 'Public contact path.',
+    href: toPublicCanonicalUrl('/contact'),
+    label: 'Contact',
+  },
+  {
+    description: 'Public privacy information.',
+    href: toPublicCanonicalUrl('/privacy-policy'),
+    label: 'Privacy policy',
+  },
+  {
+    description: 'Public legal provider information.',
+    href: toPublicCanonicalUrl('/imprint'),
+    label: 'Imprint',
+  },
+  {
+    description: 'Public page sitemap.',
+    href: toPublicCanonicalUrl('/pages-sitemap.xml'),
+    label: 'Pages sitemap',
+  },
+  {
+    description: 'Public post sitemap.',
+    href: toPublicCanonicalUrl('/posts-sitemap.xml'),
+    label: 'Posts sitemap',
+  },
+] satisfies LlmsTxtLink[]
+
+const llmsTxtDocument = {
+  intro: [
+    'Use this file as curated agent context for public findmydoc pages. It is not a full content dump, not a crawler policy, and not access to private systems.',
+  ],
+  sections: [
+    {
+      heading: 'Key URLs',
+      items: keyUrlLinks.map(renderLinkItem),
+    },
+    {
+      heading: 'Public Data Types',
+      items: [
+        'Clinics: Approved public clinic profiles and comparison details that are visible on public pages.',
+        'Articles: Published public posts and general information pages.',
+        'Legal and company pages: Public privacy, imprint, contact, and platform information.',
+        'Discovery metadata: Public sitemap entries, canonical URLs, structured data, and source-backed freshness signals.',
+      ],
+    },
+    {
+      heading: 'Citation Guidance',
+      items: [
+        `Cite canonical production URLs on ${PUBLIC_CANONICAL_SITE_URL}.`,
+        'Prefer page-level citations over inferred summaries.',
+        'Do not cite preview, authenticated, internal, draft, unpublished, or query-variant URLs.',
+        'Do not infer ratings, review counts, accreditations, prices, recommendations, or medical-quality claims unless they are visibly present on the cited public page.',
+      ],
+    },
+    {
+      heading: 'Freshness Policy',
+      items: [
+        'Prefer visible page dates, sitemap lastmod values, and source-backed freshness signals.',
+        'Treat request-time timestamps as crawl time, not content freshness.',
+        'If a public page has no visible or source-backed freshness signal, omit the freshness claim.',
+      ],
+    },
+    {
+      heading: 'Medical Disclaimer',
+      items: [
+        'findmydoc is a comparison and contact platform. It does not provide medical advice.',
+        'Public clinic and comparison information supports discovery and contact decisions; it is not a medical recommendation.',
+        'Patients should consult qualified medical professionals before making medical decisions.',
+      ],
+    },
+    {
+      heading: 'Contact Path',
+      items: [`Use [Contact](${toPublicCanonicalUrl('/contact')}) for public contact and follow-up requests.`],
+    },
+  ],
+  summary: 'findmydoc is an international patient clinic discovery, comparison, and contact platform.',
+  title: 'findmydoc',
+} satisfies LlmsTxtDocument
+
+const renderSection = ({ heading, items }: LlmsTxtSection): string => {
+  return [`## ${heading}`, '', ...items.map((item) => `- ${item}`)].join('\n')
+}
+
+const renderLlmsTxtDocument = ({ intro, sections, summary, title }: LlmsTxtDocument): string => {
+  return [`# ${title}`, '', `> ${summary}`, '', ...intro, '', ...sections.map(renderSection), ''].join('\n\n')
+}
+
+export const buildLlmsTxt = (): string => {
+  return renderLlmsTxtDocument(llmsTxtDocument)
+}
+
+export const buildLlmsTxtResponse = (access: PublicDiscoveryAccess): Response => {
+  if (!access.allowed) {
+    return buildPublicDiscoveryBlockedResponse()
+  }
+
+  return new Response(buildLlmsTxt(), {
+    headers: {
+      'Cache-Control': LLMS_TXT_CACHE_CONTROL,
+      'Content-Type': LLMS_TXT_CONTENT_TYPE,
+    },
+    status: 200,
+  })
+}

--- a/src/features/publicDiscovery/site.ts
+++ b/src/features/publicDiscovery/site.ts
@@ -1,0 +1,19 @@
+export const PUBLIC_CANONICAL_SITE_URL = 'https://findmydoc.eu'
+
+export const PUBLIC_DISCOVERY_AGENT_CONTEXT_PATHS = ['/llms.txt', '/.well-known/llms.txt'] as const
+
+export const PUBLIC_DISCOVERY_SITEMAP_PATHS = ['/pages-sitemap.xml', '/posts-sitemap.xml'] as const
+
+export const PUBLIC_DISCOVERY_SURFACE_PATHS = [
+  '/robots.txt',
+  ...PUBLIC_DISCOVERY_SITEMAP_PATHS,
+  ...PUBLIC_DISCOVERY_AGENT_CONTEXT_PATHS,
+] as const
+
+export const toPublicCanonicalUrl = (path: string): string => {
+  if (!path.startsWith('/') || path.startsWith('//')) {
+    throw new Error(`Public canonical paths must be root-relative: ${path}`)
+  }
+
+  return path === '/' ? `${PUBLIC_CANONICAL_SITE_URL}/` : `${PUBLIC_CANONICAL_SITE_URL}${path.replace(/\/+$/, '')}`
+}

--- a/src/features/runtimePolicy/core.cjs
+++ b/src/features/runtimePolicy/core.cjs
@@ -1,0 +1,70 @@
+// CommonJS mirror for tooling that cannot load the TypeScript ESM runtime policy.
+// Keep behavior aligned with core.ts; next-sitemap and runtime-policy tests cover both paths.
+const normalizeEnvValue = (value) => {
+  if (!value) return null
+
+  const normalized = value.trim().toLowerCase()
+  return normalized.length > 0 ? normalized : null
+}
+
+const toRuntimeEnvironment = (value) => {
+  if (!value) return 'unknown'
+  if (value === 'preview') return 'preview'
+  if (value === 'production') return 'production'
+  if (value === 'development') return 'development'
+  if (value === 'test') return 'test'
+  return 'unknown'
+}
+
+const toNodeRuntimeEnvironment = (value) => {
+  if (value === 'test') return 'test'
+  return 'development'
+}
+
+const toRuntimeClass = (runtimeEnvironment) => {
+  return runtimeEnvironment === 'preview' ? 'preview' : 'nonPreview'
+}
+
+const resolveServerRuntimeEnvironment = (env = process.env) => {
+  const runtimeValue = normalizeEnvValue(env.VERCEL_ENV) ?? normalizeEnvValue(env.DEPLOYMENT_ENV)
+  const runtimeEnvironment = toRuntimeEnvironment(runtimeValue)
+  return runtimeEnvironment === 'unknown'
+    ? toNodeRuntimeEnvironment(normalizeEnvValue(env.NODE_ENV))
+    : runtimeEnvironment
+}
+
+const resolveClientRuntimeEnvironment = (env = process.env) => {
+  const runtimeValue =
+    normalizeEnvValue(env.NEXT_PUBLIC_VERCEL_ENV) ?? normalizeEnvValue(env.NEXT_PUBLIC_DEPLOYMENT_ENV)
+
+  const runtimeEnvironment = toRuntimeEnvironment(runtimeValue)
+  return runtimeEnvironment === 'unknown'
+    ? toNodeRuntimeEnvironment(normalizeEnvValue(env.NODE_ENV))
+    : runtimeEnvironment
+}
+
+const resolveRuntimeClass = (env = process.env) => {
+  return toRuntimeClass(resolveServerRuntimeEnvironment(env))
+}
+
+const resolveClientRuntimeClass = (env = process.env) => {
+  return toRuntimeClass(resolveClientRuntimeEnvironment(env))
+}
+
+const isPreviewRuntime = (env = process.env) => {
+  return resolveRuntimeClass(env) === 'preview'
+}
+
+const isClientPreviewRuntime = (env = process.env) => {
+  return resolveClientRuntimeClass(env) === 'preview'
+}
+
+module.exports = {
+  isClientPreviewRuntime,
+  isPreviewRuntime,
+  normalizeEnvValue,
+  resolveClientRuntimeClass,
+  resolveClientRuntimeEnvironment,
+  resolveRuntimeClass,
+  resolveServerRuntimeEnvironment,
+}

--- a/src/features/runtimePolicy/core.ts
+++ b/src/features/runtimePolicy/core.ts
@@ -1,0 +1,74 @@
+export type RuntimeClass = 'preview' | 'nonPreview'
+
+export type RuntimeEnvironment = 'production' | 'preview' | 'development' | 'test' | 'unknown'
+
+export type ServerRuntimeEnvInput = {
+  DEPLOYMENT_ENV?: string
+  NODE_ENV?: string
+  VERCEL_ENV?: string
+}
+
+export type ClientRuntimeEnvInput = {
+  NEXT_PUBLIC_DEPLOYMENT_ENV?: string
+  NEXT_PUBLIC_VERCEL_ENV?: string
+  NODE_ENV?: string
+}
+
+export const normalizeEnvValue = (value: string | undefined): string | null => {
+  if (!value) return null
+
+  const normalized = value.trim().toLowerCase()
+  return normalized.length > 0 ? normalized : null
+}
+
+const toRuntimeEnvironment = (value: string | null): RuntimeEnvironment => {
+  if (!value) return 'unknown'
+  if (value === 'preview') return 'preview'
+  if (value === 'production') return 'production'
+  if (value === 'development') return 'development'
+  if (value === 'test') return 'test'
+  return 'unknown'
+}
+
+const toNodeRuntimeEnvironment = (value: string | null): RuntimeEnvironment => {
+  if (value === 'test') return 'test'
+  return 'development'
+}
+
+const toRuntimeClass = (runtimeEnvironment: RuntimeEnvironment): RuntimeClass => {
+  return runtimeEnvironment === 'preview' ? 'preview' : 'nonPreview'
+}
+
+export const resolveServerRuntimeEnvironment = (env: ServerRuntimeEnvInput = process.env): RuntimeEnvironment => {
+  const runtimeValue = normalizeEnvValue(env.VERCEL_ENV) ?? normalizeEnvValue(env.DEPLOYMENT_ENV)
+  const runtimeEnvironment = toRuntimeEnvironment(runtimeValue)
+  return runtimeEnvironment === 'unknown'
+    ? toNodeRuntimeEnvironment(normalizeEnvValue(env.NODE_ENV))
+    : runtimeEnvironment
+}
+
+export const resolveClientRuntimeEnvironment = (env: ClientRuntimeEnvInput = process.env): RuntimeEnvironment => {
+  const runtimeValue =
+    normalizeEnvValue(env.NEXT_PUBLIC_VERCEL_ENV) ?? normalizeEnvValue(env.NEXT_PUBLIC_DEPLOYMENT_ENV)
+
+  const runtimeEnvironment = toRuntimeEnvironment(runtimeValue)
+  return runtimeEnvironment === 'unknown'
+    ? toNodeRuntimeEnvironment(normalizeEnvValue(env.NODE_ENV))
+    : runtimeEnvironment
+}
+
+export const resolveRuntimeClass = (env: ServerRuntimeEnvInput = process.env): RuntimeClass => {
+  return toRuntimeClass(resolveServerRuntimeEnvironment(env))
+}
+
+export const resolveClientRuntimeClass = (env: ClientRuntimeEnvInput = process.env): RuntimeClass => {
+  return toRuntimeClass(resolveClientRuntimeEnvironment(env))
+}
+
+export const isPreviewRuntime = (env: ServerRuntimeEnvInput = process.env): boolean => {
+  return resolveRuntimeClass(env) === 'preview'
+}
+
+export const isClientPreviewRuntime = (env: ClientRuntimeEnvInput = process.env): boolean => {
+  return resolveClientRuntimeClass(env) === 'preview'
+}

--- a/src/features/runtimePolicy/index.ts
+++ b/src/features/runtimePolicy/index.ts
@@ -1,22 +1,17 @@
-export type RuntimeClass = 'preview' | 'nonPreview'
-
-export type RuntimeEnvironment = 'production' | 'preview' | 'development' | 'test' | 'unknown'
+import type { RuntimeClass, RuntimeEnvironment } from './core'
+export type { ClientRuntimeEnvInput, RuntimeClass, RuntimeEnvironment, ServerRuntimeEnvInput } from './core'
+export {
+  isClientPreviewRuntime,
+  isPreviewRuntime,
+  resolveClientRuntimeClass,
+  resolveClientRuntimeEnvironment,
+  resolveRuntimeClass,
+  resolveServerRuntimeEnvironment,
+} from './core'
 
 export type SeedRuntimeEnvironment = Exclude<RuntimeEnvironment, 'unknown'>
 
 type RuntimeLevel = 'info' | 'warn'
-
-type ServerRuntimeEnvInput = {
-  DEPLOYMENT_ENV?: string
-  NODE_ENV?: string
-  VERCEL_ENV?: string
-}
-
-type ClientRuntimeEnvInput = {
-  NEXT_PUBLIC_DEPLOYMENT_ENV?: string
-  NEXT_PUBLIC_VERCEL_ENV?: string
-  NODE_ENV?: string
-}
 
 type RuntimePolicy = {
   logging: {
@@ -30,31 +25,6 @@ export type SeedRuntimePolicy = {
   allowDemo: boolean
   allowEndpointPost: boolean
   allowReset: boolean
-}
-
-const normalizeEnvValue = (value: string | undefined): string | null => {
-  if (!value) return null
-
-  const normalized = value.trim().toLowerCase()
-  return normalized.length > 0 ? normalized : null
-}
-
-const toRuntimeEnvironment = (value: string | null): RuntimeEnvironment => {
-  if (!value) return 'unknown'
-  if (value === 'preview') return 'preview'
-  if (value === 'production') return 'production'
-  if (value === 'development') return 'development'
-  if (value === 'test') return 'test'
-  return 'unknown'
-}
-
-const toNodeRuntimeEnvironment = (value: string | null): RuntimeEnvironment => {
-  if (value === 'test') return 'test'
-  return 'development'
-}
-
-const toRuntimeClass = (runtimeEnvironment: RuntimeEnvironment): RuntimeClass => {
-  return runtimeEnvironment === 'preview' ? 'preview' : 'nonPreview'
 }
 
 export const RUNTIME_POLICY: Record<RuntimeClass, RuntimePolicy> = {
@@ -97,32 +67,6 @@ const SEED_RUNTIME_POLICY: Record<SeedRuntimeEnvironment, SeedRuntimePolicy> = {
     allowEndpointPost: true,
     allowReset: false,
   },
-}
-
-export const resolveServerRuntimeEnvironment = (env: ServerRuntimeEnvInput = process.env): RuntimeEnvironment => {
-  const runtimeValue = normalizeEnvValue(env.VERCEL_ENV) ?? normalizeEnvValue(env.DEPLOYMENT_ENV)
-  const runtimeEnvironment = toRuntimeEnvironment(runtimeValue)
-  return runtimeEnvironment === 'unknown'
-    ? toNodeRuntimeEnvironment(normalizeEnvValue(env.NODE_ENV))
-    : runtimeEnvironment
-}
-
-export const resolveClientRuntimeEnvironment = (env: ClientRuntimeEnvInput = process.env): RuntimeEnvironment => {
-  const runtimeValue =
-    normalizeEnvValue(env.NEXT_PUBLIC_VERCEL_ENV) ?? normalizeEnvValue(env.NEXT_PUBLIC_DEPLOYMENT_ENV)
-
-  const runtimeEnvironment = toRuntimeEnvironment(runtimeValue)
-  return runtimeEnvironment === 'unknown'
-    ? toNodeRuntimeEnvironment(normalizeEnvValue(env.NODE_ENV))
-    : runtimeEnvironment
-}
-
-export const resolveRuntimeClass = (env: ServerRuntimeEnvInput = process.env): RuntimeClass => {
-  return toRuntimeClass(resolveServerRuntimeEnvironment(env))
-}
-
-export const resolveClientRuntimeClass = (env: ClientRuntimeEnvInput = process.env): RuntimeClass => {
-  return toRuntimeClass(resolveClientRuntimeEnvironment(env))
 }
 
 export const resolveSeedRuntimePolicy = (runtimeEnvironment: SeedRuntimeEnvironment): SeedRuntimePolicy => {

--- a/src/features/searchIndexing/index.ts
+++ b/src/features/searchIndexing/index.ts
@@ -1,5 +1,5 @@
 import { PREVIEW_GUARD_LOCK_REQUEST_HEADER } from '@/features/previewGuard'
-import { resolveRuntimeClass } from '@/features/runtimePolicy'
+import { isPreviewRuntime } from '@/features/runtimePolicy'
 
 export type SearchIndexingEnvInput = {
   DEPLOYMENT_ENV?: string
@@ -11,7 +11,7 @@ export const SEARCH_ROBOTS_HEADER = 'X-Robots-Tag'
 export const SEARCH_ROBOTS_HEADER_VALUE = 'noindex, nofollow, noarchive'
 
 export const shouldBlockSearchIndexing = (env: SearchIndexingEnvInput = process.env): boolean => {
-  return resolveRuntimeClass(env) === 'preview'
+  return isPreviewRuntime(env)
 }
 
 export const shouldBlockSearchIndexingForRequest = ({

--- a/src/features/searchIndexing/sitemapGuards.ts
+++ b/src/features/searchIndexing/sitemapGuards.ts
@@ -1,19 +1,10 @@
-import { createPostHogFlagEvaluationContext, evaluatePostHogFlags, resolvePostHogSiteFlagActor } from '@/posthog/api'
-import { shouldBlockSearchIndexing, type SearchIndexingEnvInput } from './index'
+import { resolvePublicDiscoveryAccessForRequest } from '@/features/publicDiscovery/access'
+import type { SearchIndexingEnvInput } from './index'
 
 export async function shouldBlockSitemapIndexingForRequest(
   request: Request,
   env: SearchIndexingEnvInput = process.env,
 ): Promise<boolean> {
-  if (shouldBlockSearchIndexing(env)) return true
-
-  const context = createPostHogFlagEvaluationContext({
-    url: new URL(request.url),
-  })
-  const actor = resolvePostHogSiteFlagActor(context)
-  const flags = await evaluatePostHogFlags(actor, ['temporary-landing-mode'], {
-    context,
-  })
-
-  return flags.isEnabled('temporary-landing-mode')
+  const access = await resolvePublicDiscoveryAccessForRequest(request, env)
+  return !access.allowed
 }

--- a/tests/unit/app/frontend/llmsTxt.route.test.ts
+++ b/tests/unit/app/frontend/llmsTxt.route.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const posthogMocks = vi.hoisted(() => ({
+  createPostHogFlagEvaluationContext: vi.fn((input: { url: URL }) => {
+    const pathname = input.url.pathname || '/'
+    const normalizedPath = pathname !== '/' && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname
+
+    return {
+      feature_flag_site_host: input.url.hostname,
+      feature_flag_site_path: normalizedPath,
+    }
+  }),
+  evaluatePostHogFlags: vi.fn(),
+  resolvePostHogSiteFlagActor: vi.fn(),
+}))
+
+vi.mock('@/posthog/api', () => posthogMocks)
+
+const getLlmsTxtResponse = async (url = 'https://findmydoc.eu/llms.txt') => {
+  const { GET } = await import('@/app/(frontend)/llms.txt/route')
+  return GET(new Request(url))
+}
+
+const getWellKnownLlmsTxtResponse = async (url = 'https://findmydoc.eu/.well-known/llms.txt') => {
+  const { GET } = await import('@/app/(frontend)/.well-known/llms.txt/route')
+  return GET(new Request(url))
+}
+
+const expectIncludesAll = (content: string, fragments: string[]) => {
+  for (const fragment of fragments) {
+    expect(content.includes(fragment), fragment).toBe(true)
+  }
+}
+
+const expectIncludesNone = (content: string, fragments: string[]) => {
+  for (const fragment of fragments) {
+    expect(content.includes(fragment), fragment).toBe(false)
+  }
+}
+
+describe('llms.txt routes', () => {
+  const originalEnv = process.env
+  const actor = {
+    distinctId: 'site:production:findmydoc.eu',
+    isAuthenticated: false,
+    personProperties: {},
+    userType: 'anonymous',
+  }
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'production',
+      VERCEL_ENV: 'production',
+    }
+    posthogMocks.resolvePostHogSiteFlagActor.mockReturnValue(actor)
+    posthogMocks.evaluatePostHogFlags.mockResolvedValue({
+      isEnabled: vi.fn(() => false),
+    })
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('serves curated agent context at /llms.txt', async () => {
+    const response = await getLlmsTxtResponse()
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toContain('text/markdown')
+    expect(response.headers.get('Cache-Control')).toContain('s-maxage=86400')
+    expectIncludesAll(body, [
+      '# findmydoc',
+      '## Key URLs',
+      '## Public Data Types',
+      '## Citation Guidance',
+      '## Freshness Policy',
+      '## Medical Disclaimer',
+      '## Contact Path',
+    ])
+  })
+
+  it('serves the same content from the optional well-known alias', async () => {
+    const rootResponse = await getLlmsTxtResponse()
+    const wellKnownResponse = await getWellKnownLlmsTxtResponse()
+
+    expect(wellKnownResponse.status).toBe(200)
+    expect(await wellKnownResponse.text()).toBe(await rootResponse.text())
+  })
+
+  it('only exposes canonical public production references', async () => {
+    const response = await getLlmsTxtResponse()
+    const body = await response.text()
+
+    expectIncludesAll(body, [
+      'https://findmydoc.eu/',
+      'https://findmydoc.eu/listing-comparison',
+      'https://findmydoc.eu/clinics/{clinic-slug}',
+      'https://findmydoc.eu/contact',
+    ])
+    expectIncludesNone(body, [
+      'preview.findmydoc.eu',
+      '/admin',
+      '/api',
+      'https://findmydoc.eu/draft',
+      'https://findmydoc.eu/unpublished',
+    ])
+  })
+
+  it('does not expose public discovery content in preview runtime', async () => {
+    process.env = {
+      ...process.env,
+      VERCEL_ENV: 'preview',
+    }
+
+    const response = await getLlmsTxtResponse('https://findmydoc.eu/llms.txt')
+    const aliasResponse = await getWellKnownLlmsTxtResponse('https://findmydoc.eu/.well-known/llms.txt')
+    const body = await response.text()
+    const aliasBody = await aliasResponse.text()
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get('X-Robots-Tag')).toBe('noindex, nofollow, noarchive')
+    expect(body).toBe('')
+    expect(aliasResponse.status).toBe(404)
+    expect(aliasResponse.headers.get('X-Robots-Tag')).toBe('noindex, nofollow, noarchive')
+    expect(aliasBody).toBe('')
+    expect(posthogMocks.evaluatePostHogFlags).not.toHaveBeenCalled()
+  })
+
+  it('does not treat a preview host as preview when production runtime is active', async () => {
+    const response = await getLlmsTxtResponse('https://preview.findmydoc.eu/llms.txt')
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(body).toContain('# findmydoc')
+    expect(body).not.toContain('preview.findmydoc.eu')
+    expect(posthogMocks.evaluatePostHogFlags).toHaveBeenCalledOnce()
+  })
+
+  it('does not expose public discovery content while temporary landing mode is active', async () => {
+    posthogMocks.evaluatePostHogFlags.mockResolvedValue({
+      isEnabled: vi.fn((key: string) => key === 'temporary-landing-mode'),
+    })
+
+    const response = await getLlmsTxtResponse()
+    const aliasResponse = await getWellKnownLlmsTxtResponse()
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get('X-Robots-Tag')).toBe('noindex, nofollow, noarchive')
+    expect(await response.text()).toBe('')
+    expect(aliasResponse.status).toBe(404)
+    expect(aliasResponse.headers.get('X-Robots-Tag')).toBe('noindex, nofollow, noarchive')
+    expect(await aliasResponse.text()).toBe('')
+  })
+})

--- a/tests/unit/app/frontend/previewLock.middleware.test.ts
+++ b/tests/unit/app/frontend/previewLock.middleware.test.ts
@@ -248,14 +248,17 @@ describe('preview lock proxy', () => {
   it('applies temporary landing mode to canonical crawl entrypoints', async () => {
     mockGuardFlags({ 'temporary-landing-mode': true })
 
-    const robotsResponse = await proxy(new NextRequest('https://findmydoc.eu/robots.txt'))
-    const sitemapResponse = await proxy(new NextRequest('https://findmydoc.eu/sitemap.xml'))
+    const responses = await Promise.all(
+      ['/robots.txt', '/sitemap.xml', '/llms.txt', '/.well-known/llms.txt'].map((path) =>
+        proxy(new NextRequest(`https://findmydoc.eu${path}`)),
+      ),
+    )
 
-    expect(robotsResponse.status).toBe(404)
-    expect(sitemapResponse.status).toBe(404)
-    expect(robotsResponse.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
-    expect(sitemapResponse.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
-    expect(mocks.evaluatePostHogFlags).toHaveBeenCalledTimes(2)
+    expect(responses.every((response) => response.status === 404)).toBe(true)
+    expect(
+      responses.every((response) => response.headers.get(SEARCH_ROBOTS_HEADER) === SEARCH_ROBOTS_HEADER_VALUE),
+    ).toBe(true)
+    expect(mocks.evaluatePostHogFlags).toHaveBeenCalledTimes(4)
   })
 
   it('keeps admin and auth routes reachable in temporary landing mode', async () => {

--- a/tests/unit/config/next-sitemap-config.test.ts
+++ b/tests/unit/config/next-sitemap-config.test.ts
@@ -86,7 +86,7 @@ describe('next-sitemap config', () => {
     process.env = {
       ...originalEnv,
       DEPLOYMENT_ENV: undefined,
-      NEXT_PUBLIC_SERVER_URL: 'https://preview.findmydoc.eu',
+      NEXT_PUBLIC_SERVER_URL: 'https://findmydoc.eu',
       VERCEL_ENV: 'preview',
     }
 
@@ -100,7 +100,7 @@ describe('next-sitemap config', () => {
     process.env = {
       ...originalEnv,
       DEPLOYMENT_ENV: 'preview',
-      NEXT_PUBLIC_SERVER_URL: 'https://preview.findmydoc.eu',
+      NEXT_PUBLIC_SERVER_URL: 'https://findmydoc.eu',
       VERCEL_ENV: undefined,
     }
 
@@ -108,5 +108,26 @@ describe('next-sitemap config', () => {
 
     expect(config.robotsTxtOptions.policies).toEqual([{ disallow: '/', userAgent: '*' }])
     expect(config.robotsTxtOptions.additionalSitemaps).toEqual([])
+  })
+
+  it('does not block robots only because the configured site URL uses the preview host', () => {
+    process.env = {
+      ...originalEnv,
+      DEPLOYMENT_ENV: undefined,
+      NEXT_PUBLIC_SERVER_URL: 'https://preview.findmydoc.eu',
+      VERCEL_ENV: 'production',
+    }
+
+    const config = loadConfig()
+
+    expect(config.robotsTxtOptions.policies).toContainEqual({
+      allow: '/',
+      disallow: ['/admin', '/admin/*'],
+      userAgent: '*',
+    })
+    expect(config.robotsTxtOptions.additionalSitemaps).toEqual([
+      'https://preview.findmydoc.eu/pages-sitemap.xml',
+      'https://preview.findmydoc.eu/posts-sitemap.xml',
+    ])
   })
 })

--- a/tests/unit/features/publicDiscovery/access.test.ts
+++ b/tests/unit/features/publicDiscovery/access.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const posthogMocks = vi.hoisted(() => ({
+  createPostHogFlagEvaluationContext: vi.fn((input: { url: URL }) => {
+    const pathname = input.url.pathname || '/'
+    const normalizedPath = pathname !== '/' && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname
+
+    return {
+      feature_flag_site_host: input.url.hostname,
+      feature_flag_site_path: normalizedPath,
+    }
+  }),
+  evaluatePostHogFlags: vi.fn(),
+  resolvePostHogSiteFlagActor: vi.fn(),
+}))
+
+vi.mock('@/posthog/api', () => posthogMocks)
+
+describe('public discovery access', () => {
+  const actor = {
+    distinctId: 'site:findmydoc.eu:/llms.txt',
+    isAuthenticated: false,
+    personProperties: {},
+    userType: 'anonymous',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    posthogMocks.resolvePostHogSiteFlagActor.mockReturnValue(actor)
+    posthogMocks.evaluatePostHogFlags.mockResolvedValue({
+      isEnabled: vi.fn(() => false),
+    })
+  })
+
+  it('blocks preview runtimes before evaluating feature flags', async () => {
+    const { resolvePublicDiscoveryAccessForRequest } = await import('@/features/publicDiscovery/access')
+
+    await expect(
+      resolvePublicDiscoveryAccessForRequest(new Request('https://findmydoc.eu/llms.txt'), {
+        NODE_ENV: 'production',
+        VERCEL_ENV: 'preview',
+      }),
+    ).resolves.toEqual({
+      allowed: false,
+      reason: 'preview-runtime',
+    })
+
+    expect(posthogMocks.evaluatePostHogFlags).not.toHaveBeenCalled()
+  })
+
+  it('uses request URLs only as PostHog context outside preview runtime', async () => {
+    const { resolvePublicDiscoveryAccessForRequest } = await import('@/features/publicDiscovery/access')
+
+    await expect(
+      resolvePublicDiscoveryAccessForRequest(new Request('https://preview.findmydoc.eu/llms.txt'), {
+        NODE_ENV: 'production',
+        VERCEL_ENV: 'production',
+      }),
+    ).resolves.toEqual({
+      allowed: true,
+    })
+
+    expect(posthogMocks.createPostHogFlagEvaluationContext).toHaveBeenCalledWith({
+      url: new URL('https://preview.findmydoc.eu/llms.txt'),
+    })
+    expect(posthogMocks.evaluatePostHogFlags).toHaveBeenCalledOnce()
+  })
+
+  it('blocks production discovery when temporary landing mode is active', async () => {
+    const isEnabled = vi.fn((key: string) => key === 'temporary-landing-mode')
+    posthogMocks.evaluatePostHogFlags.mockResolvedValue({
+      isEnabled,
+    })
+    const { resolvePublicDiscoveryAccessForRequest } = await import('@/features/publicDiscovery/access')
+    const request = new Request('https://findmydoc.eu/llms.txt')
+
+    await expect(
+      resolvePublicDiscoveryAccessForRequest(request, {
+        NODE_ENV: 'production',
+        VERCEL_ENV: 'production',
+      }),
+    ).resolves.toEqual({
+      allowed: false,
+      reason: 'temporary-landing-mode',
+    })
+
+    expect(posthogMocks.createPostHogFlagEvaluationContext).toHaveBeenCalledWith({
+      url: new URL('https://findmydoc.eu/llms.txt'),
+    })
+    expect(posthogMocks.resolvePostHogSiteFlagActor).toHaveBeenCalledWith({
+      feature_flag_site_host: 'findmydoc.eu',
+      feature_flag_site_path: '/llms.txt',
+    })
+    expect(posthogMocks.evaluatePostHogFlags).toHaveBeenCalledWith(actor, ['temporary-landing-mode'], {
+      context: {
+        feature_flag_site_host: 'findmydoc.eu',
+        feature_flag_site_path: '/llms.txt',
+      },
+    })
+  })
+
+  it('allows production discovery when runtime and feature flag policy allow it', async () => {
+    const { resolvePublicDiscoveryAccessForRequest } = await import('@/features/publicDiscovery/access')
+
+    await expect(
+      resolvePublicDiscoveryAccessForRequest(new Request('https://findmydoc.eu/.well-known/llms.txt'), {
+        NODE_ENV: 'production',
+        VERCEL_ENV: 'production',
+      }),
+    ).resolves.toEqual({
+      allowed: true,
+    })
+  })
+
+  it('builds a blocked no-discovery response', async () => {
+    const { buildPublicDiscoveryBlockedResponse } = await import('@/features/publicDiscovery/access')
+    const response = buildPublicDiscoveryBlockedResponse({
+      headers: {
+        'Content-Type': 'text/plain',
+        'X-Robots-Tag': 'index',
+      },
+    })
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get('Content-Type')).toBe('text/plain')
+    expect(response.headers.get('X-Robots-Tag')).toBe('noindex, nofollow, noarchive')
+    expect(await response.text()).toBe('')
+  })
+})

--- a/tests/unit/features/publicDiscovery/discoveryContract.test.ts
+++ b/tests/unit/features/publicDiscovery/discoveryContract.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildLlmsTxt } from '@/features/publicDiscovery/llmsTxt'
+import {
+  PUBLIC_CANONICAL_SITE_URL,
+  PUBLIC_DISCOVERY_AGENT_CONTEXT_PATHS,
+  PUBLIC_DISCOVERY_SITEMAP_PATHS,
+  PUBLIC_DISCOVERY_SURFACE_PATHS,
+  toPublicCanonicalUrl,
+} from '@/features/publicDiscovery/site'
+
+const extractAbsoluteUrls = (content: string): string[] => {
+  return [...content.matchAll(/https?:\/\/[^\s)]+/gu)].map((match) => match[0])
+}
+
+const expectIncludesAll = (values: readonly string[], expectedValues: readonly string[]) => {
+  for (const expectedValue of expectedValues) {
+    expect(values.includes(expectedValue), expectedValue).toBe(true)
+  }
+}
+
+describe('public discovery contract', () => {
+  it('keeps the production canonical host separate from runtime URL resolution', () => {
+    expect(PUBLIC_CANONICAL_SITE_URL).toBe('https://findmydoc.eu')
+    expect(toPublicCanonicalUrl('/')).toBe('https://findmydoc.eu/')
+    expect(toPublicCanonicalUrl('/contact')).toBe('https://findmydoc.eu/contact')
+    expect(() => toPublicCanonicalUrl('https://preview.findmydoc.eu/contact')).toThrow(
+      'Public canonical paths must be root-relative',
+    )
+  })
+
+  it('tracks the public discovery surfaces that need contract coverage', () => {
+    expectIncludesAll(PUBLIC_DISCOVERY_SURFACE_PATHS, [
+      '/robots.txt',
+      '/pages-sitemap.xml',
+      '/posts-sitemap.xml',
+      '/llms.txt',
+      '/.well-known/llms.txt',
+    ])
+    expect(PUBLIC_DISCOVERY_SITEMAP_PATHS).toEqual(['/pages-sitemap.xml', '/posts-sitemap.xml'])
+    expect(PUBLIC_DISCOVERY_AGENT_CONTEXT_PATHS).toEqual(['/llms.txt', '/.well-known/llms.txt'])
+  })
+
+  it('renders llms.txt with canonical public URLs only', () => {
+    const urls = extractAbsoluteUrls(buildLlmsTxt())
+
+    expectIncludesAll(urls, [
+      'https://findmydoc.eu/',
+      'https://findmydoc.eu/listing-comparison',
+      'https://findmydoc.eu/pages-sitemap.xml',
+      'https://findmydoc.eu/posts-sitemap.xml',
+      'https://findmydoc.eu/contact',
+    ])
+    expect(urls.every((url) => url.startsWith(PUBLIC_CANONICAL_SITE_URL))).toBe(true)
+    expect(urls.some((url) => url.includes('preview.findmydoc.eu'))).toBe(false)
+    expect(urls.some((url) => url.includes('/admin'))).toBe(false)
+    expect(urls.some((url) => url.includes('/api'))).toBe(false)
+  })
+})

--- a/tests/unit/features/runtimePolicy/index.test.ts
+++ b/tests/unit/features/runtimePolicy/index.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
+  isClientPreviewRuntime,
+  isPreviewRuntime,
   resolveClientRuntimeClass,
   resolveClientRuntimeEnvironment,
   resolveRuntimeClass,
@@ -27,6 +29,36 @@ describe('runtimePolicy', () => {
         NODE_ENV: 'production',
       }),
     ).toBe('preview')
+  })
+
+  it('exposes a boolean server preview signal from Vercel env', () => {
+    expect(
+      isPreviewRuntime({
+        VERCEL_ENV: 'preview',
+        DEPLOYMENT_ENV: undefined,
+        NODE_ENV: 'production',
+      }),
+    ).toBe(true)
+  })
+
+  it('exposes a boolean server preview signal from explicit deployment env', () => {
+    expect(
+      isPreviewRuntime({
+        VERCEL_ENV: undefined,
+        DEPLOYMENT_ENV: 'preview',
+        NODE_ENV: 'production',
+      }),
+    ).toBe(true)
+  })
+
+  it('lets Vercel production override explicit preview deployment env', () => {
+    expect(
+      isPreviewRuntime({
+        VERCEL_ENV: 'production',
+        DEPLOYMENT_ENV: 'preview',
+        NODE_ENV: 'production',
+      }),
+    ).toBe(false)
   })
 
   it('resolves nonPreview runtime class for non-preview envs', () => {
@@ -59,6 +91,13 @@ describe('runtimePolicy', () => {
 
     expect(runtimeEnvironment).toBe('preview')
     expect(runtimeClass).toBe('preview')
+    expect(
+      isClientPreviewRuntime({
+        NEXT_PUBLIC_VERCEL_ENV: undefined,
+        NEXT_PUBLIC_DEPLOYMENT_ENV: 'preview',
+        NODE_ENV: 'development',
+      }),
+    ).toBe(true)
   })
 
   it('uses NODE_ENV only for client development and test fallback', () => {


### PR DESCRIPTION
## Management summary

### Deutsch

findmydoc stellt jetzt eine kuratierte Orientierung für KI-Agenten bereit, ohne interne, unveröffentlichte oder Preview-Flächen öffentlich zu machen. Dadurch können Agenten öffentliche Seiten besser einordnen und korrekt zitieren, während Preview- und Landing-Modi weiterhin aus der öffentlichen Discovery ausgeschlossen bleiben.

### English

findmydoc now provides curated orientation for AI agents without exposing internal, unpublished, or preview surfaces publicly. This helps agents understand and cite public pages correctly while keeping preview and landing modes excluded from public discovery.

## What changed

- Added `/llms.txt` and `/.well-known/llms.txt` as identical public agent-context routes with product summary, key URLs, public data boundaries, citation guidance, freshness guidance, medical disclaimer, and contact path.
- Centralized public-discovery access policy so `llms.txt`, guarded sitemaps, Preview runtime, and Temporary Landing Mode use the same blocking decision and `X-Robots-Tag` response.
- Added an environment-based runtime preview signal through `src/features/runtimePolicy`, shared with `next-sitemap.config.cjs`, so Preview detection depends on `VERCEL_ENV` first and `DEPLOYMENT_ENV` second, not request hostnames.
- Updated documentation for public discovery behavior and added focused tests for runtime policy, llms routes, public discovery access, sitemap config, and preview lock behavior.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/features/publicDiscovery/**`, `src/app/(frontend)/llms.txt/route.ts`, `src/app/(frontend)/.well-known/llms.txt/route.ts` | New public discovery routes must not expose private, draft, preview, admin, API, or unpublished surfaces. | The response content is curated, canonical, and blocked in Preview runtime and Temporary Landing Mode. | Focused route/access tests, Security reviewer, SEO reviewer |
| P1 | `src/features/runtimePolicy/**`, `next-sitemap.config.cjs`, `src/features/searchIndexing/**` | Preview blocking should be centrally environment-based and not inferred from hostnames. | `VERCEL_ENV` takes precedence over `DEPLOYMENT_ENV`, and sitemap/robots behavior reuses the same preview signal. | Runtime-policy tests, next-sitemap config tests, `pnpm build` postbuild |
| P2 | `docs/features.md`, `docs/public-discovery-strategy.md` | Documentation now defines `llms.txt` as curated context, not crawler permission or a content dump. | Docs match the implemented behavior and do not overpromise discovery scope. | `pnpm docs:check` |

## Validation

- [x] `pnpm format`: passed
- [x] `pnpm check`: passed with existing test-sense warnings only
- [x] `pnpm build`: passed; local Node printed an engine warning because the shell used Node v26 while the package expects `>=24 <25`
- [x] Focused tests: `pnpm vitest tests/unit/features/runtimePolicy/index.test.ts tests/unit/features/searchIndexing/index.test.ts tests/unit/features/searchIndexing/sitemapGuards.test.ts tests/unit/features/publicDiscovery/access.test.ts tests/unit/features/publicDiscovery/discoveryContract.test.ts tests/unit/app/frontend/llmsTxt.route.test.ts tests/unit/config/next-sitemap-config.test.ts tests/unit/app/frontend/sitemap.routes.test.ts tests/unit/app/frontend/previewLock.middleware.test.ts tests/unit/auth/utilities/firstAdminCheck.test.ts`
- [x] UI/mobile QA: no UI or visual changes
- [x] Security/privacy review: `security_reviewer` found no credible findings in scope
- [x] Migration/schema check: no Payload schema or migration changes
- [x] Documentation/instructions check: `pnpm docs:check` passed; no instruction files changed

## Risk and rollout

No migration required. Main operational risk is environment configuration: Preview deployments must keep `VERCEL_ENV=preview` or `DEPLOYMENT_ENV=preview` so public discovery remains blocked. Rollback is limited to reverting the route handlers, public-discovery helper, and runtime-policy refactor in this commit.

## Development

Closes #1034
