### PR TITLE
fix(auth): redirect expired recovery links to reset

### DIFF
--- a/src/app/(frontend)/_components/SupabaseAuthHashUrlScrubber.client.tsx
+++ b/src/app/(frontend)/_components/SupabaseAuthHashUrlScrubber.client.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import * as React from 'react'
+
+import { captureSupabaseAuthHashFromUrl } from '@/auth/utilities/hydrateSessionFromHash'
+
+export function SupabaseAuthHashUrlScrubber() {
+  React.useLayoutEffect(() => {
+    const captureAuthHash = () => {
+      captureSupabaseAuthHashFromUrl()
+    }
+
+    captureAuthHash()
+    window.addEventListener('hashchange', captureAuthHash)
+
+    return () => {
+      window.removeEventListener('hashchange', captureAuthHash)
+    }
+  }, [])
+
+  return null
+}

--- a/src/app/(frontend)/auth/invite/complete/InviteCompleteForm.tsx
+++ b/src/app/(frontend)/auth/invite/complete/InviteCompleteForm.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { z } from 'zod'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/atoms/card'
 import { Field, FieldError } from '@/components/atoms/field'
@@ -12,6 +13,8 @@ import { Alert } from '@/components/atoms/alert'
 import { createClient } from '@/auth/utilities/supaBaseClient'
 import { hydrateSessionFromHash } from '@/auth/utilities/hydrateSessionFromHash'
 import { usePublicFormValidation } from '@/components/molecules/PublicFormValidation'
