### PR TITLE
docs: document cache stack 9/9 runtime architecture

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Use this index as the main entry point for project documentation.
 - [Features & Integrations](./features.md)
 - [Monitoring and Error Logic](./monitoring-and-error-logic.md)
 - [Public Discovery Strategy](./public-discovery-strategy.md)
+- [Cache Revalidation Runtime Architecture](./engineering/cache-revalidation-runtime.md)
 - [Codex Specialist Subagents](./integrations/codex-specialists.md)
 - [Deployment & Migration Runbook](./deployment-runbook.md)
 - [CI Modularization Plan](./engineering/ci-modularization-plan.md)

--- a/docs/engineering/cache-revalidation-runtime.md
+++ b/docs/engineering/cache-revalidation-runtime.md
@@ -2,7 +2,7 @@
 
 This guide is the operational entry point for the implemented public website cache and revalidation stack.
 
-Architecture decisions remain governed by [ADR 023](../adrs/023-adr-public-website-cache-and-revalidation-strategy.md). The original [implementation plan](../roadmap/caching-strategy/cache-revalidation-implementation-plan.md) and PR work orders remain implementation provenance, but day-to-day runtime understanding should start here.
+Architecture decisions remain governed by [ADR 023](../adrs/023-adr-public-website-cache-and-revalidation-strategy.md). This guide is the current documentation reference for runtime behavior.
 
 ## Strategy
 

