### PR TITLE
docs: add cache stack 2-8 work orders

### DIFF
--- a/docs/roadmap/caching-strategy/work-orders/pr-02-policy-map.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-02-policy-map.md
@@ -125,7 +125,7 @@ The tests must prove:
 - the catalog includes the central PR 1 public routes, globals, collections, discovery surfaces, seed/bulk flows, and observability boundary
 - the policy module does not export or generate legacy tag names such as `global_header`, `pages-sitemap`, `posts-sitemap`, `redirects`, or `${collection}_${slug}`
 
-Tests should live near existing utility tests, for example `tests/unit/utilities/cachePolicy.test.ts`.
+Tests should live near existing utility tests, for example a future `cachePolicy.test.ts` file under `tests/unit/utilities/`.
 
 Do not write tests that only duplicate constants without proving a public behavior contract. Prefer table-driven assertions where they make the policy surface easier to scan.
 

--- a/docs/roadmap/caching-strategy/work-orders/pr-02-policy-map.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-02-policy-map.md
@@ -1,0 +1,196 @@
+# PR 2 Work Order: Cache Policy Map
+
+This work order defines the future PR 2 implementation packet for the public cache and revalidation stack. It is a planning artifact only. It does not implement PR 2 and does not change runtime behavior.
+
+## Summary
+
+PR 2 introduces the central, pure cache policy code contract that later PRs use for cache classes, tag families, public path builders, known public surfaces, and operation vocabulary.
+
+- Branch: `feature/cache-revalidation/02-policy-map`
+- PR title: `refactor: add cache stack 2/8 policy map`
+- Base branch: `main`
+- Dependency: PR 1 and ADR 023 are already merged into `main`.
+- Scope type: contract-only runtime code preparation.
+
+The implementation must not ask the executor to decide cache classes, freshness expectations, invalidation owners, tag families, public/private boundaries, PR order, or reviewer gates.
+
+## Source Inputs
+
+- [ADR 023 - Public Website Cache and Revalidation Strategy](../../../adrs/023-adr-public-website-cache-and-revalidation-strategy.md)
+- [Public Cache And Revalidation Implementation Plan](../cache-revalidation-implementation-plan.md)
+- [ADR 010 - Structured Logging Approach](../../../adrs/010-structured-logging-approach.md)
+- [ADR 019 - PostHog Event Taxonomy and Usage Governance](../../../adrs/019-adr-posthog-event-taxonomy-and-usage-governance.md)
+- [ADR 022 - Public Localization, Routing, SEO, and Domain Strategy](../../../adrs/022-adr-public-localization-routing-seo-and-domain-strategy.md)
+- [Public Discovery Strategy](../../../public-discovery-strategy.md)
+
+## Objective
+
+Add a central cache policy module that turns the accepted cache architecture into typed, pure, testable code without changing runtime cache behavior.
+
+The policy map must provide a stable base for PR 3 planner/executor work and PR 4-8 runtime wiring. Future implementers must be able to consume the module without inventing tag names, path shapes, cache classes, or surface IDs locally.
+
+## Non-Goals
+
+PR 2 must not:
+
+- route collection hooks, global hooks, redirect hooks, routes, sitemap routes, seed flows, or media hooks through a planner
+- call `revalidateTag` or `revalidatePath`
+- change `unstable_cache` usage
+- alter route `dynamic`, `revalidate`, `force-static`, or `force-dynamic` behavior
+- replace existing runtime tag strings in hooks or helpers
+- add legacy dual-tagging for `global_header`, `global_footer`, `global_landingPages`, `global_cookieConsent`, `pages-sitemap`, `posts-sitemap`, `redirects`, or `${collection}_${slug}`
+- repair, remove, or rewire `getCachedDocument`
+- add Redis, a custom cache handler, remote cache storage, locks, dedupe, or runtime cache persistence
+- change ADR 023 or the PR 1 implementation plan
+
+## Fixed Decisions
+
+PR 2 uses these decisions without reopening them:
+
+- Module location: `src/utilities/cachePolicy/**`
+- API shape: machine-readable catalog plus pure builders.
+- Catalog scope: full PR 1 cache assignment matrix, expressed as code contracts.
+- Tag policy: ADR-023 canonical tags only.
+- Operation policy: vocabulary only; no planner logic.
+- Input behavior: fail fast for invalid inputs.
+- Legacy behavior: existing runtime legacy tags remain unchanged until later PRs migrate their owners.
+
+The cache classes are exactly:
+
+- `critical-public`
+- `shared-public`
+- `aggregated-public`
+- `private-live`
+- `operational-scaling`
+
+The canonical tag families are exactly:
+
+- `entity:<collection>:<id>`
+- `slug:<collection>:<slug>`
+- `collection:<collection>`
+- `global:<slug>`
+- `surface:<name>`
+- `surface:sitemap:<name>`
+- `surface:discovery:<name>`
+
+The operation vocabulary must include only names needed by later planner work, such as:
+
+- `publish`
+- `update`
+- `unpublish`
+- `delete`
+- `slug-change`
+- `global-update`
+- `related-update`
+- `seed-final-flush`
+- `preview-read`
+
+The vocabulary must not compute affected tags or paths in PR 2.
+
+## Expected Implementation Shape
+
+The implementation should create a small pure module under `src/utilities/cachePolicy/**`.
+
+The module should expose:
+
+- types for cache classes, boundaries, known surfaces, tag families, and operation names
+- a `CACHE_POLICY_CATALOG` or equivalent machine-readable catalog
+- pure tag builders for entity, slug, collection, global, surface, sitemap, and discovery tags
+- pure path builders for known public path families, including page detail, post detail, clinic detail, posts index, posts pagination, fixed landing paths, sitemap paths, and discovery paths
+- surface IDs for the public route, global, collection, discovery, seed, and operational surfaces from the PR 1 matrix
+
+The catalog should be machine-readable, not prose-heavy. It should include IDs, cache class, public/private or operational boundary, owner category, relevant tag families, and path relationship where applicable. Freshness explanations stay in ADR 023, the PR 1 implementation plan, and the PR-specific work orders.
+
+Builder behavior:
+
+- root-relative paths must start with `/` and must not start with `//`
+- empty or whitespace-only IDs, slugs, collections, globals, and surface names must throw
+- unknown surface IDs must throw
+- Payload slugs must be preserved as provided after trimming; builders must not slugify, lowercase, or otherwise invent canonical content slugs
+- future locale/domain dimensions must not be hard-coded with fake values
+
+PR 2 may add local helper functions inside the policy module when they keep validation and normalization reusable. Those helpers must remain pure and must not import Payload, Next cache APIs, route modules, request objects, environment readers, loggers, or database clients.
+
+## Expected Tests
+
+Add focused unit coverage for the new policy module.
+
+The tests must prove:
+
+- cache classes match ADR 023 and PR 1
+- canonical tag builders produce `entity:*`, `slug:*`, `collection:*`, `global:*`, `surface:*`, `surface:sitemap:*`, and `surface:discovery:*` strings
+- path builders produce the known public paths, including `home` page slug to `/`, post detail paths, clinic detail paths, posts index, posts pagination, landing routes, sitemap paths, and discovery paths
+- invalid inputs fail fast
+- the operation vocabulary exists but does not compute planner output
+- the catalog includes the central PR 1 public routes, globals, collections, discovery surfaces, seed/bulk flows, and observability boundary
+- the policy module does not export or generate legacy tag names such as `global_header`, `pages-sitemap`, `posts-sitemap`, `redirects`, or `${collection}_${slug}`
+
+Tests should live near existing utility tests, for example `tests/unit/utilities/cachePolicy.test.ts`.
+
+Do not write tests that only duplicate constants without proving a public behavior contract. Prefer table-driven assertions where they make the policy surface easier to scan.
+
+## Validation
+
+The future PR 2 implementation must run:
+
+```bash
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm vitest tests/unit/utilities/cachePolicy.test.ts --project unit
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm format
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm check
+```
+
+Run `pnpm build` only if PR 2 expands into Next.js, Payload config, routing, or output-affecting changes. Under this work order, it should not.
+
+For this planning-document PR, only run:
+
+```bash
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm format
+```
+
+## Reviewers
+
+Recommended reviewers for the future PR 2 implementation:
+
+- `security-reviewer` for private-live separation, trust boundaries, and fail-fast behavior
+- `seo-reviewer` for public discovery, sitemap, canonical surface, and tag naming alignment
+
+Add `web-vitals-reviewer` only if PR 2 unexpectedly touches route caching semantics. Skip UI, accessibility, mobile UI, and Storybook reviewers unless the scope expands into those surfaces.
+
+Reviewers must run only after Sebastian explicitly confirms reviewer execution. Findings must be fixed and reviewers rerun before PR 3 starts, with the stack-wide maximum of three reviewer cycles unless Sebastian approves more.
+
+## Exit Criteria
+
+PR 2 is complete when:
+
+- `src/utilities/cachePolicy/**` exists and contains only pure policy code
+- all cache classes and tag families from ADR 023 are represented
+- the central PR 1 surface assignments are represented in a machine-readable catalog
+- canonical tag and path builders are tested
+- invalid input behavior is tested
+- operation vocabulary is present without planner logic
+- no runtime hook, route, sitemap, seed, redirect, media, or cache-helper behavior changes
+- validation passes
+- applicable reviewers report no remaining findings or documented accepted exceptions
+
+## Stop Conditions
+
+Stop and ask Sebastian before implementing further if:
+
+- ADR 023 or the PR 1 implementation plan appears wrong or incomplete
+- a new cache class, tag family, freshness policy, invalidation owner, public/private boundary, PR order, or reviewer gate seems necessary
+- runtime wiring is required to make the policy module meaningful
+- legacy dual-tagging seems required
+- `getCachedDocument` must be changed to keep PR 2 coherent
+- a surface cannot be mapped from ADR 023 or the PR 1 implementation plan
+- a direct Redis, custom cache handler, or remote cache store decision appears necessary
+
+Do not patch ADR 023 or the PR 1 implementation plan inside PR 2. Those are architecture changes and must be handled separately.
+
+## Assumptions
+
+- PR 1 is merged into `main` and remains the operative stack/order/governance source.
+- ADR 023 remains the architecture contract.
+- PR 2 is the first implementation PR but is intentionally contract-only.
+- PR 3 will add planner/executor behavior.
+- PR 4-8 will consume this policy map for runtime wiring.
+- The future full-stack execution goal may start only after work orders for PR 2 through PR 8 are all decision-complete.