+
+const expiredRecoveryHref = '/auth/password/reset?reason=expired'
 
 const passwordSchema = z
   .object({
@@ -27,6 +30,7 @@ type PasswordState = z.infer<typeof passwordSchema>
 
 export function InviteCompleteForm({ error }: { error?: string }) {
   const supabase = useMemo(() => createClient(), [])
+  const router = useRouter()
   const [isSessionReady, setSessionReady] = useState(false)
   const formValidation = usePublicFormValidation({
     messages: {
@@ -37,12 +41,10 @@ export function InviteCompleteForm({ error }: { error?: string }) {
       },
     },
   })
-  const INVITE_SESSION_ERROR_MESSAGE =
-    "We couldn't confirm your invitation. Open the invitation email in this browser and follow the link again."
 
   const [formState, setFormState] = useState<{ status: 'idle' | 'saving'; error: string | null; success: boolean }>({
     status: 'idle',
-    error: error ? INVITE_SESSION_ERROR_MESSAGE : null,
+    error: null,
     success: false,
   })
 
@@ -50,15 +52,16 @@ export function InviteCompleteForm({ error }: { error?: string }) {
     let active = true
 
     const checkSession = async () => {
+      if (error) {
+        router.replace(expiredRecoveryHref)
+        return
+      }
+
       try {
         await hydrateSessionFromHash(supabase)
       } catch (_setSessionError) {
         if (active) {
-          setFormState((prev) => ({
-            ...prev,
-            // Show a single user-friendly message for hash/session hydration problems
-            error: INVITE_SESSION_ERROR_MESSAGE,
-          }))
+          router.replace(expiredRecoveryHref)
         }
         return
       }
@@ -69,11 +72,7 @@ export function InviteCompleteForm({ error }: { error?: string }) {
       if (!active) return
 
       if (!session) {
-        setFormState((prev) => ({
-          ...prev,
-          // Use a single friendly message for both not having a session and hydration failures
-          error: INVITE_SESSION_ERROR_MESSAGE,
-        }))
+        router.replace(expiredRecoveryHref)
         return
       }
 
@@ -85,7 +84,7 @@ export function InviteCompleteForm({ error }: { error?: string }) {
     return () => {
       active = false
     }
-  }, [supabase])
+  }, [error, router, supabase])
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()

--- a/src/app/(frontend)/auth/password/reset/ResetPasswordRequestForm.tsx
+++ b/src/app/(frontend)/auth/password/reset/ResetPasswordRequestForm.tsx
@@ -22,6 +22,8 @@ type FormState =
 
 type ParsedData = z.infer<typeof formSchema>
 
+export type ResetPasswordReason = 'expired'
+
 async function submitRequest(data: ParsedData) {
   const response = await fetch('/api/auth/password/reset', {
     method: 'POST',
@@ -37,7 +39,7 @@ async function submitRequest(data: ParsedData) {
   }
 }
 
-export function ResetPasswordRequestForm() {
+export function ResetPasswordRequestForm({ reason }: { reason?: ResetPasswordReason | null }) {
   const [formState, setFormState] = useState<FormState>({ status: 'idle', error: null })
   const formValidation = usePublicFormValidation({
     messages: {
@@ -101,6 +103,11 @@ export function ResetPasswordRequestForm() {
             className="space-y-4"
             noValidate
           >
+            {reason === 'expired' ? (
+              <Alert variant="warning" role="status">
+                That link is no longer valid. Request a new password reset link.
+              </Alert>
+            ) : null}
             {formState.error && <Alert variant="error">{formState.error}</Alert>}
             {isSuccess && (
               <Alert variant="success" role="status">

--- a/src/app/(frontend)/auth/password/reset/complete/ResetPasswordCompleteForm.tsx
+++ b/src/app/(frontend)/auth/password/reset/complete/ResetPasswordCompleteForm.tsx
@@ -29,6 +29,8 @@ const passwordSchema = z
 
 type PasswordState = z.infer<typeof passwordSchema>
 
+const expiredRecoveryHref = '/auth/password/reset?reason=expired'
+
 export function ResetPasswordCompleteForm({ error }: { error?: string }) {
   const supabase = useMemo(() => createClient(), [])
   const router = useRouter()
@@ -50,23 +52,25 @@ export function ResetPasswordCompleteForm({ error }: { error?: string }) {
     error: string | null
   }>({
     status: 'idle',
-    error: error ? decodeURIComponent(error) : null,
+    error: null,
   })
 
   useEffect(() => {
     let active = true
 
     const checkSession = async () => {
+      if (error) {
+        router.replace(expiredRecoveryHref)
+        return
+      }
+
       const {
         data: { session },
       } = await supabase.auth.getSession()
       if (!active) return
 
       if (!session) {
-        setFormState((prev) => ({
-          ...prev,
-          error: 'No active session. Please request a new password reset link.',
-        }))
+        router.replace(expiredRecoveryHref)
         return
       }
 
@@ -79,7 +83,7 @@ export function ResetPasswordCompleteForm({ error }: { error?: string }) {
     return () => {
       active = false
     }
-  }, [supabase])
+  }, [error, router, supabase])
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()

--- a/src/app/(frontend)/auth/password/reset/page.tsx
+++ b/src/app/(frontend)/auth/password/reset/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { ResetPasswordRequestForm } from './ResetPasswordRequestForm'
+import { ResetPasswordRequestForm, type ResetPasswordReason } from './ResetPasswordRequestForm'
 import { createSiteMetadata } from '@/utilities/generateMeta'
 
 export const metadata: Metadata = createSiteMetadata({
@@ -11,7 +11,22 @@ export const metadata: Metadata = createSiteMetadata({
 const signInOptionLinkClassName =
   'inline-flex min-h-11 items-center rounded-md px-3 text-sm font-medium text-primary transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
 
-export default function ResetPasswordPage() {
+type ResetPasswordPageProps = {
+  searchParams?: Promise<{
+    reason?: string | string[]
+  }>
+}
+
+function resolvePasswordResetReason(reason: string | string[] | undefined): ResetPasswordReason | null {
+  const value = Array.isArray(reason) ? reason[0] : reason
+
+  return value === 'expired' ? 'expired' : null
+}
+
+export default async function ResetPasswordPage({ searchParams }: ResetPasswordPageProps = {}) {
+  const params = await searchParams
+  const reason = resolvePasswordResetReason(params?.reason)
+
   return (
     <main className="min-h-svh bg-site-canvas py-6 sm:py-12">
       <div className="mx-auto max-w-4xl px-4">
@@ -25,7 +40,7 @@ export default function ResetPasswordPage() {
             </Link>
           </nav>
         </div>
-        <ResetPasswordRequestForm />
+        <ResetPasswordRequestForm reason={reason} />
       </div>
     </main>
   )

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import '@fontsource/dm-sans'
 
 import { AdminBar } from '@/components/organisms/AdminBar'
+import { SupabaseAuthHashUrlScrubber } from '@/app/(frontend)/_components/SupabaseAuthHashUrlScrubber.client'
 import { CookieConsentManager } from '@/components/organisms/CookieConsent/CookieConsentManager.client'
 import { Footer } from '@/components/templates/Footer/Component'
 import { Header } from '@/components/templates/Header/Component'
@@ -102,6 +103,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         ) : null}
       </head>
       <body className="min-h-screen bg-site-canvas text-foreground antialiased">
+        <SupabaseAuthHashUrlScrubber />
         {!blockSearchIndexing ? <JsonLdScript data={buildSiteBaseJsonLd()} /> : null}
         <div className="flex min-h-screen min-h-svh flex-col">
           <AdminBar adminBarProps={{ preview: isEnabled }} />

--- a/src/auth/utilities/hydrateSessionFromHash.ts
+++ b/src/auth/utilities/hydrateSessionFromHash.ts
@@ -1,5 +1,63 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 
+const supabaseAuthHashKeys = new Set([
+  'access_token',
+  'error',
+  'error_code',
+  'error_description',
+  'expires_at',
+  'expires_in',
+  'refresh_token',
+  'type',
+])
+
+function hasSupabaseAuthHash(params: URLSearchParams): boolean {
+  for (const key of supabaseAuthHashKeys) {
+    if (params.has(key)) return true
+  }
+
+  return false
+}
+
+function clearUrlHash(): void {
+  window.history.replaceState({}, document.title, window.location.pathname + window.location.search)
+}
+
+let capturedSupabaseAuthHash: string | null = null
+
+function readSupabaseAuthHashFromUrl(): string | null {
+  const hash = window.location.hash.startsWith('#') ? window.location.hash.slice(1) : window.location.hash
+  if (!hash) return null
+
+  const params = new URLSearchParams(hash)
+  if (!hasSupabaseAuthHash(params)) return null
+
+  return hash
+}
+
+export function captureSupabaseAuthHashFromUrl(): boolean {
+  if (typeof window === 'undefined') return false
+
+  const hash = readSupabaseAuthHashFromUrl()
+  if (!hash) return false
+
+  capturedSupabaseAuthHash = hash
+  clearUrlHash()
+
+  return true
+}
+
+function consumeSupabaseAuthHashParams(): URLSearchParams | null {
+  captureSupabaseAuthHashFromUrl()
+
+  if (!capturedSupabaseAuthHash) return null
+
+  const params = new URLSearchParams(capturedSupabaseAuthHash)
+  capturedSupabaseAuthHash = null
+
+  return params
+}
+
 /**
  * Hydrates a Supabase client session from access and refresh tokens present in the URL hash.
  *
@@ -9,17 +67,13 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 export async function hydrateSessionFromHash(supabase: SupabaseClient): Promise<void> {
   if (typeof window === 'undefined') return
 
-  const hash = window.location.hash.startsWith('#') ? window.location.hash.slice(1) : window.location.hash
-  if (!hash) return
+  const params = consumeSupabaseAuthHashParams()
+  if (!params) return
 
-  const params = new URLSearchParams(hash)
   const accessToken = params.get('access_token')
   const refreshToken = params.get('refresh_token')
 
   if (!accessToken || !refreshToken) return
 
   await supabase.auth.setSession({ access_token: accessToken, refresh_token: refreshToken })
-
-  // Clean up the hash so tokens are not kept in the URL bar.
-  window.history.replaceState({}, document.title, window.location.pathname + window.location.search)
 }

--- a/tests/unit/app/frontend/auth/invite/complete/InviteCompleteForm.test.tsx
+++ b/tests/unit/app/frontend/auth/invite/complete/InviteCompleteForm.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { InviteCompleteForm } from '@/app/(frontend)/auth/invite/complete/InviteCompleteForm'
+
+const expiredRecoveryHref = '/auth/password/reset?reason=expired'
+
+const routerMock = vi.hoisted(() => ({
+  replace: vi.fn(),
+}))
+
+const supabaseAuthMock = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  updateUser: vi.fn(),
+}))
+
+const hydrateSessionFromHashMock = vi.hoisted(() => vi.fn())
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => routerMock,
+}))
+
+vi.mock('@/auth/utilities/supaBaseClient', () => ({
+  createClient: () => ({
+    auth: supabaseAuthMock,
+  }),
+}))
+
+vi.mock('@/auth/utilities/hydrateSessionFromHash', () => ({
+  hydrateSessionFromHash: hydrateSessionFromHashMock,
+}))
+
+describe('InviteCompleteForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hydrateSessionFromHashMock.mockResolvedValue(undefined)
+    supabaseAuthMock.getSession.mockResolvedValue({
+      data: {
+        session: {
+          user: {
+            app_metadata: {},
+          },
+        },
+      },
+    })
+    supabaseAuthMock.updateUser.mockResolvedValue({ error: null })
+  })
+
+  it('redirects hash hydration errors to the reset request page', async () => {
+    hydrateSessionFromHashMock.mockRejectedValueOnce(new Error('invalid session'))
+
+    render(<InviteCompleteForm />)
+
+    await waitFor(() => {
+      expect(routerMock.replace).toHaveBeenCalledWith(expiredRecoveryHref)
+    })
+
+    expect(supabaseAuthMock.getSession).not.toHaveBeenCalled()
+    expect(screen.queryByText('invalid session')).not.toBeInTheDocument()
+  })
+
+  it('redirects missing sessions to the reset request page', async () => {
+    supabaseAuthMock.getSession.mockResolvedValueOnce({ data: { session: null } })
+
+    render(<InviteCompleteForm />)
+
+    await waitFor(() => {
+      expect(routerMock.replace).toHaveBeenCalledWith(expiredRecoveryHref)
+    })
+    expect(screen.getByRole('button', { name: 'Set password' })).toBeDisabled()
+  })
+
+  it('redirects callback errors to the reset request page', async () => {
+    render(<InviteCompleteForm error="otp_expired" />)
+
+    await waitFor(() => {
+      expect(routerMock.replace).toHaveBeenCalledWith(expiredRecoveryHref)
+    })
+
+    expect(hydrateSessionFromHashMock).not.toHaveBeenCalled()
+    expect(supabaseAuthMock.getSession).not.toHaveBeenCalled()
+    expect(screen.queryByText('otp_expired')).not.toBeInTheDocument()
+  })
+
+  it('keeps the password form enabled when an invite session exists', async () => {
+    render(<InviteCompleteForm />)
+
+    const passwordInput = await screen.findByLabelText('New password')
+
+    await waitFor(() => {
+      expect(passwordInput).toBeEnabled()
+    })
+    expect(routerMock.replace).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/app/frontend/auth/password/reset/ResetPasswordCompleteForm.test.tsx
+++ b/tests/unit/app/frontend/auth/password/reset/ResetPasswordCompleteForm.test.tsx
@@ -115,13 +115,26 @@ describe('ResetPasswordCompleteForm', () => {
     setItemSpy.mockRestore()
   })
 
-  it('shows a session error when the recovery link did not create a session', async () => {
+  it('redirects to the reset request page when the recovery link did not create a session', async () => {
     supabaseAuthMock.getSession.mockResolvedValue({ data: { session: null } })
 
     render(<ResetPasswordCompleteForm />)
 
-    expect(await screen.findByText('No active session. Please request a new password reset link.')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(routerMock.replace).toHaveBeenCalledWith('/auth/password/reset?reason=expired')
+    })
     expect(screen.getByRole('button', { name: 'Update password' })).toBeDisabled()
+  })
+
+  it('redirects callback errors to the reset request page without exposing the raw error', async () => {
+    render(<ResetPasswordCompleteForm error="otp_expired" />)
+
+    await waitFor(() => {
+      expect(routerMock.replace).toHaveBeenCalledWith('/auth/password/reset?reason=expired')
+    })
+
+    expect(supabaseAuthMock.getSession).not.toHaveBeenCalled()
+    expect(screen.queryByText('otp_expired')).not.toBeInTheDocument()
   })
 
   it('does not show a success flash when only local sign-out succeeds after global sign-out fails', async () => {

--- a/tests/unit/app/frontend/auth/password/reset/ResetPasswordRequestForm.test.ts
+++ b/tests/unit/app/frontend/auth/password/reset/ResetPasswordRequestForm.test.ts
@@ -12,4 +12,12 @@ describe('ResetPasswordRequestForm', () => {
     expect(html).toContain('action="/api/auth/password/reset"')
     expect(html).toContain('method="post"')
   })
+
+  it('renders a generic expired-link banner without prefilling email', () => {
+    const html = renderToStaticMarkup(React.createElement(ResetPasswordRequestForm, { reason: 'expired' }))
+
+    expect(html).toContain('That link is no longer valid. Request a new password reset link.')
+    expect(html).toContain('name="email"')
+    expect(html).not.toContain('value=')
+  })
 })

--- a/tests/unit/app/frontend/auth/password/reset/page.test.tsx
+++ b/tests/unit/app/frontend/auth/password/reset/page.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { ResetPasswordRequestForm } from '@/app/(frontend)/auth/password/reset/ResetPasswordRequestForm'
+;(globalThis as unknown as { React: typeof React }).React = React
+
+type ResetPasswordRequestFormElement = React.ReactElement<{
+  reason?: 'expired' | null
+}>
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
+
+function findResetPasswordRequestForm(node: React.ReactNode): ResetPasswordRequestFormElement | null {
+  if (!React.isValidElement(node)) return null
+  if (node.type === ResetPasswordRequestForm) return node as ResetPasswordRequestFormElement
+
+  const children = isObjectRecord(node.props) ? node.props.children : undefined
+  for (const child of React.Children.toArray(children as React.ReactNode)) {
+    const result = findResetPasswordRequestForm(child)
+    if (result) return result
+  }
+
+  return null
+}
+
+describe('ResetPasswordPage', () => {
+  const getPage = async () => {
+    const pageModule = await import('@/app/(frontend)/auth/password/reset/page')
+    return pageModule.default
+  }
+
+  it('passes the expired reason to the reset request form', async () => {
+    const ResetPasswordPage = await getPage()
+    const result = await ResetPasswordPage({
+      searchParams: Promise.resolve({
+        reason: 'expired',
+      }),
+    })
+
+    expect(findResetPasswordRequestForm(result)?.props.reason).toBe('expired')
+  })
+
+  it('ignores unknown reset reasons', async () => {
+    const ResetPasswordPage = await getPage()
+    const result = await ResetPasswordPage({
+      searchParams: Promise.resolve({
+        reason: 'show-email-for-user@example.com',
+      }),
+    })
+
+    expect(findResetPasswordRequestForm(result)?.props.reason).toBeNull()
+  })
+})

--- a/tests/unit/auth/utilities/hydrateSessionFromHash.test.ts
+++ b/tests/unit/auth/utilities/hydrateSessionFromHash.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { hydrateSessionFromHash } from '@/auth/utilities/hydrateSessionFromHash'
+import { captureSupabaseAuthHashFromUrl, hydrateSessionFromHash } from '@/auth/utilities/hydrateSessionFromHash'
 
 function createSupabaseMock() {
   return {
@@ -55,16 +55,80 @@ describe('hydrateSessionFromHash', () => {
       refresh_token: 'refresh456',
     })
     expect(global.window.history.replaceState).toHaveBeenCalledWith({}, 'Test', '/auth/invite/complete')
+
+    const cleanupCallOrder = vi.mocked(global.window.history.replaceState).mock.invocationCallOrder[0]
+    const setSessionCallOrder = vi.mocked(supabase.auth.setSession).mock.invocationCallOrder[0]
+    expect(cleanupCallOrder).toEqual(expect.any(Number))
+    expect(setSessionCallOrder).toEqual(expect.any(Number))
+    expect(cleanupCallOrder!).toBeLessThan(setSessionCallOrder!)
   })
 
-  it('does not set session when tokens are incomplete', async () => {
+  it('clears token hashes before surfacing setSession errors', async () => {
+    const supabase = createSupabaseMock()
+    vi.mocked(supabase.auth.setSession).mockRejectedValueOnce(new Error('invalid session'))
+
+    global.window.location.hash = '#access_token=access123&refresh_token=refresh456'
+
+    await expect(hydrateSessionFromHash(supabase)).rejects.toThrow('invalid session')
+
+    expect(global.window.history.replaceState).toHaveBeenCalledWith({}, 'Test', '/auth/invite/complete')
+
+    const cleanupCallOrder = vi.mocked(global.window.history.replaceState).mock.invocationCallOrder[0]
+    const setSessionCallOrder = vi.mocked(supabase.auth.setSession).mock.invocationCallOrder[0]
+    expect(cleanupCallOrder).toEqual(expect.any(Number))
+    expect(setSessionCallOrder).toEqual(expect.any(Number))
+    expect(cleanupCallOrder!).toBeLessThan(setSessionCallOrder!)
+  })
+
+  it('hydrates the session from a hash captured before telemetry can initialize', async () => {
     const supabase = createSupabaseMock()
 
-    // only access_token present
+    global.window.location.hash = '#access_token=access123&refresh_token=refresh456'
+
+    expect(captureSupabaseAuthHashFromUrl()).toBe(true)
+    expect(global.window.history.replaceState).toHaveBeenCalledWith({}, 'Test', '/auth/invite/complete')
+
+    global.window.location.hash = ''
+
+    await hydrateSessionFromHash(supabase)
+
+    expect(supabase.auth.setSession).toHaveBeenCalledWith({
+      access_token: 'access123',
+      refresh_token: 'refresh456',
+    })
+  })
+
+  it('clears hashes without setting a session when tokens are incomplete', async () => {
+    const supabase = createSupabaseMock()
+
     global.window.location.hash = '#access_token=access123'
 
     await hydrateSessionFromHash(supabase)
 
     expect(supabase.auth.setSession).not.toHaveBeenCalled()
+    expect(global.window.history.replaceState).toHaveBeenCalledWith({}, 'Test', '/auth/invite/complete')
+  })
+
+  it('clears Supabase error hashes without setting a session', async () => {
+    const supabase = createSupabaseMock()
+
+    global.window.location.hash =
+      '#error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired'
+
+    await hydrateSessionFromHash(supabase)
+
+    expect(supabase.auth.setSession).not.toHaveBeenCalled()
+    expect(global.window.history.replaceState).toHaveBeenCalledWith({}, 'Test', '/auth/invite/complete')
+  })
+
+  it('preserves non-auth hashes', async () => {
+    const supabase = createSupabaseMock()
+
+    global.window.location.hash = '#clinic-directory'
+
+    await hydrateSessionFromHash(supabase)
+
+    expect(supabase.auth.setSession).not.toHaveBeenCalled()
+    expect(global.window.history.replaceState).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Management summary

### Deutsch
Abgelaufene Einladungs- und Passwort-Reset-Links führen Nutzer jetzt nicht mehr in eine Sackgasse. Stattdessen landen sie in einem klaren Wiederherstellungsfluss mit einer allgemeinen Hinweiszeile und einer neuen Anfrage-Möglichkeit.

### English
Expired invite and password-reset links no longer leave users at a dead end. They now land in a clear recovery flow with a generic notice and a way to request a fresh link.

## What changed

- Added a Supabase auth hash scrubber that clears token-bearing URL fragments at the top of the frontend layout before browser analytics can read them.
- Redirected expired or invalid invite and password-reset completion states back to `/auth/password/reset?reason=expired`.
- Added a generic expired-link banner on the reset request page with an allowlisted `reason` value only.
- Kept the password-reset request API enumeration-safe and avoided raw token or error exposure in UI/logs.
- Added focused unit coverage for hash cleanup, invite/reset redirects, and the expired-banner state.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `src/auth/utilities/hydrateSessionFromHash.ts`, `src/app/(frontend)/_components/SupabaseAuthHashUrlScrubber.client.tsx` | Auth recovery fragments must be removed before telemetry or session hydration can leak them. | The hash is scrubbed early, session hydration still works, and incomplete/error hashes do not leak into the URL. | Unit tests in `tests/unit/auth/utilities/hydrateSessionFromHash.test.ts` |
| P1 | `src/app/(frontend)/auth/invite/complete/InviteCompleteForm.tsx`, `src/app/(frontend)/auth/password/reset/complete/ResetPasswordCompleteForm.tsx` | Expired or invalid recovery states now redirect instead of surfacing dead-end errors. | Redirects stay internal, do not expose raw callback errors, and do not create recovery loops. | Unit tests in `tests/unit/app/frontend/auth/invite/complete/InviteCompleteForm.test.tsx` and `tests/unit/app/frontend/auth/password/reset/ResetPasswordCompleteForm.test.tsx` |
| P2 | `src/app/(frontend)/auth/password/reset/page.tsx`, `src/app/(frontend)/auth/password/reset/ResetPasswordRequestForm.tsx` | The reset request page now shows a generic expired-link banner only for allowlisted state. | Unknown `reason` values are ignored and the form stays free of email prefill. | Unit tests in `tests/unit/app/frontend/auth/password/reset/page.test.tsx` and `tests/unit/app/frontend/auth/password/reset/ResetPasswordRequestForm.test.ts` |

## Validation

- [x] `pnpm format`: ran successfully.
- [x] `pnpm check`: ran successfully.
- [x] `pnpm build`: ran successfully with `PAYLOAD_SECRET=dev-secret`.
- [x] Focused tests: ran the affected Vitest files for auth utilities, invite/reset flows, and the password-reset API.
- [x] UI/mobile QA: Screenshot evidence is attached below.
  <!-- gh-ui-screenshots:start -->
  ### Password Reset Expired Mobile
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":2.164102564102564,"capturedAt":"2026-06-24T17:22:52.975Z","contentType":"image/png","focus":"password-reset-expired-mobile","focusLabel":"Password Reset Expired Mobile","formFactor":"mobile","gitSha":"0af2c141","height":844,"releaseEligible":true,"releaseRole":"primary","size":42083,"sizeKb":42,"uploadName":"password-reset-expired-mobile__mobile__390x844__20260624T172252Z__0af2c141__390x844__42kb.png","viewport":"390x844","warnings":[],"width":390,"url":"https://github.com/user-attachments/assets/ef702ae9-f049-4bfb-8250-856975cb75af"} -->
  ![Password Reset Expired Mobile](https://github.com/user-attachments/assets/ef702ae9-f049-4bfb-8250-856975cb75af)
  
  ### Password Reset Expired Desktop
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":0.703125,"capturedAt":"2026-06-24T17:22:54.306Z","contentType":"image/png","focus":"password-reset-expired-desktop","focusLabel":"Password Reset Expired Desktop","formFactor":"desktop","gitSha":"0af2c141","height":900,"releaseEligible":true,"releaseRole":"secondary","size":59633,"sizeKb":59,"uploadName":"password-reset-expired-desktop__desktop__1280x900__20260624T172254Z__0af2c141__1280x900__59kb.png","viewport":"1280x900","warnings":[],"width":1280,"url":"https://github.com/user-attachments/assets/4cb0af96-614a-40ca-a678-3a17a2908b64"} -->
  ![Password Reset Expired Desktop](https://github.com/user-attachments/assets/4cb0af96-614a-40ca-a678-3a17a2908b64)
  <!-- gh-ui-screenshots:end -->
- [x] Security/privacy review: Security reviewer rerun completed with no findings at or above `5/10`.
- [ ] Migration/schema check: not applicable; no schema or migration changes.
- [ ] Documentation/instructions check: not applicable; no instruction surface changed.

## Risk and rollout

None known. This is an auth-flow and UI-only change with no schema, migration, or redirect-target expansion. Preview and local Supabase redirect URLs must remain allowlisted.

## Development

Closes #1415