--- a/docs/engineering/cache-revalidation-runtime.md
+++ b/docs/engineering/cache-revalidation-runtime.md
@@ -1,0 +1,172 @@
+# Cache Revalidation Runtime Architecture
+
+This guide is the operational entry point for the implemented public website cache and revalidation stack.
+
+Architecture decisions remain governed by [ADR 023](../adrs/023-adr-public-website-cache-and-revalidation-strategy.md). The original [implementation plan](../roadmap/caching-strategy/cache-revalidation-implementation-plan.md) and PR work orders remain implementation provenance, but day-to-day runtime understanding should start here.
+
+## Strategy
+
+The cache stack follows the ADR principle:
+
+```text
+Policy first, invalidation second, storage third.
+```
+
+The first stack uses Next.js cache primitives and Payload-driven invalidation. It does not introduce Redis, a custom cache handler, or remote cache storage. Those tools remain valid later for scale, cross-instance coordination, locks, dedupe, rate limits, external API response caching, or expensive shared computations, but not as a substitute for clear ownership and tag policy.
+
+```mermaid
+flowchart TD
+  ADR["ADR 023<br/>Policy first, invalidation second, storage third"]
+  Classes["Cache classes<br/>critical-public, shared-public, aggregated-public,<br/>private-live, operational-scaling"]
+  Policy["Policy module<br/>src/utilities/cachePolicy"]
+  Owners["Invalidation owners<br/>hooks, seed final flush, discovery owners"]
+  Planner["Pure planner<br/>src/utilities/cacheRevalidation/planner.ts"]
+  Executor["Executor<br/>tags first, paths second"]
+  Runtime["Next.js Data Cache / route regeneration"]
+  Visibility["Operational visibility<br/>redacted logs and admin widget"]
+  Deferred["Deferred storage layer<br/>Redis / custom cache handler / runtime cache"]
+
+  ADR --> Classes
+  Classes --> Policy
+  Policy --> Owners
+  Owners --> Planner
+  Planner --> Executor
+  Executor --> Runtime
+  Executor --> Visibility
+  Runtime -.-> Deferred
+```
+
+## Runtime Building Blocks
+
+`src/utilities/cachePolicy/**` is the vocabulary and builder layer. It defines cache classes, tag families, operations, known collections, globals, surfaces, discovery IDs, fixed public paths, cache policy entries, tag builders, and public path builders.
+
+`src/utilities/cacheRevalidation/**` is the planning and execution layer. It accepts normalized revalidation events, maps them to deduplicated plans, normalizes identifiers, executes `revalidateTag` before `revalidatePath`, logs redacted summaries, and records a bounded in-memory visibility history.
+
+Hook adapters convert Payload hook context into stable normalized events. They own guards such as `context.disableRevalidate` and avoid passing raw Payload documents into the planner.
+
+Read-side cached data uses Next.js `unstable_cache` only where the data is public and has a matching invalidation owner. Current cache-backed public reads include globals, redirects, pages/posts sitemaps, public post list and latest-post reads, Clinic Detail public server data, and Listing Comparison public server data.
+
+Private, draft, preview, admin, auth, patient-specific, cookie-bound, and request-bound data stays live. It does not receive persistent public cache entries.
+
+## Revalidation Flow
+
+```mermaid
+flowchart LR
+  Events["Payload/global/redirect hooks<br/>clinic/listing hooks<br/>seed final flush<br/>sitemap/discovery cases"]
+  Adapters["Adapters<br/>stable IDs, slugs, statuses,<br/>relations, affected surfaces"]
+  Planner["planRevalidation(event)<br/>pure planner"]
+  Plan["Serializable plan<br/>operation, source, subject,<br/>cache classes, surfaces,<br/>tags, paths, redacted context"]
+  Executor["executeRevalidationPlan(plan)<br/>best-effort executor"]
+  Tags["revalidateTag(tag, { expire: 0 })"]
+  Paths["revalidatePath(path)"]
+  Logs["Structured logs<br/>cache.revalidation.planned<br/>cache.revalidation.executed<br/>cache.revalidation.failed"]
+  History["Visibility ring buffer<br/>latest 200 redacted events"]
+  Admin["Protected admin dashboard card<br/>read-only visibility"]
+
+  Events --> Adapters
+  Adapters --> Planner
+  Planner --> Plan
+  Plan --> Executor
+  Executor --> Tags
+  Executor --> Paths
+  Executor --> Logs
+  Logs --> History
+  History --> Admin
+```
+
+The planner is strict about invalid public-cache inputs. Missing required IDs, slugs, statuses, unsupported operations, or unknown public-cache cases fail fast instead of inventing tags locally.
+
+The executor is best-effort after a valid plan exists. It attempts every tag and path, records failures, returns a summary, and does not break CMS writes only because a cache revalidation call failed.
+
+## Cache Classes
+
+| Cache class | Runtime meaning | Default behavior |
+| --- | --- | --- |
+| `critical-public` | Stale output can mislead users, damage trust, or break canonical SEO state. | Event-driven invalidation; concrete public routes also get path invalidation. |
+| `shared-public` | Public data appears across many routes. | Tag-first invalidation through shared tags. |
+| `aggregated-public` | Lists, landing content, comparison data, sitemaps, and discovery surfaces. | Tag-first invalidation with bounded short staleness; avoid arbitrary query path matrices. |
+| `private-live` | Admin, preview, draft, auth, private, personalized, or request-bound state. | No persistent public cache. |
+| `operational-scaling` | Bulk imports, expensive coordination, locks, dedupe, or operational visibility. | Local deterministic behavior first; batch invalidation through the planner. |
+
+Canonical tag families are built centrally:
+
+```text
+entity:<collection>:<id>
+slug:<collection>:<slug>
+collection:<collection>
+global:<slug>
+surface:<name>
+surface:sitemap:<name>
+surface:discovery:<name>
+```
+
+Runtime code should call policy builders instead of constructing cache tag strings locally.
+
+## Surface Ownership
+
+```mermaid
+flowchart TD
+  Planner["Planner-owned cache/revalidation policy"]
+
+  Core["Core content<br/>pages, posts, redirects"]
+  Globals["Shared chrome and globals<br/>header, footer, landingPages, cookieConsent"]
+  Clinic["Clinic and listing surfaces<br/>clinics, reviews, treatments,<br/>cities, specialties, accreditation, gallery entries"]
+  Discovery["Discovery surfaces<br/>pages sitemap, posts sitemap,<br/>posts list, public discovery contracts"]
+  Seed["Seed and bulk flows<br/>one terminal seed-final-flush plan"]
+  Private["Private-live exclusions<br/>admin, preview, draft, auth,<br/>favorites, submissions, request state"]
+  Visibility["Admin visibility<br/>redacted read-only operations view"]
+
+  Planner --> Core
+  Planner --> Globals
+  Planner --> Clinic
+  Planner --> Discovery
+  Planner --> Seed
+  Planner --> Visibility
+  Private -.-> Planner
+```
+
+Pages and posts use entity, slug, collection, sitemap, surface, and concrete public path invalidation. Slug changes invalidate both old and new public identifiers when known.
+
+Globals use `global:*` tags and known consuming surfaces. Header and Footer are shared public chrome. LandingPages and CookieConsent add declared surface ownership without caching private consent state.
+
+Redirect rules are cached at rule level, while reference redirect targets resolve live by ID. The removed generic cached document helper is intentionally not replaced by another broad document cache.
+
+Clinic Detail and Listing Comparison public server data are cached with canonical tags. Draft clinic reads, private favorites, cookies, auth state, preview reads, and request-bound data remain live.
+
+Post list, latest-post teasers, and sitemap reads use canonical aggregated-public tags. Paginated post lists do not maintain a path matrix; freshness is owned by tags plus bounded route/Data Cache behavior.
+
+Seed imports suppress per-record public revalidation through `disableRevalidate`. A run that wrote public-affecting data emits one terminal `seed-final-flush` plan that aggregates affected collections, globals, surfaces, sitemaps, and discovery IDs.
+
+## Operational Visibility
+
+Cache revalidation visibility is operational observability, not product analytics. The stack does not emit PostHog business events for cache decisions.
+
+The executor records redacted summaries for planned, executed, and failed revalidation events. The in-memory history keeps the latest 200 events per runtime instance. The protected endpoint and admin dashboard card expose only redacted operational fields after platform admin/support access checks pass.
+
+Visibility data must never include raw Payload documents, hook args, request bodies, headers, cookies, tokens, auth data, private data, draft or preview content, CMS field payloads, medical free text, seed fixture payloads, or raw error stacks.
+
+## Public Discovery And SEO
+
+Sitemaps and public discovery outputs participate in the same cache model as other public surfaces. Sitemap cache tags use `surface:sitemap:*`, and sitemap timestamps remain source-backed.
+
+`/llms.txt` and `/.well-known/llms.txt` remain static public-discovery contract routes unless a future ADR or work order assigns CMS-backed dependencies. Search indexing and canonical/noindex policy remain route/config policy, not ad hoc document invalidation.
+
+## Deferred Boundaries
+
+Direct media dependency resolution remains a bounded follow-up. Media inherits the cache class of the surface where it appears, and referencing documents or relations own invalidation in the first stack.
+
+Redis, custom cache handlers, remote cache storage, locale/domain cache dimensions, and broader public route families are future architecture work. They should extend the policy and planner model instead of bypassing it.
+
+## Validation And Debugging
+
+Runtime changes to cache policy, planner behavior, hooks, routes, seed flushing, visibility, or read-side `unstable_cache` usage require focused unit tests for the touched behavior, `pnpm format`, `pnpm check`, and `pnpm build` when route output, Payload config, admin UI, or generated output can change.
+
+Docs-only changes to this guide require `pnpm format`. They do not require `pnpm check` or a build unless the scope expands beyond documentation.
+
+Useful runtime test areas include:
+
+- `tests/unit/utilities/cacheRevalidation`
+- hook adapter tests for Pages, Posts, Redirects, Globals, and clinic-related collections
+- sitemap, posts list, Clinic Detail, and Listing Comparison contract tests
+- seed endpoint/import/global/task tests for terminal flush behavior
+- cache revalidation visibility endpoint, history, and dashboard card tests