--- a/docs/roadmap/caching-strategy/work-orders/pr-03-planner-executor.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-03-planner-executor.md
@@ -1,0 +1,227 @@
+# PR 3 Work Order: Revalidation Planner And Executor
+
+This work order defines the future PR 3 implementation packet for the public cache and revalidation stack. It is a planning artifact only. It does not implement PR 3 and does not change runtime behavior.
+
+## Summary
+
+PR 3 introduces the central revalidation planner and executor boundary that later PRs use to turn normalized cache events into tags, paths, execution results, and redacted operational logs.
+
+- Branch: `feature/cache-revalidation/03-planner-executor`
+- PR title: `refactor(hooks): add cache stack 3/8 revalidation planner`
+- Base branch: `feature/cache-revalidation/02-policy-map`
+- Dependency: PR 2 is implemented, validated, reviewer-clean, and based on the accepted PR 1 plan.
+- Scope type: boundary-only runtime code preparation.
+
+The implementation must not ask the executor to decide cache classes, freshness expectations, invalidation owners, tag families, public/private boundaries, PR order, or reviewer gates.
+
+## Source Inputs
+
+- [ADR 023 - Public Website Cache and Revalidation Strategy](../../../adrs/023-adr-public-website-cache-and-revalidation-strategy.md)
+- [Public Cache And Revalidation Implementation Plan](../cache-revalidation-implementation-plan.md)
+- [PR 2 Work Order: Cache Policy Map](./pr-02-policy-map.md)
+- Future PR 2 `src/utilities/cachePolicy/**` implementation output
+- [ADR 010 - Structured Logging Approach](../../../adrs/010-structured-logging-approach.md)
+- [ADR 019 - PostHog Event Taxonomy and Usage Governance](../../../adrs/019-adr-posthog-event-taxonomy-and-usage-governance.md)
+- [ADR 022 - Public Localization, Routing, SEO, and Domain Strategy](../../../adrs/022-adr-public-localization-routing-seo-and-domain-strategy.md)
+- [Public Discovery Strategy](../../../public-discovery-strategy.md)
+
+## Objective
+
+Add a central revalidation planner and executor module that turns PR 2 policy-map contracts into serializable, testable revalidation plans.
+
+The planner must be pure. It maps normalized events to deduped tags, paths, cache classes, surface IDs, and redacted log metadata. The executor performs the runtime side effects in a controlled boundary, attempts all planned work best-effort, and returns structured execution results.
+
+PR 3 prepares the runtime boundary for PR 4 core hook migration. It does not migrate existing hooks, routes, sitemaps, seed flows, media hooks, cache helpers, or `unstable_cache` call sites.
+
+## Non-Goals
+
+PR 3 must not:
+
+- route collection hooks, global hooks, redirect hooks, routes, sitemap routes, seed flows, media hooks, or cache helpers through the planner
+- change existing calls to `revalidateTag` or `revalidatePath` outside new executor tests and the new executor module
+- change `unstable_cache` usage
+- alter route `dynamic`, `revalidate`, `force-static`, or `force-dynamic` behavior
+- replace existing runtime tag strings in hooks or helpers
+- add legacy dual-tagging for `global_header`, `global_footer`, `global_landingPages`, `global_cookieConsent`, `pages-sitemap`, `posts-sitemap`, `redirects`, or `${collection}_${slug}`
+- repair, remove, or rewire `getCachedDocument`
+- implement clinic/listing, discovery, seed/bulk, direct media dependency, or observability UI behavior
+- add Redis, a custom cache handler, remote cache storage, locks, dedupe, or runtime cache persistence
+- change ADR 023, the PR 1 implementation plan, or the PR 2 policy-map contract
+
+## Fixed Decisions
+
+PR 3 uses these decisions without reopening them:
+
+- Module location: `src/utilities/cacheRevalidation/**`
+- Planner input: normalized event objects, not raw Payload hook args, raw Payload docs, request objects, or route modules.
+- Planner boundary: strictly pure.
+- Executor boundary: the executor is the only PR 3 module that may import `next/cache`.
+- Execution order: tags first, then paths.
+- Execution behavior: best-effort; attempt all planned tags and paths, log failures, and return a summary result without breaking CMS writes.
+- Runtime scope: boundary-only.
+- `disableRevalidate` handling: caller or hook-adapter responsibility. The planner and executor do not consume Payload `context`.
+- Unknown public-cache behavior: fail fast unless the event is explicitly modeled as private-live/no-op or a typed deferred case.
+- Redirect handling: supported only if PR 2 exposes canonical redirect policy support. Otherwise PR 3 must stop instead of inventing redirect tags locally.
+- Logging: operational structured logs only. No PostHog business events.
+
+The executable planner coverage is limited to PR 4 core surfaces:
+
+- Pages
+- Posts
+- Header
+- Footer
+- LandingPages
+- CookieConsent
+- Redirects, only when PR 2 provides a canonical redirect policy entry
+
+The following areas remain explicit deferred cases for later PRs:
+
+- clinic detail and Listing Comparison surfaces for PR 6
+- related clinic-visible collections for PR 6
+- sitemap, public discovery, and `llms.txt` behavior for PR 7
+- seed and bulk final flush behavior for PR 7
+- direct media dependency resolution as a bounded follow-up
+- dashboard or inspector visibility for PR 8
+
+## Expected Implementation Shape
+
+The implementation should create a small runtime module under `src/utilities/cacheRevalidation/**`.
+
+The module should expose:
+
+- normalized event types for supported collection, global, redirect, deferred, and private-live/no-op event inputs
+- a serializable revalidation plan type containing operation, source, subject, cache classes, surface IDs, tags, paths, and redacted log context
+- a pure planner that consumes PR 2 cache-policy builders and catalog data
+- an executor that imports `revalidateTag` and `revalidatePath` from `next/cache`
+- a redacted log payload builder or equivalent helper for planned, executed, and failed revalidation logs
+- a compact public API that future PRs can call from hooks, seed flows, and discovery owners without importing internal planner helpers
+
+Planner behavior:
+
+- accept normalized events only
+- compute tags and paths from the PR 2 policy map
+- dedupe tags and paths deterministically while preserving tag-first, path-second execution intent
+- return empty plans only for explicitly private-live/no-op events
+- throw on unknown public-cache owners, unsupported operations, missing required subject fields, unmapped surface IDs, or redirect policy gaps
+- preserve slug strings according to the PR 2 policy-map builder rules
+- include old and new slug inputs in plans when both are relevant and supplied
+- never import Payload, Next cache APIs, logger utilities, route modules, request objects, environment readers, database clients, PostHog utilities, or filesystem APIs
+
+Executor behavior:
+
+- execute all planned tags first with `revalidateTag(tag, { expire: 0 })`
+- execute all planned paths after tags with `revalidatePath(path)`
+- continue after individual tag or path failures
+- return a serializable result with attempted, succeeded, and failed tag and path counts
+- include failed tag or path identifiers in the result only when they are canonical public cache identifiers
+- avoid throwing for individual `revalidateTag` or `revalidatePath` failures
+- throw only for invalid executor input that cannot represent a planner-produced plan
+- avoid reading request data, Payload docs, cookies, headers, tokens, secrets, sessions, private form data, or unrelated CMS fields
+
+Log payload behavior:
+
+- stable event names include `cache.revalidation.planned`, `cache.revalidation.executed`, and `cache.revalidation.failed`
+- payloads include operation, source kind, source identifier, subject identifiers, cache classes, surface IDs, counts, failure counts, and a non-sensitive correlation field when supplied by the caller
+- payloads do not include raw documents, request bodies, headers, cookies, tokens, secrets, auth sessions, form submissions, private route data, preview/draft document content, or unrelated CMS field values
+- log helpers remain server-only and compatible with ADR 010 Payload/Pino logging conventions
+- PR 3 does not add dashboard storage, PostHog capture, analytics events, or PR 8 visibility UI
+
+The future implementation may choose local filenames inside `src/utilities/cacheRevalidation/**`, but it must keep the pure planner and side-effecting executor separated by imports and tests.
+
+## Expected Tests
+
+Add focused unit coverage for the new revalidation module.
+
+The tests must prove:
+
+- planner output is serializable and contains operation, source, subject, cache classes, surface IDs, tags, paths, and redacted log context
+- planner events for Pages and Posts produce detail paths, collection/entity/slug tags, and sitemap/list surface tags according to the PR 1 matrix and PR 2 policy map
+- planner events for Header, Footer, LandingPages, and CookieConsent produce the expected global and surface tags and known landing paths where applicable
+- redirect planner support is available only when the PR 2 policy map exposes a canonical redirect policy entry
+- unknown public-cache events, unsupported operations, missing identifiers, and unmapped surfaces fail fast
+- explicitly private-live/no-op events return empty plans without cache side effects
+- deferred clinic/listing, discovery, seed/bulk, and media cases are represented as typed unsupported/deferred cases and do not silently produce empty public plans
+- duplicate tags and paths are deduped deterministically
+- executor calls `revalidateTag` before `revalidatePath`
+- executor continues after individual tag or path failures and returns a best-effort summary result
+- executor logs planned, executed, and failed outcomes through the redacted log payload contract
+- log payload builders exclude raw docs, request bodies, cookies, tokens, secrets, sessions, private data, preview/draft content, and unrelated CMS fields
+- the pure planner module does not import `next/cache`, Payload, logger utilities, route modules, request objects, environment readers, database clients, or PostHog utilities
+
+Tests should live near existing utility tests, for example under `tests/unit/utilities/cacheRevalidation/**`.
+
+Do not write tests that only duplicate constants. Prefer behavior-focused assertions that fail when a future hook, seed, or discovery owner would receive an incomplete or unsafe plan.
+
+## Validation
+
+The future PR 3 implementation must run:
+
+```bash
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm vitest tests/unit/utilities/cacheRevalidation --project unit
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm format
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm check
+```
+
+Run `pnpm build` only if PR 3 unexpectedly expands into Next.js routing, Payload config, route output, or other build-output-affecting files. Under this work order, it should not.
+
+For this planning-document PR, only run:
+
+```bash
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm format
+```
+
+## Reviewers
+
+Recommended reviewers for the future PR 3 implementation:
+
+- `security-reviewer` for server trust boundary, fail-fast behavior, and redacted operational logging
+- `seo-reviewer` for sitemap, discovery, canonical surface, and tag/path mapping alignment
+- `web-vitals-reviewer` for cache and performance semantics
+
+Skip UI, accessibility, mobile UI, and Storybook reviewers unless the scope expands into those surfaces.
+
+Reviewers must run only after Sebastian explicitly confirms reviewer execution. Findings must be fixed and reviewers rerun before PR 4 starts, with the stack-wide maximum of three reviewer cycles unless Sebastian approves more.
+
+## Exit Criteria
+
+PR 3 is complete when:
+
+- `src/utilities/cacheRevalidation/**` exists and separates pure planning from runtime execution
+- planner input is normalized and does not require raw Payload hook args or raw docs
+- the planner imports policy-map contracts but no side-effecting runtime dependencies
+- the executor imports `next/cache` and executes tags before paths
+- execution is best-effort and returns structured result summaries
+- planned, executed, and failed log payloads use a stable redacted schema
+- PR 4 core surfaces have executable planner coverage, subject to the redirect policy guard
+- clinic/listing, discovery, seed/bulk, media, and PR 8 visibility areas remain explicit deferred cases
+- no existing hooks, routes, sitemaps, seed flows, media hooks, cache helpers, route modes, or `unstable_cache` call sites change
+- validation passes
+- applicable reviewers report no remaining findings or documented accepted exceptions
+
+## Stop Conditions
+
+Stop and ask Sebastian before implementing further if:
+
+- ADR 023, the PR 1 implementation plan, or the PR 2 policy map appears wrong or incomplete
+- a new cache class, tag family, freshness policy, invalidation owner, public/private boundary, PR order, or reviewer gate seems necessary
+- PR 2 did not provide enough policy-map surface data for PR 3 to plan PR 4 core surfaces
+- redirect support would require inventing a canonical redirect policy inside PR 3
+- raw Payload docs, request objects, cookies, sessions, headers, or unrelated CMS fields appear necessary for planner output
+- runtime hook wiring is required to make the planner useful
+- legacy dual-tagging seems required
+- `getCachedDocument` must be changed to keep PR 3 coherent
+- Redis, custom cache handlers, remote cache storage, locks, dedupe, or runtime cache persistence appear necessary
+- a PostHog business event or dashboard UI becomes necessary for cache visibility
+
+Do not patch ADR 023, the PR 1 implementation plan, or the PR 2 work order inside PR 3. Those are architecture or predecessor-contract changes and must be handled separately.
+
+## Assumptions
+
+- PR 1 is merged into `main` and remains the operative stack/order/governance source.
+- PR 2 remains valid and creates the pure `src/utilities/cachePolicy/**` contract before PR 3 starts.
+- ADR 023 remains the architecture contract.
+- PR 3 may define runtime planner and executor contracts, but it must not change cache assignments or architecture decisions.
+- PR 4 will migrate Pages, Posts, Header, Footer, LandingPages, CookieConsent, and Redirects through the planner.
+- PR 6 and PR 7 will expand planner coverage for clinic/listing, discovery, seed/bulk, and related public surfaces.
+- PR 8 will consume redacted operational outputs for privileged visibility if that scope is still needed.
+- The future full-stack execution goal may start PR 3 only after PR 2 is complete and reviewer-clean.

--- a/docs/roadmap/caching-strategy/work-orders/pr-04-core-hooks.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-04-core-hooks.md
@@ -130,7 +130,7 @@ Expected test files include:
 - `tests/unit/hooks/revalidatePage.test.ts`
 - `tests/unit/hooks/revalidatePost.test.ts`
 - `tests/unit/hooks/revalidateRedirects.test.ts`
-- `tests/unit/hooks/revalidateGlobals.test.ts`
+- future `revalidateGlobals.test.ts` under `tests/unit/hooks/`
 - `tests/unit/utilities/payloadDataFetchers.test.ts`
 - `tests/unit/app/frontend/sitemap.routes.test.ts`
 

