### PR TITLE
fix(ci): scope workflow secrets and npm policy

### DIFF
--- a/.github/scripts/deploy/vercel-deploy.sh
+++ b/.github/scripts/deploy/vercel-deploy.sh
@@ -40,6 +40,10 @@ case "${target}" in
     ;;
 esac
 
+if [[ -n "${PAYLOAD_SECRET:-}" ]]; then
+  deploy_command+=(--build-env "PAYLOAD_SECRET=${PAYLOAD_SECRET}" --env "PAYLOAD_SECRET=${PAYLOAD_SECRET}")
+fi
+
 deploy_output_file="$(mktemp)"
 deploy_error_file="$(mktemp)"
 trap 'rm -f "${deploy_output_file}" "${deploy_error_file}"' EXIT

--- a/.github/scripts/deploy/vercel-deploy.sh
+++ b/.github/scripts/deploy/vercel-deploy.sh
@@ -44,6 +44,10 @@ if [[ -n "${PAYLOAD_SECRET:-}" ]]; then
   deploy_command+=(--build-env "PAYLOAD_SECRET=${PAYLOAD_SECRET}" --env "PAYLOAD_SECRET=${PAYLOAD_SECRET}")
 fi
 
+if [[ -n "${DATABASE_URI:-}" ]]; then
+  deploy_command+=(--build-env "DATABASE_URI=${DATABASE_URI}" --env "DATABASE_URI=${DATABASE_URI}")
+fi
+
 deploy_output_file="$(mktemp)"
 deploy_error_file="$(mktemp)"
 trap 'rm -f "${deploy_output_file}" "${deploy_error_file}"' EXIT

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -33,8 +33,6 @@ concurrency:
 env:
   NODE_VERSION: 24.14.0
   PNPM_VERSION: 10.28.2
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
   PREVIEW_ALIAS_DOMAIN: preview.findmydoc.eu
   NEXT_TELEMETRY_DISABLED: 1
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Deploy to Vercel (Preview)
         id: vercel_preview
         env:
