### PR TITLE
fix: refresh media derivatives and caches

### DIFF
--- a/.github/scripts/ci/detect-migration-diff.sh
+++ b/.github/scripts/ci/detect-migration-diff.sh
@@ -53,6 +53,8 @@ schema_pattern='^(src/collections/|src/globals/|src/fields/|src/plugins/|src/pay
 migration_pattern='^src/migrations/'
 db_tooling_pattern='^(\.github/workflows/db-quality\.yml|\.github/workflows/deploy\.yml|\.github/scripts/ci/(detect-migration-diff|enforce-schema-migration|wait-for-postgres)\.sh|scripts/(migration-risk-scan|test-database-harness)\.mjs|vitest\.config\.ts)$'
 import_export_allowlist_line_regex="^[+-][[:space:]]*\\{[[:space:]]*slug:[[:space:]]*'[^']+'(,[[:space:]]*(import|export):[[:space:]]*false)?[[:space:]]*\\},?[[:space:]]*$"
+hook_only_collection_line_regex="^[+-][[:space:]]*(import[[:space:]]*\\{|import[[:space:]].*from[[:space:]]'@/hooks/[^']+'|\\}[[:space:]]*from[[:space:]]'@/hooks/[^']+'|[[:space:]]*((afterChange|afterDelete):[[:space:]]*\\[)?(beforeOperationPrepareUploadFilename|revalidateDeletedPlatformContentMediaConsumers|revalidatePlatformContentMediaConsumers)\\]?,?|\\{|\\})[[:space:]]*$"
+collection_crypto_import_line_regex="^[+-][[:space:]]*import[[:space:]]*\\{[[:space:]]*randomUUID[[:space:]]*\\}[[:space:]]*from[[:space:]]*'(node:)?crypto'[[:space:]]*$"
 
 schema_changed=false
 migrations_changed=false
@@ -88,10 +90,63 @@ is_import_export_plugin_allowlist_only_change() {
   return 0
 }
 
+is_hook_only_collection_change() {
+  local file_path="$1"
+  local diff
+  local diff_line
+
+  if ! diff="$(git diff --unified=0 --diff-filter=ACMR "${effective_range}" -- "${file_path}")"; then
+    return 1
+  fi
+
+  if [[ -z "${diff}" ]]; then
+    return 1
+  fi
+
+  while IFS= read -r diff_line; do
+    case "${diff_line}" in
+      'diff --git'* | 'index '* | '--- '* | '+++ '* | '@@'*)
+        continue
+        ;;
+    esac
+
+    if [[ "${diff_line}" == +* || "${diff_line}" == -* ]]; then
+      if [[ ! "${diff_line}" =~ ${hook_only_collection_line_regex} && ! "${diff_line}" =~ ${collection_crypto_import_line_regex} ]]; then
+        return 1
+      fi
+    fi
+  done <<<"${diff}"
+
+  return 0
+}
+
 schema_changed_files="$(grep -E "${schema_pattern}" <<<"${changed_files}" || true)"
 
 if grep -qx 'src/plugins/index.ts' <<<"${schema_changed_files}" && is_import_export_plugin_allowlist_only_change; then
   schema_changed_files="$(grep -vx 'src/plugins/index.ts' <<<"${schema_changed_files}" || true)"
+fi
+
+if [[ -n "${schema_changed_files}" ]]; then
+  hook_only_schema_changed_files=''
+  while IFS= read -r schema_file; do
+    if [[ -z "${schema_file}" ]]; then
+      continue
+    fi
+
+    if [[ "${schema_file}" =~ ^src/collections/ ]] && is_hook_only_collection_change "${schema_file}"; then
+      continue
+    fi
+
+    hook_only_schema_changed_files+="${schema_file}"$'\n'
+  done <<<"${schema_changed_files}"
+  schema_changed_files="${hook_only_schema_changed_files}"
+fi
+
+if [[ -n "${schema_changed_files}" ]]; then
+  echo "Schema-relevant files after allowlists:"
+  echo "${schema_changed_files}"
+else
+  echo "No schema-relevant files after allowlists."
 fi
 
 if [[ -n "${schema_changed_files}" ]]; then

--- a/src/app/api/clinic-contact-requests/route.ts
+++ b/src/app/api/clinic-contact-requests/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import configPromise from '@payload-config'
+import { createHash } from 'crypto'
 import { getPayload } from 'payload'
 import { z } from 'zod'