--- a/docs/roadmap/caching-strategy/work-orders/pr-04-core-hooks.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-04-core-hooks.md
@@ -1,0 +1,217 @@
+# PR 4 Work Order: Core Hooks
+
+This work order defines the future PR 4 implementation packet for the public cache and revalidation stack. It is a planning artifact only. It does not implement PR 4 and does not change runtime behavior.
+
+## Summary
+
+PR 4 routes the first runtime hook group through the PR 3 revalidation planner and executor boundary. It migrates the core public CMS hooks and the directly matching read-side cache tags together so write-side invalidation and read-side cache tags do not drift.
+
+- Branch: `feature/cache-revalidation/04-core-hooks`
+- PR title: `refactor(hooks): route cache stack 4/8 core hooks through planner`
+- Base branch: `feature/cache-revalidation/03-planner-executor`
+- Dependency: PR 3 is implemented, validated, reviewer-clean, and based on the accepted PR 1 plan.
+- Scope type: core runtime hook migration.
+
+The implementation must not ask the executor to decide cache classes, freshness expectations, invalidation owners, tag families, public/private boundaries, PR order, or reviewer gates.
+
+## Source Inputs
+
+- [ADR 023 - Public Website Cache and Revalidation Strategy](../../../adrs/023-adr-public-website-cache-and-revalidation-strategy.md)
+- [Public Cache And Revalidation Implementation Plan](../cache-revalidation-implementation-plan.md)
+- [PR 2 Work Order: Cache Policy Map](./pr-02-policy-map.md)
+- Future PR 2 `src/utilities/cachePolicy/**` implementation output
+- [PR 3 Work Order: Revalidation Planner And Executor](./pr-03-planner-executor.md)
+- Future PR 3 `src/utilities/cacheRevalidation/**` implementation output
+- [ADR 010 - Structured Logging Approach](../../../adrs/010-structured-logging-approach.md)
+- [ADR 019 - PostHog Event Taxonomy and Usage Governance](../../../adrs/019-adr-posthog-event-taxonomy-and-usage-governance.md)
+- [ADR 022 - Public Localization, Routing, SEO, and Domain Strategy](../../../adrs/022-adr-public-localization-routing-seo-and-domain-strategy.md)
+- [Public Discovery Strategy](../../../public-discovery-strategy.md)
+- Current core hook files: `src/collections/Pages/hooks/revalidatePage.ts`, `src/collections/Posts/hooks/revalidatePost.ts`, `src/globals/Header/hooks/revalidateHeader.ts`, `src/globals/Footer/hooks/revalidateFooter.ts`, `src/globals/LandingPages/hooks/revalidateLandingPages.ts`, `src/globals/CookieConsent/hooks/revalidateCookieConsent.ts`, and `src/hooks/revalidateRedirects.ts`
+- Current matching read-side files: `src/utilities/getGlobals.ts`, `src/utilities/getRedirects.ts`, `src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts`, and `src/app/(frontend)/(sitemaps)/posts-sitemap.xml/route.ts`
+
+## Objective
+
+Route Pages, Posts, Header, Footer, LandingPages, CookieConsent, and Redirects through the PR 3 planner/executor boundary while replacing the touched legacy tags with canonical ADR-023 tags from the PR 2 policy builders.
+
+PR 4 must make the first real runtime owner group consume the central cache architecture. The core hook adapters extract stable primitives from Payload hook inputs, call the PR 3 boundary with normalized events, and leave tag/path computation to the planner.
+
+PR 4 also updates the directly matching read-side cache tags for globals, redirects, and Pages/Posts sitemap caches so the new canonical hook invalidation actually reaches the cached reads it owns.
+
+## Non-Goals
+
+PR 4 must not:
+
+- add or change cache classes, tag families, freshness policies, invalidation owners, public/private boundaries, PR order, or reviewer gates
+- change ADR 023, the PR 1 implementation plan, the PR 2 policy-map contract, or the PR 3 planner/executor contract
+- route clinic detail, Listing Comparison, related clinic-visible collections, discovery expansion, seed/bulk flows, direct media dependency resolution, or observability UI through the planner
+- change `src/hooks/media/revalidateMediaConsumers.ts`
+- change `src/endpoints/seed/**`
+- repair, remove, or rewire `getCachedDocument`
+- change redirect target-document lookup behavior in `src/app/(frontend)/_components/PayloadRedirects/**`
+- alter route `dynamic`, `revalidate`, `force-static`, or `force-dynamic` behavior
+- change sitemap route content, sitemap discovery policy, noindex behavior, or source-backed timestamp rules
+- enumerate paginated blog list paths beyond the canonical `/posts` list path
+- add legacy dual-tagging for `global_header`, `global_footer`, `global_landingPages`, `global_cookieConsent`, `pages-sitemap`, `posts-sitemap`, `redirects`, or `${collection}_${slug}`
+- add Redis, a custom cache handler, remote cache storage, locks, dedupe, or runtime cache persistence
+- add PostHog events or dashboard/admin visibility
+
+## Fixed Decisions
+
+PR 4 uses these decisions without reopening them:
+
+- Scope: Pages, Posts, Header, Footer, LandingPages, CookieConsent, and Redirects.
+- Hook boundary: touched hook files stop importing `next/cache`; they consume the PR 3 public planner/executor API.
+- Read-side scope: only the matching read-side tags for `getCachedGlobal`, `getCachedRedirects`, Pages sitemap cache, and Posts sitemap cache are migrated.
+- `disableRevalidate`: remains hook-adapter responsibility. When `context.disableRevalidate` is set, the adapter returns the document without creating a plan or executing revalidation.
+- Planner inputs: normalized event objects only. The planner must not receive raw Payload hook args, raw documents, request objects, or route modules.
+- Stable input extraction: hook adapters may read only stable primitive fields required by PR 3, such as id, slug, previous slug, status, previous status, global slug, redirect id, source kind, and operation.
+- Contract errors: missing required primitives, unsupported operations, invalid hook states, unmapped surfaces, or missing canonical redirect support throw instead of being silently logged away.
+- Executor failures: individual `revalidateTag` or `revalidatePath` failures remain best-effort through the PR 3 executor and must not break CMS writes.
+- Posts list freshness: Post changes revalidate canonical post detail output plus collection/list/sitemap tags and the known `/posts` list path. PR 4 does not revalidate `/posts/page/[pageNumber]` paths.
+- Redirect support: PR 4 may migrate redirects only if PR 2 and PR 3 expose canonical redirect policy/planner support. Otherwise it must stop instead of inventing redirect tags locally.
+- Legacy tags: touched PR 4 surfaces use canonical tags only; no transition period with both legacy and canonical tags.
+
+## Expected Implementation Shape
+
+The future implementation should keep changes narrow and adapt the existing hook files in place.
+
+Hook adapter behavior:
+
+- `src/collections/Pages/hooks/revalidatePage.ts` builds normalized Pages after-change and after-delete events from id, slug, previous slug, status, and previous status, then executes the PR 3 plan.
+- `src/collections/Posts/hooks/revalidatePost.ts` builds normalized Posts after-change and after-delete events from id, slug, previous slug, status, and previous status, then executes the PR 3 plan.
+- Header, Footer, LandingPages, and CookieConsent global hooks build normalized global-update events with their known global slug, then execute the PR 3 plan.
+- `src/hooks/revalidateRedirects.ts` builds a normalized redirect-update event with the redirect subject identifier required by PR 3, then executes the PR 3 plan.
+- Hook adapters preserve the existing return-doc behavior after successful planning/execution and after best-effort executor failures.
+- Hook adapters do not compute tags or paths directly and do not import PR 3 internal helpers that bypass the public planner/executor API.
+
+Read-side cache behavior:
+
+- `src/utilities/getGlobals.ts` uses the PR 2 global tag builder for `global:<slug>` tags.
+- `src/utilities/getRedirects.ts` uses only the canonical redirect cache tag or tags exposed by PR 2. If no canonical redirect policy exists, PR 4 stops.
+- Pages sitemap and Posts sitemap route caches use the PR 2 sitemap tag builders, such as `surface:sitemap:pages` and `surface:sitemap:posts`, without changing sitemap route output.
+- Read-side cache keys may remain otherwise unchanged unless PR 2/PR 3 explicitly require a key change for correctness.
+
+Logging behavior:
+
+- PR 4 hook adapters rely on PR 3 planned, executed, and failed operational log payloads.
+- PR 4 must not add raw document logging, raw request logging, PostHog capture, dashboard storage, or ad hoc log payload shapes.
+- Any retained hook-level log statements must stay non-sensitive and must not duplicate or contradict PR 3 operational logs.
+
+Deferred legacy areas remain untouched even if they still contain legacy tags after PR 4:
+
+- `src/hooks/media/revalidateMediaConsumers.ts`
+- `src/endpoints/seed/**`
+- `src/utilities/getDocument.ts`
+- clinic/listing hooks and server data
+- public discovery expansion and `llms.txt`
+- PR 8 observability surfaces
+
+## Expected Tests
+
+Update and add focused unit coverage for the migrated core hook group and matching read-side tags.
+
+The tests must prove:
+
+- Pages hooks return the document and route through the PR 3 boundary for published updates, unpublishes, deletes, and slug changes.
+- Posts hooks return the document and route through the PR 3 boundary for published updates, unpublishes, deletes, slug changes, and `/posts` list freshness.
+- Page and Post hook events include old and new slug/status values when relevant.
+- Header, Footer, LandingPages, and CookieConsent hooks build the expected global-update events.
+- Redirect hooks build the expected redirect event only when PR 2/PR 3 canonical redirect support exists.
+- `disableRevalidate` skips planning and execution for every migrated hook.
+- adapter contract errors for missing ids, missing slugs, missing required statuses, unsupported operations, or redirect policy gaps throw instead of silently returning a document.
+- executor failures returned through the PR 3 best-effort result do not break CMS writes.
+- touched hook files no longer import `next/cache`.
+- touched read-side utilities and sitemap routes use canonical PR 2 tag builders.
+- no touched PR 4 surface emits legacy tags such as `global_header`, `global_footer`, `global_landingPages`, `global_cookieConsent`, `pages-sitemap`, `posts-sitemap`, `redirects`, or `${collection}_${slug}`.
+- `getCachedDocument`, media consumer hooks, and seed flows are not changed by PR 4.
+
+Expected test files include:
+
+- `tests/unit/hooks/revalidatePage.test.ts`
+- `tests/unit/hooks/revalidatePost.test.ts`
+- `tests/unit/hooks/revalidateRedirects.test.ts`
+- `tests/unit/hooks/revalidateGlobals.test.ts`
+- `tests/unit/utilities/payloadDataFetchers.test.ts`
+- `tests/unit/app/frontend/sitemap.routes.test.ts`
+
+Do not write tests that only duplicate constants. Prefer behavior-focused assertions that fail when a future core hook bypasses the planner, loses old-slug coverage, reintroduces legacy tags, or stops invalidating its matching read-side cache.
+
+## Validation
+
+The future PR 4 implementation must run:
+
+```bash
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm vitest tests/unit/hooks/revalidatePage.test.ts tests/unit/hooks/revalidatePost.test.ts tests/unit/hooks/revalidateRedirects.test.ts tests/unit/hooks/revalidateGlobals.test.ts tests/unit/utilities/payloadDataFetchers.test.ts tests/unit/app/frontend/sitemap.routes.test.ts --project unit
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm format
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm check
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm build
+```
+
+Build is required for the future runtime PR because PR 4 changes hook/runtime code and read-side cache tags that affect Next.js/Payload behavior.
+
+For this planning-document PR, only run:
+
+```bash
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm format
+```
+
+## Reviewers
+
+Recommended reviewers for the future PR 4 implementation:
+
+- `security-reviewer` for server trust boundaries, raw-data exclusion, strict adapter errors, and private/public cache separation
+- `seo-reviewer` for canonical page, post, redirect, sitemap, and public discovery cache behavior
+- `web-vitals-reviewer` for cache and performance semantics after the first runtime hook migration
+
+Skip UI, accessibility, mobile UI, and Storybook reviewers unless the scope expands into those surfaces.
+
+Reviewers must run only after Sebastian explicitly confirms reviewer execution. Findings must be fixed and reviewers rerun before PR 5 starts, with the stack-wide maximum of three reviewer cycles unless Sebastian approves more.
+
+## Exit Criteria
+
+PR 4 is complete when:
+
+- Pages, Posts, Header, Footer, LandingPages, CookieConsent, and Redirects route revalidation through the PR 3 public boundary
+- touched hook files no longer import `next/cache`
+- `disableRevalidate` skips planning and execution across all migrated hooks
+- hook adapters pass normalized stable primitives rather than raw Payload docs or hook args into the planner
+- contract errors are strict and executor revalidation failures remain best-effort
+- touched read-side cache tags align with the canonical PR 2 tags consumed by the migrated hooks
+- Posts updates include `/posts` list freshness but no paginated path enumeration
+- redirects are migrated only when canonical redirect policy/planner support exists
+- legacy dual-tags are not emitted by touched PR 4 surfaces
+- media, seed/bulk, clinic/listing, discovery expansion, observability, `getCachedDocument`, and redirect target-document repair remain outside PR 4
+- required tests and validation pass
+- applicable reviewers report no remaining findings or documented accepted exceptions
+
+## Stop Conditions
+
+Stop and ask Sebastian before implementing further if:
+
+- ADR 023, the PR 1 implementation plan, the PR 2 policy map, or the PR 3 planner/executor contract appears wrong or incomplete
+- PR 2 lacks canonical builders for any PR 4 core read-side tag
+- PR 3 lacks a public planner/executor API for any PR 4 core event
+- redirect support would require inventing a canonical redirect tag or planner case inside PR 4
+- raw Payload docs, request objects, cookies, sessions, headers, or unrelated CMS fields appear necessary for planner input
+- runtime behavior requires legacy dual-tagging to stay correct
+- `getCachedDocument` must be changed to keep PR 4 coherent
+- media dependency resolution, seed/bulk final flushing, clinic/listing invalidation, public discovery expansion, or observability UI becomes necessary
+- paginated blog list path enumeration appears necessary
+- Redis, custom cache handlers, remote cache storage, locks, dedupe, or runtime cache persistence appears necessary
+- a new PostHog event, cache class, tag family, freshness policy, invalidation owner, public/private boundary, PR order, or reviewer gate seems necessary
+
+Do not patch ADR 023, the PR 1 implementation plan, PR 2, or PR 3 inside PR 4. Those are architecture or predecessor-contract changes and must be handled separately.
+
+## Assumptions
+
+- PR 1 is merged into `main` and remains the operative stack/order/governance source.
+- PR 2 creates the pure `src/utilities/cachePolicy/**` contract before PR 4 starts.
+- PR 3 creates the `src/utilities/cacheRevalidation/**` planner/executor boundary before PR 4 starts.
+- PR 2 exposes canonical policy builders for all PR 4 core surfaces.
+- PR 3 exposes public normalized-event planner/executor APIs for all PR 4 core surfaces.
+- ADR 023 remains the architecture contract.
+- PR 4 may consume PR 2 and PR 3 APIs but must not redefine their architecture.
+- PR 5 handles redirect target-document drift and `getCachedDocument` cleanup.
+- PR 6 and PR 7 expand planner coverage for clinic/listing, discovery, seed/bulk, and related public surfaces.
+- PR 8 consumes redacted operational outputs for privileged visibility if that scope is still needed.
+- The future full-stack execution goal may start PR 4 only after PR 3 is complete and reviewer-clean.

--- a/docs/roadmap/caching-strategy/work-orders/pr-05-redirect-documents.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-05-redirect-documents.md
@@ -77,7 +77,7 @@ Expected runtime changes:
 
 - Delete `src/utilities/getDocument.ts` when no non-PR5 caller remains.
 - Remove `getCachedDocument` imports and tests.
-- Add a small route-local resolver, for example `src/app/(frontend)/_components/PayloadRedirects/resolveRedirectTargetPath.ts`.
+- Add a small route-local resolver under `src/app/(frontend)/_components/PayloadRedirects/`, for example named `resolveRedirectTargetPath.ts`.
 - Use the resolver from `src/app/(frontend)/_components/PayloadRedirects/index.tsx` only after a matching redirect rule is found and only for reference redirects.
 - Keep direct custom URL redirects as the fast path.
 - Update `src/utilities/getRedirects.ts` so redirect rules default to `depth: 0` and the cached read uses the PR 4 canonical redirect cache tag or tags.
@@ -134,7 +134,7 @@ The tests must prove:
 
 Expected test files include:
 
-- `tests/unit/app/frontend/payloadRedirects.test.tsx`
+- future `payloadRedirects.test.tsx` under `tests/unit/app/frontend/`
 - `tests/unit/utilities/payloadDataFetchers.test.ts`
 - `tests/unit/hooks/revalidateRedirects.test.ts`
 

--- a/docs/roadmap/caching-strategy/work-orders/pr-05-redirect-documents.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-05-redirect-documents.md
@@ -93,6 +93,8 @@ Resolver behavior:
 - Return `/<slug>` for other published Pages.
 - Return `/posts/<slug>` for published Posts.
 - Normalize and validate any returned internal path with the existing routing sanitizer/path utility, such as `src/utilities/routing/sanitizeInternalRedirectPath.ts` or its direct successor, before `PayloadRedirects` can pass it to `redirect()`.
+- Do not let a sanitizer fallback convert an invalid candidate into `/`; `/` is allowed only when the target was first resolved as a published Page with slug `home`.
+- If the existing sanitizer only exposes fallback-returning behavior, PR 5 must use or extend a shared utility so the resolver can distinguish a valid sanitized path from a fallback before redirecting.
 - Stop instead of adding an ad hoc redirect-path sanitizer if the existing utility cannot safely represent the required Page/Post path behavior.
 - Return `null` for missing, inaccessible, unpublished, deleted, invalid, unsupported, or slug-less targets.
 - Never infer a target path from the original source URL, redirect id, collection name alone, or a stale embedded reference slug.
@@ -121,6 +123,7 @@ The tests must prove:
 - a Page target with slug `home` redirects to `/`.
 - post reference redirects resolve by id and redirect to `/posts/<slug>`.
 - resolved reference paths pass through the existing redirect/path sanitizer and unsafe path candidates fail closed instead of reaching `redirect()`.
+- unsafe reference path candidates are not converted to `/` by sanitizer fallback behavior; `/` is asserted only for a verified published `home` Page target.
 - embedded reference object slugs are not used as authoritative targets; the id is re-resolved.
 - missing targets fail closed.
 - draft, unpublished, deleted, inaccessible, unsupported, invalid, or slug-less targets fail closed.

--- a/docs/roadmap/caching-strategy/work-orders/pr-05-redirect-documents.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-05-redirect-documents.md
@@ -92,6 +92,8 @@ Resolver behavior:
 - Return `/` for a published Page with slug `home`.
 - Return `/<slug>` for other published Pages.
 - Return `/posts/<slug>` for published Posts.
+- Normalize and validate any returned internal path with the existing routing sanitizer/path utility, such as `src/utilities/routing/sanitizeInternalRedirectPath.ts` or its direct successor, before `PayloadRedirects` can pass it to `redirect()`.
+- Stop instead of adding an ad hoc redirect-path sanitizer if the existing utility cannot safely represent the required Page/Post path behavior.
 - Return `null` for missing, inaccessible, unpublished, deleted, invalid, unsupported, or slug-less targets.
 - Never infer a target path from the original source URL, redirect id, collection name alone, or a stale embedded reference slug.
 
@@ -118,6 +120,7 @@ The tests must prove:
 - page reference redirects resolve by id and redirect to `/<slug>`.
 - a Page target with slug `home` redirects to `/`.
 - post reference redirects resolve by id and redirect to `/posts/<slug>`.
+- resolved reference paths pass through the existing redirect/path sanitizer and unsafe path candidates fail closed instead of reaching `redirect()`.
 - embedded reference object slugs are not used as authoritative targets; the id is re-resolved.
 - missing targets fail closed.
 - draft, unpublished, deleted, inaccessible, unsupported, invalid, or slug-less targets fail closed.