--- a/docs/features.md
+++ b/docs/features.md
@@ -169,9 +169,10 @@ View content updates in real time with SSR.
 [Payload Live Preview Docs](https://payloadcms.com/docs/live-preview/overview)
 
 ## On-demand Revalidation
-The findmydoc portal uses the [on-demand revalidation](https://nextjs.org/docs/app/getting-started/revalidating) feature of Next.js to automatically revalidate pages when you publish or update a document in Payload. That way, content changes appear on the site without a full rebuild or redeploy.
 
-> Note: if an image has been changed, for example it's been cropped, you will need to republish the page it's used on in order to be able to revalidate the Nextjs image cache.
+The findmydoc portal uses a classified public cache and revalidation runtime for Payload-backed public website content. Public reads use canonical cache tags only when a matching invalidation owner exists, and Payload hooks, seed final flushes, and discovery surfaces route cache decisions through the central planner/executor boundary.
+
+Architecture and runtime ownership are documented in [Cache Revalidation Runtime Architecture](./engineering/cache-revalidation-runtime.md). The accepted strategy is governed by [ADR 023](./adrs/023-adr-public-website-cache-and-revalidation-strategy.md).
 
 ## Public Sitemaps
 The public sitemap surface is split between the generated `robots.txt` file and App Router sitemap route handlers.

--- a/docs/roadmap/AGENTS.md
+++ b/docs/roadmap/AGENTS.md
@@ -1,0 +1,6 @@
+# Roadmap Documentation
+
+- This directory preserves planning and implementation history.
+- Treat roadmap files as context, not current engineering sources.
+- Do not link to roadmap files from ADRs or official documentation.
+- Consult them only for planning or historical context.

--- a/docs/roadmap/caching-strategy/AGENTS.md
+++ b/docs/roadmap/caching-strategy/AGENTS.md
@@ -1,0 +1,6 @@
+# Historical Cache Revalidation Planning
+
+- This directory preserves the initial cache/revalidation implementation plan and work orders.
+- Treat it as historical context, not a current engineering source.
+- Do not link to these files from ADRs or official documentation.
+- Consult them only when historical implementation context is needed.

--- a/docs/roadmap/caching-strategy/AGENTS.md
+++ b/docs/roadmap/caching-strategy/AGENTS.md
@@ -1,6 +1,0 @@
-# Historical Cache Revalidation Planning
-
-- This directory preserves the initial cache/revalidation implementation plan and work orders.
-- Treat it as historical context, not a current engineering source.
-- Do not link to these files from ADRs or official documentation.
-- Consult them only when historical implementation context is needed.

--- a/docs/roadmap/caching-strategy/cache-revalidation-implementation-plan.md
+++ b/docs/roadmap/caching-strategy/cache-revalidation-implementation-plan.md
@@ -4,6 +4,8 @@ This document is the stable implementation planning reference for aligning publi
 
 It is not the ADR, and the ADR does not depend on this document. This plan consumes the accepted ADR and turns it into concrete area assignments and a stacked PR sequence.
 
+The implemented runtime architecture is documented in [Cache Revalidation Runtime Architecture](../../engineering/cache-revalidation-runtime.md). This plan remains the stack planning, cache assignment, and execution-provenance source for the implementation sequence.
+
 ## Source Inputs
 
 - [ADR 023 - Public Website Cache and Revalidation Strategy](../../adrs/023-adr-public-website-cache-and-revalidation-strategy.md)


### PR DESCRIPTION
## Management summary

### Deutsch

Die Cache- und Revalidation-Architektur hat jetzt einen klaren technischen Einstiegspunkt. Engineering, Review und Betrieb koennen nachvollziehen, welche Website-Bereiche gecacht werden, wer ihre Aktualisierung verantwortet und welche Grenzen fuer private Daten, Redis und kuenftige Skalierung gelten.

### English

The cache and revalidation architecture now has a clear technical entry point. Engineering, review, and operations can understand which website areas are cached, who owns their freshness, and which boundaries apply to private data, Redis, and future scaling work.

## What changed

- Added `docs/engineering/cache-revalidation-runtime.md` as the final runtime guide for the implemented cache/revalidation stack, including three Mermaid architecture diagrams.
- Linked the runtime guide from `docs/README.md` and replaced the stale generic on-demand revalidation text in `docs/features.md`.
- Added a short pointer from the original cache implementation plan to the runtime guide while preserving the plan and work orders as implementation provenance.
- Removed stale inline references to the deleted legacy document helper path so the docs consistency gate stays green while the work orders remain historical implementation records.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P2 | `docs/engineering/cache-revalidation-runtime.md` | This becomes the operational entry point for cache/revalidation understanding. | The guide reflects the implemented PR2-PR8 runtime without changing ADR 023 or inventing new architecture. | `pnpm format`, `pnpm docs:check` |
| P3 | `docs/features.md`, `docs/README.md`, `docs/roadmap/caching-strategy/**` | These links determine whether readers land on the right current-vs-planning source. | The old on-demand revalidation wording is replaced without creating duplicate runtime docs, and historical work orders do not reference removed files as live paths. | Scope diff, `pnpm docs:check` |

## Validation

- [x] `pnpm format`: `rtk proxy /Users/razorspoint/Library/pnpm/pnpm format`
- [ ] `pnpm check`: Not run; PR9 is docs-only and does not touch runtime, config, schema, or lint-relevant source files.
- [ ] `pnpm build`: Not run; PR9 is docs-only and does not touch build output, routing, Payload config, or admin UI.
- [ ] Focused tests: Not applicable; documentation-only change.
- [ ] UI/mobile QA: Not applicable; no rendered UI change.
- [ ] Security/privacy review: Not run locally; recommended reviewers: `security-reviewer`, `seo-reviewer`, and `web-vitals-reviewer`.
- [ ] Migration/schema check: Not applicable; no schema or migration changes.
- [x] Documentation/instructions check: Checked `docs/AGENTS.md`; ran `rtk proxy /Users/razorspoint/Library/pnpm/pnpm docs:check`.

## Risk and rollout

Docs-only change. No runtime behavior, environment variable, migration, deployment, or rollback requirements.

## Development

Closes #1470
