### PR TITLE
test: validate turbopack rollback readiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "type": "module",
   "scripts": {
-    "build": "cross-env NODE_OPTIONS=--no-deprecation next build --webpack",
+    "build": "cross-env NODE_OPTIONS=--no-deprecation next build",
     "postbuild": "next-sitemap --config next-sitemap.config.cjs",
     "prepare": "node scripts/setup-hooks.mjs",
     "dev": "cross-env NODE_OPTIONS=\"${NODE_OPTIONS} --no-deprecation\" next dev",


### PR DESCRIPTION
## Management summary

### Deutsch

Dieser Readiness-Test zeigt: Der Turbopack-Rollback ist mit dem aktuellen Stand noch nicht bereit. Der Preview-Build mit `Next.js 16.2.9 (Turbopack)` läuft zwar durch, aber zentrale Admin- und Registrierungsrouten brechen in der Runtime mit einem `sharp`/`libvips`-Ladefehler. Der bestehende `--webpack`-Fallback bleibt deshalb die richtige Produktionsabsicherung.

### English

This readiness test shows that the Turbopack rollback is not ready on the current codebase. The Preview build with `Next.js 16.2.9 (Turbopack)` completes, but key admin and registration routes fail at runtime with a `sharp`/`libvips` loading error. The existing `--webpack` fallback therefore remains the right production safeguard.

## What changed

- Removes the explicit `--webpack` build override so `next build` uses the current Next.js default bundler.
- Keeps the change intentionally narrow as rollback-readiness evidence for #777.
- Leaves the deployment runbook unchanged because the Preview validation did not pass.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `package.json` build script | This changes the Vercel build bundler from webpack override to the Next.js default Turbopack path. | This Draft PR is failed evidence only and must not become the production rollback as-is. | Local build, PR Preview build, route smoke, Vercel runtime logs |

## Validation

- [x] Network preflight: `gh auth status`, `gh api rate_limit`, `vercel whoami`, and `vercel project inspect findmydoc-portal --scope findmydoc` passed.
- [x] `pnpm format`: Passed locally with pnpm 10.28.2.
- [x] `pnpm check`: Passed locally after removing stale local `.next` type artifacts.
- [x] `pnpm build`: Passed locally with `PAYLOAD_SECRET=dev-secret`; output showed `Next.js 16.2.9 (Turbopack)`.
- [x] Deploy Preview: Succeeded for `https://findmydoc-portal-jufyrqltf-findmydoc.vercel.app` / `dpl_DqnScLL2uoejyRN4NFoHDNudCLd5`; build log showed `next build` and `Next.js 16.2.9 (Turbopack)`.
- [ ] Focused tests: Failed. Route smoke returned `500` for `GET /admin/login`, `500` for `GET /admin`, `500` for invalid `POST /api/auth/register/patient`, and `500` for invalid `POST /api/auth/register/clinic`. `POST /api/auth/login` and `POST /api/auth/password/reset` returned expected `400`; `HEAD /api/auth/register/first-admin` returned expected `404`.
- [x] Runtime log marker check: No log hits for `An error occurred while loading the instrumentation hook` or `ERR_REQUIRE_ESM` in the test window.
- [ ] Runtime error log check: Failed. Vercel runtime logs recorded `ERR_DLOPEN_FAILED: libvips-cpp.so.8.18.3: cannot open shared object file` while loading `sharp` from `[turbopack]_runtime.js`.
- [ ] UI/mobile QA: Not applicable; no UI change.
- [ ] Security/privacy review: Not run; this PR is failed readiness evidence, not a merge candidate.
- [ ] Migration/schema check: Not applicable; no schema or migration change.
- [ ] Documentation/instructions check: Runbook update intentionally skipped because the Preview validation failed.

## Risk and rollout

This Draft PR is failed rollback-readiness evidence only. Do not merge it as a production rollback. The `--webpack` fallback remains until a follow-up isolates the Turbopack `sharp`/`libvips` runtime packaging failure and a new Preview smoke passes cleanly.

The `Development` section intentionally uses `Refs #777` rather than `Closes #777`, so the linked-issue gate can remain red while this is only a test PR.

## Development

Refs #777
