### PR TITLE
docs(frontend): add trust disclosure guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@
 - Documentation defaults: `docs/AGENTS.md`
 - Application-wide engineering defaults and analytics: `src/AGENTS.md`, `src/posthog/AGENTS.md`
 - UI/frontend and CMS boundary mapping: `src/components/AGENTS.md`, `src/app/(frontend)/AGENTS.md`, `src/blocks/AGENTS.md`, `src/app/AGENTS.md`, `src/stories/AGENTS.md`
-- Mobile-first frontend heuristics and prompt scaffolding: `docs/frontend/mobile-ai-playbook.md`
+- Mobile-first frontend heuristics, trust disclosure, and prompt scaffolding: `docs/frontend/mobile-ai-playbook.md`, `docs/frontend/trust-disclosure-playbook.md`
 - AI instruction quality: `docs/engineering/ai-anti-slop-playbook.md`, `docs/engineering/agent-instruction-review-playbook.md`
 - Payload/API/hooks/seeds: `src/collections/AGENTS.md`, `src/hooks/AGENTS.md`, `src/endpoints/seed/AGENTS.md`, `src/app/api/AGENTS.md`
 - Payload admin UI design: `src/app/(payload)/AGENTS.md`, `src/components/organisms/AdminBranding/AGENTS.md`, `src/components/organisms/DeveloperDashboard/AGENTS.md`, `src/dashboard/adminDashboard/AGENTS.md`