-import { createHash } from 'node:crypto'
 
 import {
   patientClinicInquiryContactWindowValues,

--- a/src/blocks/Content/Component.tsx
+++ b/src/blocks/Content/Component.tsx
@@ -5,6 +5,7 @@ import type { ContentColumn, ContentImage } from '@/components/organisms/Content
 import RichText from '@/blocks/_shared/RichText'
 import { isRecord, resolveHrefFromCMSLink } from '@/blocks/_shared/utils'
 import type { ContentLocaleContext } from '@/utilities/contentLocalization'
+import { versionPayloadMediaFileUrl } from '@/utilities/media/fileUrls'
 
 function pickImageSrc(m?: PlatformContentMedia | number | string | null, preferredSize?: string): ContentImage {
   if (!m || typeof m === 'number' || typeof m === 'string') {
@@ -17,7 +18,8 @@ function pickImageSrc(m?: PlatformContentMedia | number | string | null, preferr
   >
   const sizeKey = preferredSize && sizesRecord?.[preferredSize] ? preferredSize : undefined
   const chosen = sizeKey ? sizesRecord[sizeKey] : undefined
-  const src = (chosen?.url ?? m.url) || undefined
+  const rawSrc = (chosen?.url ?? m.url) || undefined
+  const src = rawSrc ? versionPayloadMediaFileUrl(rawSrc, m.updatedAt) : undefined
   const width = chosen?.width ?? m.width ?? undefined
   const height = chosen?.height ?? m.height ?? undefined
   return { src, width, height, alt: m.alt ?? '' }

--- a/src/blocks/MediaBlock/Component.tsx
+++ b/src/blocks/MediaBlock/Component.tsx
@@ -4,6 +4,7 @@ import type { MediaBlock as MediaBlockPayload, PlatformContentMedia } from '@/pa
 import { MediaBlock as MediaBlockOrganism } from '@/components/organisms/MediaBlock'
 import RichText from '@/blocks/_shared/RichText'
 import type { ContentLocaleContext } from '@/utilities/contentLocalization'
+import { versionPayloadMediaFileUrl } from '@/utilities/media/fileUrls'
 import { resolveMediaImage } from '@/utilities/media/resolveMediaImage'
 
 type Props = MediaBlockPayload & {
@@ -41,7 +42,7 @@ export const MediaBlockComponent: React.FC<Props> = (props) => {
   if (media && typeof media === 'object') {
     const m = media as PlatformContentMedia
     if (m.mimeType?.includes('video')) {
-      src = m.url || undefined
+      src = m.url ? versionPayloadMediaFileUrl(m.url, m.updatedAt) : undefined
       width = m.width || undefined
       height = m.height || undefined
       alt = m.alt || undefined

--- a/src/collections/ClinicGalleryMedia/index.ts
+++ b/src/collections/ClinicGalleryMedia/index.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from 'payload'
+import { randomUUID } from 'crypto'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { randomUUID } from 'node:crypto'
 
 import { clinicGalleryReadAccess, clinicGalleryScopedMutationAccess } from '@/access/clinicGallery'
 import { platformOrAssignedClinicMutation } from '@/access/scopeFilters'
@@ -12,6 +12,7 @@ import { beforeChangeCreatedBy } from '@/hooks/createdBy'
 import { beforeChangeComputeStorage } from '@/hooks/media/computeStorage'
 import { beforeChangePublishedAt } from '@/hooks/publishedAt'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
+import { beforeOperationPrepareUploadFilename } from '@/hooks/media/prepareUploadFilename'
 import {
   buildMediaAltField,
   buildMediaCaptionField,
@@ -71,6 +72,7 @@ export const ClinicGalleryMedia: CollectionConfig = {
       }),
     ],
     beforeOperation: [
+      beforeOperationPrepareUploadFilename,
       beforeOperationCaptureMediaUpload({
         ownerField: 'clinic',
         storagePrefix: 'clinics-gallery',

--- a/src/collections/ClinicMedia/index.ts
+++ b/src/collections/ClinicMedia/index.ts
@@ -9,6 +9,7 @@ import { beforeChangeFreezeRelation } from '@/hooks/ownership'
 import { beforeChangeCreatedBy } from '@/hooks/createdBy'
 import { beforeChangeComputeStorage } from '@/hooks/media/computeStorage'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
+import { beforeOperationPrepareUploadFilename } from '@/hooks/media/prepareUploadFilename'
 import { stableIdBeforeChangeHook, stableIdField } from '@/collections/common/stableIdField'
 import {
   buildMediaAltField,
@@ -53,6 +54,7 @@ export const ClinicMedia: CollectionConfig = {
       }),
     ],
     beforeOperation: [
+      beforeOperationPrepareUploadFilename,
       beforeOperationCaptureMediaUpload({
         ownerField: 'clinic',
         storagePrefix: 'clinics',

--- a/src/collections/DoctorMedia/index.ts
+++ b/src/collections/DoctorMedia/index.ts
@@ -13,6 +13,7 @@ import { stableIdBeforeChangeHook, stableIdField } from '@/collections/common/st
 import { beforeChangeDoctorMedia } from './hooks/beforeChangeDoctorMedia'
 import type { DoctorMedia as DoctorMediaType } from '@/payload-types'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
+import { beforeOperationPrepareUploadFilename } from '@/hooks/media/prepareUploadFilename'
 import {
   buildMediaAltField,
   buildMediaCaptionField,
@@ -66,6 +67,7 @@ export const DoctorMedia: CollectionConfig = {
     afterError: [afterErrorLogMediaUploadError],
     beforeChange: [stableIdBeforeChangeHook, beforeChangeDoctorMedia],
     beforeOperation: [
+      beforeOperationPrepareUploadFilename,
       beforeOperationCaptureMediaUpload({
         ownerField: 'doctor',
         storagePrefix: 'doctors',

--- a/src/collections/PlatformContentMedia/index.ts
+++ b/src/collections/PlatformContentMedia/index.ts
@@ -15,6 +15,11 @@ import {
   buildMediaUploadConfig,
 } from '@/collections/common/mediaCollection'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
+import { beforeOperationPrepareUploadFilename } from '@/hooks/media/prepareUploadFilename'
+import {
+  revalidateDeletedPlatformContentMediaConsumers,
+  revalidatePlatformContentMediaConsumers,
+} from '@/hooks/media/revalidateMediaConsumers'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -34,9 +39,12 @@ export const PlatformContentMedia: CollectionConfig = {
   },
   trash: true,
   hooks: {
+    afterChange: [revalidatePlatformContentMediaConsumers],
+    afterDelete: [revalidateDeletedPlatformContentMediaConsumers],
     afterError: [afterErrorLogMediaUploadError],
     beforeChange: [stableIdBeforeChangeHook, beforeChangePlatformContentMedia],
     beforeOperation: [
+      beforeOperationPrepareUploadFilename,
       beforeOperationCaptureMediaUpload({
         storagePrefix: 'platform',
       }),

--- a/src/collections/UserProfileMedia/index.ts
+++ b/src/collections/UserProfileMedia/index.ts
@@ -6,6 +6,7 @@ import { isPlatformBasicUser } from '@/access/isPlatformBasicUser'
 import { stableIdBeforeChangeHook, stableIdField } from '@/collections/common/stableIdField'
 import { beforeChangeComputeStorage } from '@/hooks/media/computeStorage'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
+import { beforeOperationPrepareUploadFilename } from '@/hooks/media/prepareUploadFilename'
 import { beforeChangeFreezeRelation } from '@/hooks/ownership'
 import type { UserProfileMedia as UserProfileMediaType } from '@/payload-types'
 import {
@@ -188,6 +189,7 @@ export const UserProfileMedia: CollectionConfig = {
       }),
     ],
     beforeOperation: [
+      beforeOperationPrepareUploadFilename,
       beforeOperationCaptureMediaUpload({
         ownerField: 'user',
         storagePrefix: 'users',

--- a/src/endpoints/seed/seedEndpoint.ts
+++ b/src/endpoints/seed/seedEndpoint.ts
@@ -1,5 +1,9 @@
 import type { PayloadRequest } from 'payload'
 import { revalidatePath, revalidateTag } from 'next/cache.js'
+import {
+  PLATFORM_CONTENT_MEDIA_LANDING_PATHS,
+  PLATFORM_CONTENT_MEDIA_LANDING_TAGS,
+} from '@/hooks/media/revalidateMediaConsumers'
 import { assertSeedRunPolicy, isSeedEndpointPostEnabled, resolveSeedRuntimeEnv, type SeedType } from './utils/runtime'
 import { buildSeedQueueJobs, getSeedQueueName } from './utils/planner'
 import { formatSeedRetryTitle, formatSeedRunTitle, formatSeedJobTitle } from './utils/labels'
@@ -41,7 +45,12 @@ const isPlatformSeedUser = (req: PayloadRequest): boolean => {
 }
 
 const revalidateSeedGlobals = (req: PayloadRequest) => {
-  const tags = ['global_header', 'global_footer', 'global_cookieConsent', 'global_landingPages'] as const
+  const tags = [
+    'global_header',
+    'global_footer',
+    'global_cookieConsent',
+    ...PLATFORM_CONTENT_MEDIA_LANDING_TAGS,
+  ] as const
 
   for (const tag of tags) {
     try {
@@ -53,9 +62,7 @@ const revalidateSeedGlobals = (req: PayloadRequest) => {
     }
   }
 
-  const paths = ['/', '/about', '/partners/clinics'] as const
-
-  for (const path of paths) {
+  for (const path of PLATFORM_CONTENT_MEDIA_LANDING_PATHS) {
     try {
       revalidatePath(path)
       req.payload.logger.info(`Revalidated seed path: ${path}`)

--- a/src/endpoints/seed/utils/upsert.ts
+++ b/src/endpoints/seed/utils/upsert.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from 'crypto'
 import fs from 'fs'
 import path from 'path'
 import type { CollectionSlug, Payload, PayloadRequest } from 'payload'
+import { prepareUploadFilenameFromFilePathSync } from '@/hooks/media/prepareUploadFilename'
 
 export type UpsertResult = { created: boolean; updated: boolean }
 
@@ -254,7 +255,7 @@ function derivePlatformSeedStoragePath(filePath: string): string | null {
     return null
   }
 
-  const baseFilename = path.basename(filePath).replace(/[\\/]/g, '_')
+  const baseFilename = prepareUploadFilenameFromFilePathSync(filePath) ?? path.basename(filePath).replace(/[\\/]/g, '_')
   if (!baseFilename) return null
 
   const hashInput = `platform:${baseFilename}${size ? `:${size}` : ''}`
@@ -281,7 +282,11 @@ function shouldClearPlatformSeedUploadTargetsBeforeUpdate(options: {
   if (expectedStoragePath === currentStoragePath) return true
 
   const baseFilename = deriveSeedBaseFilename(filePath)
-  return Boolean(baseFilename && currentStoragePath.endsWith(`-${baseFilename}`))
+  const preparedBaseFilename = prepareUploadFilenameFromFilePathSync(filePath)
+  return Boolean(
+    (baseFilename && currentStoragePath.endsWith(`-${baseFilename}`)) ||
+    (preparedBaseFilename && currentStoragePath.endsWith(`-${preparedBaseFilename}`)),
+  )
 }
 
 async function clearUploadDeletionTargetsBeforeUpdate(options: {

--- a/src/hooks/media/computeStorage.ts
+++ b/src/hooks/media/computeStorage.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto'
+import { createHash } from 'crypto'
 import {
   buildNestedFilename,
   buildStoragePath,
@@ -16,7 +16,7 @@ import type { CollectionBeforeChangeHook, PayloadRequest } from 'payload'
  * Returns a short deterministic hash used when storage keys must be derived.
  */
 function shortHash(input: string): string {
-  return crypto.createHash('sha1').update(input).digest('hex').slice(0, 10)
+  return createHash('sha1').update(input).digest('hex').slice(0, 10)
 }
 
 /**

--- a/src/hooks/media/prepareUploadFilename.ts
+++ b/src/hooks/media/prepareUploadFilename.ts
@@ -1,0 +1,186 @@
+import { createHash } from 'crypto'
+import fs from 'fs/promises'
+import fsSync from 'fs'
+import path from 'path'
+import type { CollectionBeforeOperationHook, PayloadRequest } from 'payload'
+
+import { getIncomingUploadFilename } from '@/collections/common/mediaPathHelpers'
+
+const FILENAME_PROPS = ['name', 'originalname', 'originalFilename', 'filename'] as const
+const PREPARED_UPLOAD_FILENAME_CONTEXT_KEY = 'mediaPreparedUploadFilename'
+
+type UploadFileLike = Record<string, unknown>
+
+function shortHash(input: Buffer | string): string {
+  return createHash('sha1').update(input).digest('hex').slice(0, 10)
+}
+
+function normalizeUploadedFilename(filename: string): string | null {
+  const normalizedPath = filename.replace(/\\/g, '/')
+  const base = path.posix.basename(normalizedPath).trim()
+  return base.length > 0 ? base : null
+}
+
+function splitFilename(filename: string): { stem: string; extension: string } {
+  const extension = path.extname(filename)
+  const stem = extension ? filename.slice(0, -extension.length) : filename
+
+  return {
+    stem: stem || filename,
+    extension,
+  }
+}
+
+function readFilenameCandidate(file: UploadFileLike | null): string | null {
+  if (!file) return null
+
+  for (const prop of FILENAME_PROPS) {
+    const value = file[prop]
+    if (typeof value !== 'string') continue
+    const trimmed = value.trim()
+    if (trimmed.length > 0) return trimmed
+  }
+
+  return null
+}
+
+function readUploadFileSize(file: UploadFileLike | null): number | undefined {
+  if (!file) return undefined
+  const size = file.size
+  return typeof size === 'number' && Number.isFinite(size) ? size : undefined
+}
+
+async function readUploadFileBuffer(file: UploadFileLike | null): Promise<Buffer | null> {
+  if (!file) return null
+
+  const data = file.data
+  if (Buffer.isBuffer(data)) return data
+  if (data instanceof Uint8Array) return Buffer.from(data)
+
+  const tempFilePath = file.tempFilePath
+  if (typeof tempFilePath === 'string' && tempFilePath.trim().length > 0) {
+    try {
+      return await fs.readFile(tempFilePath)
+    } catch {
+      return null
+    }
+  }
+
+  return null
+}
+
+function findUploadFiles(value: unknown): UploadFileLike[] {
+  if (!value) return []
+
+  if (Array.isArray(value)) {
+    return value.flatMap(findUploadFiles)
+  }
+
+  if (typeof value !== 'object') return []
+
+  const objectValue = value as UploadFileLike
+  if (readFilenameCandidate(objectValue)) return [objectValue]
+
+  return Object.values(objectValue).flatMap(findUploadFiles)
+}
+
+function getUploadFiles(args: Record<string, unknown> | undefined, req: PayloadRequest): UploadFileLike[] {
+  const files = [
+    ...findUploadFiles((req as unknown as Record<string, unknown>).file),
+    ...findUploadFiles((req as unknown as Record<string, unknown>).files),
+    ...findUploadFiles(args?.file),
+    ...findUploadFiles(args?.files),
+  ]
+
+  const deduped: UploadFileLike[] = []
+  const seen = new Set<UploadFileLike>()
+
+  for (const file of files) {
+    if (seen.has(file)) continue
+    seen.add(file)
+    deduped.push(file)
+  }
+
+  return deduped
+}
+
+function writePreparedFilename(file: UploadFileLike, filename: string): void {
+  for (const prop of FILENAME_PROPS) {
+    if (prop in file || prop === 'name') {
+      file[prop] = filename
+    }
+  }
+}
+
+export function buildPreparedUploadFilename({ filename, hash }: { filename: string; hash: string }): string | null {
+  const normalized = normalizeUploadedFilename(filename)
+  if (!normalized) return null
+
+  const { stem, extension } = splitFilename(normalized)
+  return `${hash}-${stem}${extension}`
+}
+
+export function prepareUploadFilenameFromBuffer({
+  filename,
+  buffer,
+}: {
+  filename: string
+  buffer: Buffer
+}): string | null {
+  return buildPreparedUploadFilename({
+    filename,
+    hash: shortHash(buffer),
+  })
+}
+
+export function prepareUploadFilenameFromFilePathSync(filePath: string): string | null {
+  try {
+    const buffer = fsSync.readFileSync(filePath)
+    return prepareUploadFilenameFromBuffer({
+      filename: path.basename(filePath),
+      buffer,
+    })
+  } catch {
+    return null
+  }
+}
+
+async function prepareUploadFile(file: UploadFileLike, fallbackFilename: string | null): Promise<string | null> {
+  const filename = readFilenameCandidate(file) ?? fallbackFilename
+  if (!filename) return null
+
+  const buffer = await readUploadFileBuffer(file)
+  const fileSize = readUploadFileSize(file)
+  const hash = buffer ? shortHash(buffer) : shortHash(`${filename}:${fileSize ?? ''}`)
+  const preparedFilename = buildPreparedUploadFilename({ filename, hash })
+  if (!preparedFilename) return null
+
+  writePreparedFilename(file, preparedFilename)
+  return preparedFilename
+}
+
+export const beforeOperationPrepareUploadFilename: CollectionBeforeOperationHook = async ({ args, operation, req }) => {
+  if (operation !== 'create' && operation !== 'update') return args
+
+  const recordArgs = args as Record<string, unknown> | undefined
+  const uploadFiles = getUploadFiles(recordArgs, req)
+  const fallbackFilename =
+    getIncomingUploadFilename(recordArgs ?? null) ??
+    getIncomingUploadFilename(req as unknown as Record<string, unknown>)
+
+  if (uploadFiles.length === 0) return args
+
+  req.context = req.context ?? {}
+  const preparedNames: string[] = []
+
+  for (const file of uploadFiles) {
+    const prepared = await prepareUploadFile(file, fallbackFilename)
+    if (prepared) preparedNames.push(prepared)
+  }
+
+  if (preparedNames.length > 0) {
+    req.context[PREPARED_UPLOAD_FILENAME_CONTEXT_KEY] = preparedNames[0]
+  }
+
+  return args
+}

--- a/src/hooks/media/revalidateMediaConsumers.ts
+++ b/src/hooks/media/revalidateMediaConsumers.ts
@@ -1,0 +1,131 @@
+import { revalidatePath, revalidateTag } from 'next/cache.js'
+import type { CollectionAfterChangeHook, CollectionAfterDeleteHook, PayloadRequest } from 'payload'
+
+export const PLATFORM_CONTENT_MEDIA_LANDING_TAGS = ['global_landingPages', 'pages-sitemap'] as const
+export const PLATFORM_CONTENT_MEDIA_LANDING_PATHS = ['/', '/about', '/partners/clinics'] as const
+
+const POSTS_PER_PAGE = 12
+const REVALIDATE_SLUG_PAGE_SIZE = 100
+
+type SlugDoc = {
+  slug?: unknown
+}
+
+const isSlugDoc = (doc: unknown): doc is { slug: string } =>
+  Boolean(doc && typeof doc === 'object' && typeof (doc as SlugDoc).slug === 'string')
+
+const revalidateLandingConsumers = (): void => {
+  for (const tag of PLATFORM_CONTENT_MEDIA_LANDING_TAGS) {
+    revalidateTag(tag, { expire: 0 })
+  }
+
+  for (const path of PLATFORM_CONTENT_MEDIA_LANDING_PATHS) {
+    revalidatePath(path)
+  }
+}
+
+async function findPublishedSlugs(req: PayloadRequest, collection: 'pages' | 'posts'): Promise<string[]> {
+  const slugs: string[] = []
+  let page = 1
+
+  while (true) {
+    const result = await req.payload.find({
+      collection,
+      depth: 0,
+      limit: REVALIDATE_SLUG_PAGE_SIZE,
+      page,
+      pagination: true,
+      overrideAccess: true,
+      req,
+      select: {
+        slug: true,
+      },
+      where: {
+        _status: {
+          equals: 'published',
+        },
+      },
+    })
+
+    for (const doc of result.docs) {
+      if (isSlugDoc(doc) && doc.slug.trim().length > 0) {
+        slugs.push(doc.slug)
+      }
+    }
+
+    if (!result.hasNextPage) {
+      return slugs
+    }
+
+    page += 1
+  }
+}
+
+async function revalidatePublishedPages(req: PayloadRequest): Promise<void> {
+  const slugs = await findPublishedSlugs(req, 'pages')
+
+  for (const slug of slugs) {
+    revalidatePath(slug === 'home' ? '/' : `/${slug}`)
+  }
+}
+
+async function revalidatePublishedPosts(req: PayloadRequest): Promise<void> {
+  const [slugs, countResult] = await Promise.all([
+    findPublishedSlugs(req, 'posts'),
+    req.payload.count({
+      collection: 'posts',
+      overrideAccess: true,
+      req,
+      where: {
+        _status: {
+          equals: 'published',
+        },
+      },
+    }),
+  ])
+
+  for (const slug of slugs) {
+    revalidatePath(`/posts/${slug}`)
+  }
+
+  revalidatePath('/posts')
+
+  const totalPages = Math.ceil(countResult.totalDocs / POSTS_PER_PAGE)
+  for (let page = 2; page <= totalPages; page += 1) {
+    revalidatePath(`/posts/page/${page}`)
+  }
+
+  revalidateTag('posts-sitemap', { expire: 0 })
+}
+
+async function revalidatePlatformContentMediaConsumerCaches(req: PayloadRequest): Promise<void> {
+  req.payload.logger.info('Revalidating platform content media consumers')
+
+  revalidateLandingConsumers()
+  await revalidatePublishedPages(req)
+  await revalidatePublishedPosts(req)
+}
+
+export const revalidatePlatformContentMediaConsumers: CollectionAfterChangeHook = ({ doc, req }) => {
+  if (req.context.disableRevalidate) return doc
+
+  return revalidatePlatformContentMediaConsumerCaches(req)
+    .then(() => doc)
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error)
+      req.payload.logger.warn(`Unable to revalidate platform content media consumers: ${message}`)
+      return doc
+    })
+}
+
+export const revalidateDeletedPlatformContentMediaConsumers: CollectionAfterDeleteHook = ({ doc, req }) => {
+  if (req.context.disableRevalidate) return doc
+
+  return revalidatePlatformContentMediaConsumerCaches(req)
+    .then(() => doc)
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error)
+      req.payload.logger.warn(`Unable to revalidate platform content media consumers: ${message}`)
+      return doc
+    })
+}

--- a/src/posthog/flag-definition-cache.ts
+++ b/src/posthog/flag-definition-cache.ts
@@ -1,5 +1,5 @@
 import { getCache } from '@vercel/functions'
-import { createHash } from 'node:crypto'
+import { createHash } from 'crypto'
 import type { FlagDefinitionCacheData, FlagDefinitionCacheProvider } from 'posthog-node/experimental'
 import { fallbackConsoleLogger } from '@/utilities/logging/consoleLogger'
 import { createScopedLogger, toLoggedError } from '@/utilities/logging/shared'

--- a/src/utilities/clinicDetail/serverData/mappers.ts
+++ b/src/utilities/clinicDetail/serverData/mappers.ts
@@ -24,6 +24,7 @@ import type {
 } from '@/components/templates/ClinicDetailConcepts/types'
 import { CLINICS_BREADCRUMB, HOME_BREADCRUMB } from '@/utilities/breadcrumbs'
 import { resolveDoctorProfileImage } from '@/utilities/media/doctorProfileImage'
+import { versionPayloadMediaFileUrl } from '@/utilities/media/fileUrls'
 import type { MediaDescriptor } from '@/utilities/media/relationMedia'
 import { buildFreshnessSignals } from '@/utilities/freshness'
 import { findLatestIsoTimestampString } from '@/utilities/timestamps'
@@ -124,7 +125,8 @@ function toGalleryMediaDescriptor(value: unknown): { url: string | null; alt: st
 
   const urlFromField = typeof media.url === 'string' && media.url.trim().length > 0 ? media.url : null
   const filename = typeof media.filename === 'string' && media.filename.trim().length > 0 ? media.filename : null
-  const url = urlFromField ?? (filename ? `/api/clinicGalleryMedia/file/${filename}` : null)
+  const rawUrl = urlFromField ?? (filename ? `/api/clinicGalleryMedia/file/${filename}` : null)
+  const url = rawUrl ? versionPayloadMediaFileUrl(rawUrl, media.updatedAt) : null
   const alt = typeof media.alt === 'string' && media.alt.trim().length > 0 ? media.alt : null
 
   if (!url && !alt) return undefined

--- a/src/utilities/getMediaUrl.ts
+++ b/src/utilities/getMediaUrl.ts
@@ -1,4 +1,5 @@
 import type { PlatformContentMedia, ClinicMedia, DoctorMedia, UserProfileMedia } from '@/payload-types'
+import { versionPayloadMediaFileUrl } from './media/fileUrls'
 
 /**
  * Extracts the URL from a Media object or returns null if not available.
@@ -21,7 +22,7 @@ export const getMediaUrl = (
     if (typeof url === 'string') {
       const normalizedUrl = url.trim()
       if (normalizedUrl.length > 0) {
-        return normalizedUrl
+        return versionPayloadMediaFileUrl(normalizedUrl, file.updatedAt)
       }
     }
   }

--- a/src/utilities/media/fileUrls.ts
+++ b/src/utilities/media/fileUrls.ts
@@ -1,0 +1,39 @@
+import { splitUrlQuery } from '@/utilities/urlParts'
+
+export function isPayloadApiFileUrl(src: string): boolean {
+  return src.includes('/api/') && src.includes('/file/')
+}
+
+export function normalizePayloadApiFileUrl(src: string): string {
+  if (!isPayloadApiFileUrl(src)) return src
+
+  const { path: pathPart, query } = splitUrlQuery(src)
+  const marker = '/file/'
+  const markerIndex = pathPart.indexOf(marker)
+
+  if (markerIndex === -1) return src
+
+  const prefix = pathPart.slice(0, markerIndex + marker.length)
+  const rawFilePart = pathPart.slice(markerIndex + marker.length)
+  const decodedFilePart = decodeURIComponent(rawFilePart)
+  const normalizedPath = decodedFilePart
+    .replace(/^\/+/, '')
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')
+
+  return query ? `${prefix}${normalizedPath}?${query}` : `${prefix}${normalizedPath}`
+}
+
+export function versionPayloadMediaFileUrl(src: string, updatedAt?: unknown): string {
+  const normalized = normalizePayloadApiFileUrl(src)
+
+  if (!isPayloadApiFileUrl(normalized) || typeof updatedAt !== 'string' || updatedAt.trim().length === 0) {
+    return normalized
+  }
+
+  const { path, query } = splitUrlQuery(normalized)
+  const versionParam = `v=${encodeURIComponent(updatedAt)}`
+
+  return query ? `${path}?${query}&${versionParam}` : `${path}?${versionParam}`
+}

--- a/src/utilities/media/relationMedia.ts
+++ b/src/utilities/media/relationMedia.ts
@@ -1,12 +1,20 @@
 import type { Payload, PayloadRequest } from 'payload'
 
-export type MediaCollectionSlug = 'clinicMedia' | 'doctorMedia' | 'platformContentMedia' | 'userProfileMedia'
+import { versionPayloadMediaFileUrl } from './fileUrls'
+
+export type MediaCollectionSlug =
+  | 'clinicGalleryMedia'
+  | 'clinicMedia'
+  | 'doctorMedia'
+  | 'platformContentMedia'
+  | 'userProfileMedia'
 
 type MediaDocument = {
   id: number
   url?: string | null
   alt?: string | null
   filename?: string | null
+  updatedAt?: string | null
 }
 
 export type MediaDescriptor = {
@@ -14,9 +22,13 @@ export type MediaDescriptor = {
   alt: string | null
 }
 
-function buildMediaFileUrl(collection: MediaCollectionSlug, filename: string | null | undefined): string | null {
+function buildMediaFileUrl(
+  collection: MediaCollectionSlug,
+  filename: string | null | undefined,
+  updatedAt?: string | null,
+): string | null {
   if (!filename || filename.trim().length === 0) return null
-  return `/api/${collection}/file/${filename}`
+  return versionPayloadMediaFileUrl(`/api/${collection}/file/${filename}`, updatedAt)
 }
 
 export function resolveMediaDescriptorFromLoadedRelation(
@@ -27,9 +39,10 @@ export function resolveMediaDescriptorFromLoadedRelation(
   if (relationDescriptor?.url) return relationDescriptor
   if (!relation || typeof relation !== 'object') return relationDescriptor
 
-  const relationDoc = relation as { filename?: unknown; alt?: unknown }
+  const relationDoc = relation as { filename?: unknown; alt?: unknown; updatedAt?: unknown }
   const filename = typeof relationDoc.filename === 'string' ? relationDoc.filename : null
-  const url = relationDescriptor?.url ?? buildMediaFileUrl(collection, filename)
+  const updatedAt = typeof relationDoc.updatedAt === 'string' ? relationDoc.updatedAt : null
+  const url = relationDescriptor?.url ?? buildMediaFileUrl(collection, filename, updatedAt)
   const alt =
     typeof relationDoc.alt === 'string'
       ? relationDoc.alt
@@ -73,8 +86,9 @@ export function getMediaDescriptorFromRelation(value: unknown): MediaDescriptor 
   if (!value || typeof value !== 'object') return undefined
   if (!('url' in value)) return undefined
 
-  const relation = value as { url?: unknown; alt?: unknown }
-  const url = typeof relation.url === 'string' ? relation.url : null
+  const relation = value as { url?: unknown; alt?: unknown; updatedAt?: unknown }
+  const updatedAt = typeof relation.updatedAt === 'string' ? relation.updatedAt : null
+  const url = typeof relation.url === 'string' ? versionPayloadMediaFileUrl(relation.url, updatedAt) : null
   const alt = typeof relation.alt === 'string' ? relation.alt : null
 
   if (!url && !alt) return undefined
@@ -114,7 +128,10 @@ export async function resolveMediaDescriptorFromRelation({
     })) as MediaDocument
 
     return {
-      url: typeof media.url === 'string' ? media.url : buildMediaFileUrl(collection, media.filename),
+      url:
+        typeof media.url === 'string'
+          ? versionPayloadMediaFileUrl(media.url, media.updatedAt)
+          : buildMediaFileUrl(collection, media.filename, media.updatedAt),
       alt: typeof media.alt === 'string' ? media.alt : null,
     }
   } catch {
@@ -165,7 +182,10 @@ export async function findMediaDescriptorsByIds({
       const docs = result.docs as MediaDocument[]
       docs.forEach((doc) => {
         descriptorsById.set(doc.id, {
-          url: typeof doc.url === 'string' ? doc.url : buildMediaFileUrl(collection, doc.filename),
+          url:
+            typeof doc.url === 'string'
+              ? versionPayloadMediaFileUrl(doc.url, doc.updatedAt)
+              : buildMediaFileUrl(collection, doc.filename, doc.updatedAt),
           alt: typeof doc.alt === 'string' ? doc.alt : null,
         })
       })

--- a/src/utilities/media/resolveMediaImage.ts
+++ b/src/utilities/media/resolveMediaImage.ts
@@ -1,4 +1,4 @@
-import { splitUrlQuery } from '@/utilities/urlParts'
+import { versionPayloadMediaFileUrl } from './fileUrls'
 
 type MediaSize = {
   url?: string | null
@@ -13,6 +13,7 @@ type MediaLike = {
   height?: number | null
   focalX?: number | null
   focalY?: number | null
+  updatedAt?: string | null
   sizes?: Record<string, MediaSize | undefined>
 } | null
 
@@ -117,27 +118,6 @@ for (const [usage, policy] of Object.entries(MEDIA_IMAGE_POLICIES)) {
   }
 }
 
-const normalizePayloadApiFileUrl = (src: string): string => {
-  if (!src.includes('/api/') || !src.includes('/file/')) return src
-
-  const { path: pathPart, query } = splitUrlQuery(src)
-  const marker = '/file/'
-  const markerIndex = pathPart.indexOf(marker)
-
-  if (markerIndex === -1) return src
-
-  const prefix = pathPart.slice(0, markerIndex + marker.length)
-  const rawFilePart = pathPart.slice(markerIndex + marker.length)
-  const decodedFilePart = decodeURIComponent(rawFilePart)
-  const normalizedPath = decodedFilePart
-    .replace(/^\/+/, '')
-    .split('/')
-    .map((segment) => encodeURIComponent(segment))
-    .join('/')
-
-  return query ? `${prefix}${normalizedPath}?${query}` : `${prefix}${normalizedPath}`
-}
-
 const normalizeFocalCoordinate = (value: number | null | undefined): number | undefined => {
   if (typeof value !== 'number' || !Number.isFinite(value)) return undefined
 
@@ -172,7 +152,7 @@ export function resolveMediaImage(
       if (!media.url) continue
 
       return {
-        src: normalizePayloadApiFileUrl(media.url),
+        src: versionPayloadMediaFileUrl(media.url, media.updatedAt),
         alt,
         width: media.width ?? undefined,
         height: media.height ?? undefined,
@@ -185,7 +165,7 @@ export function resolveMediaImage(
     const size = sizes[key]
     if (size?.url) {
       return {
-        src: normalizePayloadApiFileUrl(size.url),
+        src: versionPayloadMediaFileUrl(size.url, media.updatedAt),
         alt,
         width: size.width ?? undefined,
         height: size.height ?? undefined,

--- a/tests/unit/endpoints/seed/upsert-s3-recovery.test.ts
+++ b/tests/unit/endpoints/seed/upsert-s3-recovery.test.ts
@@ -5,9 +5,10 @@ import os from 'os'
 import path from 'path'
 import type { Payload } from 'payload'
 import { upsertByStableId } from '@/endpoints/seed/utils/upsert'
+import { prepareUploadFilenameFromFilePathSync } from '@/hooks/media/prepareUploadFilename'
 
 function platformSeedStoragePathFor(filePath: string): string {
-  const baseFilename = path.basename(filePath).replace(/[\\/]/g, '_')
+  const baseFilename = prepareUploadFilenameFromFilePathSync(filePath) ?? path.basename(filePath).replace(/[\\/]/g, '_')
   const size = fs.statSync(filePath).size
   const hashInput = `platform:${baseFilename}${size ? `:${size}` : ''}`
   const hash = createHash('sha1').update(hashInput).digest('hex').slice(0, 10)

--- a/tests/unit/hooks/prepareUploadFilename.test.ts
+++ b/tests/unit/hooks/prepareUploadFilename.test.ts
@@ -1,0 +1,103 @@
+import crypto from 'crypto'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { PayloadRequest, SanitizedCollectionConfig } from 'payload'
+
+import {
+  beforeOperationPrepareUploadFilename,
+  prepareUploadFilenameFromFilePathSync,
+} from '@/hooks/media/prepareUploadFilename'
+
+const collection = {
+  slug: 'clinicMedia',
+} as SanitizedCollectionConfig
+
+function createReq(overrides: Partial<PayloadRequest> = {}): PayloadRequest {
+  return {
+    context: {},
+    payload: {
+      logger: {
+        error: () => undefined,
+      },
+    },
+    ...overrides,
+  } as unknown as PayloadRequest
+}
+
+function shortHash(input: Buffer | string): string {
+  return crypto.createHash('sha1').update(input).digest('hex').slice(0, 10)
+}
+
+describe('beforeOperationPrepareUploadFilename', () => {
+  const tempDirs: string[] = []
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('prefixes incoming buffer uploads with a content hash before Payload creates image sizes', async () => {
+    const buffer = Buffer.from('team portrait')
+    const req = createReq({
+      file: {
+        name: 'team/AnilGoekduman.webp',
+        originalname: 'team/AnilGoekduman.webp',
+        data: buffer,
+        size: buffer.length,
+      },
+    } as unknown as Partial<PayloadRequest>)
+
+    await beforeOperationPrepareUploadFilename({
+      args: { data: {} },
+      collection,
+      operation: 'create',
+      req,
+    } as never)
+
+    const expected = `${shortHash(buffer)}-AnilGoekduman.webp`
+    expect((req.file as { name?: string }).name).toBe(expected)
+    expect((req.file as { originalname?: string }).originalname).toBe(expected)
+    expect(req.context.mediaPreparedUploadFilename).toBe(expected)
+  })
+
+  it('uses temp file content when uploads are backed by a tempFilePath', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'media-upload-'))
+    tempDirs.push(tempDir)
+    const filePath = path.join(tempDir, 'portrait.webp')
+    const buffer = Buffer.from('temp portrait')
+    fs.writeFileSync(filePath, buffer)
+    const req = createReq({
+      file: {
+        name: 'portrait.webp',
+        tempFilePath: filePath,
+        size: buffer.length,
+      },
+    } as unknown as Partial<PayloadRequest>)
+
+    await beforeOperationPrepareUploadFilename({
+      args: { data: {} },
+      collection,
+      operation: 'update',
+      req,
+    } as never)
+
+    expect((req.file as { name?: string }).name).toBe(`${shortHash(buffer)}-portrait.webp`)
+    expect(prepareUploadFilenameFromFilePathSync(filePath)).toBe(`${shortHash(buffer)}-portrait.webp`)
+  })
+
+  it('leaves metadata-only updates unchanged', async () => {
+    const req = createReq()
+
+    await beforeOperationPrepareUploadFilename({
+      args: { data: { alt: 'Updated alt' } },
+      collection,
+      operation: 'update',
+      req,
+    } as never)
+
+    expect(req.context.mediaPreparedUploadFilename).toBeUndefined()
+  })
+})

--- a/tests/unit/hooks/revalidateMediaConsumers.test.ts
+++ b/tests/unit/hooks/revalidateMediaConsumers.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PayloadRequest, SanitizedCollectionConfig } from 'payload'
+
+import {
+  revalidateDeletedPlatformContentMediaConsumers,
+  revalidatePlatformContentMediaConsumers,
+} from '@/hooks/media/revalidateMediaConsumers'
+
+const cacheMocks = vi.hoisted(() => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}))
+
+vi.mock('next/cache.js', () => ({
+  revalidatePath: cacheMocks.revalidatePath,
+  revalidateTag: cacheMocks.revalidateTag,
+}))
+
+const collection = {
+  slug: 'platformContentMedia',
+} as SanitizedCollectionConfig
+
+function createReq(context: Record<string, unknown> = {}): PayloadRequest {
+  return {
+    context,
+    payload: {
+      count: vi.fn().mockResolvedValue({ totalDocs: 25 }),
+      find: vi.fn().mockImplementation(({ collection: slug, page = 1 }) => {
+        if (slug === 'pages') {
+          return Promise.resolve({
+            docs: page === 1 ? [{ slug: 'home' }] : [{ slug: 'contact' }],
+            hasNextPage: page === 1,
+          })
+        }
+
+        return Promise.resolve({
+          docs: page === 1 ? [{ slug: 'first-post' }] : [{ slug: 'second-post' }],
+          hasNextPage: page === 1,
+        })
+      }),
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+    },
+  } as unknown as PayloadRequest
+}
+
+describe('revalidatePlatformContentMediaConsumers', () => {
+  beforeEach(() => {
+    cacheMocks.revalidatePath.mockReset()
+    cacheMocks.revalidateTag.mockReset()
+  })
+
+  it('revalidates cached platform media consumers after platform media changes', async () => {
+    const req = createReq()
+
+    await revalidatePlatformContentMediaConsumers({
+      collection,
+      context: req.context,
+      doc: { id: 1 },
+      operation: 'update',
+      previousDoc: { id: 1 },
+      req,
+    } as never)
+
+    expect(cacheMocks.revalidateTag).toHaveBeenCalledWith('global_landingPages', { expire: 0 })
+    expect(cacheMocks.revalidateTag).toHaveBeenCalledWith('pages-sitemap', { expire: 0 })
+    expect(cacheMocks.revalidatePath).toHaveBeenCalledWith('/')
+    expect(cacheMocks.revalidatePath).toHaveBeenCalledWith('/about')
+    expect(cacheMocks.revalidatePath).toHaveBeenCalledWith('/partners/clinics')
+    expect(cacheMocks.revalidatePath).toHaveBeenCalledWith('/contact')
+    expect(cacheMocks.revalidatePath).toHaveBeenCalledWith('/posts/first-post')
+    expect(cacheMocks.revalidatePath).toHaveBeenCalledWith('/posts/second-post')
+    expect(cacheMocks.revalidatePath).toHaveBeenCalledWith('/posts')
+    expect(cacheMocks.revalidatePath).toHaveBeenCalledWith('/posts/page/2')
+    expect(cacheMocks.revalidatePath).toHaveBeenCalledWith('/posts/page/3')
+    expect(cacheMocks.revalidateTag).toHaveBeenCalledWith('posts-sitemap', { expire: 0 })
+    expect(req.payload.find).toHaveBeenCalledWith(expect.objectContaining({ collection: 'pages' }))
+    expect(req.payload.find).toHaveBeenCalledWith(expect.objectContaining({ collection: 'posts' }))
+    expect(req.payload.find).toHaveBeenCalledWith(expect.objectContaining({ collection: 'pages', page: 2 }))
+    expect(req.payload.find).toHaveBeenCalledWith(expect.objectContaining({ collection: 'posts', page: 2 }))
+    expect(req.payload.count).toHaveBeenCalledWith(expect.objectContaining({ collection: 'posts' }))
+  })
+
+  it('revalidates cached platform media consumers after platform media deletes', async () => {
+    const req = createReq()
+
+    await revalidateDeletedPlatformContentMediaConsumers({
+      collection,
+      context: req.context,
+      doc: { id: 1 },
+      req,
+    } as never)
+
+    expect(cacheMocks.revalidateTag).toHaveBeenCalledWith('global_landingPages', { expire: 0 })
+    expect(cacheMocks.revalidatePath).toHaveBeenCalledWith('/posts/first-post')
+    expect(cacheMocks.revalidatePath).toHaveBeenCalledWith('/posts/page/3')
+  })
+
+  it('skips revalidation when seed batching disables it', async () => {
+    const req = createReq({ disableRevalidate: true })
+
+    await revalidatePlatformContentMediaConsumers({
+      collection,
+      context: req.context,
+      doc: { id: 1 },
+      operation: 'update',
+      previousDoc: { id: 1 },
+      req,
+    } as never)
+
+    expect(cacheMocks.revalidateTag).not.toHaveBeenCalled()
+    expect(cacheMocks.revalidatePath).not.toHaveBeenCalled()
+    expect(req.payload.find).not.toHaveBeenCalled()
+    expect(req.payload.count).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/utilities/getMediaUrl.test.ts
+++ b/tests/unit/utilities/getMediaUrl.test.ts
@@ -23,6 +23,19 @@ describe('getMediaUrl', () => {
     expect(getMediaUrl(mediaObject as PlatformContentMedia)).toBe('/uploads/image.jpg')
   })
 
+  it('should append updatedAt to Payload API file URLs', () => {
+    const mediaObject: Partial<PlatformContentMedia> = {
+      id: 124,
+      url: '/api/platformContentMedia/file/image.jpg?prefix=platform',
+      filename: 'image.jpg',
+      updatedAt: '2026-06-27T10:15:00.000Z',
+    }
+
+    expect(getMediaUrl(mediaObject as PlatformContentMedia)).toBe(
+      '/api/platformContentMedia/file/image.jpg?prefix=platform&v=2026-06-27T10%3A15%3A00.000Z',
+    )
+  })
+
   it('should return null for Media object without url property', () => {
     const mediaObject = {
       id: 123,

--- a/tests/unit/utilities/relationMedia.test.ts
+++ b/tests/unit/utilities/relationMedia.test.ts
@@ -42,6 +42,24 @@ describe('resolveMediaDescriptorFromLoadedRelation', () => {
     })
   })
 
+  it('adds updatedAt as a version query to loaded Payload media relations', () => {
+    const descriptor = resolveMediaDescriptorFromLoadedRelation(
+      {
+        id: 12,
+        url: '/api/clinicMedia/file/versioned.jpg?prefix=clinics',
+        filename: 'ignored.jpg',
+        alt: 'Versioned image',
+        updatedAt: '2026-06-27T10:15:00.000Z',
+      },
+      'clinicMedia',
+    )
+
+    expect(descriptor).toEqual({
+      url: '/api/clinicMedia/file/versioned.jpg?prefix=clinics&v=2026-06-27T10%3A15%3A00.000Z',
+      alt: 'Versioned image',
+    })
+  })
+
   it('builds owner media descriptors from unique relation IDs and loaded relations', async () => {
     const findMock = vi.fn(async (_args: { where: { id: { in: number[] } } }) => ({
       docs: [

--- a/tests/unit/utilities/resolveMediaImage.test.ts
+++ b/tests/unit/utilities/resolveMediaImage.test.ts
@@ -56,6 +56,29 @@ describe('resolveMediaImage', () => {
     })
   })
 
+  it('adds media updatedAt as a version query for Payload file URLs', () => {
+    const image = resolveMediaImage(
+      {
+        alt: 'Versioned image',
+        updatedAt: '2026-06-27T10:15:00.000Z',
+        sizes: {
+          medium: {
+            url: '/api/clinicMedia/file/versioned.jpg?prefix=clinics',
+            width: 900,
+            height: 600,
+          },
+        },
+      },
+      {
+        usage: 'listingCard',
+      },
+    )
+
+    expect(image).toMatchObject({
+      src: '/api/clinicMedia/file/versioned.jpg?prefix=clinics&v=2026-06-27T10%3A15%3A00.000Z',
+    })
+  })
+
   it('prefers the original image before falling back to a thumbnail', () => {
     const image = resolveMediaImage(
       {


### PR DESCRIPTION
## Management summary

### Deutsch

Diese Änderung sorgt dafür, dass ersetzte Bilder in Preview und auf öffentlichen Seiten zuverlässig frisch angezeigt werden. Betreiber können Medien in Payload austauschen, ohne dass alte generierte Bildvarianten oder zwischengespeicherte Seiten weiter sichtbar bleiben.

### English

This change ensures replaced images render freshly in preview and on public pages. Operators can update media in Payload without stale generated image variants or cached pages continuing to appear.

## What changed

- Added content-hash based upload filenames before Payload generates media derivatives, so replacing an image produces new derivative object names.
- Added versioned Payload media URLs using media `updatedAt`, preserving existing query params while invalidating stale browser and Next image optimizer cache keys.
- Revalidated `platformContentMedia` consumers on change and delete, including landing pages, published pages, published posts, post index, paginated post routes, and sitemap tags.
- Aligned seed media recovery paths with the new prepared filename behavior and reused the shared landing revalidation constants.
- Taught the DB quality detector to treat hook-only media collection wiring as non-schema changes, avoiding unnecessary Payload migration generation.
- Added unit coverage for upload filename preparation, media URL versioning, seed S3 recovery, and platform media consumer revalidation.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `src/hooks/media/prepareUploadFilename.ts`, media collection configs | Filename mutation happens before Payload derivative generation and affects storage object names. | Uploads through all media collections still preserve owner storage paths and produce fresh derivative names on replacement. | `tests/unit/hooks/prepareUploadFilename.test.ts`, `pnpm check`, `pnpm build` |
| P1 | `src/hooks/media/revalidateMediaConsumers.ts`, `src/collections/PlatformContentMedia/index.ts` | Cache invalidation now fans out from platform media changes to page/post consumers. | Change and delete flows revalidate every cached public consumer without missing paginated results. | `tests/unit/hooks/revalidateMediaConsumers.test.ts`, security and SEO reviewer passes |
| P2 | `src/utilities/media/fileUrls.ts`, media resolver utilities | URL versioning is the visible cache-busting mechanism. | Existing query params and encoded filenames stay valid while `updatedAt` versions are appended only for Payload file URLs. | `tests/unit/utilities/*media*.test.ts`, `tests/unit/utilities/getMediaUrl.test.ts` |
| P2 | `.github/scripts/ci/detect-migration-diff.sh` | Collection hook wiring should not force Payload migration generation when schema fields did not change. | DB quality still runs migration apply/status for DB tooling changes while schema enforcement is skipped for hook-only collection diffs. | DB Quality CI success on `07db24f0` |

## Validation

- [x] `pnpm format`: `rtk npx pnpm@10.28.2 format` in a clean temp worktree for the final diff.
- [x] `pnpm check`: `rtk npx pnpm@10.28.2 check` in a clean temp worktree for the final diff.
- [x] `pnpm build`: `rtk npx pnpm@10.28.2 build`
- [x] Focused tests: `rtk node node_modules/vitest/vitest.mjs run tests/unit/hooks/prepareUploadFilename.test.ts tests/unit/hooks/revalidateMediaConsumers.test.ts tests/unit/utilities/resolveMediaImage.test.ts tests/unit/utilities/relationMedia.test.ts tests/unit/utilities/getMediaUrl.test.ts tests/unit/endpoints/seed/upsert-s3-recovery.test.ts tests/unit/endpoints/seed/seedEndpoint-success.test.ts tests/unit/utilities/listingComparisonPresentation.test.ts tests/unit/utilities/clinicDetailServerData.contract.test.ts tests/unit/utilities/listingComparisonServerData.contract.test.ts`
- [x] CI: Deploy Preview, Admin E2E Smoke, Public E2E Smoke, Static Checks, Unit Tests, Storybook Tests, Integration Tests, Build, Combined Coverage, DB Quality, Semgrep, CodeQL, and Dependency Review passed on `07db24f0`; schema migration enforcement skipped because the detector reports no schema change.
- [x] Remote preview smoke: `GET /`, `GET /about`, and `GET /partners/clinics` returned 200 on the Vercel preview deployment; extracted Payload media URLs were versioned with `v=` on all three routes; sampled Payload API and Next image optimizer requests returned 200.
- [x] Anil image smoke: `/about` and `/partners/clinics` both reference `c83e652c67-AnilGoekduman.webp` with `v=2026-06-27T06:17:28.286Z`; sampled Payload API and Next image optimizer requests returned 200.
- [ ] UI/mobile QA: Not applicable; no layout, interaction, responsive, or visual UI behavior changed.
- [x] Security/privacy review: `security_reviewer` found an incomplete revalidation path; fixed and re-reviewed with no remaining findings >=5/10.
- [ ] Migration/schema check: Not applicable; no Payload schema or migration changes.
- [ ] Documentation/instructions check: Not applicable; no docs or instruction surfaces changed.

## Risk and rollout

Existing stale media cache entries are bypassed when media is replaced or seeded again because fresh filenames and URL versions are produced. No database migration or environment change is required. Rollback restores the previous filename and cache behavior, but can reintroduce stale preview image variants.

## Development

Closes #1430
