### PR TITLE
fix: require deterministic Vercel project binding

### DIFF
--- a/.github/scripts/deploy/assert-vercel-project-binding.sh
+++ b/.github/scripts/deploy/assert-vercel-project-binding.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${VERCEL_ORG_ID:-}" ]]; then
+  echo "VERCEL_ORG_ID is required." >&2
+  exit 1
+fi
+
+if [[ -z "${VERCEL_PROJECT_ID:-}" ]]; then
+  echo "VERCEL_PROJECT_ID is required." >&2
+  exit 1
+fi
+
+if [[ -n "${EXPECTED_VERCEL_PROJECT_ID:-}" && "${VERCEL_PROJECT_ID}" != "${EXPECTED_VERCEL_PROJECT_ID}" ]]; then
+  echo "VERCEL_PROJECT_ID must match EXPECTED_VERCEL_PROJECT_ID for this deployment workflow." >&2
+  exit 1
+fi

--- a/.github/scripts/deploy/vercel-deploy.sh
+++ b/.github/scripts/deploy/vercel-deploy.sh
@@ -10,20 +10,8 @@ if [[ -z "${VERCEL_TOKEN:-}" ]]; then
   exit 1
 fi
 
-if [[ -z "${VERCEL_ORG_ID:-}" ]]; then
-  echo "VERCEL_ORG_ID is required." >&2
-  exit 1
-fi
-
-if [[ -z "${VERCEL_PROJECT_ID:-}" ]]; then
-  echo "VERCEL_PROJECT_ID is required." >&2
-  exit 1
-fi
-
-if [[ -n "${EXPECTED_VERCEL_PROJECT_ID:-}" && "${VERCEL_PROJECT_ID}" != "${EXPECTED_VERCEL_PROJECT_ID}" ]]; then
-  echo "VERCEL_PROJECT_ID must match EXPECTED_VERCEL_PROJECT_ID for this deployment workflow." >&2
-  exit 1
-fi
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+bash "${script_dir}/assert-vercel-project-binding.sh"
 
 if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
   echo "GITHUB_OUTPUT is required." >&2
@@ -42,11 +30,11 @@ fi
 
 case "${target}" in
   preview)
-    deploy_command=(pnpm dlx vercel@canary deploy --target preview --token="${VERCEL_TOKEN}")
+    deploy_command=(pnpm dlx vercel@canary deploy --target preview)
     label="Preview"
     ;;
   production)
-    deploy_command=(pnpm dlx vercel@canary deploy --prod --token="${VERCEL_TOKEN}")
+    deploy_command=(pnpm dlx vercel@canary deploy --prod)
     label="Production"
     ;;
   *)

--- a/.github/scripts/deploy/vercel-deploy.sh
+++ b/.github/scripts/deploy/vercel-deploy.sh
@@ -10,6 +10,21 @@ if [[ -z "${VERCEL_TOKEN:-}" ]]; then
   exit 1
 fi
 
+if [[ -z "${VERCEL_ORG_ID:-}" ]]; then
+  echo "VERCEL_ORG_ID is required." >&2
+  exit 1
+fi
+
+if [[ -z "${VERCEL_PROJECT_ID:-}" ]]; then
+  echo "VERCEL_PROJECT_ID is required." >&2
+  exit 1
+fi
+
+if [[ -n "${EXPECTED_VERCEL_PROJECT_ID:-}" && "${VERCEL_PROJECT_ID}" != "${EXPECTED_VERCEL_PROJECT_ID}" ]]; then
+  echo "VERCEL_PROJECT_ID must match EXPECTED_VERCEL_PROJECT_ID for this deployment workflow." >&2
+  exit 1
+fi
+
 if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
   echo "GITHUB_OUTPUT is required." >&2
   exit 1

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -75,17 +75,8 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          if [[ -z "${VERCEL_ORG_ID}" || -z "${VERCEL_PROJECT_ID}" ]]; then
-            echo "VERCEL_ORG_ID and VERCEL_PROJECT_ID are required for deterministic Vercel project binding." >&2
-            exit 1
-          fi
-
-          if [[ "${VERCEL_PROJECT_ID}" != "${EXPECTED_VERCEL_PROJECT_ID}" ]]; then
-            echo "VERCEL_PROJECT_ID does not match the expected findmydoc-portal project." >&2
-            exit 1
-          fi
-
-          pnpm dlx vercel@canary pull --yes --environment=preview --token="$VERCEL_TOKEN"
+          bash ./.github/scripts/deploy/assert-vercel-project-binding.sh
+          pnpm dlx vercel@canary pull --yes --environment=preview
 
       - name: Deploy to Vercel (Preview)
         id: vercel_preview