--- a/docs/roadmap/caching-strategy/work-orders/pr-05-redirect-documents.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-05-redirect-documents.md
@@ -1,0 +1,212 @@
+# PR 5 Work Order: Redirect Document Reads
+
+This work order defines the future PR 5 implementation packet for the public cache and revalidation stack. It is a planning artifact only. It does not implement PR 5 and does not change runtime behavior.
+
+## Summary
+
+PR 5 resolves redirect target document drift. The current `getCachedDocument` helper is slug-based, but the visible redirect caller passes a Payload relationship id into it. The helper also creates `${collection}_${slug}` cache tags that are outside the ADR-023 canonical tag model and are not a stable owned cache surface.
+
+- Branch: `feature/cache-revalidation/05-redirect-documents`
+- PR title: `fix(redirects): align cache stack 5/8 redirect document reads`
+- Base branch: `feature/cache-revalidation/04-core-hooks`
+- Dependency: PR 4 is implemented, validated, reviewer-clean, and based on the accepted PR 1 plan.
+- Scope type: redirect target document read alignment.
+
+PR 5 removes `getCachedDocument` instead of replacing it with another generic document cache helper. Reference redirect targets are resolved live by id, only when a matching reference redirect is actually used.
+
+## Source Inputs
+
+- [ADR 023 - Public Website Cache and Revalidation Strategy](../../../adrs/023-adr-public-website-cache-and-revalidation-strategy.md)
+- [Public Cache And Revalidation Implementation Plan](../cache-revalidation-implementation-plan.md)
+- [PR 2 Work Order: Cache Policy Map](./pr-02-policy-map.md)
+- Future PR 2 `src/utilities/cachePolicy/**` implementation output
+- [PR 3 Work Order: Revalidation Planner And Executor](./pr-03-planner-executor.md)
+- Future PR 3 `src/utilities/cacheRevalidation/**` implementation output
+- [PR 4 Work Order: Core Hooks](./pr-04-core-hooks.md)
+- Future PR 4 core-hook and read-side tag implementation output
+- [ADR 010 - Structured Logging Approach](../../../adrs/010-structured-logging-approach.md)
+- [ADR 019 - PostHog Event Taxonomy and Usage Governance](../../../adrs/019-adr-posthog-event-taxonomy-and-usage-governance.md)
+- [ADR 022 - Public Localization, Routing, SEO, and Domain Strategy](../../../adrs/022-adr-public-localization-routing-seo-and-domain-strategy.md)
+- [Public Discovery Strategy](../../../public-discovery-strategy.md)
+- Current redirect files: `src/app/(frontend)/_components/PayloadRedirects/index.tsx`, `src/utilities/getDocument.ts`, and `src/utilities/getRedirects.ts`
+- Current tests and route usage: `tests/unit/utilities/payloadDataFetchers.test.ts`, `src/app/(frontend)/(pages)/[...slug]/page.tsx`, and `src/app/(frontend)/posts/[slug]/page.tsx`
+
+## Objective
+
+Remove the misleading generic cached document helper and make reference redirect target resolution explicit, public-safe, and narrow.
+
+PR 5 must preserve custom URL redirects and existing `PayloadRedirects` route behavior while removing the slug-versus-id mismatch. Redirect rules remain cached through the PR 4 canonical redirect cache tag model. Target document reads are live by id because they happen only for matched reference redirects and must not imply a separate unowned cache policy.
+
+## Non-Goals
+
+PR 5 must not:
+
+- add a new generic cached document helper
+- replace `getCachedDocument` with a new broad cache abstraction
+- introduce new cache classes, tag families, freshness policies, invalidation owners, public/private boundaries, PR order, or reviewer gates
+- change ADR 023, the PR 1 implementation plan, the PR 2 policy-map contract, the PR 3 planner/executor contract, or the PR 4 core-hook contract
+- change redirect authoring semantics or plugin configuration beyond the read-side behavior required here
+- change public route matching behavior for Pages or Posts outside `PayloadRedirects`
+- add locale/domain-specific redirect behavior
+- change sitemap, public discovery, `llms.txt`, seed/bulk, clinic/listing, media dependency, or observability behavior
+- add legacy dual-tagging or keep `${collection}_${slug}` cache tags in touched code
+- add Redis, a custom cache handler, remote cache storage, locks, dedupe, or runtime cache persistence
+- add PostHog events or dashboard/admin visibility
+
+## Fixed Decisions
+
+PR 5 uses these decisions without reopening them:
+
+- `getCachedDocument` is removed.
+- Reference redirect targets are resolved live by Payload id.
+- Only `pages` and `posts` reference targets are supported.
+- Redirect rules themselves stay cached through `getCachedRedirects`, but they are loaded at `depth: 0`.
+- Embedded reference object slugs are not authoritative redirect targets. If a reference value is an object, the resolver uses its stable id and re-resolves the public target.
+- Reference target reads must be public-safe: `overrideAccess: false`, `draft: false`, `depth: 0`, and a narrow field selection.
+- Missing, inaccessible, draft/unpublished, deleted, invalid, or slug-less targets fail closed.
+- Fail-closed means no redirect to an empty, guessed, fallback, or unsafe URL. Existing `disableNotFound` behavior decides whether the component returns `null` or calls `notFound()`.
+- Custom URL redirects stay unchanged.
+- The additional Payload/database read happens only for matched reference redirects, not for ordinary requests without a matching redirect rule and not for custom URL redirects.
+- Redacted warnings are allowed only if they follow existing server logging patterns and do not log raw documents, request data, headers, cookies, tokens, sessions, or unrelated CMS fields.
+
+## Expected Implementation Shape
+
+The future implementation should keep redirect target resolution local to the redirect component boundary.
+
+Expected runtime changes:
+
+- Delete `src/utilities/getDocument.ts` when no non-PR5 caller remains.
+- Remove `getCachedDocument` imports and tests.
+- Add a small route-local resolver, for example `src/app/(frontend)/_components/PayloadRedirects/resolveRedirectTargetPath.ts`.
+- Use the resolver from `src/app/(frontend)/_components/PayloadRedirects/index.tsx` only after a matching redirect rule is found and only for reference redirects.
+- Keep direct custom URL redirects as the fast path.
+- Update `src/utilities/getRedirects.ts` so redirect rules default to `depth: 0` and the cached read uses the PR 4 canonical redirect cache tag or tags.
+
+Resolver behavior:
+
+- Accept only normalized redirect reference data needed to resolve the target: relation collection and value id.
+- Support only `pages` and `posts`.
+- Convert string ids to the id type accepted by Payload only when the conversion is safe and explicit.
+- Resolve Pages by id with public-safe Payload reads and select only fields needed to validate and build the public path.
+- Resolve Posts by id with public-safe Payload reads and select only fields needed to validate and build the public path.
+- Return `/` for a published Page with slug `home`.
+- Return `/<slug>` for other published Pages.
+- Return `/posts/<slug>` for published Posts.
+- Return `null` for missing, inaccessible, unpublished, deleted, invalid, unsupported, or slug-less targets.
+- Never infer a target path from the original source URL, redirect id, collection name alone, or a stale embedded reference slug.
+
+`PayloadRedirects` behavior:
+
+- Fetch cached redirect rules.
+- Find the matching rule by `from`.
+- Redirect immediately for custom URL targets.
+- For reference targets, call the resolver.
+- Redirect only when the resolver returns a non-empty safe internal path.
+- Preserve existing `disableNotFound`: return `null` when disabled and no usable redirect target exists; otherwise call `notFound()`.
+
+## Expected Tests
+
+Add focused tests for redirect target resolution and update existing utility tests.
+
+The tests must prove:
+
+- `getCachedDocument` tests and imports are removed.
+- no touched code emits or expects `${collection}_${slug}` tags.
+- `getRedirects` defaults to `depth: 0`.
+- `getCachedRedirects` keeps cached redirect rules and uses PR 4 canonical redirect tags.
+- custom URL redirects still call `redirect()` with the configured URL.
+- page reference redirects resolve by id and redirect to `/<slug>`.
+- a Page target with slug `home` redirects to `/`.
+- post reference redirects resolve by id and redirect to `/posts/<slug>`.
+- embedded reference object slugs are not used as authoritative targets; the id is re-resolved.
+- missing targets fail closed.
+- draft, unpublished, deleted, inaccessible, unsupported, invalid, or slug-less targets fail closed.
+- fail-closed with `disableNotFound` returns `null`.
+- fail-closed without `disableNotFound` calls `notFound()`.
+- reference target resolution uses public-safe Payload reads with `overrideAccess: false`, `draft: false`, `depth: 0`, and narrow field selection.
+- custom URL redirects and requests without a matching redirect rule do not perform target document reads.
+
+Expected test files include:
+
+- `tests/unit/app/frontend/payloadRedirects.test.tsx`
+- `tests/unit/utilities/payloadDataFetchers.test.ts`
+- `tests/unit/hooks/revalidateRedirects.test.ts`
+
+Do not write tests that only duplicate constants. Prefer behavior-focused assertions that fail when redirect target resolution falls back to stale embedded slugs, reintroduces unowned document caching, or redirects to an unsafe empty path.
+
+## Validation
+
+The future PR 5 implementation must run:
+
+```bash
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm vitest tests/unit/app/frontend/payloadRedirects.test.tsx tests/unit/utilities/payloadDataFetchers.test.ts tests/unit/hooks/revalidateRedirects.test.ts --project unit
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm format
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm check
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm build
+```
+
+Build is required for the future runtime PR because PR 5 changes Next.js route component behavior and Payload-backed runtime utilities.
+
+For this planning-document PR, only run:
+
+```bash
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm format
+```
+
+## Reviewers
+
+Recommended reviewers for the future PR 5 implementation:
+
+- `security-reviewer` for public-safe target reads, fail-closed behavior, raw-data exclusion, and redirect safety
+- `seo-reviewer` for canonical redirect targets, no empty/fallback redirects, and Page/Post path behavior
+
+Add `web-vitals-reviewer` only if implementation broadens beyond reference redirect target resolution or changes route/cache behavior on ordinary non-redirect page views.
+
+Skip UI, accessibility, mobile UI, and Storybook reviewers unless the scope expands into those surfaces.
+
+Reviewers must run only after Sebastian explicitly confirms reviewer execution. Findings must be fixed and reviewers rerun before PR 6 starts, with the stack-wide maximum of three reviewer cycles unless Sebastian approves more.
+
+## Exit Criteria
+
+PR 5 is complete when:
+
+- `getCachedDocument` and its tests/imports are removed
+- no touched code emits or expects `${collection}_${slug}` cache tags
+- `PayloadRedirects` resolves reference targets by id through a narrow public-safe resolver
+- only Pages and Posts reference targets are supported
+- redirect rules are cached at `depth: 0` through the canonical PR 4 redirect tag model
+- custom URL redirects keep their existing behavior
+- missing, inaccessible, draft/unpublished, deleted, invalid, unsupported, or slug-less targets fail closed
+- `disableNotFound` and `notFound()` behavior remains compatible with current Page/Post route usage
+- no generic document cache helper, Redis, PostHog event, locale/domain redirect policy, or discovery expansion is introduced
+- required tests and validation pass
+- applicable reviewers report no remaining findings or documented accepted exceptions
+
+## Stop Conditions
+
+Stop and ask Sebastian before implementing further if:
+
+- ADR 023, the PR 1 implementation plan, the PR 2 policy map, the PR 3 planner/executor contract, or the PR 4 core-hook output appears wrong or incomplete
+- a generic cached document helper appears necessary
+- reference target reads cannot be implemented with public-safe Payload access
+- redirect correctness requires using embedded reference object slugs as authoritative targets
+- redirect behavior needs a new cache class, tag family, freshness policy, invalidation owner, public/private boundary, PR order, or reviewer gate
+- redirect behavior needs locale/domain routing policy changes
+- implementation requires changing sitemap, discovery, seed/bulk, media, clinic/listing, or observability behavior
+- runtime behavior requires legacy dual-tagging or `${collection}_${slug}` tags
+- Redis, custom cache handlers, remote cache storage, locks, dedupe, or runtime cache persistence appears necessary
+- a PostHog business event or dashboard UI becomes necessary
+
+Do not patch ADR 023, the PR 1 implementation plan, PR 2, PR 3, or PR 4 inside PR 5. Those are architecture or predecessor-contract changes and must be handled separately.
+
+## Assumptions
+
+- PR 1 is merged into `main` and remains the operative stack/order/governance source.
+- PR 2 creates the pure `src/utilities/cachePolicy/**` contract before PR 5 starts.
+- PR 3 creates the `src/utilities/cacheRevalidation/**` planner/executor boundary before PR 5 starts.
+- PR 4 aligns Redirect rule invalidation and read-side tags through the planner and canonical PR 2 tags before PR 5 starts.
+- `pages` and `posts` access rules with `overrideAccess: false` expose only public/published content for anonymous redirect resolution.
+- PR 5 intentionally favors architecture clarity over caching redirect target document reads.
+- PR 6 and PR 7 expand planner coverage for clinic/listing, discovery, seed/bulk, and related public surfaces.
+- PR 8 consumes redacted operational outputs for privileged visibility if that scope is still needed.
+- The future full-stack execution goal may start PR 5 only after PR 4 is complete and reviewer-clean.

