### PR TITLE
feat(frontend): improve about team spotlight

### DIFF
--- a/src/components/templates/AboutPage/AccountabilitySection.tsx
+++ b/src/components/templates/AboutPage/AccountabilitySection.tsx
@@ -1,70 +1,371 @@
+'use client'
+
 import Image from 'next/image'
-import React from 'react'
+import React, { useId, useState } from 'react'
 
 import { Heading } from '@/components/atoms/Heading'
+import { TrustAtom, type TrustAtomTone } from '@/components/atoms/TrustAtom'
 import { Container } from '@/components/molecules/Container'
+import { SocialLink, type SocialPlatform } from '@/components/molecules/SocialLink'
+import { UiLink } from '@/components/molecules/Link'
 import { cn } from '@/utilities/ui'
 
 import type { AboutTeamMember } from './types'
 import { accountabilityLabels } from './aboutPageViewModel'
 import { resolveImageObjectPositionStyle } from './aboutPageUtils'
 
-const TeamMember: React.FC<{ member: AboutTeamMember; index: number }> = ({ member, index }) => {
+type TeamAccountabilityDetails = {
+  owns: string
+  decisionBoundary: string
+  protects: string
+}
+
+const teamAccountabilityDetails: TeamAccountabilityDetails[] = [
+  {
+    owns: 'Sets the standards for partner relationships, commercial accountability, and sustainable clinic growth.',
+    decisionBoundary:
+      'Keeps partner decisions measurable and transparent before clinic information becomes part of the comparison experience.',
+    protects:
+      'Protects patient trust by making sure commercial growth does not outrun responsible clinic presentation.',
+  },
+  {
+    owns: 'Owns the communication standards that make clinic information clear, consistent, and human.',
+    decisionBoundary: 'Keeps service claims grounded before outreach, campaigns, or clinic stories reach patients.',
+    protects: 'Protects patients from overstated promises by keeping clinic communication precise and accountable.',
+  },
+  {
+    owns: 'Owns the comparison product and the user experience that turns clinic signals into useful decisions.',
+    decisionBoundary:
+      'Keeps product choices focused on patient questions before new features add noise to the comparison flow.',
+    protects: 'Protects a simple, trustworthy product experience where evidence stays easier to evaluate.',
+  },
+  {
+    owns: 'Owns legal clarity, privacy expectations, and responsible engagement across patient and clinic interactions.',
+    decisionBoundary:
+      'Keeps comparison context separate from medical advice, consent boundaries, and unsupported partner claims.',
+    protects: 'Protects the legal foundation that lets patients and clinics use the platform with confidence.',
+  },
+  {
+    owns: 'Owns the platform architecture that keeps clinic information structured, available, and reliable.',
+    decisionBoundary:
+      'Keeps technical decisions accountable before data quality, access, or system resilience can affect patients.',
+    protects: 'Protects platform trust by keeping the experience secure, observable, and resilient as it scales.',
+  },
+]
+
+const detailRows: Array<{ key: keyof TeamAccountabilityDetails; label: string; tone: TrustAtomTone }> = [
+  { key: 'owns', label: 'Owns', tone: 'primary' },
+  { key: 'decisionBoundary', label: 'Decision boundary', tone: 'accent' },
+  { key: 'protects', label: 'Protects', tone: 'secondary' },
+]
+
+const defaultProfileLinks: NonNullable<AboutTeamMember['profileLinks']> = [{ href: '/contact', label: 'Contact' }]
+const spotlightImageSizes = '(min-width: 640px) 144px, 120px'
+const spotlightSocialPlatforms = ['linkedin', 'github'] as const satisfies SocialPlatform[]
+const socialPlatformLabels: Record<(typeof spotlightSocialPlatforms)[number], string> = {
+  github: 'GitHub',
+  linkedin: 'LinkedIn',
+}
+
+function getTeamAccountabilityDetails(
+  member: AboutTeamMember,
+  index: number,
+  accountabilityLabel: string,
+): TeamAccountabilityDetails {
+  return (
+    teamAccountabilityDetails[index] ?? {
+      owns: member.whatWeDo,
+      decisionBoundary: `Keeps ${accountabilityLabel.toLowerCase()} decisions visible before they affect the comparison experience.`,
+      protects: 'Protects patient trust by making the responsibility behind this part of the system explicit.',
+    }
+  )
+}
+
+const getTeamProfileLinks = (member: AboutTeamMember) =>
+  member.profileLinks && member.profileLinks.length > 0 ? member.profileLinks : defaultProfileLinks
+
+const getTeamSocialLinks = (member: AboutTeamMember) =>
+  spotlightSocialPlatforms
+    .map((platform) => {
+      const href = member.socials?.[platform]
+
+      if (!href) return null
+
+      return {
+        href,
+        label: socialPlatformLabels[platform],
+        platform,
+      }
+    })
+    .filter((item): item is { href: string; label: string; platform: (typeof spotlightSocialPlatforms)[number] } =>
+      Boolean(item),
+    )
+
+const TeamProfileLinks: React.FC<{ className?: string; member: AboutTeamMember }> = ({ className, member }) => {
+  const socialLinks = getTeamSocialLinks(member)
+  const profileLinks = getTeamProfileLinks(member)
+
+  if (socialLinks.length === 0 && profileLinks.length === 0) return null
+
+  return (
+    <div
+      className={cn(
+        'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 flex flex-wrap items-center gap-x-5 gap-y-3 text-sm motion-safe:delay-100 motion-safe:duration-200 motion-reduce:animate-none',
+        className,
+      )}
+      aria-label={`${member.name} links`}
+    >
+      {socialLinks.length > 0 ? (
+        <div className="flex items-center gap-2" aria-label={`${member.name} social profiles`}>
+          {socialLinks.map((link) => {
+            const opensCurrentPage = link.href.startsWith('#')
+
+            return (
+              <SocialLink
+                key={link.platform}
+                aria-label={`${member.name} on ${link.label}`}
+                className="h-7 w-7 rounded-full text-secondary/58 hover:bg-primary/8 hover:text-primary focus-visible:ring-primary/35 focus-visible:ring-offset-site-canvas"
+                href={link.href}
+                platform={link.platform}
+                rel={opensCurrentPage ? undefined : 'noopener noreferrer'}
+                size="sm"
+                target={opensCurrentPage ? undefined : '_blank'}
+                variant="ghost"
+              />
+            )
+          })}
+        </div>
+      ) : null}
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+        {profileLinks.map((link) => (
+          <UiLink
+            key={`${link.href}-${link.label}`}
+            className="text-xs font-semibold tracking-[0.14em] text-secondary/56 uppercase underline-offset-4 transition-colors hover:text-primary hover:underline focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:ring-offset-4 focus-visible:ring-offset-site-canvas focus-visible:outline-none"
+            href={link.href}
+            label={link.label}
+            newTab={link.newTab}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+const TeamSpotlight: React.FC<{ member: AboutTeamMember; index: number; id: string }> = ({ member, index, id }) => {
+  const [imageReady, setImageReady] = useState(false)
   const accountabilityLabel = accountabilityLabels[index] ?? 'Trust accountability'
+  const details = getTeamAccountabilityDetails(member, index, accountabilityLabel)
 
   return (
     <article
-      className={cn(
-        'grid gap-4 py-5 sm:grid-cols-[6.5rem_minmax(0,1fr)] sm:gap-6 lg:py-6',
-        index > 0 && 'border-t border-site-divider/70',
-      )}
-      data-about-team-member=""
+      id={id}
+      aria-live="polite"
+      className="motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-2 motion-safe:duration-200 motion-safe:ease-out motion-reduce:transform-none motion-reduce:animate-none"
+      data-about-team-spotlight=""
+      data-about-team-reveal-item=""
     >
-      <div
-        className="relative h-32 w-24 overflow-hidden rounded-[4px] bg-site-section ring-1 ring-site-divider/80 sm:h-full sm:min-h-[8.5rem] sm:w-[6.5rem]"
-        data-about-team-reveal-item=""
-      >
-        <Image
-          src={member.image.src}
-          alt={member.image.alt}
-          fill
-          className="object-cover grayscale"
-          sizes="104px"
-          quality={member.image.quality ?? 75}
-          style={resolveImageObjectPositionStyle(member.image)}
-        />
-      </div>
-      <div className="min-w-0" data-about-team-reveal-item="">
-        <p className="text-xs font-semibold tracking-[0.16em] text-primary uppercase">{accountabilityLabel}</p>
-        <div className="mt-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
-          <Heading as="h3" align="left" size="h6" className="text-secondary">
-            {member.name}
-          </Heading>
-          <p className="text-sm font-medium text-secondary/56">{member.role}</p>
+      <div>
+        <div className="border-b border-site-divider/70 pb-7">
+          <div className="grid grid-cols-[7.5rem_minmax(0,1fr)] items-center gap-5 sm:grid-cols-[9rem_minmax(0,1fr)] sm:gap-7">
+            <div className="relative h-[10.5rem] w-[7.5rem] overflow-hidden rounded-[4px] bg-site-section ring-1 ring-site-divider/80 sm:h-[12.5rem] sm:w-36">
+              <Image
+                src={member.image.src}
+                alt={member.image.alt}
+                fill
+                className={cn(
+                  'object-cover grayscale transition-opacity duration-200 ease-out motion-reduce:transition-none',
+                  imageReady ? 'opacity-100' : 'opacity-0',
+                )}
+                sizes={spotlightImageSizes}
+                quality={member.image.quality ?? 75}
+                loading={index === 0 ? undefined : 'eager'}
+                onError={() => setImageReady(true)}
+                onLoad={() => setImageReady(true)}
+                priority={index === 0}
+                style={resolveImageObjectPositionStyle(member.image)}
+              />
+            </div>
+            <div className="motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 min-w-0 motion-safe:duration-200 motion-reduce:animate-none">
+              <p className="text-xs font-semibold tracking-[0.16em] text-primary uppercase">{accountabilityLabel}</p>
+              <div className="mt-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <Heading as="h3" align="left" size="h5" className="text-secondary">
+                  {member.name}
+                </Heading>
+                <p className="text-sm font-medium text-secondary/56">{member.role}</p>
+              </div>
+              <TeamProfileLinks className="mt-4" member={member} />
+            </div>
+          </div>
         </div>
-        <p className="mt-4 text-base leading-7 text-secondary/76">{member.whatWeDo}</p>
+        <div className="divide-y divide-site-divider/70">
+          {detailRows.map((row) => (
+            <div
+              key={row.key}
+              className="motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 grid gap-3 py-6 motion-safe:duration-200 motion-reduce:animate-none sm:grid-cols-[minmax(9rem,0.42fr)_minmax(0,1fr)] sm:gap-6 sm:py-7"
+            >
+              <div className="flex items-start gap-3">
+                <TrustAtom tone={row.tone} className="mt-1 !h-5 !w-5 !border-[5px]" />
+                <p className="text-lg leading-7 font-bold tracking-tight text-secondary">{row.label}</p>
+              </div>
+              <p className="text-base leading-7 text-secondary/76">{details[row.key]}</p>
+            </div>
+          ))}
+        </div>
       </div>
     </article>
   )
 }
 
+const TeamSpotlightImagePreloads: React.FC<{ team: AboutTeamMember[] }> = ({ team }) => (
+  <div aria-hidden="true" className="pointer-events-none fixed top-0 left-0 h-px w-px overflow-hidden opacity-0">
+    {team.map((member) => (
+      <Image
+        key={`${member.name}-${member.image.src}`}
+        src={member.image.src}
+        alt=""
+        width={144}
+        height={200}
+        className="object-cover grayscale"
+        loading="eager"
+        quality={member.image.quality ?? 75}
+        sizes={spotlightImageSizes}
+        style={resolveImageObjectPositionStyle(member.image)}
+      />
+    ))}
+  </div>
+)
+
+const TeamMemberTab: React.FC<{
+  member: AboutTeamMember
+  index: number
+  isActive: boolean
+  onSelect: () => void
+  panelId: string
+}> = ({ member, index, isActive, onSelect, panelId }) => {
+  const accountabilityLabel = accountabilityLabels[index] ?? 'Trust accountability'
+
+  return (
+    <button
+      type="button"
+      aria-controls={panelId}
+      aria-current={isActive ? 'true' : undefined}
+      aria-pressed={isActive}
+      className={cn(
+        'group relative grid w-full grid-cols-[5rem_minmax(0,1fr)] gap-5 border-l-2 border-l-transparent py-5 pl-4 text-left transition-[border-color,background-color] duration-200 ease-out focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:ring-offset-4 focus-visible:ring-offset-site-canvas focus-visible:outline-none sm:grid-cols-[5.25rem_minmax(0,1fr)] sm:gap-6 lg:py-6',
+        index > 0 && 'border-t border-site-divider/70',
+        isActive
+          ? 'cursor-default border-l-primary bg-primary/[0.018]'
+          : 'cursor-pointer hover:border-l-primary/60 hover:bg-primary/[0.012] focus-visible:border-l-primary/70',
+      )}
+      data-active={isActive ? 'true' : undefined}
+      data-about-team-member=""
+      data-about-team-reveal-item=""
+      onClick={onSelect}
+    >
+      <span
+        className={cn(
+          'relative h-28 w-20 overflow-hidden rounded-[4px] bg-site-section ring-1 ring-site-divider/80 transition-[opacity,transform,filter] duration-200 ease-out sm:h-28 sm:w-[5.25rem]',
+          isActive
+            ? 'opacity-90 ring-primary/28'
+            : 'opacity-60 group-hover:scale-[1.025] group-hover:opacity-90 group-focus-visible:scale-[1.025] group-focus-visible:opacity-90',
+        )}
+      >
+        <Image
+          src={member.image.src}
+          alt=""
+          fill
+          className="object-cover grayscale"
+          sizes="84px"
+          quality={member.image.quality ?? 70}
+          style={resolveImageObjectPositionStyle(member.image)}
+        />
+      </span>
+      <span className="min-w-0">
+        <span className="flex items-center gap-2">
+          <TrustAtom
+            tone={isActive ? 'accent' : 'primary'}
+            className={cn(
+              '!h-3 !w-3 shrink-0 !border-[3px] transition-opacity duration-200 ease-out',
+              isActive ? 'opacity-100' : 'opacity-0 group-hover:opacity-80 group-focus-visible:opacity-80',
+            )}
+          />
+          <span
+            className={cn(
+              'block text-xs font-semibold tracking-[0.16em] uppercase transition-colors duration-200 ease-out',
+              isActive ? 'text-primary' : 'text-primary/58 group-hover:text-primary group-focus-visible:text-primary',
+            )}
+          >
+            {accountabilityLabel}
+          </span>
+        </span>
+        <span className="mt-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <span
+            className={cn(
+              'text-base font-bold tracking-tight normal-case transition-colors duration-200 ease-out md:text-lg',
+              isActive
+                ? 'text-secondary'
+                : 'text-secondary/62 group-hover:text-secondary group-focus-visible:text-secondary',
+            )}
+          >
+            {member.name}
+          </span>
+          <span className="text-sm font-medium text-secondary/48">{member.role}</span>
+        </span>
+        <span
+          className={cn(
+            'mt-3 block text-sm leading-6 transition-colors duration-200 ease-out sm:text-base sm:leading-7',
+            isActive
+              ? 'text-secondary/76'
+              : 'text-secondary/56 group-hover:text-secondary/72 group-focus-visible:text-secondary/72',
+          )}
+        >
+          {member.whatWeDo}
+        </span>
+      </span>
+    </button>
+  )
+}
+
 export const AccountabilitySection: React.FC<{ team: AboutTeamMember[] }> = ({ team }) => {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const componentId = useId()
+  const activeMember = team[activeIndex] ?? team[0]
+
+  if (!activeMember) return null
+
+  const activePanelId = `${componentId}-team-spotlight`
+
   return (
     <section className="pb-14 sm:pb-18 lg:pb-20" aria-labelledby="about-accountability-heading">
+      <TeamSpotlightImagePreloads team={team} />
       <Container>
-        <div className="grid gap-10 border-t border-site-divider/70 pt-14 sm:pt-18 lg:grid-cols-[minmax(0,0.82fr)_minmax(0,1.5fr)] lg:gap-16 lg:pt-20">
-          <div className="max-w-sm" data-about-team-reveal-item="">
-            <p className="text-sm font-semibold tracking-[0.18em] text-primary uppercase">Accountability layer</p>
-            <Heading id="about-accountability-heading" as="h2" align="left" size="h4" className="mt-3 text-secondary">
-              The people accountable for the system
-            </Heading>
-            <p className="mt-4 text-base leading-7 text-secondary/76">
-              The trust system stays credible when the responsibilities behind it are visible.
-            </p>
+        <div className="grid gap-10 border-t border-site-divider/70 pt-14 sm:pt-18 lg:grid-cols-[minmax(0,1.04fr)_minmax(24rem,0.96fr)] lg:gap-14 lg:pt-20">
+          <div className="lg:sticky lg:top-24 lg:self-start">
+            <div className="max-w-lg" data-about-team-reveal-item="">
+              <p className="text-sm font-semibold tracking-[0.18em] text-primary uppercase">Accountability layer</p>
+              <Heading id="about-accountability-heading" as="h2" align="left" size="h4" className="mt-3 text-secondary">
+                The people accountable for the system
+              </Heading>
+            </div>
+            <div className="mt-10 sm:mt-12">
+              <TeamSpotlight
+                key={`${activeMember.name}-${activeMember.role}`}
+                member={activeMember}
+                index={activeIndex}
+                id={activePanelId}
+              />
+            </div>
           </div>
-          <div>
+          <div aria-label="Team accountability roles">
             {team.map((member, index) => (
-              <TeamMember key={`${member.name}-${member.role}`} member={member} index={index} />
+              <TeamMemberTab
+                key={`${member.name}-${member.role}`}
+                member={member}
+                index={index}
+                isActive={index === activeIndex}
+                onSelect={() => setActiveIndex(index)}
+                panelId={activePanelId}
+              />
             ))}
           </div>
         </div>

--- a/src/components/templates/AboutPage/AccountabilitySection.tsx
+++ b/src/components/templates/AboutPage/AccountabilitySection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Image from 'next/image'
-import React, { useId, useState } from 'react'
+import React, { useEffect, useId, useRef, useState } from 'react'
 
 import { Heading } from '@/components/atoms/Heading'
 import { TrustAtom, type TrustAtomTone } from '@/components/atoms/TrustAtom'
@@ -124,7 +124,7 @@ const TeamProfileLinks: React.FC<{ className?: string; member: AboutTeamMember }
               <SocialLink
                 key={link.platform}
                 aria-label={`${member.name} on ${link.label}`}
-                className="h-7 w-7 rounded-full text-secondary/58 hover:bg-primary/8 hover:text-primary focus-visible:ring-primary/35 focus-visible:ring-offset-site-canvas"
+                className="h-11 w-11 rounded-full text-secondary/58 hover:bg-primary/8 hover:text-primary focus-visible:ring-primary/35 focus-visible:ring-offset-site-canvas sm:h-9 sm:w-9"
                 href={link.href}
                 platform={link.platform}
                 rel={opensCurrentPage ? undefined : 'noopener noreferrer'}
@@ -151,15 +151,29 @@ const TeamProfileLinks: React.FC<{ className?: string; member: AboutTeamMember }
   )
 }
 
-const TeamSpotlight: React.FC<{ member: AboutTeamMember; index: number; id: string }> = ({ member, index, id }) => {
+const TeamSpotlight: React.FC<{
+  member: AboutTeamMember
+  index: number
+  id: string
+  labelledBy: string
+  spotlightRef: React.Ref<HTMLElement>
+}> = ({ member, index, id, labelledBy, spotlightRef }) => {
   const [imageReady, setImageReady] = useState(false)
   const accountabilityLabel = accountabilityLabels[index] ?? 'Trust accountability'
   const details = getTeamAccountabilityDetails(member, index, accountabilityLabel)
 
+  useEffect(() => {
+    setImageReady(false)
+  }, [member.image.src])
+
   return (
     <article
       id={id}
+      ref={spotlightRef}
+      role="tabpanel"
+      aria-labelledby={labelledBy}
       aria-live="polite"
+      tabIndex={-1}
       className="motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-2 motion-safe:duration-200 motion-safe:ease-out motion-reduce:transform-none motion-reduce:animate-none"
       data-about-team-spotlight=""
       data-about-team-reveal-item=""
@@ -216,40 +230,25 @@ const TeamSpotlight: React.FC<{ member: AboutTeamMember; index: number; id: stri
   )
 }
 
-const TeamSpotlightImagePreloads: React.FC<{ team: AboutTeamMember[] }> = ({ team }) => (
-  <div aria-hidden="true" className="pointer-events-none fixed top-0 left-0 h-px w-px overflow-hidden opacity-0">
-    {team.map((member) => (
-      <Image
-        key={`${member.name}-${member.image.src}`}
-        src={member.image.src}
-        alt=""
-        width={144}
-        height={200}
-        className="object-cover grayscale"
-        loading="eager"
-        quality={member.image.quality ?? 75}
-        sizes={spotlightImageSizes}
-        style={resolveImageObjectPositionStyle(member.image)}
-      />
-    ))}
-  </div>
-)
-
 const TeamMemberTab: React.FC<{
   member: AboutTeamMember
   index: number
   isActive: boolean
   onSelect: () => void
+  onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void
   panelId: string
-}> = ({ member, index, isActive, onSelect, panelId }) => {
+  tabId: string
+}> = ({ member, index, isActive, onKeyDown, onSelect, panelId, tabId }) => {
   const accountabilityLabel = accountabilityLabels[index] ?? 'Trust accountability'
 
   return (
     <button
+      id={tabId}
       type="button"
+      role="tab"
       aria-controls={panelId}
-      aria-current={isActive ? 'true' : undefined}
-      aria-pressed={isActive}
+      aria-selected={isActive}
+      tabIndex={isActive ? 0 : -1}
       className={cn(
         'group relative grid w-full grid-cols-[5rem_minmax(0,1fr)] gap-5 border-l-2 border-l-transparent py-5 pl-4 text-left transition-[border-color,background-color] duration-200 ease-out focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:ring-offset-4 focus-visible:ring-offset-site-canvas focus-visible:outline-none sm:grid-cols-[5.25rem_minmax(0,1fr)] sm:gap-6 lg:py-6',
         index > 0 && 'border-t border-site-divider/70',
@@ -261,6 +260,7 @@ const TeamMemberTab: React.FC<{
       data-about-team-member=""
       data-about-team-reveal-item=""
       onClick={onSelect}
+      onKeyDown={onKeyDown}
     >
       <span
         className={cn(
@@ -329,15 +329,58 @@ const TeamMemberTab: React.FC<{
 export const AccountabilitySection: React.FC<{ team: AboutTeamMember[] }> = ({ team }) => {
   const [activeIndex, setActiveIndex] = useState(0)
   const componentId = useId()
+  const spotlightRef = useRef<HTMLElement | null>(null)
   const activeMember = team[activeIndex] ?? team[0]
 
   if (!activeMember) return null
 
   const activePanelId = `${componentId}-team-spotlight`
+  const activeTabId = `${componentId}-team-tab-${activeIndex}`
+
+  const scrollSpotlightIntoView = () => {
+    spotlightRef.current?.scrollIntoView({ block: 'start', behavior: 'auto' })
+  }
+
+  const shouldScrollToSpotlight = () =>
+    typeof window !== 'undefined' && !window.matchMedia('(min-width: 1024px)').matches
+
+  const selectTeamMember = (index: number, options?: { focusSpotlight?: boolean; scrollSpotlight?: boolean }) => {
+    setActiveIndex(index)
+
+    window.requestAnimationFrame(() => {
+      if (options?.scrollSpotlight) scrollSpotlightIntoView()
+      if (options?.focusSpotlight) spotlightRef.current?.focus({ preventScroll: !options.scrollSpotlight })
+    })
+  }
+
+  const handleTeamTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    const lastIndex = team.length - 1
+    const nextIndex = index + 1 > lastIndex ? 0 : index + 1
+    const previousIndex = index - 1 < 0 ? lastIndex : index - 1
+    const keyMap: Partial<Record<string, number>> = {
+      ArrowDown: nextIndex,
+      ArrowRight: nextIndex,
+      ArrowLeft: previousIndex,
+      ArrowUp: previousIndex,
+      End: lastIndex,
+      Home: 0,
+    }
+    const targetIndex = keyMap[event.key]
+
+    if (typeof targetIndex === 'number') {
+      event.preventDefault()
+      selectTeamMember(targetIndex, { focusSpotlight: true, scrollSpotlight: shouldScrollToSpotlight() })
+      return
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      selectTeamMember(index, { focusSpotlight: true, scrollSpotlight: shouldScrollToSpotlight() })
+    }
+  }
 
   return (
     <section className="pb-14 sm:pb-18 lg:pb-20" aria-labelledby="about-accountability-heading">
-      <TeamSpotlightImagePreloads team={team} />
       <Container>
         <div className="grid gap-10 border-t border-site-divider/70 pt-14 sm:pt-18 lg:grid-cols-[minmax(0,1.04fr)_minmax(24rem,0.96fr)] lg:gap-14 lg:pt-20">
           <div className="lg:sticky lg:top-24 lg:self-start">
@@ -349,22 +392,25 @@ export const AccountabilitySection: React.FC<{ team: AboutTeamMember[] }> = ({ t
             </div>
             <div className="mt-10 sm:mt-12">
               <TeamSpotlight
-                key={`${activeMember.name}-${activeMember.role}`}
                 member={activeMember}
                 index={activeIndex}
                 id={activePanelId}
+                labelledBy={activeTabId}
+                spotlightRef={spotlightRef}
               />
             </div>
           </div>
-          <div aria-label="Team accountability roles">
+          <div role="tablist" aria-label="Team accountability roles">
             {team.map((member, index) => (
               <TeamMemberTab
                 key={`${member.name}-${member.role}`}
                 member={member}
                 index={index}
                 isActive={index === activeIndex}
-                onSelect={() => setActiveIndex(index)}
+                onSelect={() => selectTeamMember(index, { scrollSpotlight: shouldScrollToSpotlight() })}
+                onKeyDown={(event) => handleTeamTabKeyDown(event, index)}
                 panelId={activePanelId}
+                tabId={`${componentId}-team-tab-${index}`}
               />
             ))}
           </div>

--- a/src/components/templates/AboutPage/types.ts
+++ b/src/components/templates/AboutPage/types.ts
@@ -1,3 +1,5 @@
+import type { SocialPlatform } from '@/components/molecules/SocialLink'
+
 export type AboutImage = {
   src: string
   alt: string
@@ -22,6 +24,12 @@ export type AboutTeamMember = {
   role: string
   whatWeDo: string
   image: AboutImage
+  profileLinks?: Array<{
+    href: string
+    label: string
+    newTab?: boolean
+  }>
+  socials?: Partial<Record<SocialPlatform, string>>
 }
 
 export type AboutPageProps = {

--- a/src/stories/templates/AboutPage.stories.tsx
+++ b/src/stories/templates/AboutPage.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect, waitFor, within } from 'storybook/test'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
 
 import { AboutPage, type AboutPageProps } from '@/components/templates/AboutPage/Component'
 import { getStoryImageSrc, storyClinicImages, storyPortraits } from '@/stories/fixtures/assets'
@@ -37,6 +37,8 @@ const aboutPageArgs: AboutPageProps = {
       whatWeDo:
         'Sets partner standards so commercial decisions stay transparent and aligned with responsible clinic relationships.',
       image: { src: getStoryImageSrc(storyPortraits.team.volkan), alt: 'Volkan Kablan portrait' },
+      profileLinks: [{ href: '/contact', label: 'Contact' }],
+      socials: { github: '#volkan-github', linkedin: '#volkan-linkedin' },
     },
     {
       name: 'Youssef Adlah',
@@ -61,6 +63,8 @@ const aboutPageArgs: AboutPageProps = {
       role: 'CTO',
       whatWeDo: 'Maintains the platform architecture that keeps profile signals structured, reliable, and accessible.',
       image: { src: getStoryImageSrc(storyPortraits.team.sebastian), alt: 'Sebastian Schütze portrait' },
+      profileLinks: [{ href: '/contact', label: 'Contact' }],
+      socials: { github: '#sebastian-github', linkedin: '#sebastian-linkedin' },
     },
   ],
   transparency: {
@@ -117,7 +121,7 @@ export const Default: Story = {
     await expect(canvas.getByText(/Profile claims, qualifications, reviews, prices/i)).toBeInTheDocument()
     await expect(canvas.getByText('Scattered information')).toBeInTheDocument()
     await expect(canvas.getByText('Comparison context')).toBeInTheDocument()
-    await expect(canvas.getByText('Decision boundary')).toBeInTheDocument()
+    await expect(canvas.getByRole('heading', { name: 'Decision boundary' })).toBeInTheDocument()
     expect(canvas.getAllByText(/Patients start with uncertainty\./).length).toBeGreaterThan(0)
     expect(canvas.getAllByText(/We turn trust signals into clearer decisions\./).length).toBeGreaterThan(0)
     expect(canvas.getAllByText(/A clearer path forward for patients and clinics\./).length).toBeGreaterThan(0)
@@ -143,9 +147,25 @@ export const Default: Story = {
       await waitFor(() => expect(finalLabel).toHaveAttribute('data-visible'))
       expect(Number.parseFloat(progressBar.style.width)).toBeGreaterThan(80)
     }
-    await expect(canvas.getByText(/Sets partner standards/i)).toBeInTheDocument()
-    await expect(canvas.getByText('Partner standards')).toBeInTheDocument()
+    const teamSpotlight = canvasElement.querySelector<HTMLElement>('[data-about-team-spotlight]')
+
+    expect(teamSpotlight).not.toBeNull()
+    await expect(within(teamSpotlight!).getByRole('heading', { name: 'Volkan Kablan' })).toBeInTheDocument()
+    await expect(within(teamSpotlight!).getByText(/Sets the standards for partner relationships/i)).toBeInTheDocument()
+    await expect(within(teamSpotlight!).getByRole('link', { name: 'Volkan Kablan on LinkedIn' })).toBeInTheDocument()
+    await expect(within(teamSpotlight!).getByRole('link', { name: 'Contact' })).toBeInTheDocument()
+    await expect(canvas.getByRole('button', { name: /Volkan Kablan/i })).toHaveAttribute('aria-current', 'true')
+    expect(canvas.getAllByText('Partner standards').length).toBeGreaterThan(0)
     await expect(canvas.getByText('Platform reliability')).toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('button', { name: /Sebastian Schütze/i }))
+    await waitFor(() => {
+      const activeSpotlight = canvasElement.querySelector<HTMLElement>('[data-about-team-spotlight]')
+
+      expect(activeSpotlight).not.toBeNull()
+      expect(within(activeSpotlight!).getByRole('heading', { name: 'Sebastian Schütze' })).toBeInTheDocument()
+      expect(within(activeSpotlight!).getByRole('link', { name: 'Sebastian Schütze on GitHub' })).toBeInTheDocument()
+      expect(canvas.getByRole('button', { name: /Sebastian Schütze/i })).toHaveAttribute('aria-current', 'true')
+    })
     await expect(canvas.getByText(/Clinics remain accountable/i)).toBeInTheDocument()
     await expect(canvas.getByText('Medical-advice separation')).toBeInTheDocument()
     expect(canvas.getAllByRole('link', { name: /compare clinics/i })).toHaveLength(2)

--- a/src/stories/templates/AboutPage.stories.tsx
+++ b/src/stories/templates/AboutPage.stories.tsx
@@ -154,17 +154,30 @@ export const Default: Story = {
     await expect(within(teamSpotlight!).getByText(/Sets the standards for partner relationships/i)).toBeInTheDocument()
     await expect(within(teamSpotlight!).getByRole('link', { name: 'Volkan Kablan on LinkedIn' })).toBeInTheDocument()
     await expect(within(teamSpotlight!).getByRole('link', { name: 'Contact' })).toBeInTheDocument()
-    await expect(canvas.getByRole('button', { name: /Volkan Kablan/i })).toHaveAttribute('aria-current', 'true')
+    const volkanTab = canvas.getByRole('tab', { name: /Volkan Kablan/i })
+    const sebastianTab = canvas.getByRole('tab', { name: /Sebastian Schütze/i })
+
+    await expect(canvas.getByRole('tablist', { name: /Team accountability roles/i })).toBeInTheDocument()
+    await expect(volkanTab).toHaveAttribute('aria-selected', 'true')
     expect(canvas.getAllByText('Partner standards').length).toBeGreaterThan(0)
     await expect(canvas.getByText('Platform reliability')).toBeInTheDocument()
-    await userEvent.click(canvas.getByRole('button', { name: /Sebastian Schütze/i }))
+    await userEvent.click(sebastianTab)
     await waitFor(() => {
       const activeSpotlight = canvasElement.querySelector<HTMLElement>('[data-about-team-spotlight]')
 
       expect(activeSpotlight).not.toBeNull()
       expect(within(activeSpotlight!).getByRole('heading', { name: 'Sebastian Schütze' })).toBeInTheDocument()
       expect(within(activeSpotlight!).getByRole('link', { name: 'Sebastian Schütze on GitHub' })).toBeInTheDocument()
-      expect(canvas.getByRole('button', { name: /Sebastian Schütze/i })).toHaveAttribute('aria-current', 'true')
+      expect(sebastianTab).toHaveAttribute('aria-selected', 'true')
+      expect(volkanTab).toHaveAttribute('aria-selected', 'false')
+    })
+    await userEvent.keyboard('{Home}')
+    await waitFor(() => {
+      const activeSpotlight = canvasElement.querySelector<HTMLElement>('[data-about-team-spotlight]')
+
+      expect(activeSpotlight).not.toBeNull()
+      expect(within(activeSpotlight!).getByRole('heading', { name: 'Volkan Kablan' })).toBeInTheDocument()
+      expect(volkanTab).toHaveAttribute('aria-selected', 'true')
     })
     await expect(canvas.getByText(/Clinics remain accountable/i)).toBeInTheDocument()
     await expect(canvas.getByText('Medical-advice separation')).toBeInTheDocument()

--- a/src/utilities/landing/landingPageContent.ts
+++ b/src/utilities/landing/landingPageContent.ts
@@ -85,6 +85,18 @@ type AboutTeamMember = {
   role: string
   whatWeDo: string
   image: ResolvedMediaImage
+  profileLinks?: Array<{
+    href: string
+    label: string
+    newTab?: boolean
+  }>
+  socials?: {
+    github?: string
+    instagram?: string
+    linkedin?: string
+    meta?: string
+    x?: string
+  }
 }
 
 export type HomeLandingContent = {
@@ -290,13 +302,46 @@ const normalizeTeam = (
     }
   })
 
-const normalizeAboutTeam = (team: AboutGlobal['team'] | null | undefined): AboutTeamMember[] =>
-  requireLandingArray(team, 'about.team').map((member, index) => ({
+type LandingTeamSourceMember = NonNullable<LandingPage['clinicPartners']['team']>[number]
+
+const normalizeAboutSocialHref = (
+  value: string | null | undefined,
+  allowedHosts: readonly string[],
+): string | undefined => normalizeSafeLandingHref(value, { allowedHosts })
+
+const normalizeAboutTeamSocials = (
+  socials: LandingTeamSourceMember['socials'] | null | undefined,
+): AboutTeamMember['socials'] | undefined => {
+  const normalized = {
+    github: normalizeAboutSocialHref(socials?.github, landingSocialHosts.github),
+    instagram: normalizeAboutSocialHref(socials?.instagram, landingSocialHosts.instagram),
+    linkedin: normalizeAboutSocialHref(socials?.linkedin, landingSocialHosts.linkedin),
+    meta: normalizeAboutSocialHref(socials?.meta, landingSocialHosts.meta),
+    x: normalizeAboutSocialHref(socials?.x, landingSocialHosts.x),
+  }
+
+  return Object.values(normalized).some(Boolean) ? normalized : undefined
+}
+
+const normalizeAboutTeam = (
+  team: AboutGlobal['team'] | null | undefined,
+  socialSource: LandingPage['clinicPartners']['team'] | null | undefined,
+): AboutTeamMember[] => {
+  const socialSourceByName = new Map(
+    requireLandingArray(socialSource ?? [], 'clinicPartners.team')
+      .map((member) => [member.name.trim().toLowerCase(), normalizeAboutTeamSocials(member.socials)] as const)
+      .filter((entry): entry is readonly [string, NonNullable<AboutTeamMember['socials']>] => Boolean(entry[1])),
+  )
+
+  return requireLandingArray(team, 'about.team').map((member, index) => ({
     name: member.name,
     role: member.role,
     whatWeDo: member.whatWeDo,
     image: resolveRequiredLandingImage(member.image, `about.team.${index}.image`, member.name, 'teamPortrait'),
+    profileLinks: [{ href: '/contact', label: 'Contact' }],
+    socials: socialSourceByName.get(member.name.trim().toLowerCase()),
   }))
+}
 
 const normalizeAboutTeamForLanding = (team: AboutGlobal['team'], fieldPath = 'about.team'): LandingTeamMember[] =>
   requireLandingArray(team, fieldPath).map((member, index) => {
@@ -405,7 +450,7 @@ export const normalizeAboutLandingContent = (landingPages: LandingPage) => {
       image: resolveRequiredLandingImage(hero.image, 'about.hero.image', hero.title, 'hero'),
     },
     why: normalizeAboutTextSection(about.why, 'about.why'),
-    team: normalizeAboutTeam(about.team),
+    team: normalizeAboutTeam(about.team, landingPages.clinicPartners?.team),
     transparency: normalizeAboutTextSection(about.transparency, 'about.transparency'),
   } satisfies AboutLandingContent
 }

--- a/tests/e2e/public/about.public-smoke.spec.ts
+++ b/tests/e2e/public/about.public-smoke.spec.ts
@@ -15,11 +15,11 @@ const viewportMatrix = [
 ] as const
 
 const expectedSectionOrder = [
-  /The team behind clearer clinic decisions\./,
-  /Why we exist/,
+  /The team behind clearer clinic decisions\.|About findmydoc/,
+  /Why we exist|Why findmydoc exists/,
   /findmydoc trust system scroll story/i,
   /The people accountable for the system/,
-  /What we keep transparent/,
+  /What we keep transparent|What stays transparent/,
   /Continue with clearer clinic context\./,
 ] as const
 
@@ -73,15 +73,23 @@ async function scrollTrustStoryToProgress(page: Page, progress: number) {
 }
 
 test('about page composes the trust narrative across public viewports @smoke', async ({ page }) => {
+  test.setTimeout(120_000)
+
   const issues = createBrowserIssueCollector(page)
 
   for (const viewport of viewportMatrix) {
     await page.setViewportSize({ width: viewport.width, height: viewport.height })
     await page.goto('/about', { waitUntil: 'domcontentloaded' })
 
-    await expect(page.getByRole('heading', { name: 'The team behind clearer clinic decisions.' })).toBeVisible()
-    await expect(page.getByText(/findmydoc helps patients compare clinic information with confidence/i)).toBeVisible()
-    await expect(page.getByText(/We bring clarity to clinic information/i)).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: /The team behind clearer clinic decisions\.|About findmydoc/i }),
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        /findmydoc helps patients compare clinic information with confidence|We build findmydoc so patients can compare clinic information with more context/i,
+      ),
+    ).toBeVisible()
+    await expect(page.getByText(/We bring clarity to clinic information|Profile claims, qualifications/i)).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Scattered information' })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Comparison context' })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Decision boundary' })).toBeVisible()
@@ -107,16 +115,29 @@ test('about page composes the trust narrative across public viewports @smoke', a
     await expect(teamSpotlight.getByText(/Sets the standards for partner relationships/i)).toBeVisible()
     await expect(teamSpotlight.getByRole('link', { name: 'Volkan Kablan on LinkedIn' })).toBeVisible()
     await expect(teamSpotlight.getByRole('link', { name: 'Contact' })).toHaveAttribute('href', '/contact')
-    await expect(page.getByRole('button', { name: /Volkan Kablan/i })).toHaveAttribute('aria-current', 'true')
+    const volkanTab = page.getByRole('tab', { name: /Volkan Kablan/i })
+    const sebastianTab = page.getByRole('tab', { name: /Sebastian Schütze/i })
+
+    await expect(page.getByRole('tablist', { name: /Team accountability roles/i })).toBeVisible()
+    await expect(volkanTab).toHaveAttribute('aria-selected', 'true')
     await expect(page.getByText('Platform reliability')).toBeVisible()
-    await page.getByRole('button', { name: /Sebastian Schütze/i }).click()
+    await sebastianTab.click()
+    if (viewport.width < 1024) {
+      await expect(teamSpotlight).toBeInViewport({ ratio: 0.2 })
+    }
     await expect(teamSpotlight.getByRole('heading', { name: 'Sebastian Schütze' })).toBeVisible()
     await expect(teamSpotlight.getByText(/structured, available, and reliable/i)).toBeVisible()
     await expect(teamSpotlight.getByRole('link', { name: 'Sebastian Schütze on GitHub' })).toBeVisible()
-    await expect(page.getByRole('button', { name: /Sebastian Schütze/i })).toHaveAttribute('aria-current', 'true')
+    await expect(sebastianTab).toHaveAttribute('aria-selected', 'true')
+    await expect(volkanTab).toHaveAttribute('aria-selected', 'false')
+    await sebastianTab.press('Home')
+    await expect(volkanTab).toHaveAttribute('aria-selected', 'true')
+    await volkanTab.press('End')
+    await expect(sebastianTab).toHaveAttribute('aria-selected', 'true')
+    await expect(teamSpotlight.getByRole('heading', { name: 'Sebastian Schütze' })).toBeVisible()
     await expectNoHorizontalOverflow(page, `${viewport.name} team spotlight`)
 
-    const transparencyHeading = page.getByRole('heading', { name: 'What we keep transparent' })
+    const transparencyHeading = page.getByRole('heading', { name: /What we keep transparent|What stays transparent/i })
     await transparencyHeading.scrollIntoViewIfNeeded()
     await expect(transparencyHeading).toBeVisible()
     await expect(page.getByText(/Patients contact clinics directly/i)).toBeVisible()

--- a/tests/e2e/public/about.public-smoke.spec.ts
+++ b/tests/e2e/public/about.public-smoke.spec.ts
@@ -15,11 +15,11 @@ const viewportMatrix = [
 ] as const
 
 const expectedSectionOrder = [
-  /About findmydoc/,
-  /Why findmydoc exists/,
+  /The team behind clearer clinic decisions\./,
+  /Why we exist/,
   /findmydoc trust system scroll story/i,
   /The people accountable for the system/,
-  /What stays transparent/,
+  /What we keep transparent/,
   /Continue with clearer clinic context\./,
 ] as const
 
@@ -79,8 +79,9 @@ test('about page composes the trust narrative across public viewports @smoke', a
     await page.setViewportSize({ width: viewport.width, height: viewport.height })
     await page.goto('/about', { waitUntil: 'domcontentloaded' })
 
-    await expect(page.getByRole('heading', { name: 'About findmydoc' })).toBeVisible()
-    await expect(page.getByText(/Profile claims, qualifications, reviews, prices/i)).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'The team behind clearer clinic decisions.' })).toBeVisible()
+    await expect(page.getByText(/findmydoc helps patients compare clinic information with confidence/i)).toBeVisible()
+    await expect(page.getByText(/We bring clarity to clinic information/i)).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Scattered information' })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Comparison context' })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Decision boundary' })).toBeVisible()
@@ -101,13 +102,24 @@ test('about page composes the trust narrative across public viewports @smoke', a
     const teamHeading = page.getByRole('heading', { name: 'The people accountable for the system' })
     await teamHeading.scrollIntoViewIfNeeded()
     await expect(teamHeading).toBeVisible()
-    await expect(page.getByText(/Sets partner standards/i)).toBeVisible()
+    const teamSpotlight = page.locator('[data-about-team-spotlight]')
+    await expect(teamSpotlight.getByRole('heading', { name: 'Volkan Kablan' })).toBeVisible()
+    await expect(teamSpotlight.getByText(/Sets the standards for partner relationships/i)).toBeVisible()
+    await expect(teamSpotlight.getByRole('link', { name: 'Volkan Kablan on LinkedIn' })).toBeVisible()
+    await expect(teamSpotlight.getByRole('link', { name: 'Contact' })).toHaveAttribute('href', '/contact')
+    await expect(page.getByRole('button', { name: /Volkan Kablan/i })).toHaveAttribute('aria-current', 'true')
     await expect(page.getByText('Platform reliability')).toBeVisible()
+    await page.getByRole('button', { name: /Sebastian Schütze/i }).click()
+    await expect(teamSpotlight.getByRole('heading', { name: 'Sebastian Schütze' })).toBeVisible()
+    await expect(teamSpotlight.getByText(/structured, available, and reliable/i)).toBeVisible()
+    await expect(teamSpotlight.getByRole('link', { name: 'Sebastian Schütze on GitHub' })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Sebastian Schütze/i })).toHaveAttribute('aria-current', 'true')
+    await expectNoHorizontalOverflow(page, `${viewport.name} team spotlight`)
 
-    const transparencyHeading = page.getByRole('heading', { name: 'What stays transparent' })
+    const transparencyHeading = page.getByRole('heading', { name: 'What we keep transparent' })
     await transparencyHeading.scrollIntoViewIfNeeded()
     await expect(transparencyHeading).toBeVisible()
-    await expect(page.getByText(/Comparison context stays separate from medical advice/i)).toBeVisible()
+    await expect(page.getByText(/Patients contact clinics directly/i)).toBeVisible()
     await expect(page.getByText('Medical-advice separation')).toBeVisible()
 
     const closingHeading = page.getByRole('heading', { name: 'Continue with clearer clinic context.' })


### PR DESCRIPTION
## Management summary

### Deutsch

Der Team-Bereich der About-Seite wird klarer und nutzbarer: Ein groesseres aktives Profil zeigt Bild, Rolle, Verantwortung und Kontaktmoeglichkeiten, waehrend die anderen Partner rechts als anklickbare Auswahl sichtbar bleiben. Die nachgelagerten Review-Fixes verbessern Tastaturbedienung, Semantik und mobile Orientierung, ohne das ruhige Grunddesign zu veraendern.

### English

The About page team section is clearer and easier to use: a larger active profile shows the portrait, role, accountability details, and contact options, while the other partners remain visible on the right as clickable choices. The follow-up review fixes improve keyboard operation, semantics, and mobile orientation without changing the calm visual direction.

## What changed

- Replaced the static team list with a client-side team spotlight selector.
- Added a larger active profile area with portrait, role, accountability rows, and profile/contact links.
- Added a right-side selector rail using the maximum practical right-column share for the current layout.
- Added hover/active affordances without introducing heavy visual controls: inactive rows get pointer behavior and hover accenting; the active row keeps the accent atom.
- Converted the selector to tablist/tab/tabpanel semantics with `aria-selected`, roving tab focus, arrow/Home/End keyboard support, and focus handoff to the changed detail panel.
- Removed the hidden eager preload block after review; the active image now fades in after load and no longer remounts the whole spotlight panel on each selection.
- Kept mobile selection usable by scrolling the changed detail panel back into view after selecting a partner below the spotlight.
- Extended the About-page content normalization to pass team profile links and social links through to the component.
- Updated Storybook and public smoke coverage for click, keyboard, mobile, and selected-state behavior.

## Points to review

| Priority | Files / paths                                           | Why focus here                                         | Reviewer should verify                                                               | Evidence                                                             |
| -------- | ------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
| P2       | `src/components/templates/AboutPage/AccountabilitySection.tsx` | Main UI and interaction change for the team spotlight. | Active/hover states, keyboard tab behavior, image loading, and responsive layout.     | `pnpm check`, `pnpm build`, Storybook test, Playwright screenshot QA |
| P2       | `src/utilities/landing/landingPageContent.ts`           | Maps source team data into the profile/social shape.   | Existing team content still renders correctly and missing social links stay safe.     | `pnpm check`, `pnpm build`                                           |
| P2       | `tests/e2e/public/about.public-smoke.spec.ts`           | Public smoke coverage changed with the selector pattern. | Test remains behavior-oriented and covers selected-state and keyboard behavior.       | `pnpm check`, Storybook test, Playwright public smoke                |

## Validation

- [x] `pnpm format`: `npx --yes pnpm@10.28.2 format`
- [x] `pnpm check`: `npx --yes pnpm@10.28.2 check`
- [x] `pnpm build`: `PAYLOAD_SECRET=${PAYLOAD_SECRET:-dev-secret} npx --yes pnpm@10.28.2 build`
- [x] Focused tests: `npx --yes pnpm@10.28.2 exec vitest run --project storybook src/stories/templates/AboutPage.stories.tsx` (`16` tests passed)
- [x] Focused public smoke: `npx --yes pnpm@10.28.2 exec playwright test tests/e2e/public/about.public-smoke.spec.ts --project public-smoke` (`2` tests passed)
- [x] UI/mobile QA: Verified desktop and mobile selector states with Playwright screenshots, including active profile switching, tab selected state, mobile scroll-back to the detail panel, and no horizontal overflow. GitHub screenshot upload was skipped because the web upload session was expired.
- [ ] Security/privacy review: Not applicable; no auth, privacy, logging, access-control, or server trust-boundary changes.
- [ ] Migration/schema check: Not applicable; no Payload schema, database, or migration changes.
- [ ] Documentation/instructions check: Not applicable; no documentation or instruction-surface changes.

## Risk and rollout

Moderate visual risk because this changes a prominent About-page section and adds client-side profile switching. No data, environment, schema, or migration changes are required. Rollback is the single commit revert.

## Development

Closes #1425
