### PR TITLE
refactor: add cache stack 2/8 policy map

### DIFF
--- a/src/utilities/cachePolicy/index.ts
+++ b/src/utilities/cachePolicy/index.ts
@@ -71,6 +71,7 @@ export const CACHE_POLICY_COLLECTIONS = [
   'favoriteclinics',
   'patients',
   'basicUsers',
+  'clinicStaff',
   'platformStaff',
   'clinicApplications',
   'patientClinicInquiries',
@@ -78,6 +79,32 @@ export const CACHE_POLICY_COLLECTIONS = [
 ] as const
 
 export type CachePolicyCollection = (typeof CACHE_POLICY_COLLECTIONS)[number]
+
+export const CACHE_TAGGABLE_COLLECTIONS = [
+  'pages',
+  'posts',
+  'redirects',
+  'clinics',
+  'clinictreatments',
+  'doctors',
+  'doctorspecialties',
+  'doctortreatments',
+  'reviews',
+  'accreditation',
+  'clinicMedia',
+  'clinicGalleryEntries',
+  'clinicGalleryMedia',
+  'doctorMedia',
+  'platformContentMedia',
+  'treatments',
+  'medical-specialties',
+  'cities',
+  'countries',
+  'categories',
+  'tags',
+] as const satisfies readonly CachePolicyCollection[]
+
+export type CacheTaggableCollection = (typeof CACHE_TAGGABLE_COLLECTIONS)[number]
 
 export const CACHE_POLICY_GLOBALS = ['header', 'footer', 'landingPages', 'cookieConsent'] as const
 
@@ -105,6 +132,24 @@ export const CACHE_SURFACE_IDS = [
 ] as const
 
 export type CacheSurfaceId = (typeof CACHE_SURFACE_IDS)[number]
+
+export const CACHE_TAGGABLE_SURFACE_IDS = [
+  'page-detail',
+  'post-detail',
+  'posts-list',
+  'clinic-detail',
+  'home',
+  'about',
+  'partners-clinics',
+  'listing-comparison',
+  'contact',
+  'clinic-registration',
+  'patient-registration',
+  'redirects',
+  'public-chrome',
+] as const satisfies readonly CacheSurfaceId[]
+
+export type CacheTaggableSurfaceId = (typeof CACHE_TAGGABLE_SURFACE_IDS)[number]
 
 export const PARAMETERIZED_SURFACE_IDS = ['clinic-detail'] as const
 
@@ -141,7 +186,14 @@ export type FixedPublicPathSurfaceId = keyof typeof FIXED_PUBLIC_PATHS
 
 export type CachePolicyBoundary = 'public' | 'private' | 'operational'
 
-export type CachePolicyEntryKind = 'public-route' | 'global' | 'collection' | 'discovery' | 'seed-flow' | 'operational'
+export type CachePolicyEntryKind =
+  | 'public-route'
+  | 'private-route'
+  | 'global'
+  | 'collection'
+  | 'discovery'
+  | 'seed-flow'
+  | 'operational'
 
 export type CachePolicyOwner =
   | 'collection-hook'
@@ -265,12 +317,13 @@ export const CACHE_POLICY_CATALOG = [
     cacheClass: 'aggregated-public',
     boundary: 'public',
     owner: 'global-hook',
-    tagFamilies: ['global', 'collection', 'surface'],
+    tagFamilies: ['global', 'collection', 'surface', 'surface:sitemap'],
     pathRelationship: 'known-paths',
     pathFamilies: ['fixed-public-path'],
     collections: ['posts', 'medical-specialties', 'cities'],
     globals: ['landingPages'],
     surfaces: ['home'],
+    sitemapSurfaces: ['pages'],
   },
   {
     id: 'route:about',
@@ -278,11 +331,12 @@ export const CACHE_POLICY_CATALOG = [
     cacheClass: 'aggregated-public',
     boundary: 'public',
     owner: 'global-hook',
-    tagFamilies: ['global', 'surface'],
+    tagFamilies: ['global', 'surface', 'surface:sitemap'],
     pathRelationship: 'known-paths',
     pathFamilies: ['fixed-public-path'],
     globals: ['landingPages'],
     surfaces: ['about'],
+    sitemapSurfaces: ['pages'],
   },
   {
     id: 'route:partners-clinics',
@@ -290,12 +344,13 @@ export const CACHE_POLICY_CATALOG = [
     cacheClass: 'aggregated-public',
     boundary: 'public',
     owner: 'global-hook',
-    tagFamilies: ['global', 'collection', 'surface'],
+    tagFamilies: ['global', 'collection', 'surface', 'surface:sitemap'],
     pathRelationship: 'known-paths',
     pathFamilies: ['fixed-public-path'],
     collections: ['posts', 'medical-specialties', 'treatments'],
     globals: ['landingPages'],
     surfaces: ['partners-clinics'],
+    sitemapSurfaces: ['pages'],
   },
   {
     id: 'route:listing-comparison',
@@ -323,7 +378,7 @@ export const CACHE_POLICY_CATALOG = [
   },
   {
     id: 'route:patient-favorites-and-auth',
-    kind: 'public-route',
+    kind: 'private-route',
     cacheClass: 'private-live',
     boundary: 'private',
     owner: 'auth-owner',
@@ -335,7 +390,7 @@ export const CACHE_POLICY_CATALOG = [
   },
   {
     id: 'route:admin-and-preview',
-    kind: 'public-route',
+    kind: 'private-route',
     cacheClass: 'private-live',
     boundary: 'private',
     owner: 'auth-owner',
@@ -436,7 +491,7 @@ export const CACHE_POLICY_CATALOG = [
     tagFamilies: [],
     pathRelationship: 'private-live',
     pathFamilies: ['none'],
-    collections: ['platformStaff', 'clinicApplications', 'patientClinicInquiries'],
+    collections: ['platformStaff', 'clinicStaff', 'clinicApplications', 'patientClinicInquiries'],
   },
   {
     id: 'discovery:sitemap:pages',
@@ -611,11 +666,31 @@ const assertPositivePageNumber = (page: number): number => {
 export const assertKnownCollection = (collection: string): CachePolicyCollection =>
   assertKnownValue(collection, CACHE_POLICY_COLLECTIONS, 'collection')
 
+export const assertTaggableCollection = (collection: string): CacheTaggableCollection => {
+  const normalizedCollection = assertKnownCollection(collection)
+
+  if (!CACHE_TAGGABLE_COLLECTIONS.includes(normalizedCollection as CacheTaggableCollection)) {
+    throw new Error(`Collection is not public-cache taggable: ${normalizedCollection}`)
+  }
+
+  return normalizedCollection as CacheTaggableCollection
+}
+
 export const assertKnownGlobal = (global: string): CachePolicyGlobal =>
   assertKnownValue(global, CACHE_POLICY_GLOBALS, 'global')
 
 export const assertKnownSurfaceId = (surfaceId: string): CacheSurfaceId =>
   assertKnownValue(surfaceId, CACHE_SURFACE_IDS, 'surface')
+
+export const assertTaggableSurfaceId = (surfaceId: string): CacheTaggableSurfaceId => {
+  const normalizedSurface = assertKnownSurfaceId(surfaceId)
+
+  if (!CACHE_TAGGABLE_SURFACE_IDS.includes(normalizedSurface as CacheTaggableSurfaceId)) {
+    throw new Error(`Surface is not public-cache taggable: ${normalizedSurface}`)
+  }
+
+  return normalizedSurface as CacheTaggableSurfaceId
+}
 
 export const assertKnownSitemapId = (sitemapId: string): CacheSitemapId =>
   assertKnownValue(sitemapId, CACHE_SITEMAP_IDS, 'sitemap')
@@ -635,16 +710,16 @@ export const getCachePolicyEntry = (id: string): CachePolicyCatalogEntry => {
 }
 
 export const buildEntityTag = (collection: string, id: string | number): string =>
-  `entity:${assertKnownCollection(collection)}:${assertCacheToken(id, 'id')}`
+  `entity:${assertTaggableCollection(collection)}:${assertCacheToken(id, 'id')}`
 
 export const buildSlugTag = (collection: string, slug: string): string =>
-  `slug:${assertKnownCollection(collection)}:${assertPayloadSlug(slug, 'slug', { allowNested: true })}`
+  `slug:${assertTaggableCollection(collection)}:${assertPayloadSlug(slug, 'slug', { allowNested: true })}`
 
-export const buildCollectionTag = (collection: string): string => `collection:${assertKnownCollection(collection)}`
+export const buildCollectionTag = (collection: string): string => `collection:${assertTaggableCollection(collection)}`
 
 export const buildGlobalTag = (global: string): string => `global:${assertKnownGlobal(global)}`
 
-export const buildSurfaceTag = (surfaceId: string): string => `surface:${assertKnownSurfaceId(surfaceId)}`
+export const buildSurfaceTag = (surfaceId: string): string => `surface:${assertTaggableSurfaceId(surfaceId)}`
 
 export const buildSurfaceInstanceTag = (surfaceId: ParameterizedSurfaceId, id: string | number): string => {
   const normalizedSurface = assertKnownValue(surfaceId, PARAMETERIZED_SURFACE_IDS, 'parameterized surface')

--- a/src/utilities/cachePolicy/index.ts
+++ b/src/utilities/cachePolicy/index.ts
@@ -1,0 +1,712 @@
+export const CACHE_CLASSES = [
+  'critical-public',
+  'shared-public',
+  'aggregated-public',
+  'private-live',
+  'operational-scaling',
+] as const
+
+export type CacheClass = (typeof CACHE_CLASSES)[number]
+
+export const CACHE_TAG_FAMILY_TEMPLATES = [
+  'entity:<collection>:<id>',
+  'slug:<collection>:<slug>',
+  'collection:<collection>',
+  'global:<slug>',
+  'surface:<name>',
+  'surface:sitemap:<name>',
+  'surface:discovery:<name>',
+] as const
+
+export type CacheTagFamilyTemplate = (typeof CACHE_TAG_FAMILY_TEMPLATES)[number]
+
+export const CACHE_TAG_FAMILIES = [
+  'entity',
+  'slug',
+  'collection',
+  'global',
+  'surface',
+  'surface:sitemap',
+  'surface:discovery',
+] as const
+
+export type CacheTagFamily = (typeof CACHE_TAG_FAMILIES)[number]
+
+export const CACHE_OPERATIONS = [
+  'publish',
+  'update',
+  'unpublish',
+  'delete',
+  'slug-change',
+  'global-update',
+  'related-update',
+  'seed-final-flush',
+  'preview-read',
+] as const
+
+export type CacheOperation = (typeof CACHE_OPERATIONS)[number]
+
+export const CACHE_POLICY_COLLECTIONS = [
+  'pages',
+  'posts',
+  'redirects',
+  'clinics',
+  'clinictreatments',
+  'doctors',
+  'doctorspecialties',
+  'doctortreatments',
+  'reviews',
+  'accreditation',
+  'clinicMedia',
+  'clinicGalleryEntries',
+  'clinicGalleryMedia',
+  'doctorMedia',
+  'platformContentMedia',
+  'treatments',
+  'medical-specialties',
+  'cities',
+  'countries',
+  'categories',
+  'tags',
+  'favoriteclinics',
+  'patients',
+  'basicUsers',
+  'platformStaff',
+  'clinicApplications',
+  'patientClinicInquiries',
+  'userProfileMedia',
+] as const
+
+export type CachePolicyCollection = (typeof CACHE_POLICY_COLLECTIONS)[number]
+
+export const CACHE_POLICY_GLOBALS = ['header', 'footer', 'landingPages', 'cookieConsent'] as const
+
+export type CachePolicyGlobal = (typeof CACHE_POLICY_GLOBALS)[number]
+
+export const CACHE_SURFACE_IDS = [
+  'page-detail',
+  'post-detail',
+  'posts-list',
+  'clinic-detail',
+  'home',
+  'about',
+  'partners-clinics',
+  'listing-comparison',
+  'contact',
+  'clinic-registration',
+  'patient-registration',
+  'redirects',
+  'public-chrome',
+  'patient-favorites',
+  'auth',
+  'admin',
+  'preview',
+  'cache-visibility',
+] as const
+
+export type CacheSurfaceId = (typeof CACHE_SURFACE_IDS)[number]
+
+export const PARAMETERIZED_SURFACE_IDS = ['clinic-detail'] as const
+
+export type ParameterizedSurfaceId = (typeof PARAMETERIZED_SURFACE_IDS)[number]
+
+export const CACHE_SITEMAP_IDS = ['pages', 'posts'] as const
+
+export type CacheSitemapId = (typeof CACHE_SITEMAP_IDS)[number]
+
+export const CACHE_DISCOVERY_IDS = [
+  'robots',
+  'sitemap-index',
+  'llms',
+  'well-known-llms',
+  'canonical-noindex',
+  'structured-data',
+] as const
+
+export type CacheDiscoveryId = (typeof CACHE_DISCOVERY_IDS)[number]
+
+export const FIXED_PUBLIC_PATHS = {
+  home: '/',
+  about: '/about',
+  'partners-clinics': '/partners/clinics',
+  'listing-comparison': '/listing-comparison',
+  contact: '/contact',
+  'clinic-registration': '/register/clinic',
+  'patient-registration': '/register/patient',
+} as const
+
+export const FIXED_PUBLIC_PATH_SURFACE_IDS = Object.keys(FIXED_PUBLIC_PATHS) as FixedPublicPathSurfaceId[]
+
+export type FixedPublicPathSurfaceId = keyof typeof FIXED_PUBLIC_PATHS
+
+export type CachePolicyBoundary = 'public' | 'private' | 'operational'
+
+export type CachePolicyEntryKind = 'public-route' | 'global' | 'collection' | 'discovery' | 'seed-flow' | 'operational'
+
+export type CachePolicyOwner =
+  | 'collection-hook'
+  | 'global-hook'
+  | 'redirect-hook'
+  | 'route-owner'
+  | 'public-discovery'
+  | 'search-indexing'
+  | 'seed-runner'
+  | 'admin-dashboard'
+  | 'auth-owner'
+  | 'media-dependency-follow-up'
+
+export type CachePathRelationship =
+  | 'path-second'
+  | 'tag-first'
+  | 'known-paths'
+  | 'no-path-invalidation'
+  | 'private-live'
+  | 'operational-terminal-flush'
+  | 'deferred'
+
+export type CachePolicyPathFamily =
+  | 'page-detail'
+  | 'post-detail'
+  | 'posts-index'
+  | 'posts-pagination'
+  | 'clinic-detail'
+  | 'fixed-public-path'
+  | 'sitemap'
+  | 'discovery'
+  | 'none'
+
+export interface CachePolicyCatalogEntry {
+  readonly id: string
+  readonly kind: CachePolicyEntryKind
+  readonly cacheClass: CacheClass
+  readonly boundary: CachePolicyBoundary
+  readonly owner: CachePolicyOwner
+  readonly tagFamilies: readonly CacheTagFamily[]
+  readonly pathRelationship: CachePathRelationship
+  readonly pathFamilies: readonly CachePolicyPathFamily[]
+  readonly collections?: readonly CachePolicyCollection[]
+  readonly globals?: readonly CachePolicyGlobal[]
+  readonly surfaces?: readonly CacheSurfaceId[]
+  readonly sitemapSurfaces?: readonly CacheSitemapId[]
+  readonly discoverySurfaces?: readonly CacheDiscoveryId[]
+}
+
+export const CACHE_POLICY_CATALOG = [
+  {
+    id: 'route:pages',
+    kind: 'public-route',
+    cacheClass: 'critical-public',
+    boundary: 'public',
+    owner: 'collection-hook',
+    tagFamilies: ['entity', 'slug', 'collection', 'surface:sitemap'],
+    pathRelationship: 'path-second',
+    pathFamilies: ['page-detail'],
+    collections: ['pages'],
+    sitemapSurfaces: ['pages'],
+  },
+  {
+    id: 'route:posts:detail',
+    kind: 'public-route',
+    cacheClass: 'critical-public',
+    boundary: 'public',
+    owner: 'collection-hook',
+    tagFamilies: ['entity', 'slug', 'collection', 'surface:sitemap'],
+    pathRelationship: 'path-second',
+    pathFamilies: ['post-detail'],
+    collections: ['posts'],
+    sitemapSurfaces: ['posts'],
+  },
+  {
+    id: 'route:posts:list',
+    kind: 'public-route',
+    cacheClass: 'aggregated-public',
+    boundary: 'public',
+    owner: 'collection-hook',
+    tagFamilies: ['collection', 'surface'],
+    pathRelationship: 'tag-first',
+    pathFamilies: ['posts-index', 'posts-pagination'],
+    collections: ['posts'],
+    surfaces: ['posts-list', 'home', 'partners-clinics'],
+  },
+  {
+    id: 'route:clinics:detail',
+    kind: 'public-route',
+    cacheClass: 'critical-public',
+    boundary: 'public',
+    owner: 'collection-hook',
+    tagFamilies: ['entity', 'slug', 'collection', 'surface'],
+    pathRelationship: 'path-second',
+    pathFamilies: ['clinic-detail'],
+    collections: ['clinics'],
+    surfaces: ['clinic-detail'],
+  },
+  {
+    id: 'route:clinic-detail:related-data',
+    kind: 'collection',
+    cacheClass: 'critical-public',
+    boundary: 'public',
+    owner: 'collection-hook',
+    tagFamilies: ['collection', 'surface'],
+    pathRelationship: 'path-second',
+    pathFamilies: ['clinic-detail'],
+    collections: [
+      'clinictreatments',
+      'doctors',
+      'doctorspecialties',
+      'reviews',
+      'accreditation',
+      'clinicGalleryEntries',
+    ],
+    surfaces: ['clinic-detail'],
+  },
+  {
+    id: 'route:home',
+    kind: 'public-route',
+    cacheClass: 'aggregated-public',
+    boundary: 'public',
+    owner: 'global-hook',
+    tagFamilies: ['global', 'collection', 'surface'],
+    pathRelationship: 'known-paths',
+    pathFamilies: ['fixed-public-path'],
+    collections: ['posts', 'medical-specialties', 'cities'],
+    globals: ['landingPages'],
+    surfaces: ['home'],
+  },
+  {
+    id: 'route:about',
+    kind: 'public-route',
+    cacheClass: 'aggregated-public',
+    boundary: 'public',
+    owner: 'global-hook',
+    tagFamilies: ['global', 'surface'],
+    pathRelationship: 'known-paths',
+    pathFamilies: ['fixed-public-path'],
+    globals: ['landingPages'],
+    surfaces: ['about'],
+  },
+  {
+    id: 'route:partners-clinics',
+    kind: 'public-route',
+    cacheClass: 'aggregated-public',
+    boundary: 'public',
+    owner: 'global-hook',
+    tagFamilies: ['global', 'collection', 'surface'],
+    pathRelationship: 'known-paths',
+    pathFamilies: ['fixed-public-path'],
+    collections: ['posts', 'medical-specialties', 'treatments'],
+    globals: ['landingPages'],
+    surfaces: ['partners-clinics'],
+  },
+  {
+    id: 'route:listing-comparison',
+    kind: 'public-route',
+    cacheClass: 'aggregated-public',
+    boundary: 'public',
+    owner: 'collection-hook',
+    tagFamilies: ['collection', 'surface', 'surface:sitemap'],
+    pathRelationship: 'tag-first',
+    pathFamilies: ['fixed-public-path'],
+    collections: ['clinics', 'clinictreatments', 'reviews', 'treatments', 'medical-specialties', 'cities'],
+    surfaces: ['listing-comparison'],
+    sitemapSurfaces: ['pages'],
+  },
+  {
+    id: 'route:contact-and-registration',
+    kind: 'public-route',
+    cacheClass: 'aggregated-public',
+    boundary: 'public',
+    owner: 'route-owner',
+    tagFamilies: ['global', 'surface'],
+    pathRelationship: 'known-paths',
+    pathFamilies: ['fixed-public-path'],
+    surfaces: ['contact', 'clinic-registration', 'patient-registration'],
+  },
+  {
+    id: 'route:patient-favorites-and-auth',
+    kind: 'public-route',
+    cacheClass: 'private-live',
+    boundary: 'private',
+    owner: 'auth-owner',
+    tagFamilies: [],
+    pathRelationship: 'private-live',
+    pathFamilies: ['none'],
+    collections: ['favoriteclinics', 'patients', 'basicUsers', 'userProfileMedia'],
+    surfaces: ['patient-favorites', 'auth'],
+  },
+  {
+    id: 'route:admin-and-preview',
+    kind: 'public-route',
+    cacheClass: 'private-live',
+    boundary: 'private',
+    owner: 'auth-owner',
+    tagFamilies: [],
+    pathRelationship: 'private-live',
+    pathFamilies: ['none'],
+    surfaces: ['admin', 'preview'],
+  },
+  {
+    id: 'global:header',
+    kind: 'global',
+    cacheClass: 'shared-public',
+    boundary: 'public',
+    owner: 'global-hook',
+    tagFamilies: ['global', 'surface'],
+    pathRelationship: 'tag-first',
+    pathFamilies: ['none'],
+    globals: ['header'],
+    surfaces: ['public-chrome'],
+  },
+  {
+    id: 'global:footer',
+    kind: 'global',
+    cacheClass: 'shared-public',
+    boundary: 'public',
+    owner: 'global-hook',
+    tagFamilies: ['global', 'surface'],
+    pathRelationship: 'tag-first',
+    pathFamilies: ['none'],
+    globals: ['footer'],
+    surfaces: ['public-chrome'],
+  },
+  {
+    id: 'global:landingPages',
+    kind: 'global',
+    cacheClass: 'aggregated-public',
+    boundary: 'public',
+    owner: 'global-hook',
+    tagFamilies: ['global', 'surface'],
+    pathRelationship: 'known-paths',
+    pathFamilies: ['fixed-public-path'],
+    globals: ['landingPages'],
+    surfaces: ['home', 'about', 'partners-clinics'],
+  },
+  {
+    id: 'global:cookieConsent',
+    kind: 'global',
+    cacheClass: 'shared-public',
+    boundary: 'public',
+    owner: 'global-hook',
+    tagFamilies: ['global', 'surface'],
+    pathRelationship: 'tag-first',
+    pathFamilies: ['none'],
+    globals: ['cookieConsent'],
+    surfaces: ['public-chrome'],
+  },
+  {
+    id: 'collection:redirects',
+    kind: 'collection',
+    cacheClass: 'critical-public',
+    boundary: 'public',
+    owner: 'redirect-hook',
+    tagFamilies: ['collection', 'surface'],
+    pathRelationship: 'tag-first',
+    pathFamilies: ['none'],
+    collections: ['redirects'],
+    surfaces: ['redirects'],
+  },
+  {
+    id: 'collection:listing-support',
+    kind: 'collection',
+    cacheClass: 'aggregated-public',
+    boundary: 'public',
+    owner: 'collection-hook',
+    tagFamilies: ['collection', 'surface'],
+    pathRelationship: 'tag-first',
+    pathFamilies: ['fixed-public-path'],
+    collections: ['treatments', 'medical-specialties', 'cities', 'countries', 'categories', 'tags'],
+    surfaces: ['listing-comparison', 'home', 'partners-clinics'],
+  },
+  {
+    id: 'collection:media-inherited',
+    kind: 'collection',
+    cacheClass: 'critical-public',
+    boundary: 'public',
+    owner: 'media-dependency-follow-up',
+    tagFamilies: ['entity', 'collection'],
+    pathRelationship: 'deferred',
+    pathFamilies: ['none'],
+    collections: ['clinicMedia', 'clinicGalleryMedia', 'doctorMedia', 'platformContentMedia'],
+  },
+  {
+    id: 'collection:private-operational',
+    kind: 'collection',
+    cacheClass: 'private-live',
+    boundary: 'private',
+    owner: 'auth-owner',
+    tagFamilies: [],
+    pathRelationship: 'private-live',
+    pathFamilies: ['none'],
+    collections: ['platformStaff', 'clinicApplications', 'patientClinicInquiries'],
+  },
+  {
+    id: 'discovery:sitemap:pages',
+    kind: 'discovery',
+    cacheClass: 'aggregated-public',
+    boundary: 'public',
+    owner: 'public-discovery',
+    tagFamilies: ['surface:sitemap', 'collection', 'surface'],
+    pathRelationship: 'tag-first',
+    pathFamilies: ['sitemap'],
+    sitemapSurfaces: ['pages'],
+  },
+  {
+    id: 'discovery:sitemap:posts',
+    kind: 'discovery',
+    cacheClass: 'aggregated-public',
+    boundary: 'public',
+    owner: 'public-discovery',
+    tagFamilies: ['surface:sitemap', 'collection'],
+    pathRelationship: 'tag-first',
+    pathFamilies: ['sitemap'],
+    sitemapSurfaces: ['posts'],
+  },
+  {
+    id: 'discovery:robots-and-indexing',
+    kind: 'discovery',
+    cacheClass: 'critical-public',
+    boundary: 'public',
+    owner: 'search-indexing',
+    tagFamilies: ['surface:discovery'],
+    pathRelationship: 'no-path-invalidation',
+    pathFamilies: ['discovery'],
+    discoverySurfaces: ['robots', 'sitemap-index', 'canonical-noindex', 'structured-data'],
+  },
+  {
+    id: 'discovery:llms',
+    kind: 'discovery',
+    cacheClass: 'aggregated-public',
+    boundary: 'public',
+    owner: 'public-discovery',
+    tagFamilies: ['surface:discovery'],
+    pathRelationship: 'tag-first',
+    pathFamilies: ['discovery'],
+    discoverySurfaces: ['llms', 'well-known-llms'],
+  },
+  {
+    id: 'seed:queued-runs',
+    kind: 'seed-flow',
+    cacheClass: 'operational-scaling',
+    boundary: 'operational',
+    owner: 'seed-runner',
+    tagFamilies: ['collection', 'global', 'surface', 'surface:sitemap', 'surface:discovery'],
+    pathRelationship: 'operational-terminal-flush',
+    pathFamilies: ['none'],
+  },
+  {
+    id: 'seed:baseline',
+    kind: 'seed-flow',
+    cacheClass: 'operational-scaling',
+    boundary: 'operational',
+    owner: 'seed-runner',
+    tagFamilies: ['collection', 'global', 'surface', 'surface:sitemap', 'surface:discovery'],
+    pathRelationship: 'operational-terminal-flush',
+    pathFamilies: ['none'],
+  },
+  {
+    id: 'seed:demo',
+    kind: 'seed-flow',
+    cacheClass: 'operational-scaling',
+    boundary: 'operational',
+    owner: 'seed-runner',
+    tagFamilies: ['collection', 'global', 'surface', 'surface:sitemap', 'surface:discovery'],
+    pathRelationship: 'operational-terminal-flush',
+    pathFamilies: ['none'],
+  },
+  {
+    id: 'operational:search-sync-suppression',
+    kind: 'operational',
+    cacheClass: 'operational-scaling',
+    boundary: 'operational',
+    owner: 'seed-runner',
+    tagFamilies: [],
+    pathRelationship: 'no-path-invalidation',
+    pathFamilies: ['none'],
+  },
+  {
+    id: 'operational:cache-visibility',
+    kind: 'operational',
+    cacheClass: 'operational-scaling',
+    boundary: 'operational',
+    owner: 'admin-dashboard',
+    tagFamilies: [],
+    pathRelationship: 'no-path-invalidation',
+    pathFamilies: ['none'],
+    surfaces: ['cache-visibility'],
+  },
+] as const satisfies readonly CachePolicyCatalogEntry[]
+
+const CONTROL_CHARACTERS_PATTERN = /[\u0000-\u001F\u007F]/
+const WHITESPACE_PATTERN = /\s/
+
+const assertNonEmptyText = (value: string, label: string): string => {
+  const normalized = value.trim()
+
+  if (!normalized) {
+    throw new Error(`Invalid ${label}: value must not be empty`)
+  }
+
+  return normalized
+}
+
+const assertKnownValue = <AllowedValue extends string>(
+  value: string,
+  allowedValues: readonly AllowedValue[],
+  label: string,
+): AllowedValue => {
+  const normalized = assertCacheToken(value, label)
+
+  if (!allowedValues.includes(normalized as AllowedValue)) {
+    throw new Error(`Unknown ${label}: ${normalized}`)
+  }
+
+  return normalized as AllowedValue
+}
+
+const assertCacheToken = (value: string | number, label: string): string => {
+  const normalized = String(value).trim()
+
+  if (!normalized) {
+    throw new Error(`Invalid ${label}: value must not be empty`)
+  }
+
+  if (CONTROL_CHARACTERS_PATTERN.test(normalized) || WHITESPACE_PATTERN.test(normalized)) {
+    throw new Error(`Invalid ${label}: value must not contain whitespace or control characters`)
+  }
+
+  if (normalized.includes(':')) {
+    throw new Error(`Invalid ${label}: value must not contain ":"`)
+  }
+
+  return normalized
+}
+
+const assertPayloadSlug = (slug: string, label: string, { allowNested = false }: { allowNested?: boolean } = {}) => {
+  const normalized = assertCacheToken(slug, label)
+
+  if (
+    normalized.startsWith('/') ||
+    normalized.endsWith('/') ||
+    normalized.includes('//') ||
+    normalized.includes('?') ||
+    normalized.includes('#')
+  ) {
+    throw new Error(`Invalid ${label}: value must be a Payload slug, not a path`)
+  }
+
+  if (!allowNested && normalized.includes('/')) {
+    throw new Error(`Invalid ${label}: nested slugs are not allowed for this path family`)
+  }
+
+  return normalized
+}
+
+const assertPositivePageNumber = (page: number): number => {
+  if (!Number.isInteger(page) || page < 1) {
+    throw new Error('Invalid page: value must be a positive integer')
+  }
+
+  return page
+}
+
+export const assertKnownCollection = (collection: string): CachePolicyCollection =>
+  assertKnownValue(collection, CACHE_POLICY_COLLECTIONS, 'collection')
+
+export const assertKnownGlobal = (global: string): CachePolicyGlobal =>
+  assertKnownValue(global, CACHE_POLICY_GLOBALS, 'global')
+
+export const assertKnownSurfaceId = (surfaceId: string): CacheSurfaceId =>
+  assertKnownValue(surfaceId, CACHE_SURFACE_IDS, 'surface')
+
+export const assertKnownSitemapId = (sitemapId: string): CacheSitemapId =>
+  assertKnownValue(sitemapId, CACHE_SITEMAP_IDS, 'sitemap')
+
+export const assertKnownDiscoveryId = (discoveryId: string): CacheDiscoveryId =>
+  assertKnownValue(discoveryId, CACHE_DISCOVERY_IDS, 'discovery surface')
+
+export const getCachePolicyEntry = (id: string): CachePolicyCatalogEntry => {
+  const normalizedId = assertNonEmptyText(id, 'policy entry id')
+  const entry = CACHE_POLICY_CATALOG.find((candidate) => candidate.id === normalizedId)
+
+  if (!entry) {
+    throw new Error(`Unknown policy entry id: ${normalizedId}`)
+  }
+
+  return entry
+}
+
+export const buildEntityTag = (collection: string, id: string | number): string =>
+  `entity:${assertKnownCollection(collection)}:${assertCacheToken(id, 'id')}`
+
+export const buildSlugTag = (collection: string, slug: string): string =>
+  `slug:${assertKnownCollection(collection)}:${assertPayloadSlug(slug, 'slug', { allowNested: true })}`
+
+export const buildCollectionTag = (collection: string): string => `collection:${assertKnownCollection(collection)}`
+
+export const buildGlobalTag = (global: string): string => `global:${assertKnownGlobal(global)}`
+
+export const buildSurfaceTag = (surfaceId: string): string => `surface:${assertKnownSurfaceId(surfaceId)}`
+
+export const buildSurfaceInstanceTag = (surfaceId: ParameterizedSurfaceId, id: string | number): string => {
+  const normalizedSurface = assertKnownValue(surfaceId, PARAMETERIZED_SURFACE_IDS, 'parameterized surface')
+
+  return `surface:${normalizedSurface}:${assertCacheToken(id, 'surface id')}`
+}
+
+export const buildSitemapTag = (sitemapId: string): string => `surface:sitemap:${assertKnownSitemapId(sitemapId)}`
+
+export const buildDiscoveryTag = (discoveryId: string): string =>
+  `surface:discovery:${assertKnownDiscoveryId(discoveryId)}`
+
+export const buildPagePath = (slug: string): string => {
+  const normalizedSlug = assertPayloadSlug(slug, 'page slug', { allowNested: true })
+
+  if (normalizedSlug === 'home') {
+    return '/'
+  }
+
+  return `/${normalizedSlug}`
+}
+
+export const buildPostPath = (slug: string): string =>
+  `/posts/${assertPayloadSlug(slug, 'post slug', { allowNested: false })}`
+
+export const buildClinicPath = (slug: string): string =>
+  `/clinics/${assertPayloadSlug(slug, 'clinic slug', { allowNested: false })}`
+
+export const buildPostsIndexPath = (): string => '/posts'
+
+export const buildPostsPaginationPath = (page: number): string => {
+  const normalizedPage = assertPositivePageNumber(page)
+
+  return normalizedPage === 1 ? buildPostsIndexPath() : `/posts/page/${normalizedPage}`
+}
+
+export const buildFixedPublicPath = (surfaceId: string): string => {
+  const normalizedSurfaceId = assertKnownValue(surfaceId, FIXED_PUBLIC_PATH_SURFACE_IDS, 'fixed public surface')
+
+  return FIXED_PUBLIC_PATHS[normalizedSurfaceId]
+}
+
+export const buildSitemapPath = (sitemapId: string): string => {
+  const normalizedSitemapId = assertKnownSitemapId(sitemapId)
+
+  return `/${normalizedSitemapId}-sitemap.xml`
+}
+
+export const buildDiscoveryPath = (discoveryId: string): string => {
+  const normalizedDiscoveryId = assertKnownDiscoveryId(discoveryId)
+
+  switch (normalizedDiscoveryId) {
+    case 'robots':
+      return '/robots.txt'
+    case 'sitemap-index':
+      return '/sitemap.xml'
+    case 'llms':
+      return '/llms.txt'
+    case 'well-known-llms':
+      return '/.well-known/llms.txt'
+    case 'canonical-noindex':
+    case 'structured-data':
+      throw new Error(`Discovery surface does not have a standalone path: ${normalizedDiscoveryId}`)
+  }
+}

--- a/tests/unit/utilities/cachePolicy.test.ts
+++ b/tests/unit/utilities/cachePolicy.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildClinicPath,
+  buildCollectionTag,
+  buildDiscoveryPath,
+  buildDiscoveryTag,
+  buildEntityTag,
+  buildFixedPublicPath,
+  buildGlobalTag,
+  buildPagePath,
+  buildPostPath,
+  buildPostsIndexPath,
+  buildPostsPaginationPath,
+  buildSitemapPath,
+  buildSitemapTag,
+  buildSlugTag,
+  buildSurfaceInstanceTag,
+  buildSurfaceTag,
+  CACHE_CLASSES,
+  CACHE_DISCOVERY_IDS,
+  CACHE_OPERATIONS,
+  CACHE_POLICY_CATALOG,
+  CACHE_POLICY_COLLECTIONS,
+  CACHE_POLICY_GLOBALS,
+  CACHE_SITEMAP_IDS,
+  CACHE_SURFACE_IDS,
+  CACHE_TAG_FAMILIES,
+  CACHE_TAG_FAMILY_TEMPLATES,
+  getCachePolicyEntry,
+  type CachePolicyCatalogEntry,
+} from '@/utilities/cachePolicy'
+
+describe('cache policy contract', () => {
+  it('exposes the accepted ADR 023 cache classes and tag families', () => {
+    expect(CACHE_CLASSES).toEqual([
+      'critical-public',
+      'shared-public',
+      'aggregated-public',
+      'private-live',
+      'operational-scaling',
+    ])
+
+    expect(CACHE_TAG_FAMILY_TEMPLATES).toEqual([
+      'entity:<collection>:<id>',
+      'slug:<collection>:<slug>',
+      'collection:<collection>',
+      'global:<slug>',
+      'surface:<name>',
+      'surface:sitemap:<name>',
+      'surface:discovery:<name>',
+    ])
+
+    expect(CACHE_TAG_FAMILIES).toEqual([
+      'entity',
+      'slug',
+      'collection',
+      'global',
+      'surface',
+      'surface:sitemap',
+      'surface:discovery',
+    ])
+  })
+
+  it('builds canonical cache tags without legacy tag strings', () => {
+    const generatedTags = [
+      buildEntityTag('posts', 123),
+      buildSlugTag('pages', 'medical-tourism/checklist'),
+      buildCollectionTag('clinics'),
+      buildGlobalTag('landingPages'),
+      buildSurfaceTag('listing-comparison'),
+      buildSurfaceInstanceTag('clinic-detail', 42),
+      buildSitemapTag('pages'),
+      buildDiscoveryTag('llms'),
+    ]
+
+    expect(generatedTags).toEqual([
+      'entity:posts:123',
+      'slug:pages:medical-tourism/checklist',
+      'collection:clinics',
+      'global:landingPages',
+      'surface:listing-comparison',
+      'surface:clinic-detail:42',
+      'surface:sitemap:pages',
+      'surface:discovery:llms',
+    ])
+
+    expect(generatedTags).not.toContain('global_header')
+    expect(generatedTags).not.toContain('global_footer')
+    expect(generatedTags).not.toContain('global_landingPages')
+    expect(generatedTags).not.toContain('global_cookieConsent')
+    expect(generatedTags).not.toContain('pages-sitemap')
+    expect(generatedTags).not.toContain('posts-sitemap')
+    expect(generatedTags).not.toContain('redirects')
+    expect(generatedTags).not.toContain('pages_home')
+    expect(generatedTags.every((tag) => tag.includes(':'))).toBe(true)
+  })
+
+  it('builds known public route, sitemap, and discovery paths', () => {
+    expect(buildPagePath('home')).toBe('/')
+    expect(buildPagePath('medical-tourism/checklist')).toBe('/medical-tourism/checklist')
+    expect(buildPostPath('clinic-checklist')).toBe('/posts/clinic-checklist')
+    expect(buildClinicPath('berlin-health')).toBe('/clinics/berlin-health')
+    expect(buildPostsIndexPath()).toBe('/posts')
+    expect(buildPostsPaginationPath(1)).toBe('/posts')
+    expect(buildPostsPaginationPath(3)).toBe('/posts/page/3')
+    expect(buildFixedPublicPath('about')).toBe('/about')
+    expect(buildFixedPublicPath('partners-clinics')).toBe('/partners/clinics')
+    expect(buildFixedPublicPath('listing-comparison')).toBe('/listing-comparison')
+    expect(buildSitemapPath('pages')).toBe('/pages-sitemap.xml')
+    expect(buildSitemapPath('posts')).toBe('/posts-sitemap.xml')
+    expect(buildDiscoveryPath('robots')).toBe('/robots.txt')
+    expect(buildDiscoveryPath('sitemap-index')).toBe('/sitemap.xml')
+    expect(buildDiscoveryPath('llms')).toBe('/llms.txt')
+    expect(buildDiscoveryPath('well-known-llms')).toBe('/.well-known/llms.txt')
+  })
+
+  it('fails fast for invalid ids, slugs, paths, and surface ids', () => {
+    expect(() => buildEntityTag('unknown', 1)).toThrow(/Unknown collection/)
+    expect(() => buildEntityTag('posts', ' ')).toThrow(/must not be empty/)
+    expect(() => buildSlugTag('posts', 'hello world')).toThrow(/whitespace/)
+    expect(() => buildSlugTag('posts', 'hello:world')).toThrow(/must not contain ":"/)
+    expect(() => buildPagePath('/about')).toThrow(/not a path/)
+    expect(() => buildPagePath('about/')).toThrow(/not a path/)
+    expect(() => buildPostPath('category/post')).toThrow(/nested slugs/)
+    expect(() => buildClinicPath('berlin?draft=1')).toThrow(/not a path/)
+    expect(() => buildPostsPaginationPath(0)).toThrow(/positive integer/)
+    expect(() => buildPostsPaginationPath(1.5)).toThrow(/positive integer/)
+    expect(() => buildFixedPublicPath('unknown')).toThrow(/Unknown fixed public surface/)
+    expect(() => buildSurfaceTag('unknown')).toThrow(/Unknown surface/)
+    expect(() => buildSitemapTag('unknown')).toThrow(/Unknown sitemap/)
+    expect(() => buildDiscoveryTag('unknown')).toThrow(/Unknown discovery surface/)
+    expect(() => buildDiscoveryPath('canonical-noindex')).toThrow(/does not have a standalone path/)
+  })
+
+  it('keeps operations as vocabulary without planner output', () => {
+    expect(CACHE_OPERATIONS).toEqual([
+      'publish',
+      'update',
+      'unpublish',
+      'delete',
+      'slug-change',
+      'global-update',
+      'related-update',
+      'seed-final-flush',
+      'preview-read',
+    ])
+
+    expect(CACHE_OPERATIONS.every((operation) => typeof operation === 'string')).toBe(true)
+  })
+
+  it('maps the PR1 cache assignment matrix into a machine-readable catalog', () => {
+    const expectedEntries = [
+      'route:pages',
+      'route:posts:detail',
+      'route:posts:list',
+      'route:clinics:detail',
+      'route:clinic-detail:related-data',
+      'route:home',
+      'route:about',
+      'route:partners-clinics',
+      'route:listing-comparison',
+      'route:contact-and-registration',
+      'route:patient-favorites-and-auth',
+      'route:admin-and-preview',
+      'global:header',
+      'global:footer',
+      'global:landingPages',
+      'global:cookieConsent',
+      'collection:redirects',
+      'collection:listing-support',
+      'collection:media-inherited',
+      'collection:private-operational',
+      'discovery:sitemap:pages',
+      'discovery:sitemap:posts',
+      'discovery:robots-and-indexing',
+      'discovery:llms',
+      'seed:queued-runs',
+      'seed:baseline',
+      'seed:demo',
+      'operational:search-sync-suppression',
+      'operational:cache-visibility',
+    ]
+
+    expect(CACHE_POLICY_CATALOG.map((entry) => entry.id)).toEqual(expectedEntries)
+
+    expect(getCachePolicyEntry('route:pages')).toMatchObject({
+      cacheClass: 'critical-public',
+      boundary: 'public',
+      owner: 'collection-hook',
+      tagFamilies: ['entity', 'slug', 'collection', 'surface:sitemap'],
+      pathRelationship: 'path-second',
+      pathFamilies: ['page-detail'],
+      collections: ['pages'],
+      sitemapSurfaces: ['pages'],
+    })
+
+    expect(getCachePolicyEntry('route:patient-favorites-and-auth')).toMatchObject({
+      cacheClass: 'private-live',
+      boundary: 'private',
+      tagFamilies: [],
+      pathRelationship: 'private-live',
+    })
+
+    expect(getCachePolicyEntry('seed:queued-runs')).toMatchObject({
+      cacheClass: 'operational-scaling',
+      boundary: 'operational',
+      owner: 'seed-runner',
+      pathRelationship: 'operational-terminal-flush',
+    })
+  })
+
+  it('keeps every catalog reference inside the exported policy vocabulary', () => {
+    const classes = new Set<string>(CACHE_CLASSES)
+    const tagFamilies = new Set<string>(CACHE_TAG_FAMILIES)
+    const collections = new Set<string>(CACHE_POLICY_COLLECTIONS)
+    const globals = new Set<string>(CACHE_POLICY_GLOBALS)
+    const surfaces = new Set<string>(CACHE_SURFACE_IDS)
+    const sitemapSurfaces = new Set<string>(CACHE_SITEMAP_IDS)
+    const discoverySurfaces = new Set<string>(CACHE_DISCOVERY_IDS)
+
+    for (const entry of CACHE_POLICY_CATALOG as readonly CachePolicyCatalogEntry[]) {
+      expect(classes.has(entry.cacheClass)).toBe(true)
+      expect(entry.tagFamilies.every((family) => tagFamilies.has(family))).toBe(true)
+      expect(entry.collections?.every((collection) => collections.has(collection)) ?? true).toBe(true)
+      expect(entry.globals?.every((global) => globals.has(global)) ?? true).toBe(true)
+      expect(entry.surfaces?.every((surface) => surfaces.has(surface)) ?? true).toBe(true)
+      expect(entry.sitemapSurfaces?.every((surface) => sitemapSurfaces.has(surface)) ?? true).toBe(true)
+      expect(entry.discoverySurfaces?.every((surface) => discoverySurfaces.has(surface)) ?? true).toBe(true)
+    }
+  })
+})

--- a/tests/unit/utilities/cachePolicy.test.ts
+++ b/tests/unit/utilities/cachePolicy.test.ts
@@ -25,6 +25,8 @@ import {
   CACHE_POLICY_GLOBALS,
   CACHE_SITEMAP_IDS,
   CACHE_SURFACE_IDS,
+  CACHE_TAGGABLE_COLLECTIONS,
+  CACHE_TAGGABLE_SURFACE_IDS,
   CACHE_TAG_FAMILIES,
   CACHE_TAG_FAMILY_TEMPLATES,
   getCachePolicyEntry,
@@ -94,6 +96,34 @@ describe('cache policy contract', () => {
     expect(generatedTags).not.toContain('redirects')
     expect(generatedTags).not.toContain('pages_home')
     expect(generatedTags.every((tag) => tag.includes(':'))).toBe(true)
+  })
+
+  it('fails closed before generating cache tags for private-live collections and surfaces', () => {
+    const privateCollections = [
+      'favoriteclinics',
+      'patients',
+      'basicUsers',
+      'clinicStaff',
+      'platformStaff',
+      'clinicApplications',
+      'patientClinicInquiries',
+      'userProfileMedia',
+    ]
+
+    const privateSurfaces = ['patient-favorites', 'auth', 'admin', 'preview', 'cache-visibility']
+
+    for (const collection of privateCollections) {
+      expect(CACHE_POLICY_COLLECTIONS).toContain(collection)
+      expect(CACHE_TAGGABLE_COLLECTIONS).not.toContain(collection)
+      expect(() => buildEntityTag(collection, 1)).toThrow(/not public-cache taggable/)
+      expect(() => buildCollectionTag(collection)).toThrow(/not public-cache taggable/)
+    }
+
+    for (const surface of privateSurfaces) {
+      expect(CACHE_SURFACE_IDS).toContain(surface)
+      expect(CACHE_TAGGABLE_SURFACE_IDS).not.toContain(surface)
+      expect(() => buildSurfaceTag(surface)).toThrow(/not public-cache taggable/)
+    }
   })
 
   it('builds known public route, sitemap, and discovery paths', () => {
@@ -195,7 +225,26 @@ describe('cache policy contract', () => {
       sitemapSurfaces: ['pages'],
     })
 
+    expect(getCachePolicyEntry('route:home')).toMatchObject({
+      tagFamilies: ['global', 'collection', 'surface', 'surface:sitemap'],
+      surfaces: ['home'],
+      sitemapSurfaces: ['pages'],
+    })
+
+    expect(getCachePolicyEntry('route:about')).toMatchObject({
+      tagFamilies: ['global', 'surface', 'surface:sitemap'],
+      surfaces: ['about'],
+      sitemapSurfaces: ['pages'],
+    })
+
+    expect(getCachePolicyEntry('route:partners-clinics')).toMatchObject({
+      tagFamilies: ['global', 'collection', 'surface', 'surface:sitemap'],
+      surfaces: ['partners-clinics'],
+      sitemapSurfaces: ['pages'],
+    })
+
     expect(getCachePolicyEntry('route:patient-favorites-and-auth')).toMatchObject({
+      kind: 'private-route',
       cacheClass: 'private-live',
       boundary: 'private',
       tagFamilies: [],
@@ -208,6 +257,18 @@ describe('cache policy contract', () => {
       owner: 'seed-runner',
       pathRelationship: 'operational-terminal-flush',
     })
+  })
+
+  it('keeps public-route catalog iteration public-only', () => {
+    const publicRouteEntries = (CACHE_POLICY_CATALOG as readonly CachePolicyCatalogEntry[]).filter(
+      (entry) => entry.kind === 'public-route',
+    )
+
+    expect(publicRouteEntries.length).toBeGreaterThan(0)
+    expect(publicRouteEntries.every((entry) => entry.boundary === 'public')).toBe(true)
+    expect(publicRouteEntries.every((entry) => entry.cacheClass !== 'private-live')).toBe(true)
+    expect(publicRouteEntries.map((entry) => entry.id)).not.toContain('route:patient-favorites-and-auth')
+    expect(publicRouteEntries.map((entry) => entry.id)).not.toContain('route:admin-and-preview')
   })
 
   it('keeps every catalog reference inside the exported policy vocabulary', () => {


### PR DESCRIPTION
## Management summary

### Deutsch

Diese Änderung schafft die gemeinsame Grundlage für die geplante Cache- und Aktualisierungsarbeit. Sie macht die vereinbarten öffentlichen, privaten und betrieblichen Cache-Bereiche als geprüften Vertrag verfügbar, ohne das Verhalten der Website bereits zu verändern.

### English

This change creates the shared foundation for the planned cache and freshness work. It makes the agreed public, private, and operational cache boundaries available as a tested contract without changing current website behavior.

## What changed

- Added `src/utilities/cachePolicy/index.ts` with the PR2 contract-only cache policy module.
- Added the accepted cache classes, canonical tag-family vocabulary, operation vocabulary, known public surfaces, known discovery surfaces, and known global/collection policy inputs.
- Added pure canonical tag builders for entity, slug, collection, global, surface, sitemap, and discovery tags.
- Added pure path builders for pages, posts, clinics, posts list pagination, fixed public paths, sitemap paths, and discovery paths.
- Added `CACHE_POLICY_CATALOG` as the machine-readable PR1 cache assignment contract for later PR3-PR8 implementation work.
- Hardened the contract after reviewer feedback so tag builders fail closed for private-live collections/surfaces and private routes cannot appear in public-route catalog iteration.
- Added pages sitemap assignment for landing/fixed route entries that feed `/pages-sitemap.xml` freshness.
- Added focused unit coverage in `tests/unit/utilities/cachePolicy.test.ts`.
- Left existing hooks, route cache modes, `unstable_cache`, sitemap routes, redirects, seed flows, media hooks, and legacy runtime tag strings unchanged.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `src/utilities/cachePolicy/index.ts` | This becomes the policy source for later revalidation planner work. | Cache classes, canonical tag families, public/private/operational boundaries, and catalog entries match ADR 023 and the PR1 implementation plan. | `pnpm vitest tests/unit/utilities/cachePolicy.test.ts --project unit`; `pnpm check`; security/SEO reviewer rerun clean |
| P2 | `src/utilities/cachePolicy/index.ts` | Builder validation controls whether future PRs can generate ambiguous tags or paths. | Invalid ids, slugs, paths, private-live collections/surfaces, and unknown surfaces fail fast; builders do not slugify or invent content slugs. | `pnpm vitest tests/unit/utilities/cachePolicy.test.ts --project unit`; security reviewer rerun clean |
| P2 | `tests/unit/utilities/cachePolicy.test.ts` | The test must prove behavior without becoming a planner implementation. | Coverage is contract-focused and does not assert planner output or runtime revalidation behavior. | `pnpm check`; reviewer reruns clean |

## Validation

- [x] `pnpm format`: `rtk proxy /Users/razorspoint/Library/pnpm/pnpm format`
- [x] `pnpm check`: `rtk proxy /Users/razorspoint/Library/pnpm/pnpm check`
- [ ] `pnpm build`: Not run; PR2 is contract-only utility/test work and does not touch Next.js, Payload config, routing, or output-affecting files.
- [x] Focused tests: `rtk proxy /Users/razorspoint/Library/pnpm/pnpm vitest tests/unit/utilities/cachePolicy.test.ts --project unit`
- [ ] UI/mobile QA: Not applicable; no rendered UI changes.
- [x] Security/privacy review: `security_reviewer` rerun clean; no remaining findings >=5/10 after boundary hardening.
- [ ] Migration/schema check: Not applicable; no Payload schema or migration changes.
- [ ] Documentation/instructions check: Not applicable; no docs or instruction files changed.

## Risk and rollout

Runtime risk is low because this PR adds pure policy code and tests only. Existing cache behavior, revalidation behavior, route modes, seed behavior, redirects, and sitemap output remain unchanged. The main risk is contract drift, so review focused on alignment with ADR 023, the PR1 implementation plan, and the PR2 work order. Reviewer findings around private-live boundaries and sitemap assignment were fixed and rerun clean.

## Development

Closes #1453