--- a/docs/roadmap/caching-strategy/work-orders/pr-06-clinic-listing-surfaces.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-06-clinic-listing-surfaces.md
@@ -1,0 +1,256 @@
+# PR 6 Work Order: Clinic And Listing Surfaces
+
+This work order defines the future PR 6 implementation packet for the public cache and revalidation stack. It is a planning artifact only. It does not implement PR 6 and does not change runtime behavior.
+
+## Summary
+
+PR 6 expands the cache stack to Clinic Detail, Listing Comparison, and the known clinic-visible related collections. It adds tag-backed public Data Cache coverage for the public server data that these surfaces use, while keeping request-bound route state live.
+
+- Branch: `feature/cache-revalidation/06-clinic-listing-surfaces`
+- PR title: `fix(collections): invalidate cache stack 6/8 clinic surfaces`
+- Base branch: `feature/cache-revalidation/05-redirect-documents`
+- Dependency: PR 5 is implemented, validated, reviewer-clean, and based on the accepted PR 1 plan.
+- Scope type: clinic/listing runtime cache and hook migration.
+
+PR 6 must not ask the executor to decide cache classes, freshness expectations, invalidation owners, tag families, public/private boundaries, PR order, or reviewer gates.
+
+## Source Inputs
+
+- [ADR 023 - Public Website Cache and Revalidation Strategy](../../../adrs/023-adr-public-website-cache-and-revalidation-strategy.md)
+- [Public Cache And Revalidation Implementation Plan](../cache-revalidation-implementation-plan.md)
+- [PR 2 Work Order: Cache Policy Map](./pr-02-policy-map.md)
+- Future PR 2 `src/utilities/cachePolicy/**` implementation output
+- [PR 3 Work Order: Revalidation Planner And Executor](./pr-03-planner-executor.md)
+- Future PR 3 `src/utilities/cacheRevalidation/**` implementation output
+- [PR 4 Work Order: Core Hooks](./pr-04-core-hooks.md)
+- Future PR 4 core-hook and read-side tag implementation output
+- [PR 5 Work Order: Redirect Document Reads](./pr-05-redirect-documents.md)
+- Future PR 5 redirect document read output
+- [ADR 010 - Structured Logging Approach](../../../adrs/010-structured-logging-approach.md)
+- [ADR 019 - PostHog Event Taxonomy and Usage Governance](../../../adrs/019-adr-posthog-event-taxonomy-and-usage-governance.md)
+- [ADR 022 - Public Localization, Routing, SEO, and Domain Strategy](../../../adrs/022-adr-public-localization-routing-seo-and-domain-strategy.md)
+- [Public Discovery Strategy](../../../public-discovery-strategy.md)
+- Current Clinic Detail files: `src/app/(frontend)/clinics/[slug]/page.tsx` and `src/utilities/clinicDetail/serverData/**`
+- Current Listing Comparison files: `src/app/(frontend)/listing-comparison/page.tsx` and `src/utilities/listingComparison/serverData/**`
+- Current landing and sitemap files: `src/app/(frontend)/page.tsx`, `src/app/(frontend)/partners/clinics/page.tsx`, `src/utilities/landing/**`, and `src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts`
+- Current collection and hook files: `src/collections/Clinics.ts`, `src/collections/ClinicTreatments/index.ts`, `src/collections/Doctors.ts`, `src/collections/DoctorSpecialties.ts`, `src/collections/Reviews.ts`, `src/collections/Treatments.ts`, `src/collections/MedicalSpecialties.ts`, `src/collections/Cities.ts`, `src/collections/Accreditation.ts`, `src/collections/ClinicGalleryEntries/**`, `src/collections/ClinicTreatments/hooks/**`, and `src/hooks/calculations/updateAverageRatings.ts`
+
+## Objective
+
+Align Clinic Detail and Listing Comparison freshness with ADR 023 by routing their owning collection changes through the PR 3 planner boundary and by adding canonical tag-backed public Data Cache coverage for the public server data these surfaces consume.
+
+PR 6 must make public clinic facts and listing aggregation data invalidatable without caching private, draft, preview, auth, cookie, or patient-specific route state. It also must preserve existing average price and average rating calculations while making the source write events responsible for visible cache invalidation.
+
+## Non-Goals
+
+PR 6 must not:
+
+- add or change cache classes, tag families, freshness policies, invalidation owners, public/private boundaries, PR order, or reviewer gates
+- change ADR 023, the PR 1 implementation plan, the PR 2 policy-map contract, the PR 3 planner/executor contract, PR 4 core-hook behavior, or PR 5 redirect behavior
+- change rendered Clinic Detail, Listing Comparison, home, partner landing, or sitemap content
+- change route `dynamic`, `revalidate`, `force-static`, or `force-dynamic` behavior
+- cache patient favorites, cookie consent state, auth state, request headers, cookies, preview state, draft reads, or any personalized data
+- enumerate Listing Comparison query variant paths or create a per-query path invalidation matrix
+- build broad all-clinic path revalidation for taxonomy changes
+- build a generic reverse-dependency graph across all clinic, treatment, specialty, accreditation, gallery, and media references
+- implement raw media upload reverse-dependency resolution for `clinicMedia`, `clinicGalleryMedia`, `doctorMedia`, or `platformContentMedia`
+- change seed/bulk final flush behavior, public discovery expansion, `llms.txt`, observability UI, dashboard storage, or PostHog events
+- add legacy dual-tagging or emit legacy tags from touched PR 6 code
+- add Redis, a custom cache handler, remote cache storage, locks, dedupe, or runtime cache persistence
+
+## Fixed Decisions
+
+PR 6 uses these decisions without reopening them:
+
+- Runtime scope: Clinic Detail, Listing Comparison, known clinic-visible related collections, and the directly affected home, partner landing, and Pages sitemap surface tags.
+- Data Cache scope: tag-backed public server data for Clinic Detail and Listing Comparison only.
+- Route behavior: Clinic Detail and Listing Comparison routes remain `force-dynamic`.
+- Public/private boundary: only public, non-draft, non-preview, non-request-bound server data may enter persistent Data Cache.
+- Draft behavior: Clinic Detail draft reads stay live and bypass the public cached read.
+- Listing query behavior: canonical Listing Comparison route and data tags are invalidated; query variants do not receive independent path invalidation.
+- Fanout policy: concrete `/clinics/<slug>` path revalidation happens only when the changed event directly or safely identifies impacted clinic ids and slugs.
+- Broad taxonomy policy: Treatments, MedicalSpecialties, Cities, and Accreditation changes use collection and surface tags unless exact impacted clinic paths are safely known.
+- Landing dependency policy: Cities, Treatments, and MedicalSpecialties may invalidate `surface:home`, `surface:partners-clinics`, `/`, and `/partners/clinics` where current route usage proves the dependency.
+- Sitemap dependency policy: Listing Comparison freshness sources include `surface:sitemap:pages`; PR 6 does not change sitemap route content or discovery policy.
+- Bounded relation policy: `clinicGalleryEntries` and Accreditation are included as bounded relation cases.
+- Media policy: media inherits the referencing surface, but raw media upload reverse-dependency resolution remains deferred.
+- Hook composition: new PR 6 hook adapters are added without replacing existing ownership, validation, average price, or average rating hooks.
+- Calculated update policy: source Review and ClinicTreatment events own visible revalidation; updates caused through `context.skipHooks` must not trigger duplicate revalidation.
+- Disable guard: new PR 6 hook adapters respect `context.disableRevalidate`.
+- Logging: use PR 3 redacted operational logging only; no raw documents, request data, cookies, auth state, form data, secrets, or PostHog events.
+
+The collection coverage is:
+
+- `clinics`
+- `clinictreatments`
+- `doctors`
+- `doctorspecialties`
+- `reviews`
+- `treatments`
+- `medical-specialties`
+- `cities`
+- `clinicGalleryEntries`
+- `accreditation`
+
+## Expected Implementation Shape
+
+The future implementation should extend the existing PR 2 and PR 3 modules, then adapt the owning collection hooks in place.
+
+Planner and policy behavior:
+
+- add or update PR 2 policy entries for Clinic Detail, Listing Comparison, home/partner landing dependencies, Pages sitemap listing freshness, and bounded clinic relation cases when missing
+- add PR 3 normalized event types for PR 6 collection events
+- keep the planner pure and free of Payload, Next cache APIs, logger utilities, route modules, request objects, environment readers, database clients, and PostHog utilities
+- compute canonical tags and paths through PR 2 builders only
+- return typed deferred or fail-fast results for direct media dependency resolution and other unmapped public dependencies
+
+Hook adapter behavior:
+
+- add Clinic hook adapters that include clinic id, current slug, previous slug, current status, previous status, and operation when available
+- add ClinicTreatment hook adapters that include current and previous clinic ids and treatment ids, and preserve average price hook ordering
+- add Doctor hook adapters that include current and previous clinic ids, current and previous public doctor identifiers, and preserve existing ownership hooks
+- add DoctorSpecialty hook adapters that resolve the related doctor and clinic before planning when the relation is not already stable enough
+- add Review hook adapters that include current and previous clinic, doctor, treatment, status, and review visibility fields, and preserve average rating hook ordering
+- add Treatment, MedicalSpecialty, and City hook adapters that use broad collection/surface invalidation plus known home and partner landing paths
+- add bounded clinicGalleryEntries and Accreditation hook adapters that revalidate exact clinic paths only when impacted clinic ids and slugs can be safely resolved
+- skip planning and execution when `context.disableRevalidate` is set
+- skip duplicate planning for hook-triggered calculated updates marked with `context.skipHooks`
+- never pass raw Payload docs into the planner; adapters extract stable primitives first
+
+Data Cache behavior:
+
+- wrap only the public, non-draft Clinic Detail server-data read with canonical tags for clinic entity, clinic slug, collection, clinic-detail surface, and known related collection/surface dependencies
+- keep Clinic Detail draft reads live and uncached
+- keep cookie consent resolution, patient favorite lookup, headers, cookies, and auth-dependent data outside the cached Clinic Detail server-data read
+- wrap Listing Comparison server data with canonical tags for `surface:listing-comparison`, relevant collection tags, and normalized listing query inputs
+- avoid per-query path invalidation for Listing Comparison query variants
+- align the in-process Listing Comparison catalog cache with the public Data Cache behavior without turning it into a separate freshness authority
+- include `surface:sitemap:pages` in planner output for Listing Comparison freshness sources while leaving sitemap content and route policy unchanged
+
+Legacy and deferred areas:
+
+- touched PR 6 code must not emit legacy tags such as `pages-sitemap`, `global_landingPages`, or ad hoc clinic/listing tag strings
+- `src/hooks/media/revalidateMediaConsumers.ts` remains outside PR 6 unless an existing import must be adjusted because of PR 2 or PR 3 public API shape
+- `src/endpoints/seed/**`, `llms.txt`, cache observability UI, and direct media upload reverse-dependency mapping remain for PR 7, PR 8, or follow-up work
+
+## Expected Tests
+
+Add focused unit coverage for planner output, hook adapters, Data Cache tags, and existing calculation-hook preservation.
+
+The tests must prove:
+
+- planner output exists for Clinics, ClinicTreatments, Doctors, DoctorSpecialties, Reviews, Treatments, MedicalSpecialties, Cities, clinicGalleryEntries, and Accreditation
+- planner output uses canonical PR 2 tags and paths only
+- Clinic publish, update, unpublish, delete, and slug-change events include old and new clinic paths when known
+- related collection events revalidate exact clinic paths only when the impacted clinic ids and slugs are safely known
+- broad taxonomy changes use collection and surface tags without all-clinic path blasting
+- Listing Comparison events invalidate `surface:listing-comparison` and collection tags without enumerating query variant paths
+- Cities, Treatments, and MedicalSpecialties events include home and partner landing surface tags and known paths where current route usage proves the dependency
+- Listing Comparison freshness sources include `surface:sitemap:pages` without changing sitemap route content
+- `context.disableRevalidate` skips planning and execution for every new PR 6 adapter
+- `context.skipHooks` prevents duplicate revalidation for calculated average price and average rating follow-up updates
+- existing average price and average rating hooks keep their behavior
+- Clinic Detail public server data uses canonical Data Cache tags and draft reads bypass persistent public cache
+- Listing Comparison server data uses canonical Data Cache tags and stable normalized query keys
+- patient favorites, cookie consent state, headers, cookies, auth state, and request-bound data are not cached
+- direct media upload reverse-dependency behavior remains deferred
+- touched PR 6 code does not emit legacy tags or use legacy dual-tagging
+
+Expected test files include:
+
+- `tests/unit/utilities/cacheRevalidation/**`
+- `tests/unit/hooks/revalidateClinicSurfaces.test.ts`
+- `tests/unit/hooks/revalidateClinicRelatedCollections.test.ts`
+- `tests/unit/hooks/updateAveragePrices.hooks.test.ts`
+- `tests/unit/hooks/updateAverageRatings.test.ts`
+- `tests/unit/utilities/clinicDetailServerData.contract.test.ts`
+- `tests/unit/utilities/listingComparisonServerData.contract.test.ts`
+- `tests/unit/app/frontend/clinic-detail.page.test.tsx`
+- `tests/unit/app/frontend/listing-comparison.page.test.ts`
+- `tests/unit/app/frontend/sitemap.routes.test.ts`
+
+Do not write tests that only duplicate constants. Prefer behavior-focused assertions that fail when a future collection hook bypasses the planner, leaks request-bound data into cache, reintroduces legacy tags, or broadens path revalidation beyond the fixed fanout policy.
+
+## Validation
+
+The future PR 6 implementation must run:
+
+```bash
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm vitest tests/unit/utilities/cacheRevalidation tests/unit/hooks/revalidateClinicSurfaces.test.ts tests/unit/hooks/revalidateClinicRelatedCollections.test.ts tests/unit/utilities/clinicDetailServerData.contract.test.ts tests/unit/utilities/listingComparisonServerData.contract.test.ts tests/unit/app/frontend/clinic-detail.page.test.tsx tests/unit/app/frontend/listing-comparison.page.test.ts tests/unit/app/frontend/sitemap.routes.test.ts --project unit
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm format
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm check
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm build
+```
+
+Build is required for the future runtime PR because PR 6 changes collection hooks, runtime cache behavior, and public route data dependencies.
+
+For this planning-document PR, only run:
+
+```bash
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm format
+```
+
+## Reviewers
+
+Recommended reviewers for the future PR 6 implementation:
+
+- `security-reviewer` for public/private cache separation, request-bound data exclusion, fail-fast adapter behavior, and raw-data logging boundaries
+- `seo-reviewer` for Clinic Detail, Listing Comparison, sitemap freshness tags, canonical query behavior, and public discovery alignment
+- `web-vitals-reviewer` for Data Cache behavior, route performance semantics, and avoiding path invalidation storms
+
+Skip UI, accessibility, mobile UI, and Storybook reviewers unless the scope expands into rendered UI or Storybook surfaces.
+
+Reviewers must run only after Sebastian explicitly confirms reviewer execution. Findings must be fixed and reviewers rerun before PR 7 starts, with the stack-wide maximum of three reviewer cycles unless Sebastian approves more.
+
+## Exit Criteria
+
+PR 6 is complete when:
+
+- Clinic Detail and Listing Comparison public server data have tag-backed canonical Data Cache coverage
+- Clinic Detail draft, preview, cookie, auth, favorite, header, and request-bound state remain uncached and live
+- PR 3 planner coverage exists for all PR 6 collections and bounded relation cases
+- collection hooks route through PR 3 public planner/executor APIs without importing `next/cache`
+- existing average price and average rating hooks remain behavior-compatible
+- `context.disableRevalidate` and `context.skipHooks` policies are implemented and tested
+- exact clinic path fanout happens only when impacted clinic ids and slugs are safely known
+- broad taxonomy changes do not trigger all-clinic path revalidation
+- Listing Comparison query variants do not receive per-query path invalidation
+- Home, partner landing, and Pages sitemap surface tags are included where the current dependency map requires them
+- sitemap route content, discovery expansion, seed/bulk behavior, direct media upload reverse-dependency resolution, observability UI, Redis, and PostHog events remain outside PR 6
+- required tests and validation pass
+- applicable reviewers report no remaining findings or documented accepted exceptions
+
+## Stop Conditions
+
+Stop and ask Sebastian before implementing further if:
+
+- ADR 023, the PR 1 implementation plan, or the PR 2-PR 5 outputs appear wrong or incomplete
+- a new cache class, tag family, freshness policy, invalidation owner, public/private boundary, PR order, or reviewer gate seems necessary
+- Clinic Detail or Listing Comparison cannot be cached without including request-bound, draft, preview, auth, cookie, favorite, or private data
+- exact clinic path fanout requires broad reverse lookups or all-clinic path blasting
+- a generic media dependency resolver becomes necessary
+- direct media upload changes must be handled to keep PR 6 coherent
+- Listing Comparison correctness appears to require enumerating query variant paths
+- sitemap route content, public discovery expansion, `llms.txt`, seed/bulk final flushing, or observability UI becomes necessary
+- runtime behavior requires legacy dual-tagging
+- Redis, custom cache handlers, remote cache storage, locks, dedupe, or runtime cache persistence appears necessary
+- a PostHog business event becomes necessary
+- locale/domain routing or cache dimensions must be introduced to complete PR 6
+
+Do not patch ADR 023, the PR 1 implementation plan, PR 2, PR 3, PR 4, or PR 5 inside PR 6. Those are architecture or predecessor-contract changes and must be handled separately.
+
+## Assumptions
+
+- PR 1 is merged into `main` and remains the operative stack/order/governance source.
+- PR 2 creates the pure `src/utilities/cachePolicy/**` contract before PR 6 starts.
+- PR 3 creates the `src/utilities/cacheRevalidation/**` planner/executor boundary before PR 6 starts.
+- PR 4 aligns core hooks and matching read-side tags before PR 6 starts.
+- PR 5 removes `getCachedDocument` drift and keeps redirect behavior outside the clinic/listing scope.
+- `clinics.status === 'approved'` is the public Clinic visibility boundary.
+- `reviews.status === 'approved'` is the public Review visibility boundary.
+- Clinic Detail and Listing Comparison public server-data functions can be split so public cacheable data is separated from request-bound route state.
+- Broad taxonomy and Accreditation changes can be represented through collection and surface tags without a generic reverse-dependency graph in PR 6.
+- Direct media upload reverse-dependency resolution is a bounded follow-up, not a PR 6 requirement.
+- PR 7 expands discovery and seed/bulk behavior after PR 6 is complete and reviewer-clean.
+- PR 8 consumes redacted operational outputs for privileged visibility if that scope is still needed.
+- The future full-stack execution goal may start PR 6 only after PR 5 is complete and reviewer-clean.