+          DATABASE_URI: ${{ secrets.DATABASE_URI }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: bash ./.github/scripts/deploy/vercel-deploy.sh preview

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Deploy to Vercel (Preview)
         id: vercel_preview
         env:
+          PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: bash ./.github/scripts/deploy/vercel-deploy.sh preview
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Deploy to Vercel (Production)
         id: vercel_production
         env:
+          PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: bash ./.github/scripts/deploy/vercel-deploy.sh production
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,9 +13,6 @@ concurrency:
 env:
   NODE_VERSION: 24.14.0
   PNPM_VERSION: 10.28.2
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
   PRODUCTION_ALIAS_DOMAIN: findmydoc.eu
   NEXT_TELEMETRY_DISABLED: 1
 
@@ -53,14 +50,20 @@ jobs:
           cache: 'pnpm'
 
       - name: Pull Vercel Environment Variables for Production
-        run: pnpm dlx vercel@canary pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: pnpm dlx vercel@canary pull --yes --environment=production --token="$VERCEL_TOKEN"
 
       - name: Deploy to Vercel (Production)
         id: vercel_production
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: bash ./.github/scripts/deploy/vercel-deploy.sh production
 
       - name: Set Production Alias
-        run: pnpm dlx vercel@canary alias set ${{ steps.vercel_production.outputs.deploymentUrl }} ${{ env.PRODUCTION_ALIAS_DOMAIN }} --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: pnpm dlx vercel@canary alias set "${{ steps.vercel_production.outputs.deploymentUrl }}" "${{ env.PRODUCTION_ALIAS_DOMAIN }}" --token="$VERCEL_TOKEN"
 
       - name: Generate deployment summary
         if: always()

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+min-release-age=7

--- a/docs/features.md
+++ b/docs/features.md
@@ -161,7 +161,7 @@ Preview deployments use runtime policy for auth recovery and search-index protec
 Implementation and usage:
 - [Setup: Run Local Dev in Preview Runtime](./setup.md#run-local-dev-in-preview-runtime)
 - [Preview Guard Technical Notes](../src/features/previewGuard/README.md)
-- [Preview Admin Recovery Decision Flow](../src/auth/README.md#preview-runtime-admin-recovery-flow)
+- [Preview Admin Recovery Decision Flow](../src/auth/README.md#runtime-admin-recovery)
 
 ## Live Preview
 View content updates in real time with SSR.

--- a/src/stories/organisms/PostHero.stories.tsx
+++ b/src/stories/organisms/PostHero.stories.tsx
@@ -154,8 +154,12 @@ const brokenHeroImageBase: Story = {
     const heroImage = canvas.getByAltText('Broken post hero image')
 
     await waitFor(() => {
-      const src = heroImage.getAttribute('src') ?? ''
-      expect(src).toContain('blog-placeholder-1600-900')
+      const imageSources = [
+        heroImage.getAttribute('src') ?? '',
+        heroImage.getAttribute('srcset') ?? '',
+        heroImage instanceof HTMLImageElement ? heroImage.currentSrc : '',
+      ].join(' ')
+      expect(imageSources).toContain('blog-placeholder-1600-900')
     })
   },
 }


### PR DESCRIPTION
## Management summary

### Deutsch

Die nächtliche Qualitätsprüfung kann wieder grün werden, weil die CI-Konfiguration Secrets enger begrenzt, npm-Pakete nicht unmittelbar nach Veröffentlichung auflöst und Preview-Deployments die erforderlichen Payload- und Datenbankwerte kontrolliert an Vercel übergeben. Zusätzlich ist ein instabiler Storybook-Fallback-Test stabilisiert, damit die PR-Prüfung nicht an einem falschen Bildquellen-Vergleich hängen bleibt.

### English

The nightly quality check can return to green because the CI configuration now scopes secrets more tightly, avoids resolving npm packages immediately after release, and passes the required Payload and database values to Vercel preview deployments in a controlled way. A flaky Storybook fallback test is also stabilized so PR checks no longer fail on an incorrect image-source comparison.

## What changed

- Removed workflow-level Vercel secret exposure from `.github/workflows/deploy-preview.yml` and `.github/workflows/deploy-production.yml`.
- Scoped `VERCEL_TOKEN`, `PAYLOAD_SECRET`, and Preview `DATABASE_URI` to the deployment steps that actually use them.
- Updated `.github/scripts/deploy/vercel-deploy.sh` to pass `PAYLOAD_SECRET` and `DATABASE_URI` to Vercel as build-time and runtime env only when they are available.
- Added `min-release-age=7` to `.npmrc` so Semgrep package-policy rules pass.
- Stabilized the `PostHero` broken-image Storybook assertion by checking all effective image source attributes instead of only `src`.
- Kept the existing preview admin recovery documentation link fix from this branch.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `.github/workflows/deploy-preview.yml`, `.github/workflows/deploy-production.yml`, `.github/scripts/deploy/vercel-deploy.sh` | CI/deploy workflows handle deployment secrets and now forward required Vercel build/runtime env. | Secrets remain step-scoped and Vercel receives the required Payload and Preview database values without widening workflow-level exposure. | `pnpm format`, `pnpm check`; PR Semgrep, Workflow Security, and Deploy Preview passed on prior push before Storybook-only update. |
| P2 | `.npmrc` | Package resolution policy affects install behavior. | `min-release-age=7` is compatible with pnpm 10 and the repository install flow. | `pnpm format`, `pnpm check`; PR Semgrep passed on prior pushes. |
| P2 | `src/stories/organisms/PostHero.stories.tsx` | Storybook fallback coverage was failing on a brittle Next Image `src` assertion. | The assertion still proves the fallback placeholder is used without depending on one specific image attribute. | `pnpm vitest --project storybook --run src/stories/organisms/PostHero.stories.tsx` passed. |

## Validation

- [x] `pnpm format`: passed locally with `/Users/razorspoint/Library/pnpm/pnpm format`; no file changes left behind. Local Node warned because this machine is on Node 26 while the repository expects Node 24.
- [x] `pnpm check`: passed locally with `/Users/razorspoint/Library/pnpm/pnpm check`; existing test-sense warnings only. Local Node warned because this machine is on Node 26 while the repository expects Node 24.
- [ ] `pnpm build`: not run locally; GitHub Actions Build/Deploy Preview are the relevant remote confirmation.
- [x] Focused tests: `pnpm vitest --project storybook --run src/stories/organisms/PostHero.stories.tsx` passed.
- [ ] UI/mobile QA: not applicable; no UI rendering change, only test assertion behavior.
- [x] Security/privacy review: deployment secrets are step-scoped and passed through the deploy script only when present.
- [ ] Migration/schema check: not applicable; no schema or migration changes.
- [x] Documentation/instructions check: docs link fix retained and docs consistency is covered by PR checks.

## Risk and rollout

The application runtime change risk is low, but deployment behavior depends on the GitHub Preview environment secrets `PAYLOAD_SECRET` and `DATABASE_URI` being present and valid. This PR intentionally avoids putting Vercel secrets back into workflow-level `env` and instead scopes all deployment secrets to the deployment steps.

## Development

Closes #1441