@@ -102,9 +93,14 @@ jobs:
         if: github.event_name == 'push' && github.ref_name == 'main'
         env:
           DEPLOYMENT_URL: ${{ steps.vercel_preview.outputs.deploymentUrl }}
+          EXPECTED_VERCEL_PROJECT_ID: ${{ env.EXPECTED_VERCEL_PROJECT_ID }}
           PREVIEW_ALIAS_DOMAIN: ${{ env.PREVIEW_ALIAS_DOMAIN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: pnpm dlx vercel@canary alias set "$DEPLOYMENT_URL" "$PREVIEW_ALIAS_DOMAIN" --token="$VERCEL_TOKEN"
+        run: |
+          bash ./.github/scripts/deploy/assert-vercel-project-binding.sh
+          pnpm dlx vercel@canary alias set "$DEPLOYMENT_URL" "$PREVIEW_ALIAS_DOMAIN"
 
       - name: Generate deployment summary
         if: always()

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -33,6 +33,7 @@ concurrency:
 env:
   NODE_VERSION: 24.14.0
   PNPM_VERSION: 10.28.2
+  EXPECTED_VERCEL_PROJECT_ID: prj_J8dOCr0Ft97TlCAUnbpdHG29Vtgx
   PREVIEW_ALIAS_DOMAIN: preview.findmydoc.eu
   NEXT_TELEMETRY_DISABLED: 1
 
@@ -69,14 +70,31 @@ jobs:
 
       - name: Pull Vercel Environment Variables for Preview
         env:
+          EXPECTED_VERCEL_PROJECT_ID: ${{ env.EXPECTED_VERCEL_PROJECT_ID }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: pnpm dlx vercel@canary pull --yes --environment=preview --token="$VERCEL_TOKEN"
+        run: |
+          if [[ -z "${VERCEL_ORG_ID}" || -z "${VERCEL_PROJECT_ID}" ]]; then
+            echo "VERCEL_ORG_ID and VERCEL_PROJECT_ID are required for deterministic Vercel project binding." >&2
+            exit 1
+          fi
+
+          if [[ "${VERCEL_PROJECT_ID}" != "${EXPECTED_VERCEL_PROJECT_ID}" ]]; then
+            echo "VERCEL_PROJECT_ID does not match the expected findmydoc-portal project." >&2
+            exit 1
+          fi
+
+          pnpm dlx vercel@canary pull --yes --environment=preview --token="$VERCEL_TOKEN"
 
       - name: Deploy to Vercel (Preview)
         id: vercel_preview
         env:
           DATABASE_URI: ${{ secrets.DATABASE_URI }}
+          EXPECTED_VERCEL_PROJECT_ID: ${{ env.EXPECTED_VERCEL_PROJECT_ID }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: bash ./.github/scripts/deploy/vercel-deploy.sh preview
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,6 +13,7 @@ concurrency:
 env:
   NODE_VERSION: 24.14.0
   PNPM_VERSION: 10.28.2
+  EXPECTED_VERCEL_PROJECT_ID: prj_J8dOCr0Ft97TlCAUnbpdHG29Vtgx
   PRODUCTION_ALIAS_DOMAIN: findmydoc.eu
   NEXT_TELEMETRY_DISABLED: 1
 
@@ -51,13 +52,30 @@ jobs:
 
       - name: Pull Vercel Environment Variables for Production
         env:
+          EXPECTED_VERCEL_PROJECT_ID: ${{ env.EXPECTED_VERCEL_PROJECT_ID }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: pnpm dlx vercel@canary pull --yes --environment=production --token="$VERCEL_TOKEN"
+        run: |
+          if [[ -z "${VERCEL_ORG_ID}" || -z "${VERCEL_PROJECT_ID}" ]]; then
+            echo "VERCEL_ORG_ID and VERCEL_PROJECT_ID are required for deterministic Vercel project binding." >&2
+            exit 1
+          fi
+
+          if [[ "${VERCEL_PROJECT_ID}" != "${EXPECTED_VERCEL_PROJECT_ID}" ]]; then
+            echo "VERCEL_PROJECT_ID does not match the expected findmydoc-portal project." >&2
+            exit 1
+          fi
+
+          pnpm dlx vercel@canary pull --yes --environment=production --token="$VERCEL_TOKEN"
 
       - name: Deploy to Vercel (Production)
         id: vercel_production
         env:
+          EXPECTED_VERCEL_PROJECT_ID: ${{ env.EXPECTED_VERCEL_PROJECT_ID }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: bash ./.github/scripts/deploy/vercel-deploy.sh production
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -57,17 +57,8 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          if [[ -z "${VERCEL_ORG_ID}" || -z "${VERCEL_PROJECT_ID}" ]]; then
-            echo "VERCEL_ORG_ID and VERCEL_PROJECT_ID are required for deterministic Vercel project binding." >&2
-            exit 1
-          fi
-
-          if [[ "${VERCEL_PROJECT_ID}" != "${EXPECTED_VERCEL_PROJECT_ID}" ]]; then
-            echo "VERCEL_PROJECT_ID does not match the expected findmydoc-portal project." >&2
-            exit 1
-          fi
-
-          pnpm dlx vercel@canary pull --yes --environment=production --token="$VERCEL_TOKEN"
+          bash ./.github/scripts/deploy/assert-vercel-project-binding.sh
+          pnpm dlx vercel@canary pull --yes --environment=production
 
       - name: Deploy to Vercel (Production)
         id: vercel_production
@@ -81,8 +72,15 @@ jobs:
 
       - name: Set Production Alias
         env:
+          DEPLOYMENT_URL: ${{ steps.vercel_production.outputs.deploymentUrl }}
+          EXPECTED_VERCEL_PROJECT_ID: ${{ env.EXPECTED_VERCEL_PROJECT_ID }}
+          PRODUCTION_ALIAS_DOMAIN: ${{ env.PRODUCTION_ALIAS_DOMAIN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: pnpm dlx vercel@canary alias set "${{ steps.vercel_production.outputs.deploymentUrl }}" "${{ env.PRODUCTION_ALIAS_DOMAIN }}" --token="$VERCEL_TOKEN"
+        run: |
+          bash ./.github/scripts/deploy/assert-vercel-project-binding.sh
+          pnpm dlx vercel@canary alias set "$DEPLOYMENT_URL" "$PRODUCTION_ALIAS_DOMAIN"
 
       - name: Generate deployment summary
         if: always()


### PR DESCRIPTION
## Management summary

### Deutsch

Die Preview-Umgebung ist wieder ohne fremdes Login erreichbar. Künftige Preview- und Produktionsveröffentlichungen brechen kontrolliert ab, wenn die interne Projektzuordnung driftet, statt versehentlich eine falsche Umgebung sichtbar zu machen.

### English

The preview environment is available again without an external login gate. Future preview and production releases now stop safely when the internal project binding drifts instead of accidentally exposing the wrong environment.

## What changed

- Restored deterministic Vercel project binding for preview and production deploy workflows by requiring `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` on pull, deploy, and alias steps.
- Added a shared expected project ID guard for `findmydoc-portal`, so a missing or wrong project secret fails before a deployment can be aliased.
- Updated the deploy script to reuse the shared binding guard for both preview and production deploys.
- Removed Vercel token CLI flags from the affected deploy paths; Vercel receives `VERCEL_TOKEN` through the step environment instead of process arguments.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `.github/workflows/deploy-preview.yml`, `.github/workflows/deploy-production.yml` | Deploy workflows now fail closed on project binding drift before pull, deploy, and alias. | Existing repository/environment secrets still provide the intended `findmydoc-portal` IDs, and missing/wrong values block before aliasing. | `pnpm check`, direct Preview redeploy, live HTTP 200 check |
| P1 | `.github/scripts/deploy/assert-vercel-project-binding.sh`, `.github/scripts/deploy/vercel-deploy.sh` | Shared deploy guard now enforces the same project contract and avoids token flags. | The guard runs before Vercel deploy commands and does not print secret values. | `bash -n`, focused guard failure tests, `rg --fixed-strings -- "--token"` on affected paths |

## Validation

- [x] `pnpm format`: `/Users/razorspoint/Library/pnpm/pnpm format`
- [x] `pnpm check`: `/Users/razorspoint/Library/pnpm/pnpm check`
- [ ] `pnpm build`: skipped; workflow/script-only CI-critical change. The direct Vercel preview deployment completed a remote build successfully.
- [x] Focused tests: `bash -n .github/scripts/deploy/assert-vercel-project-binding.sh .github/scripts/deploy/vercel-deploy.sh`; focused guard failure tests with dummy env; `rg --line-number --fixed-strings -- "--token"` returned no matches in the affected Vercel deploy paths; `curl --head https://preview.findmydoc.eu` returned HTTP 200 after alias repair.
- [ ] UI/mobile QA: not applicable; no UI changes.
- [x] Security/privacy review: no secret values were added to repository files; the guard uses existing GitHub secrets and a non-secret expected project ID. Reviewer findings below 5/10 were addressed by removing token flags and guarding alias steps.
- [ ] Migration/schema check: not applicable; no schema or migration changes.
- [ ] Documentation/instructions check: not applicable; no docs or instruction files changed.

## Risk and rollout

Preview was repaired manually before this PR by deploying `main@cbd9c8cf` to `findmydoc-portal` and reassigning `preview.findmydoc.eu`. After merge, deploy workflows require the existing Vercel org/project secrets to be present and to match `findmydoc-portal`; if they do not, pull/deploy/alias steps fail before changing any alias.

## Development

Closes #1446