--- a/docs/roadmap/caching-strategy/work-orders/pr-06-clinic-listing-surfaces.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-06-clinic-listing-surfaces.md
@@ -120,9 +120,11 @@ Hook adapter behavior:
 Data Cache behavior:
 
 - wrap only the public, non-draft Clinic Detail server-data read with canonical tags for clinic entity, clinic slug, collection, clinic-detail surface, and known related collection/surface dependencies
+- expose the cached Clinic Detail server-data boundary through a narrow public input contract such as slug, normalized locale when available, and explicit draft/public mode; the cached function must not import or capture `headers()`, `cookies()`, auth/session helpers, favorite lookups, or request objects
 - keep Clinic Detail draft reads live and uncached
 - keep cookie consent resolution, patient favorite lookup, headers, cookies, and auth-dependent data outside the cached Clinic Detail server-data read
 - wrap Listing Comparison server data with canonical tags for `surface:listing-comparison`, relevant collection tags, and normalized listing query inputs
+- expose the cached Listing Comparison server-data boundary through stable public query state only; patient favorites, cookies, headers, auth state, and request-scoped values must be joined outside the cached function
 - avoid per-query path invalidation for Listing Comparison query variants
 - align the in-process Listing Comparison catalog cache with the public Data Cache behavior without turning it into a separate freshness authority
 - include `surface:sitemap:pages` in planner output for Listing Comparison freshness sources while leaving sitemap content and route policy unchanged
@@ -152,7 +154,8 @@ The tests must prove:
 - existing average price and average rating hooks keep their behavior
 - Clinic Detail public server data uses canonical Data Cache tags and draft reads bypass persistent public cache
 - Listing Comparison server data uses canonical Data Cache tags and stable normalized query keys
-- patient favorites, cookie consent state, headers, cookies, auth state, and request-bound data are not cached
+- patient favorites, cookie consent state, headers, cookies, auth state, and request-bound data are not cached, not captured by cached function closures, and not imported into cache-wrapper modules
+- route-level tests or contract tests prove favorites/cookie/header/auth reads still happen outside the public cached data boundary
 - direct media upload reverse-dependency behavior remains deferred
 - touched PR 6 code does not emit legacy tags or use legacy dual-tagging
 

--- a/docs/roadmap/caching-strategy/work-orders/pr-06-clinic-listing-surfaces.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-06-clinic-listing-surfaces.md
@@ -162,8 +162,8 @@ The tests must prove:
 Expected test files include:
 
 - `tests/unit/utilities/cacheRevalidation/**`
-- `tests/unit/hooks/revalidateClinicSurfaces.test.ts`
-- `tests/unit/hooks/revalidateClinicRelatedCollections.test.ts`
+- future `revalidateClinicSurfaces.test.ts` under `tests/unit/hooks/`
+- future `revalidateClinicRelatedCollections.test.ts` under `tests/unit/hooks/`
 - `tests/unit/hooks/updateAveragePrices.hooks.test.ts`
 - `tests/unit/hooks/updateAverageRatings.test.ts`
 - `tests/unit/utilities/clinicDetailServerData.contract.test.ts`

--- a/docs/roadmap/caching-strategy/work-orders/pr-07-discovery-and-seeding.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-07-discovery-and-seeding.md
@@ -127,6 +127,7 @@ The tests must prove:
 - planner output uses canonical PR 2 tags and paths only
 - touched sitemap routes use canonical `surface:sitemap:pages` and `surface:sitemap:posts` behavior and do not emit legacy `pages-sitemap` or `posts-sitemap` tags
 - sitemap `lastmod` values remain source-backed and route content policy remains unchanged
+- `robots.txt` remains route/config-policy driven, keeps the expected sitemap references and preview blocking behavior, and does not become normal Payload document invalidation scope
 - `llms.txt` remains static, contract-tested, and not CMS-backed or cache-tag backed in PR 7
 - public discovery contract, temporary landing blocking, sitemap guard behavior, and crawler monitoring redaction remain intact
 - public post list, paginated post list, and latest-post reads use stable public cache keys and canonical tags
@@ -145,6 +146,7 @@ Expected test files include:
 - `tests/unit/utilities/cacheRevalidation/**`
 - `tests/unit/app/frontend/sitemap.routes.test.ts`
 - `tests/unit/app/frontend/llmsTxt.route.test.ts`
+- `tests/unit/config/next-sitemap-config.test.ts`
 - `tests/unit/features/publicDiscovery/discoveryContract.test.ts`
 - `tests/unit/features/searchIndexing/sitemapGuards.test.ts`
 - `tests/unit/app/frontend/posts.page.test.tsx`

--- a/docs/roadmap/caching-strategy/work-orders/pr-07-discovery-and-seeding.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-07-discovery-and-seeding.md
@@ -1,0 +1,236 @@
+# PR 7 Work Order: Discovery And Seeding
+
+This work order defines the future PR 7 implementation packet for the public cache and revalidation stack. It is a planning artifact only. It does not implement PR 7 and does not change runtime behavior.
+
+## Summary
+
+PR 7 aligns public discovery, blog list freshness, and seed/bulk terminal flush behavior with the accepted cache stack. It extends the PR 2 policy map and PR 3 planner only inside the existing ADR 023 and PR 1 architecture.
+
+- Branch: `feature/cache-revalidation/07-discovery-and-seeding`
+- PR title: `fix(seeding): batch cache stack 7/8 discovery flushes`
+- Base branch: `feature/cache-revalidation/06-clinic-listing-surfaces`
+- Dependency: PR 6 is implemented, validated, reviewer-clean, and based on the accepted PR 1 plan.
+- Scope type: discovery/list freshness and seed final-flush runtime alignment.
+
+PR 7 must not ask the executor to decide cache classes, freshness expectations, invalidation owners, tag families, public/private boundaries, PR order, or reviewer gates.
+
+## Source Inputs
+
+- [ADR 023 - Public Website Cache and Revalidation Strategy](../../../adrs/023-adr-public-website-cache-and-revalidation-strategy.md)
+- [Public Cache And Revalidation Implementation Plan](../cache-revalidation-implementation-plan.md)
+- [PR 2 Work Order: Cache Policy Map](./pr-02-policy-map.md)
+- Future PR 2 `src/utilities/cachePolicy/**` implementation output
+- [PR 3 Work Order: Revalidation Planner And Executor](./pr-03-planner-executor.md)
+- Future PR 3 `src/utilities/cacheRevalidation/**` implementation output
+- [PR 4 Work Order: Core Hooks](./pr-04-core-hooks.md)
+- Future PR 4 core-hook and read-side tag implementation output
+- [PR 5 Work Order: Redirect Document Reads](./pr-05-redirect-documents.md)
+- Future PR 5 redirect document read output
+- [PR 6 Work Order: Clinic And Listing Surfaces](./pr-06-clinic-listing-surfaces.md)
+- Future PR 6 clinic/listing and pages sitemap freshness output
+- [ADR 010 - Structured Logging Approach](../../../adrs/010-structured-logging-approach.md)
+- [ADR 019 - PostHog Event Taxonomy and Usage Governance](../../../adrs/019-adr-posthog-event-taxonomy-and-usage-governance.md)
+- [ADR 022 - Public Localization, Routing, SEO, and Domain Strategy](../../../adrs/022-adr-public-localization-routing-seo-and-domain-strategy.md)
+- [Public Discovery Strategy](../../../public-discovery-strategy.md)
+- Existing sitemap and discovery files: `src/app/(frontend)/(sitemaps)/pages-sitemap.xml/route.ts`, `src/app/(frontend)/(sitemaps)/posts-sitemap.xml/route.ts`, `src/app/(frontend)/llms.txt/route.ts`, `src/app/(frontend)/.well-known/llms.txt/route.ts`, `src/features/publicDiscovery/**`, `src/features/searchIndexing/**`, `next-sitemap.config.cjs`, and `src/proxy.ts`
+- Existing posts-list files: `src/app/(frontend)/posts/page.tsx`, `src/app/(frontend)/posts/page/[pageNumber]/page.tsx`, and `src/utilities/content/serverData/posts.ts`
+- Existing seed files: `src/endpoints/seed/seedEndpoint.ts`, `src/endpoints/seed/tasks/seedChunkTask.ts`, `src/endpoints/seed/utils/state.ts`, `src/endpoints/seed/utils/planner.ts`, `src/endpoints/seed/utils/plan.ts`, `src/endpoints/seed/utils/import-collection.ts`, `src/endpoints/seed/utils/import-globals.ts`, and `src/endpoints/seed/utils/upsert.ts`
+- Existing tests for sitemap routes, `llms.txt`, public discovery, search indexing, posts pages, seed endpoint success paths, seed imports, global seeds, and seed chunk tasks
+
+## Objective
+
+Align discovery and seed-driven freshness with ADR 023 by routing sitemap, posts-list, public-discovery static/no-op, and `seed-final-flush` cases through the PR 3 planner boundary.
+
+PR 7 must make discovery/list outputs and seed/bulk completion states invalidatable through canonical PR 2 tags without changing public route content, indexing policy, seed safety policy, or the existing per-record seed suppression model.
+
+## Non-Goals
+
+PR 7 must not:
+
+- add or change cache classes, tag families, freshness policies, invalidation owners, public/private boundaries, PR order, or reviewer gates
+- change ADR 023, the PR 1 implementation plan, or the PR 2-PR 6 architecture contracts
+- change sitemap route content, sitemap inclusion policy, canonical/noindex policy, structured data content, or source-backed timestamp rules
+- make `/llms.txt` or `/.well-known/llms.txt` CMS-backed or tag-backed while they remain static public-discovery contract routes
+- change robots/indexing behavior, temporary landing mode behavior, preview blocking, or crawler monitoring semantics
+- enumerate paginated posts paths or create a posts pagination path invalidation matrix
+- build doc-level seed reverse mapping, broad media reverse-dependency resolution, or seed-record-specific path fanout
+- change production seed guards, baseline/demo separation, reset policy, queue ordering, retry behavior, or seed-run snapshot shape except for a minimal final-flush marker
+- cache draft, preview, auth, cookie, request-bound, private, admin-only, or personalized data
+- add legacy dual-tagging or emit legacy tags from touched PR 7 code
+- add Redis, a custom cache handler, remote cache storage, PostHog events, observability UI, or dashboard storage
+
+## Fixed Decisions
+
+PR 7 uses these decisions without reopening them:
+
+- Sitemaps use canonical PR 2 `surface:sitemap:*` tags and source-backed timestamps only.
+- Robots and indexing policy remain route/config policy, not normal Payload document invalidation.
+- `llms.txt` routes remain static in PR 7. They may be represented as public-discovery static/no-op planner cases, but they must not get CMS-backed cache wiring.
+- Blog list and latest-post reads are `aggregated-public` surfaces and use canonical post collection/list/surface tags.
+- `/posts` may remain a known path for list freshness. Paginated post list freshness relies on tags and bounded cache staleness, not a path matrix.
+- Listing Comparison sitemap freshness remains source-backed through the PR 6 output; PR 7 may align sitemap tags but must not change sitemap content policy.
+- Seed imports continue suppressing per-record public revalidation through `disableRevalidate`.
+- Seed/bulk public freshness is owned by one terminal `seed-final-flush` planner event per seed run.
+- Seed final flush uses job-level aggregation from completed job records or equivalent run-state metadata. It must not inspect raw seed records for doc-level fanout.
+- Terminal seed flush runs on `completed`, `partial`, `failed`, or `cancelled` states only when at least one public-affecting seed job has written or completed public work before termination.
+- Rejected runs and cancelled runs with no public-affecting completed work do not flush public caches.
+- Retry runs are separate seed runs and get separate final-flush evaluation.
+- Executor semantics remain PR 3-owned: tags first, paths second, best-effort failures, and redacted operational logging.
+
+## Expected Implementation Shape
+
+Policy and planner expansion:
+
+- add or update PR 2 policy entries for sitemap surfaces, post-list surfaces, public-discovery static/no-op surfaces, and seed/bulk final-flush surfaces
+- add or update PR 3 planner event types for sitemap freshness, posts-list freshness, public-discovery static/no-op, and `seed-final-flush`
+- keep planner inputs normalized and serializable; do not pass raw Payload docs, raw seed records, request objects, cookies, headers, or file contents into the planner
+- fail fast in tests and implementation if a public-affecting seed step or discovery surface is missing from the PR 2 policy map
+- keep private/admin/operational-only seed steps as explicit public revalidation no-ops
+
+Discovery and sitemap read-side alignment:
+
+- replace legacy `pages-sitemap` and `posts-sitemap` tags in touched sitemap code with PR 2 canonical sitemap tag builders
+- keep sitemap output, fixed public paths, excluded paths, noindex blocking, and source-backed `lastmod` behavior unchanged
+- keep `llms.txt` routes static and contract-tested; do not wrap them in CMS-backed `unstable_cache` or add runtime CMS dependencies
+- keep public discovery crawler logging redacted and operational; do not add PostHog events or product analytics
+
+Posts-list read-side alignment:
+
+- align public post list, paginated post list, and latest-post teaser reads with canonical PR 2 post collection/list/surface tags
+- base cache keys only on stable public inputs such as locale, page, limit, and normalized list parameters
+- keep draft, preview, auth, cookie, header, request-bound, and personalized inputs outside persistent public cache
+- use tag invalidation for paginated posts freshness instead of enumerating `/posts/page/<n>` paths
+
+Seed final-flush behavior:
+
+- add a small seed final-flush aggregation helper under the seed runtime area or cache revalidation boundary, whichever best matches the future PR 3 public API
+- derive affected collections, globals, surfaces, and operation context from seed job records and seed plan metadata, not raw seed JSON records
+- count a job as public-affecting only when its collection/global maps to a public PR 2 policy entry and it has completed or written public work
+- treat `created + updated > 0` as the primary write signal; global seed updates with updated counts also qualify
+- execute at most one final flush per run by storing a serializable marker on the seed run record or an equivalent idempotence guard
+- do not convert a completed seed run response into a hard failure because a final cache flush operation failed; log the redacted cache failure and preserve the seed terminal snapshot
+- keep planner contract errors strict during implementation and tests. If a mapped public seed step cannot be planned, stop the PR instead of inventing local tags.
+
+Logging behavior:
+
+- log seed final-flush planning, execution, and failures through the PR 3 redacted operational log schema
+- include only run id, seed type, reset flag, terminal status, affected collections/globals/surfaces, counts, and failure summaries
+- never log raw docs, raw seed records, file contents, request bodies, headers, cookies, tokens, auth data, private data, CMS field payloads, medical free text, or seed fixture payloads
+
+## Expected Tests
+
+Add focused unit coverage for planner output, read-side tag alignment, and seed terminal flush behavior.
+
+The tests must prove:
+
+- planner output exists for sitemap, posts-list, public-discovery static/no-op, and `seed-final-flush` events
+- planner output uses canonical PR 2 tags and paths only
+- touched sitemap routes use canonical `surface:sitemap:pages` and `surface:sitemap:posts` behavior and do not emit legacy `pages-sitemap` or `posts-sitemap` tags
+- sitemap `lastmod` values remain source-backed and route content policy remains unchanged
+- `llms.txt` remains static, contract-tested, and not CMS-backed or cache-tag backed in PR 7
+- public discovery contract, temporary landing blocking, sitemap guard behavior, and crawler monitoring redaction remain intact
+- public post list, paginated post list, and latest-post reads use stable public cache keys and canonical tags
+- draft, preview, auth, cookie, header, request-bound, and personalized values do not enter posts-list public cache keys
+- seed per-record writes still pass `disableRevalidate` and do not trigger direct public cache invalidation
+- seed final flush happens for `completed`, `partial`, `failed`, and cancelled-after-public-work terminal states
+- rejected runs and cancelled runs with no public-affecting completed work do not flush public caches
+- each seed run executes at most one terminal final flush
+- retry runs are evaluated independently from their source runs
+- seed final-flush logs and results are redacted and do not contain raw docs, seed records, request data, auth data, private data, or file contents
+- executor failures remain best-effort and do not break seed terminal snapshot responses
+- touched PR 7 code does not add legacy dual-tagging or emit legacy tags
+
+Expected test files include:
+
+- `tests/unit/utilities/cacheRevalidation/**`
+- `tests/unit/app/frontend/sitemap.routes.test.ts`
+- `tests/unit/app/frontend/llmsTxt.route.test.ts`
+- `tests/unit/features/publicDiscovery/discoveryContract.test.ts`
+- `tests/unit/features/searchIndexing/sitemapGuards.test.ts`
+- `tests/unit/app/frontend/posts.page.test.tsx`
+- `tests/unit/app/frontend/posts.page-number.page.test.tsx`
+- `tests/unit/endpoints/seed/seedEndpoint-success.test.ts`
+- `tests/unit/endpoints/seed/import-collection.test.ts`
+- `tests/unit/endpoints/seed/globals-seed.test.ts`
+- `tests/unit/endpoints/seed/seedChunkTask.test.ts`
+
+Do not write tests that only duplicate constants. Prefer behavior-focused assertions that fail when a future route or seed flow bypasses the planner, reintroduces legacy tags, logs raw seed data, or broadens path revalidation beyond the fixed policy.
+
+## Validation
+
+The future PR 7 implementation must run:
+
+```bash
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm vitest tests/unit/utilities/cacheRevalidation tests/unit/app/frontend/sitemap.routes.test.ts tests/unit/app/frontend/llmsTxt.route.test.ts tests/unit/features/publicDiscovery/discoveryContract.test.ts tests/unit/features/searchIndexing/sitemapGuards.test.ts tests/unit/app/frontend/posts.page.test.tsx tests/unit/app/frontend/posts.page-number.page.test.tsx tests/unit/endpoints/seed/seedEndpoint-success.test.ts tests/unit/endpoints/seed/import-collection.test.ts tests/unit/endpoints/seed/globals-seed.test.ts tests/unit/endpoints/seed/seedChunkTask.test.ts --project unit
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm format
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm check
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm build
+```
+
+Run the public discovery health check only when PR 7 changes route output, headers, or deployed discovery behavior beyond cache tags:
+
+```bash
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm discovery:health
+```
+
+Build is required for the future runtime PR because PR 7 changes public route cache behavior, seed endpoint behavior, and runtime revalidation paths.
+
+For this planning-document PR, only run:
+
+```bash
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm format
+```
+
+## Reviewers
+
+Recommended reviewers for the future PR 7 implementation:
+
+- `seo-reviewer` for sitemap, public discovery, canonical list freshness, indexing policy preservation, and `llms.txt` contract alignment
+- `security-reviewer` for seed endpoint trust boundaries, public/private cache separation, redacted logging, and fail-closed discovery behavior
+- `web-vitals-reviewer` for Data Cache behavior, route performance semantics, and avoiding path invalidation storms
+
+Skip UI, accessibility, mobile UI, and Storybook reviewers unless the scope expands into rendered UI or Storybook surfaces.
+
+Reviewers must run only after Sebastian explicitly confirms reviewer execution. Findings must be fixed and reviewers rerun before PR 8 starts, with the stack-wide maximum of three reviewer cycles unless Sebastian approves more.
+
+## Exit Criteria
+
+PR 7 is complete when:
+
+- sitemap read-side tags are canonical and no touched sitemap code emits legacy sitemap tags
+- sitemap output, noindex policy, and source-backed timestamp behavior remain unchanged
+- `llms.txt` remains static and not CMS/cache-tag backed
+- posts-list and latest-post public data use canonical tags and stable public inputs
+- paginated posts freshness does not enumerate a path matrix
+- seed imports continue suppressing per-record public revalidation
+- terminal seed final-flush behavior runs once per qualifying seed run and uses job-level aggregation only
+- rejected or cancelled runs without public-affecting completed work do not flush
+- retry runs are handled as independent runs
+- redacted seed final-flush logs/results contain no raw docs, seed records, request data, auth data, private data, or file contents
+- production guard, baseline/demo separation, queue semantics, retry behavior, and seed-run snapshots remain behavior-compatible
+- no Redis, PostHog event, observability UI, direct media reverse-dependency resolver, locale/domain cache dimension, new cache class, new tag family, or new public route family is introduced
+- required tests and validation pass
+- applicable reviewers report no remaining findings or documented accepted exceptions
+
+## Stop Conditions
+
+Stop and ask Sebastian before implementing further if:
+
+- ADR 023, the PR 1 implementation plan, or PR 2-PR 6 outputs appear wrong or incomplete
+- a new cache class, tag family, freshness policy, invalidation owner, public/private boundary, PR order, or reviewer gate seems necessary
+- `llms.txt` needs CMS-backed content, Payload reads, tag-backed caching, or a changed ownership model
+- discovery changes require new public route families, locale/domain discovery policy, or new sitemap inclusion rules
+- seed final flush cannot be implemented from job-level aggregation and would require raw seed-record inspection or doc-level reverse mapping
+- seed final flush needs broad media reverse-dependency resolution or direct media upload invalidation
+- posts-list cache behavior would need draft, preview, auth, cookie, header, request-bound, private, or personalized inputs
+- implementation would need Redis, a custom cache store, PostHog events, observability UI, or dashboard storage
+- implementation would need legacy dual tags to keep touched PR 7 surfaces working
+
+## Assumptions
+
+- PR 6 has already landed canonical Clinic Detail, Listing Comparison, and Pages sitemap freshness behavior.
+- PR 2 exposes canonical policy builders for discovery, posts-list, sitemap, and seed surfaces.
+- PR 3 exposes planner/executor APIs that PR 7 can extend without changing the boundary.
+- Job-level seed aggregation is precise enough for the first cache stack and intentionally avoids doc-level fanout.
+- `llms.txt` has no CMS-backed dependency in PR 7 and stays a static public-discovery contract route.
+- This work order may define runtime contracts, but must not change ADR 023 or the PR 1 cache assignment architecture.

