### PR TITLE
fix: allow release tag production deploys

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -30,10 +30,14 @@ jobs:
       name: Production
       url: ${{ steps.vercel_production.outputs.deploymentUrl }}
     steps:
-      - name: Require main branch
+      - name: Validate deploy ref
         run: |
           if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
-            echo "::error::Deploy Production can only run from refs/heads/main."
+            if [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              exit 0
+            fi
+
+            echo "::error::Deploy Production can only run from refs/heads/main or a semantic release tag matching refs/tags/vX.Y.Z."
             exit 1
           fi
 


### PR DESCRIPTION
## Management summary

### Deutsch

Der Produktions-Release-Prozess wird zuverlässiger: Ein veröffentlichter Versionstag kann den Produktionsdeploy wieder direkt auslösen, während unbeabsichtigte Branches oder falsch benannte Tags weiterhin kontrolliert blockiert werden.

### English

The production release process is more reliable: a published version tag can trigger the production deployment directly again, while unintended branches or incorrectly named tags remain blocked in a controlled way.

## What changed

- Updated the `Deploy Production` workflow guard to accept `refs/heads/main` and semantic release tags matching `refs/tags/vX.Y.Z`.
- Kept the deploy guard fail-closed for all other refs.
- Aligned the workflow guard with the existing release publishing script, which dispatches production deployment from the newly created release tag.

## Points to review

| Priority | Files / paths                              | Why focus here                                      | Reviewer should verify                                                                         | Evidence                                      |
| -------- | ------------------------------------------ | --------------------------------------------------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------- |
| P1       | `.github/workflows/deploy-production.yml` | This guard controls which refs may deploy to prod. | `main` and semantic release tags are allowed, while non-release tags and feature refs reject. | Local guard simulation; `pnpm format`; `pnpm check`; `detect-secrets-hook` |

## Validation

- [x] `pnpm format`: `rtk proxy /Users/razorspoint/Library/pnpm/pnpm format`
- [x] `pnpm check`: `rtk proxy /Users/razorspoint/Library/pnpm/pnpm check`
- [ ] `pnpm build`: not run; workflow-only CI/deploy guard change with no runtime source, schema, routing, Payload config, or build output change.
- [x] Focused tests: local guard simulation verified `refs/heads/main` and `refs/tags/v1.2.3` allow, while `refs/tags/v1.2` and `refs/heads/feature/test` reject.
- [ ] UI/mobile QA: not applicable; no UI changed.
- [ ] Security/privacy review: not run; recommended before merge because this changes a production deployment guard.
- [ ] Migration/schema check: not applicable; no Payload schema or migration changes.
- [ ] Documentation/instructions check: not applicable; no docs or instruction surfaces changed.

## Risk and rollout

Risk is limited to production deployment ref validation. The intended release path now works for semantic version tags, and all other refs stay blocked. Rollback is reverting this workflow change; manual production deployment from `main` remains supported.

## Development

Closes #1465
