### PR TITLE
ci: reduce low-signal pipeline work

### DIFF
--- a/.github/workflows/admin-e2e-smoke.yml
+++ b/.github/workflows/admin-e2e-smoke.yml
@@ -2,6 +2,7 @@ name: Admin E2E Smoke
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,8 +25,74 @@ defaults:
     shell: bash
 
 jobs:
+  e2e-scope:
+    name: E2E Scope
+    runs-on: ubuntu-latest
+    outputs:
+      e2e_required: ${{ steps.scope.outputs.e2e_required }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect E2E-relevant changes
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            runtime:
+              - 'src/**'
+              - '!**/*.md'
+            public_assets:
+              - 'public/**'
+              - '!**/*.md'
+            e2e_tests:
+              - 'tests/e2e/**'
+              - '!**/*.md'
+            testinfra:
+              - 'scripts/{e2e-server.mjs,playwright-*.ts,public-e2e-*.ts,test-env.mjs}'
+            config:
+              - '{playwright.config.ts,next.config.js,postcss.config.js,tsconfig.json}'
+            dependencies:
+              - '{package.json,pnpm-lock.yaml}'
+
+      - name: Set E2E scope
+        id: scope
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "e2e_required=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ steps.filter.outputs.runtime }}" = "true" ] ||
+            [ "${{ steps.filter.outputs.public_assets }}" = "true" ] ||
+            [ "${{ steps.filter.outputs.e2e_tests }}" = "true" ] ||
+            [ "${{ steps.filter.outputs.testinfra }}" = "true" ] ||
+            [ "${{ steps.filter.outputs.config }}" = "true" ] ||
+            [ "${{ steps.filter.outputs.dependencies }}" = "true" ]; then
+            echo "e2e_required=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "e2e_required=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Summarize E2E scope
+        run: |
+          {
+            echo "## E2E Smoke Scope"
+            echo "- **E2E required**: ${{ steps.scope.outputs.e2e_required }}"
+            echo "- **Runtime**: ${{ steps.filter.outputs.runtime }}"
+            echo "- **Public assets**: ${{ steps.filter.outputs.public_assets }}"
+            echo "- **E2E tests**: ${{ steps.filter.outputs.e2e_tests }}"
+            echo "- **Test infrastructure**: ${{ steps.filter.outputs.testinfra }}"
+            echo "- **Relevant config**: ${{ steps.filter.outputs.config }}"
+            echo "- **Dependencies**: ${{ steps.filter.outputs.dependencies }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   admin-smoke:
     name: Admin E2E Smoke
+    needs: e2e-scope
+    if: needs.e2e-scope.outputs.e2e_required == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: admin-e2e-smoke
@@ -79,10 +146,14 @@ jobs:
             output/playwright/artifacts/**
             output/playwright/report/**
           if-no-files-found: ignore
+          retention-days: 7
 
   public-smoke:
     name: Public E2E Smoke
-    needs: admin-smoke
+    needs:
+      - e2e-scope
+      - admin-smoke
+    if: needs.e2e-scope.outputs.e2e_required == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -131,3 +202,37 @@ jobs:
             output/playwright/artifacts/**
             output/playwright/report/**
           if-no-files-found: ignore
+          retention-days: 7
+
+  e2e-smoke-gate:
+    name: E2E Smoke Gate
+    needs:
+      - e2e-scope
+      - admin-smoke
+      - public-smoke
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce E2E smoke policy
+        run: |
+          if [ "${{ needs.e2e-scope.result }}" != "success" ]; then
+            echo "E2E scope detection did not complete successfully."
+            exit 1
+          fi
+
+          if [ "${{ needs.e2e-scope.outputs.e2e_required }}" != "true" ]; then
+            echo "E2E smoke tests skipped because no E2E-relevant changes were detected."
+            exit 0
+          fi
+
+          if [ "${{ needs.admin-smoke.result }}" != "success" ]; then
+            echo "Admin E2E smoke tests were required but did not pass."
+            exit 1
+          fi
+
+          if [ "${{ needs.public-smoke.result }}" != "success" ]; then
+            echo "Public E2E smoke tests were required but did not pass."
+            exit 1
+          fi
+
+          echo "E2E smoke policy satisfied."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -186,17 +186,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Cache Playwright Browsers
-        id: playwright-cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-
-      - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: mkdir -p ~/.cache/ms-playwright && pnpm exec playwright install chromium
-
       - name: Run unit tests
         id: unit
         run: pnpm vitest --project unit --run --coverage
@@ -221,6 +210,7 @@ jobs:
             coverage/unit/coverage-summary.json
             coverage/unit/coverage-final.json
           if-no-files-found: ignore
+          retention-days: 7
 
       - name: Generate job summary
         if: always()
@@ -289,6 +279,7 @@ jobs:
             coverage/storybook/coverage-summary.json
             coverage/storybook/coverage-final.json
           if-no-files-found: ignore
+          retention-days: 7
 
       - name: Generate job summary
         if: always()
@@ -430,6 +421,7 @@ jobs:
             coverage/integration/coverage-summary.json
             coverage/integration/coverage-final.json
           if-no-files-found: ignore
+          retention-days: 7
 
       - name: Generate job summary
         if: always()
@@ -476,6 +468,7 @@ jobs:
           name: coverage-combined
           path: coverage/combined/**
           if-no-files-found: ignore
+          retention-days: 7
 
       - name: Publish combined coverage summary
         if: always()

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -160,14 +160,14 @@
         "filename": ".github/workflows/deploy.yml",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 314
+        "line_number": 305
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/deploy.yml",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 322
+        "line_number": 313
       }
     ],
     "docker-compose.test.yml": [
@@ -11267,5 +11267,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-09T11:51:00Z"
+  "generated_at": "2026-07-05T13:38:14Z"
 }

--- a/docs/engineering/github-actions-pipeline-refactor-temporary.md
+++ b/docs/engineering/github-actions-pipeline-refactor-temporary.md
@@ -1,0 +1,115 @@
+# Temporary GitHub Actions Pipeline Refactor Plan
+
+This document is the implementation handoff for a possible larger pipeline refactor. It intentionally does not change workflows. Use it after the quickwin PR has run long enough to show whether more work is justified.
+
+## Current workflow shape
+
+The repository already separates the main CI concerns:
+
+- `PR Validation` owns merge-critical static checks, unit tests, Storybook tests, build, targeted integration tests, and coverage reporting.
+- `DB Quality` owns migration and schema safety with a stable `db-quality-gate` job.
+- `Workflow Security` owns workflow linting, zizmor, and secret scanning for workflow/security changes plus scheduled coverage.
+- `Deploy Preview` owns preview deployment for deployable changes.
+- `Admin E2E Smoke` owns admin and public Playwright smoke coverage.
+- `Deep Quality Lane` owns broad nightly hygiene.
+
+The current high-cost gaps are routing gaps, not proof that the pipeline needs a full rewrite. A docs-only PR can still run E2E smoke checks, and several jobs repeat checkout, pnpm setup, install, browser cache setup, coverage publication, and artifact upload.
+
+## Baseline to collect before refactoring
+
+Collect 14 to 30 days of GitHub Actions data before changing the architecture. Capture workflow name, job name, event, branch, conclusion, start time, end time, duration, rerun count, and whether the job was required for merge.
+
+Recommended command shape:
+
+```bash
+rtk gh run list --repo findmydoc-platform/website --limit 200 --json databaseId,workflowName,event,headBranch,conclusion,createdAt,updatedAt,url
+rtk gh run view <run-id> --repo findmydoc-platform/website --json jobs
+```
+
+Classify the data into these change classes:
+
+| Change class | Examples | PR feedback target |
+| --- | --- | --- |
+| docs | `README.md`, `docs/**`, Markdown-only ADRs | docs check and policy gates |
+| workflow/security | `.github/workflows/**`, `.github/actions/**`, `.secrets.baseline`, `zizmor.yml` | workflow security and repository policy gates |
+| frontend/ui | route components, blocks, shared UI, CSS, public assets | static checks, unit/Storybook/build, targeted UI smoke when relevant |
+| backend/api | API routes, auth, access, hooks, server utilities | static checks, unit/build, targeted integration |
+| Payload/DB | collections, migrations, Payload config, schema-adjacent hooks | DB quality, integration, build |
+| dependency | `package.json`, `pnpm-lock.yaml`, GitHub Actions dependencies | risk-tiered checks based on dependency type |
+| deployable | runtime sources and build/deploy configuration | PR validation and deploy preview |
+| E2E | Playwright config, E2E tests/helpers, E2E runtime server, runtime surfaces covered by smoke | E2E smoke gate |
+
+## Refactor decision
+
+A larger refactor is justified only if the quickwins still leave repeated waste in common PRs or if required checks remain hard to understand. The larger refactor should not be a full rewrite. It should consolidate routing decisions and preserve the existing concern boundaries.
+
+Do not refactor when the baseline shows the remaining cost comes mostly from intentional runtime, dependency, or deployment validation.
+
+## Target architecture
+
+Introduce one shared change classifier and make existing workflows consume its outputs:
+
+- A lightweight classifier job or reusable workflow produces `docs`, `workflow_security`, `frontend_ui`, `backend_api`, `payload_db`, `dependency`, `deployable`, and `e2e` outputs.
+- `PR Validation` remains the fast merge-critical workflow, but individual expensive jobs use classifier outputs instead of local one-off path filters.
+- `DB Quality` keeps the stable `db-quality-gate` and uses classifier output only to avoid duplicate path logic, not to weaken DB safety.
+- `Admin E2E Smoke` keeps a stable gate and runs smoke tests only when `e2e` or high-risk runtime classes require it.
+- `Deploy Preview` runs only for `deployable` changes, trusted same-repository PRs, `main`, and manual dispatch.
+- `Deep Quality Lane` stays scheduled/manual and does not become PR-blocking.
+- CodeQL stays on the current default setup unless measurement shows it is a material cost source for low-signal PRs. If it is material, move to checked-in advanced setup with explicit path routing in a separate security-reviewed PR.
+
+## Implementation sequence
+
+1. Add a read-only classifier workflow or shared action.
+   - Inputs: event name, base ref, changed paths.
+   - Outputs: the eight change classes above plus a summary for GitHub Step Summary.
+   - Validation: synthetic path cases for docs-only, workflow-only, frontend, backend, Payload/DB, dependency, deployable, and E2E.
+
+2. Move `Admin E2E Smoke` to the shared classifier.
+   - Keep `E2E Smoke Gate` as the stable required-check candidate.
+   - Preserve manual dispatch as always-run.
+
+3. Move `PR Validation` path decisions to the shared classifier.
+   - Keep Static Checks as the broad baseline.
+   - Run Storybook tests for frontend/UI, Storybook, dependency, and manual cases.
+   - Run Integration Tests for backend/API, Payload/DB, dependency, `main`, and manual cases.
+   - Run Build for deployable, dependency, `main`, and manual cases.
+   - Run Combined Coverage only when at least one coverage-producing job ran.
+
+4. Move `Deploy Preview` routing to the shared classifier.
+   - Preserve the trusted-source guard for PR secrets.
+   - Keep `main` alias behavior unchanged.
+
+5. Review repository settings.
+   - Required checks should point only at stable gates: PR validation gate, `DB Quality / db-quality-gate`, `E2E Smoke Gate` if E2E remains required, workflow security gate if workflow/security changes are required.
+   - Do not require path-skipped implementation jobs directly.
+
+6. Consider CodeQL advanced setup only after measurement.
+   - Keep security reviewer approval as a decision gate.
+   - Preserve language coverage for Actions, JavaScript/TypeScript, and Python.
+
+## Feedback signals that must not be lost
+
+- Workflow changes still need actionlint, zizmor, and secret scanning.
+- Auth, access-control, API, Payload, schema, and migration changes still need targeted backend or DB validation.
+- Runtime dependency and framework updates still need broad build/test coverage.
+- Same-repository PRs that can deploy must keep preview deploy confidence unless the classifier proves the change is non-deployable.
+- Public and admin smoke coverage must still run for runtime surfaces that those tests protect.
+- Required checks must never remain pending because an implementation job was path-skipped.
+
+## Acceptance criteria for the later refactor
+
+- Docs-only PRs run no runtime build, preview deploy, E2E smoke, or broad test jobs.
+- Workflow-only PRs run workflow security and repository policy checks without runtime deployment or E2E smoke.
+- Runtime PRs retain PR validation, build, deploy preview when trusted, and relevant smoke coverage.
+- Payload/DB PRs retain DB quality and targeted integration coverage.
+- Dependency PRs use risk-tiered routing with conservative fallback for runtime, framework, test-runner, and security updates.
+- The required-check list contains only stable gates.
+- The baseline report shows lower billed work for low-risk PRs without removing high-signal validation from risky PRs.
+
+## Out of scope for the quickwin PR
+
+- No central classifier implementation.
+- No CodeQL configuration migration.
+- No branch-protection or ruleset change.
+- No workflow consolidation.
+- No removal of existing security, DB, deployment, or runtime validation signals.


### PR DESCRIPTION
## Management summary

### Deutsch

Diese Änderung reduziert unnötige CI-Arbeit bei risikoarmen Änderungen und hält teure Laufzeitprüfungen auf die Fälle konzentriert, in denen sie sinnvolles Feedback liefern. Gleichzeitig bleibt der größere Pipeline-Umbau bewusst als geprüfte Planungsarbeit getrennt, damit Kostenoptimierung nicht auf Kosten von Sicherheit oder Release-Vertrauen passiert.

### English

This change reduces unnecessary CI work for low-risk changes and keeps expensive runtime checks focused on cases where they provide useful feedback. At the same time, the larger pipeline redesign remains a reviewed planning effort, so cost optimization does not trade away security or release confidence.

## What changed

- Added an E2E scope gate to `Admin E2E Smoke` so admin and public smoke tests run only for runtime, E2E, test-infrastructure, dependency, or relevant configuration changes, while manual dispatch always runs them.
- Split E2E scope filters so docs-only, workflow-only, instruction-only, and pure Markdown changes do not trigger admin/public smoke tests.
- Removed Playwright browser cache/install setup from the node-based unit test job in `PR Validation`.
- Set short retention for Playwright and coverage debug artifacts.
- Added `docs/engineering/github-actions-pipeline-refactor-temporary.md` as the temporary handoff for any later larger pipeline architecture refactor.
- Synced `.secrets.baseline` line numbers after the workflow edit so the workflow security lane stays green.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `.github/workflows/admin-e2e-smoke.yml` | E2E routing changes could skip or require smoke checks incorrectly. | The E2E path set covers runtime, E2E, dependency, and relevant config changes, while docs-only, workflow-only, instruction-only, and pure Markdown changes are safe to skip. | Scenario simulation, `rtk /Users/razorspoint/Library/pnpm/pnpm check`, GitHub `E2E Scope` + `E2E Smoke Gate` |
| P1 | `.github/workflows/deploy.yml`, `.secrets.baseline` | Unit validation loses browser setup, artifact retention changes affect debug evidence, and secret baseline line numbers changed. | Unit tests do not need Playwright browser install, coverage artifacts remain available long enough for PR debugging, and the baseline only reflects line-number drift. | `detect-secrets-hook --baseline .secrets.baseline`, `rtk /Users/razorspoint/Library/pnpm/pnpm check` |
| P2 | `docs/engineering/github-actions-pipeline-refactor-temporary.md` | This document is the implementation handoff for a possible later CI refactor. | The larger refactor remains planning-only and does not smuggle implementation scope into this PR. | `rtk /Users/razorspoint/Library/pnpm/pnpm format` |

## Validation

- [x] `pnpm format`: `rtk /Users/razorspoint/Library/pnpm/pnpm format`
- [x] `pnpm check`: `rtk /Users/razorspoint/Library/pnpm/pnpm check`
- [ ] `pnpm build`: Not run; this changes CI workflow routing and documentation only, with no runtime application output changed.
- [x] Focused tests: YAML parse for changed workflows; static E2E scope scenario simulation for docs-only, instruction-only, workflow-only, pure Markdown, runtime, backend/Payload, workflow-security, dependency, and E2E changes; `rtk git diff --check`; `detect-secrets-hook --baseline .secrets.baseline`
- [x] GitHub PR checks: `rtk gh pr checks 1445 --repo findmydoc-platform/website` returned `Passed: 17`, `Failed: 0`; current PR evidence shows `Admin E2E Smoke` and `Public E2E Smoke` skipped while `E2E Smoke Gate` passed.
- [ ] UI/mobile QA: Not applicable; no UI change.
- [ ] Security/privacy review: Not run; recommend security reviewer because workflow routing changed. The added `pull-requests: read` permission is read-only and is used by `dorny/paths-filter` to list PR files.
- [ ] Migration/schema check: Not applicable; no schema or migration change.
- [x] Documentation/instructions check: `rtk /Users/razorspoint/Library/pnpm/pnpm format`

## Risk and rollout

The main risk is path routing that skips E2E smoke coverage for a change that should run it. The E2E scope intentionally uses a conservative runtime/config/dependency path set, manual dispatch remains available for explicit smoke runs, and the stable gate keeps the workflow check from remaining pending when smoke jobs are skipped. Rollback is reverting the workflow and temporary documentation changes.

## Development

Closes #1444