--- a/docs/roadmap/caching-strategy/work-orders/pr-08-observability.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-08-observability.md
@@ -151,8 +151,8 @@ The tests must prove:
 Expected test files include:
 
 - `tests/unit/utilities/cacheRevalidation/**`
-- `tests/unit/endpoints/cacheRevalidationVisibility.test.ts`
-- `tests/unit/components/cacheRevalidationVisibility.test.tsx`
+- future `cacheRevalidationVisibility.test.ts` under `tests/unit/endpoints/`
+- future `cacheRevalidationVisibility.test.tsx` under `tests/unit/components/`
 - `tests/unit/dashboard/adminDashboard/config.test.ts`
 
 Do not write tests that only duplicate constants. Prefer behavior-focused assertions that fail when visibility reads bypass access control, raw data reaches history/UI, manual cache actions appear, PostHog capture is added, or the seeding dashboard widget regresses.

--- a/docs/roadmap/caching-strategy/work-orders/pr-08-observability.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-08-observability.md
@@ -114,6 +114,7 @@ Admin dashboard card:
 - add a minimal read-only dashboard card under the existing Payload Admin dashboard/widget conventions
 - show recent event name/status, operation/source, surfaces, tag/path counts, failure counts, and a manual refresh button that only refetches the protected read endpoint
 - show empty, loading, error, and access-denied states without leaking event data to unauthorized users
+- keep the card purely operational; do not add public-discovery data, sitemap/robots links, canonical/indexation controls, or links to crawlable public surfaces in PR 8
 - keep controls typed and normalized at component boundaries
 - use Payload admin theme variables and existing Developer Dashboard visual conventions
 - keep the existing seeding widget behavior intact
@@ -185,7 +186,7 @@ Recommended reviewers for the future PR 8 implementation:
 - `accessibility-reviewer` for the rendered Admin card states, keyboard/focus behavior, loading/error announcements, and read-only controls
 - `mobile-ui-reviewer` for responsive Admin dashboard behavior and dense event-table/card readability
 
-Skip `seo-reviewer` unless PR 8 changes discovery output, sitemap output, redirects, canonical/noindex behavior, structured data, or other public discovery behavior.
+Skip `seo-reviewer` unless PR 8 changes discovery output, sitemap output, robots behavior, redirects, canonical/noindex behavior, structured data, public-discovery data, links to crawlable public surfaces, or other public discovery behavior.
 
 Skip `web-vitals-reviewer` unless PR 8 changes public route rendering, public route runtime cache behavior, bundle-sensitive public code, or public performance semantics.
 

