### PR TITLE
fix(frontend): soften about trust story transitions

### DIFF
--- a/src/components/organisms/AboutTrustSystemStory/AboutTrustSystemStory.module.css
+++ b/src/components/organisms/AboutTrustSystemStory/AboutTrustSystemStory.module.css
@@ -117,7 +117,7 @@
   opacity: 1;
   pointer-events: auto;
   transform: none;
-  transition: opacity 100ms ease;
+  transition: opacity 260ms ease;
 }
 
 .copyStack.isFading .copyCard.isActive {

--- a/src/components/organisms/AboutTrustSystemStory/index.tsx
+++ b/src/components/organisms/AboutTrustSystemStory/index.tsx
@@ -825,7 +825,7 @@ export const AboutTrustSystemStory: React.FC<AboutTrustSystemStoryProps> = ({ fi
         })
         activeCardIndex = pendingCardIndex
         requestAnimationFrame(() => copyStack.classList.remove(isFadingClass))
-      }, 80)
+      }, 140)
     }
 
     const makeParticle = (index: number): Particle => {
@@ -968,8 +968,8 @@ export const AboutTrustSystemStory: React.FC<AboutTrustSystemStoryProps> = ({ fi
       })
     }
 
-    const updateDom = (p: number) => {
-      const active = p < 0.28 ? 0 : p < 0.64 ? 1 : 2
+    const updateDom = (p: number, narrativeP = p) => {
+      const active = narrativeP < 0.28 ? 0 : narrativeP < 0.64 ? 1 : 2
 
       setActiveCard(active)
       steps.forEach((step, index) => {
@@ -1036,8 +1036,11 @@ export const AboutTrustSystemStory: React.FC<AboutTrustSystemStoryProps> = ({ fi
         particleOrbitRotation += deltaSeconds * 0.09 * orbitRotationStrength
       }
 
+      const narrativeProgress =
+        force || reducedMotion || progressIsStatic ? progress : lerp(progress, visualProgress, 0.45)
+
       updateParticles(visualProgress)
-      updateDom(progress)
+      updateDom(progress, narrativeProgress)
     }
 
     const resize = () => {


### PR DESCRIPTION
## Management summary

### Deutsch

Die About-Seite fuehrt ruhiger durch die Trust-System-Story. Der Wechsel zwischen Why, How und What wirkt weniger abrupt, sodass der rechte visuelle Teil nicht mehr vom Textwechsel ueberlagert wird und die Erzaehlung fokussierter bleibt.

### English

The About page now moves more calmly through the trust-system story. The switch between Why, How, and What feels less abrupt, so the right-side visual remains less disrupted by the text change and the narrative stays more focused.

## What changed

- Slowed the active copy-card transition in the About trust-system story.
- Split narrative progress from visual progress so the content state changes less aggressively while the visual system remains responsive.
- Kept the scope limited to transition pacing; no content, layout, data, or schema changes.

## Points to review

| Priority | Files / paths                                                           | Why focus here                                              | Reviewer should verify                                                   | Evidence                         |
| -------- | ----------------------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------ | -------------------------------- |
| P2       | `src/components/organisms/AboutTrustSystemStory/index.tsx`              | Scroll-progress handling can affect perceived story timing. | The copy state changes feel calmer without making the section sluggish.  | `pnpm check`, `pnpm build`       |
| P2       | `src/components/organisms/AboutTrustSystemStory/AboutTrustSystemStory.module.css` | Motion timing affects visual distraction.                   | The transition remains subtle and respects the existing visual language. | `pnpm check`, `pnpm build`       |

## Validation

- [x] `pnpm format`: `npx --yes pnpm@10.28.2 format`
- [x] `pnpm check`: `npx --yes pnpm@10.28.2 check`
- [x] `pnpm build`: `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} npx --yes pnpm@10.28.2 build`
- [ ] Focused tests: Not run separately; this PR only changes motion pacing in the existing About story component.
- [ ] UI/mobile QA: Static screenshots do not verify this timing-only change; reviewer should validate the scroll-story pacing in-browser.
- [ ] Security/privacy review: Not applicable; no auth, privacy, logging, access-control, or server trust-boundary changes.
- [ ] Migration/schema check: Not applicable; no Payload schema, database, or migration changes.
- [ ] Documentation/instructions check: Not applicable; no documentation or instruction-surface changes.

## Risk and rollout

Low visual risk. The change only adjusts client-side motion timing in one About-page story section. Rollback is the single commit revert.

## Development

Closes #1424