--- a/docs/frontend/trust-disclosure-playbook.md
+++ b/docs/frontend/trust-disclosure-playbook.md
@@ -1,0 +1,67 @@
+# Trust Disclosure UI Playbook
+
+This playbook is the repository-local reference for public trust, conversion, and disclosure UI. Keep hard rules in the nearest relevant `AGENTS.md` file and use this document for source rationale, heuristics, and prompt scaffolding.
+
+## Purpose
+
+Use this playbook when designing or reviewing public pages that show clinic trust, medical safety, verification, review, accreditation, language, price, or provider-quality information.
+
+The goal is to keep primary trust signals visible and readable while moving supporting detail into accessible disclosure patterns that do not overload the page.
+
+## Source Principles
+
+- NN/g's trust guidance emphasizes professional design, upfront disclosure, complete information, and visible external or evidence-based signals.
+- NN/g's progressive disclosure guidance supports revealing advanced or supporting detail gradually when the default view remains understandable.
+- Baymard's product-page research cautions against hiding decision-critical content in tabs or other low-discoverability containers.
+- Google's structured data policies require markup to represent user-visible page content.
+- WAI-ARIA dialog guidance requires modal dialogs to manage focus, keyboard dismissal, and focus return.
+- Material Design bottom sheets are appropriate for supplementary mobile content when they preserve the user's current task context.
+
+## Page Hierarchy
+
+- Keep the primary trust signal visible in the page flow when it can affect user confidence or conversion.
+- Prefer compact inline facts, summary rows, or quiet evidence groups over large marketing-style trust clusters.
+- Show enough summary value to make disclosure worthwhile, for example `Languages: English, German + 3 more`, not a vague standalone `Details`.
+- Link review summaries to the existing review section when the page already has one instead of duplicating detail in a modal.
+- Use modals, drawers, popovers, or bottom sheets for full lists, definitions, source context, verification explanations, and secondary evidence.
+
+## Pills and Badges
+
+- Use badges for compact status, category, verification, count, or filter states where the visual treatment improves scanning.
+- Do not use pills or badges as the default presentation for factual content, trust evidence, explanations, languages, accreditations, prices, or review metadata.
+- Prefer readable text, summary rows, compact lists, or table-like evidence groups when users need to read, compare, or evaluate information.
+- Avoid clusters of many pills in public trust or medical-context UI. If more than three or four values are present, show the strongest values inline and move the full list behind a clear disclosure trigger.
+- Keep badge styling restrained: small type, low visual weight, semantic color only when it carries meaning, and no oversized decorative badges.
+- Badge labels must be independently understandable. Avoid vague labels such as `Trusted`, `Premium`, or `Top` unless the criteria and meaning are visible nearby or available through disclosure.
+
+## Disclosure Behavior
+
+- Essential trust, conversion, or safety information remains available without hover-only interactions.
+- Disclosure controls state the value they expand, and the expanded surface keeps the user in the same task context.
+- Desktop detail surfaces may use popovers, dialogs, or side panels when the content is short and task-local.
+- Mobile detail surfaces should usually use a bottom sheet for supplementary content and a full dialog only when the task requires focused reading or action.
+- Any dialog, drawer, popover, or bottom sheet must provide keyboard access, Escape or close behavior, focus return, scroll containment, and short-height mobile resilience.
+
+## Discoverability and SEO
+
+- Structured data, metadata, and machine-readable facts must match equivalent human-readable facts on the page.
+- Do not add structured data that claims a public fact only hidden in implementation details or invisible metadata.
+- Details that affect user trust can be collapsed, but the page must still show a clear visible summary that the information exists.
+- Prefer server-rendered or otherwise accessible disclosure content for public facts that should remain discoverable.
+
+## Prompt Scaffolding
+
+Use this ingredient when asking an agent to design or review public trust UI:
+
+```text
+Preserve the current visual language. Keep the primary trust signals visible without badge-heavy or pill-heavy clusters. Use progressive disclosure only for supporting detail such as full language lists, accreditation details, or verification explanations. Disclosure triggers must include the summary value they expand. Verify modal, drawer, popover, or bottom-sheet accessibility, focus return, scroll containment, mobile short-height behavior, and structured-data parity with visible content when relevant.
+```
+
+## Source Links
+
+- [NN/g: Trustworthiness in Web Design](https://www.nngroup.com/articles/trustworthy-design/)
+- [NN/g: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
+- [Baymard: Avoid Horizontal Tabs](https://baymard.com/blog/avoid-horizontal-tabs)
+- [Google Search Central: Structured Data Policies](https://developers.google.com/search/docs/appearance/structured-data/sd-policies)
+- [WAI-ARIA Authoring Practices: Dialog Modal Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)
+- [Material Design: Bottom Sheets](https://m3.material.io/components/bottom-sheets/overview)

--- a/src/app/(frontend)/AGENTS.md
+++ b/src/app/(frontend)/AGENTS.md
@@ -22,6 +22,15 @@
 - Prefer vertical flow, clear content priority, and compact CTA grouping over early multi-column density.
 - Do not rely on hover-only disclosure, pointer-precision affordances, or side-by-side layouts that collapse into ambiguous mobile order.
 
+## Trust and Disclosure UI
+
+- For public trust, medical, clinic, review, verification, accreditation, price, or language information, keep the primary trust signal visible in the page flow.
+- Use progressive disclosure only for supporting detail, explanations, full lists, or source context; do not hide the fact that the information exists behind a generic `Details` trigger.
+- Avoid badge-heavy, pill-heavy, or marketing-style trust clusters unless the existing route already uses that pattern intentionally.
+- Prefer quiet inline facts, concise summary rows, or grouped evidence sections that match the current page hierarchy.
+- When structured data or metadata references a public fact, make the user-visible page contain an equivalent human-readable fact.
+- For detailed heuristics and source rationale, use `docs/frontend/trust-disclosure-playbook.md`.
+
 ## Boundary Reminder
 
 - UI components stay Payload-free.

--- a/src/components/AGENTS.md
+++ b/src/components/AGENTS.md
@@ -25,6 +25,15 @@
 - Avoid component layouts that depend on horizontal scrolling unless the component is explicitly a scrollable pattern and provides clear touch affordances.
 - Keep touch targets, spacing, and text wrapping resilient at narrow widths before layering larger-screen enhancements.
 
+## Disclosure Components
+
+- Disclosure triggers must state the summary value they expand, for example `Languages: English, German + 3 more`, not a vague standalone `Details`.
+- Essential trust, conversion, or safety information must remain available without hover-only interactions.
+- Dialogs, popovers, drawers, and bottom sheets must be keyboard-accessible and include deterministic open/use/close states in stories when reused.
+- Use compact text, row separators, and typography before adding badges, pills, borders, or shadows.
+- Use badges only for compact status, category, verification, count, or filter states where the visual treatment improves scanning.
+- Do not use pills or badges as the default presentation for factual content, trust evidence, explanations, languages, accreditations, prices, or review metadata.
+
 ## Boundary Rules
 
 - `src/components/**` must stay Payload-free.


### PR DESCRIPTION
## Management summary

### Deutsch

Neue Gestaltungsleitlinien helfen dabei, Vertrauensinformationen auf öffentlichen Seiten ruhiger, verständlicher und verlässlicher darzustellen. Wichtige Signale bleiben sichtbar, Detailinformationen werden zugänglich erklärt, und überladene Badge- oder Pill-Muster werden vermieden.

### English

New design guidance helps public pages present trust information in a calmer, clearer, and more reliable way. Important signals stay visible, supporting details remain accessible, and overloaded badge or pill patterns are discouraged.

## What changed

- Added a frontend trust-disclosure playbook with source rationale for visible trust signals, progressive disclosure, accessibility, structured-data parity, and restrained pill/badge usage.
- Updated frontend route instructions so public trust, medical, review, verification, accreditation, price, and language facts stay visible at summary level instead of being hidden behind vague disclosure.
- Updated component instructions so reusable disclosure surfaces, badges, and pills have clearer usage boundaries.
- Updated the root instruction map to point agents to the new trust-disclosure playbook alongside mobile-first guidance.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P2 | `docs/frontend/trust-disclosure-playbook.md` | This becomes the source rationale for future public trust UI work. | The guidance is accurate, source-grounded, and not too broad for the repo. | `pnpm ai:slop-check` passed. |
| P2 | `src/app/(frontend)/AGENTS.md`, `src/components/AGENTS.md` | These are always-loaded scoped rules for future frontend work. | The rules stay concise, scoped, non-conflicting, and actionable for agents. | `pnpm ai:slop-check` passed. |

## Validation

- [x] `pnpm format`: passed via `npx --yes pnpm@10.28.2 format`.
- [ ] `pnpm check`: not run; docs/instruction-only change with no runtime code, schema, hooks, or lint-relevant source changes.
- [ ] `pnpm build`: not run; docs/instruction-only change with no build-relevant source changes.
- [ ] Focused tests: not run; no executable behavior changed.
- [ ] UI/mobile QA: not applicable; no production UI changed.
- [ ] Security/privacy review: not applicable; no auth, secrets, data access, logging, or server trust boundary changed.
- [ ] Migration/schema check: not applicable; no Payload schema or data model changed.
- [x] Documentation/instructions check: `npx --yes pnpm@10.28.2 ai:slop-check` passed; pre-push `ai:slop-check:prepush` passed in changed-files mode.

## Risk and rollout

None known. This is an instruction and documentation-only change. Rollback is a normal revert of the PR commit.

## Development

Closes #1434