--- a/docs/roadmap/caching-strategy/work-orders/pr-08-observability.md
+++ b/docs/roadmap/caching-strategy/work-orders/pr-08-observability.md
@@ -1,0 +1,244 @@
+# PR 8 Work Order: Observability
+
+This work order defines the future PR 8 implementation packet for the public cache and revalidation stack. It is a planning artifact only. It does not implement PR 8 and does not change runtime behavior.
+
+## Summary
+
+PR 8 adds redacted operational cache/revalidation visibility for privileged platform staff. It consumes the PR 3 planner/executor summaries after PR 7 has routed discovery, posts-list, and seed final-flush events through the cache stack.
+
+- Branch: `feature/cache-revalidation/08-observability`
+- PR title: `feat(admin): expose cache stack 8/8 invalidation visibility`
+- Base branch: `feature/cache-revalidation/07-discovery-and-seeding`
+- Dependency: PR 7 is implemented, validated, reviewer-clean, and based on the accepted PR 1 plan.
+- Scope type: operational observability and admin visibility.
+
+PR 8 must not ask the executor to decide cache classes, freshness expectations, invalidation owners, tag families, public/private boundaries, PR order, or reviewer gates.
+
+## Source Inputs
+
+- [ADR 023 - Public Website Cache and Revalidation Strategy](../../../adrs/023-adr-public-website-cache-and-revalidation-strategy.md)
+- [Public Cache And Revalidation Implementation Plan](../cache-revalidation-implementation-plan.md)
+- [PR 2 Work Order: Cache Policy Map](./pr-02-policy-map.md)
+- Future PR 2 `src/utilities/cachePolicy/**` implementation output
+- [PR 3 Work Order: Revalidation Planner And Executor](./pr-03-planner-executor.md)
+- Future PR 3 `src/utilities/cacheRevalidation/**` planner, executor, redacted log, and execution-result output
+- [PR 4 Work Order: Core Hooks](./pr-04-core-hooks.md)
+- Future PR 4 core hook and read-side tag output
+- [PR 5 Work Order: Redirect Document Reads](./pr-05-redirect-documents.md)
+- Future PR 5 redirect document read output
+- [PR 6 Work Order: Clinic And Listing Surfaces](./pr-06-clinic-listing-surfaces.md)
+- Future PR 6 clinic/listing output
+- [PR 7 Work Order: Discovery And Seeding](./pr-07-discovery-and-seeding.md)
+- Future PR 7 discovery, posts-list, and seed final-flush output
+- [ADR 010 - Structured Logging Approach](../../../adrs/010-structured-logging-approach.md)
+- [ADR 019 - PostHog Event Taxonomy and Usage Governance](../../../adrs/019-adr-posthog-event-taxonomy-and-usage-governance.md)
+- [ADR 022 - Public Localization, Routing, SEO, and Domain Strategy](../../../adrs/022-adr-public-localization-routing-seo-and-domain-strategy.md)
+- [Public Discovery Strategy](../../../public-discovery-strategy.md)
+- [PostHog Integration](../../../integrations/posthog.md)
+- [Logging Guide](../../../logging.md)
+- Current admin dashboard files: `src/dashboard/adminDashboard/config.ts`, `src/dashboard/adminDashboard/AGENTS.md`, and `tests/unit/dashboard/adminDashboard/config.test.ts`
+- Current Developer Dashboard files: `src/components/organisms/DeveloperDashboard/**`, `src/components/organisms/DeveloperDashboard/AGENTS.md`, `tests/unit/components/seedingCard.test.tsx`, and `tests/unit/components/seedingCardView.test.tsx`
+- Current access-control files: `src/access/isPlatformBasicUser.ts`, `src/access/fieldAccess.ts`, `src/collections/PlatformStaff.ts`, and related access tests
+- Current logging files: `src/utilities/logging/**` and `tests/unit/utilities/loggingShared.test.ts`
+
+## Objective
+
+Expose recent cache and revalidation decisions to privileged platform operators without changing cache behavior.
+
+PR 8 must make planner/executor activity visible through redacted operational history and a minimal Payload Admin dashboard card. This visibility is diagnostic only. It must not become product analytics, an audit log, a persistent data store, or a manual cache-control surface.
+
+## Non-Goals
+
+PR 8 must not:
+
+- add or change cache classes, tag families, freshness policies, invalidation owners, public/private boundaries, PR order, or reviewer gates
+- change ADR 023, the PR 1 implementation plan, or the PR 2-PR 7 architecture contracts
+- change public routes, sitemap output, discovery output, redirect behavior, canonical/noindex policy, seed behavior, route cache settings, cache tags, planner decisions, or revalidation semantics
+- add manual cache actions such as revalidate, retry, flush, purge, reset, or path/tag mutation controls
+- add Payload collections, database tables, migrations, persistent history, external log drains, or audit-log storage
+- add PostHog events, PostHog Actions, product analytics capture, or business telemetry for cache mechanics
+- expose raw documents, raw Payload hook args, request bodies, headers, cookies, tokens, auth data, private data, draft/preview content, CMS field payloads, medical free text, seed fixture payloads, or raw error stacks
+- implement direct media dependency resolution
+- add Redis, custom cache handlers, remote cache storage, locks, dedupe, or runtime cache persistence
+- add legacy dual-tagging or emit legacy tags from touched PR 8 code
+
+## Fixed Decisions
+
+PR 8 uses these decisions without reopening them:
+
+- Visibility shape: a minimal Payload Admin dashboard card is implemented.
+- History source: a bounded in-memory ring buffer stores recent redacted cache/revalidation summaries per runtime instance.
+- Ring-buffer size: keep the latest 200 events per runtime instance.
+- Persistence boundary: the in-memory history is volatile and not an audit log.
+- Access boundary: only `basicUsers` with `userType === "platform"` and a matching `platformStaff` profile with `role` in `["admin", "support"]` may read visibility data.
+- Denied roles: `content-manager`, clinic users, patient users, anonymous requests, missing platform staff profiles, and role lookup failures are denied.
+- Endpoint boundary: the protected read endpoint must complete access control before reading the in-memory history.
+- UI boundary: the dashboard card is read-only and diagnostic.
+- Analytics boundary: no PostHog events are added.
+- Follow-up boundary: a separate lightweight issue captures direct media dependency resolution; PR 8 does not implement that resolver.
+
+PR 8 should add one dedicated Payload dashboard widget for cache visibility, for example slug `cache-revalidation-visibility`, while preserving the existing `developer-seeding` widget and layout behavior. If Payload dashboard constraints require placing the card inside the existing Developer Dashboard component instead, the implementation must keep the same access-control, read-only, and test requirements.
+
+## Expected Implementation Shape
+
+Visibility history:
+
+- extend `src/utilities/cacheRevalidation/**` with a small visibility/history sink that records only redacted PR 3 planner/executor summaries
+- record summaries for `cache.revalidation.planned`, `cache.revalidation.executed`, and `cache.revalidation.failed`
+- keep planner purity intact; the pure planner must not import the visibility sink, logger utilities, Payload, request objects, or UI modules
+- keep executor ordering intact; tags still execute before paths and failures remain best-effort
+- expose small helpers to record a redacted event, read a snapshot, and clear/reset history for tests only
+- dedupe nothing beyond the planner/executor result that PR 3 already produced; the visibility layer is observational
+- keep the buffer bounded to 200 events with newest-event ordering in the returned snapshot
+
+Stored event shape:
+
+- store only timestamp, event name, operation, source kind, source id, subject identifiers, cache classes, surface IDs, tag count, path count, failure count, capped tag previews, capped path previews, capped failure summaries, and truncation flags
+- cap exposed tag previews, path previews, and failure summaries to a small fixed count such as 10 entries each
+- keep full counts even when previews are truncated
+- accept only canonical public cache identifiers, surface IDs, operation names, and redacted failure summaries from the PR 3 result/log payload contracts
+- never store raw docs, raw Payload hook args, request bodies, headers, cookies, tokens, auth data, private data, draft/preview content, CMS field payloads, medical free text, seed fixture payloads, or raw error stacks
+
+Protected endpoint:
+
+- add a Payload endpoint such as `GET /api/cache-revalidation/visibility`
+- use the existing Payload endpoint pattern from the seed endpoint and register it in `src/payload.config.ts`
+- fail closed when the request user is missing, not a `basicUsers` platform user, has no matching `platformStaff` profile, has a denied role, or the role lookup fails
+- perform the platform-staff role lookup before reading the visibility ring buffer
+- return only the redacted history snapshot plus operational metadata such as buffer limit, count, and truncation status
+- log access-control lookup failures through ADR 010-compatible redacted operational logs
+- do not include raw auth state, profile documents, request headers, cookies, or user profile fields in the response or logs
+
+Admin dashboard card:
+
+- add a minimal read-only dashboard card under the existing Payload Admin dashboard/widget conventions
+- show recent event name/status, operation/source, surfaces, tag/path counts, failure counts, and a manual refresh button that only refetches the protected read endpoint
+- show empty, loading, error, and access-denied states without leaking event data to unauthorized users
+- keep controls typed and normalized at component boundaries
+- use Payload admin theme variables and existing Developer Dashboard visual conventions
+- keep the existing seeding widget behavior intact
+- do not add manual cache mutation buttons or controls
+
+Follow-up issue:
+
+- before opening the future PR 8 implementation PR, create or link a lightweight website issue for bounded direct media dependency resolution
+- the issue must describe the unresolved problem that direct media replacement can leave referencing public surfaces stale until the referencing document changes
+- the issue must not be implemented or folded into PR 8
+
+## Expected Tests
+
+Add focused unit coverage for visibility history, redaction, protected access, and dashboard rendering.
+
+The tests must prove:
+
+- ring-buffer ordering is newest-first or otherwise documented and stable
+- the buffer keeps at most 200 events and drops oldest entries when full
+- test-only reset/isolation helpers prevent cross-test history leakage
+- recorded `planned`, `executed`, and `failed` summaries preserve counts and capped previews
+- preview truncation flags are set when tag, path, or failure previews exceed their cap
+- forbidden values are not stored or exposed, including raw docs, Payload hook args, request bodies, headers, cookies, tokens, auth data, private data, CMS field payloads, seed fixture payloads, medical free text, and raw error stacks
+- executor/history integration records planned, executed, and failed events without changing tag-first/path-second order
+- the protected endpoint allows platform `admin` and `support`
+- the endpoint denies platform `content-manager`, clinic, patient, anonymous, missing platform staff profile, and role lookup failure
+- the endpoint does not read the history sink before access control passes
+- the endpoint response contains only redacted history and non-sensitive operational metadata
+- dashboard config registers the cache visibility card or widget without removing or regressing the existing seeding widget
+- the Admin card renders empty, denied, success, failure, loading, and manual-refresh states
+- the Admin card does not render manual cache mutation controls
+- no PR 8 code captures PostHog business events
+
+Expected test files include:
+
+- `tests/unit/utilities/cacheRevalidation/**`
+- `tests/unit/endpoints/cacheRevalidationVisibility.test.ts`
+- `tests/unit/components/cacheRevalidationVisibility.test.tsx`
+- `tests/unit/dashboard/adminDashboard/config.test.ts`
+
+Do not write tests that only duplicate constants. Prefer behavior-focused assertions that fail when visibility reads bypass access control, raw data reaches history/UI, manual cache actions appear, PostHog capture is added, or the seeding dashboard widget regresses.
+
+## Validation
+
+The future PR 8 implementation must run:
+
+```bash
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm vitest tests/unit/utilities/cacheRevalidation tests/unit/endpoints/cacheRevalidationVisibility.test.ts tests/unit/components/cacheRevalidationVisibility.test.tsx tests/unit/dashboard/adminDashboard/config.test.ts --project unit
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm format
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm check
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm build
+```
+
+Because PR 8 adds rendered admin UI, the future implementation must also capture Playwright admin dashboard screenshot evidence using the existing ignored artifacts/session workflow. Use the shared admin session `output/playwright/sessions/admin.local.json` when available; refresh and validate it with the existing admin session commands if needed.
+
+Build is required for the future runtime PR because PR 8 changes Payload endpoint registration and rendered admin UI.
+
+For this planning-document PR, only run:
+
+```bash
+rtk proxy /Users/razorspoint/Library/pnpm/pnpm format
+```
+
+## Reviewers
+
+Recommended reviewers for the future PR 8 implementation:
+
+- `security-reviewer` for endpoint authorization, role lookup, redaction, private/public boundary, and no raw operational data exposure
+- `accessibility-reviewer` for the rendered Admin card states, keyboard/focus behavior, loading/error announcements, and read-only controls
+- `mobile-ui-reviewer` for responsive Admin dashboard behavior and dense event-table/card readability
+
+Skip `seo-reviewer` unless PR 8 changes discovery output, sitemap output, redirects, canonical/noindex behavior, structured data, or other public discovery behavior.
+
+Skip `web-vitals-reviewer` unless PR 8 changes public route rendering, public route runtime cache behavior, bundle-sensitive public code, or public performance semantics.
+
+Skip Storybook reviewer unless PR 8 changes Storybook stories, Storybook config, or story-governance files.
+
+Reviewers must run only after Sebastian explicitly confirms reviewer execution. Findings must be fixed and reviewers rerun before the stack is considered complete, with the stack-wide maximum of three reviewer cycles unless Sebastian approves more.
+
+## Exit Criteria
+
+PR 8 is complete when:
+
+- recent PR 3-PR 7 cache/revalidation planner and executor outcomes are visible through a redacted bounded in-memory history
+- the ring buffer is capped at 200 events per runtime instance
+- the visibility history is explicitly volatile and not persistent audit storage
+- `cache.revalidation.planned`, `cache.revalidation.executed`, and `cache.revalidation.failed` summaries are recorded without changing planner purity or executor semantics
+- the protected endpoint checks platform admin/support access before reading history
+- platform content-manager, clinic, patient, anonymous, missing profile, and role lookup failure cases are denied
+- the dashboard card is read-only and exposes only redacted operational summaries
+- the existing seeding dashboard widget remains registered and behavior-compatible
+- no raw docs, request data, auth data, private data, CMS field payloads, seed fixture payloads, medical free text, or raw error stacks are stored or exposed
+- no PostHog event, product analytics capture, manual cache action, persistent store, Redis/custom cache store, migration, direct media dependency resolver, new cache class, new tag family, new invalidation owner, public route change, or discovery output change is introduced
+- the direct media dependency resolver follow-up issue is created or linked before opening the future PR 8 implementation PR
+- required tests, validation, and admin screenshot evidence pass
+- applicable reviewers report no remaining findings or documented accepted exceptions
+
+## Stop Conditions
+
+Stop and ask Sebastian before implementing further if:
+
+- ADR 023, the PR 1 implementation plan, or PR 2-PR 7 outputs appear wrong or incomplete
+- a new cache class, tag family, freshness policy, invalidation owner, public/private boundary, PR order, or reviewer gate seems necessary
+- PR 3 does not expose redacted planner/executor summaries stable enough for PR 8 to consume
+- PR 7 did not route seed final-flush, posts-list, or discovery events through the planner as expected
+- visibility requires persistent storage, Payload collections, migrations, external log drains, Redis, custom cache storage, or multi-instance history
+- direct media dependency resolution becomes necessary to make PR 8 coherent
+- a manual cache mutation control is requested or appears necessary
+- endpoint authorization cannot be implemented without reading history first
+- access control requires broader roles than platform admin/support
+- the dashboard would need to expose raw operational data, raw errors, request data, auth data, private data, CMS field payloads, or seed fixture payloads
+- PostHog product analytics events appear necessary
+- public routes, public discovery output, sitemap output, redirects, canonical/noindex behavior, seed behavior, cache tags, planner decisions, or revalidation semantics need to change
+
+Do not patch ADR 023, the PR 1 implementation plan, or PR 2-PR 7 work orders inside PR 8. Those are architecture or predecessor-contract changes and must be handled separately.
+
+## Assumptions
+
+- PR 1 is merged into `main` and remains the operative stack/order/governance source.
+- PR 2 creates the pure `src/utilities/cachePolicy/**` contract before PR 8 starts.
+- PR 3 creates stable redacted planner/executor summaries that PR 8 can consume.
+- PR 4-PR 6 route core hooks, redirects, clinic detail, and Listing Comparison through the cache stack before PR 8 starts.
+- PR 7 routes discovery, posts-list, and seed final-flush events through the planner before PR 8 starts.
+- A volatile per-instance in-memory history is sufficient for first-stack operational visibility and is intentionally not an audit log.
+- Platform admin and support roles are the accepted visibility boundary.
+- The existing Payload Admin dashboard and Developer Dashboard conventions are sufficient for a minimal read-only cache visibility card.
+- PR 8 may define runtime visibility contracts, but must not change cache assignments or architecture decisions.
+- The future full-stack execution goal may start PR 8 only after PR 7 is complete and reviewer-clean.


### PR DESCRIPTION
## Management summary

### Deutsch

Die Cache-/Revalidation-Umstellung bekommt eine klare Arbeitsgrundlage für die restlichen Umsetzungsschritte. Damit können die nächsten PRs später geordnet, nachvollziehbar und ohne neue Architekturentscheidungen abgearbeitet werden.

### English

The cache and revalidation rollout now has a clear working foundation for the remaining implementation steps. This lets the next PRs be executed later in an ordered, traceable way without reopening architecture decisions.

## What changed

- Added dedicated work-order documents for cache stack PR2 through PR8 under `docs/roadmap/caching-strategy/work-orders/`.
- Captured the future branch, title, base dependency, scope, non-goals, implementation contract, validation commands, reviewer expectations, exit criteria, and stop conditions for each remaining stack PR.
- Tightened reviewer-raised guardrails for redirect path sanitization, public/request-bound cache separation, robots/indexation coverage, and observability SEO boundaries.
- Kept the PR docs-only: no runtime code, cache behavior, Payload hooks, routes, seed behavior, or observability code changed.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P2 | `docs/roadmap/caching-strategy/work-orders/` | These documents become the execution contract for PR2-PR8. | The work orders preserve ADR 023 and PR1 guardrails, keep PR order clear, and avoid runtime implementation in this PR. | `pnpm format`; `pnpm docs:check`; docs-only scope check |

## Validation

- [x] `pnpm format`: `rtk proxy /Users/razorspoint/Library/pnpm/pnpm format`
- [ ] `pnpm check`: not run; docs-only planning change with no runtime, lint-relevant, schema, or config files changed.
- [ ] `pnpm build`: not run; docs-only planning change with no build-relevant source changes.
- [ ] Focused tests: not run; no runtime code changed.
- [ ] UI/mobile QA: not applicable; no UI changed.
- [x] Security/privacy review: `security-reviewer`; rerun after fixes, no findings `>=5/10`.
- [ ] Migration/schema check: not applicable; no Payload schema or migration changes.
- [x] Documentation/instructions check: `rtk proxy /Users/razorspoint/Library/pnpm/pnpm docs:check`; layered repository and docs instructions reviewed; scope limited to seven work-order documents.

## Risk and rollout

None known. This PR documents the execution contract only and does not change production behavior. The main risk is review-time ambiguity in the later implementation stack if a work order is incomplete, so the PR should be reviewed for consistency with ADR 023 and the accepted cache implementation plan before merge.

## Development

Closes #1451
