### PR TITLE
docs: document production monitoring operations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Use this index as the main entry point for project documentation.
 
 - [Setup & Development](./setup.md)
 - [Features & Integrations](./features.md)
+- [Monitoring and Error Logic](./monitoring-and-error-logic.md)
 - [Public Discovery Strategy](./public-discovery-strategy.md)
 - [Codex Specialist Subagents](./integrations/codex-specialists.md)
 - [Deployment & Migration Runbook](./deployment-runbook.md)

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,6 +18,7 @@ A production-ready Next.js front-end with:
   - [Search](#search)
   - [Redirects](#redirects)
   - [PostHog Analytics](#posthog-analytics)
+  - [Monitoring and Error Logic](#monitoring-and-error-logic)
   - [Preview Access Policy](#preview-access-policy)
   - [Draft Preview](#draft-preview)
   - [Live Preview](#live-preview)
@@ -264,3 +265,6 @@ Create URL redirects to manage content migrations.
 ## PostHog Analytics
 Session replay, error tracking, and web analytics with automatic user identification.
 [PostHog Integration Docs](./integrations/posthog.md)
+
+## Monitoring and Error Logic
+Production monitoring combines Vercel runtime logs, structured server events, PostHog error tracking, and GitHub/Vercel deployment signals. The operating map lives in [Monitoring and Error Logic](./monitoring-and-error-logic.md).

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -79,7 +79,7 @@ Logger-level redaction is configured centrally in [src/utilities/logging/payload
 - `auth.supabase.*`
 - `storage.media.upload_failed`
 - `telemetry.posthog.*`
-- `api.forms.submit.failed`
+- `api.formBridge.submit.failed`
 
 ## Reading Logs on Vercel
 
@@ -90,8 +90,11 @@ Recommended filters:
 - `event:auth.supabase.authenticate.failed`
 - `event:auth.supabase.admin.client_init_failed`
 - `event:storage.media.upload_failed`
+- `event:api.formBridge.submit.failed`
 
 If an upload is rejected by Vercel before the app receives the request, Payload cannot log that failure. Those cases must be diagnosed from Vercel request/runtime logs instead of application logs.
+
+For the flow-level operating map, escalation rules, and privacy boundaries, see [Monitoring and Error Logic](./monitoring-and-error-logic.md).
 
 ## Local Development
 

--- a/docs/monitoring-and-error-logic.md
+++ b/docs/monitoring-and-error-logic.md
@@ -1,0 +1,92 @@
+# Monitoring and Error Logic
+
+This document defines the operational monitoring map for the `findmydoc` portal. It covers what the team watches, where signals are available, how to read them, who reacts, and which privacy boundaries apply.
+
+For logger implementation details, see [Logging](./logging.md) and [ADR 010](./adrs/010-structured-logging-approach.md). For PostHog event governance, see [PostHog Integration](./integrations/posthog.md) and [ADR 019](./adrs/019-adr-posthog-event-taxonomy-and-usage-governance.md).
+
+## Operating Model
+
+Production monitoring uses three signal groups:
+
+1. **Runtime and request logs**
+   Preview and production deployments emit structured JSON logs to `stdout` and `stderr`. Vercel ingests those logs and exposes them through the Vercel dashboard and CLI. Server-side application logs use Payload's Pino logger or scoped wrappers around it.
+2. **PostHog error tracking and product telemetry**
+   Next.js request errors are forwarded through `src/instrumentation.ts` into PostHog error tracking when PostHog is configured. Product telemetry remains consent-controlled and governed by the event registry; it is not the escalation source for operational incidents.
+3. **Deployment and migration signals**
+   GitHub Actions and Vercel deployment logs show build, migration, deploy, and aliasing failures. These signals belong to release operations, not product analytics.
+
+As of the implementation check for this document, the connected PostHog project has error tracking data and no configured `system.logs_alerts` entries. No dashboard matched the search terms `monitoring`, `error`, or `reliability`. Structured visibility exists, but active reliability dashboards and log alerts are a separate follow-up, not part of this documentation change.
+
+## Reading Production Logs
+
+Use the Vercel project `findmydoc-portal` under the `findmydoc` scope.
+
+```bash
+vercel logs --project findmydoc-portal --scope findmydoc --environment production --since 1h --level error --json --limit 100
+```
+
+For known application events, search by the stable event string:
+
+```bash
+vercel logs --project findmydoc-portal --scope findmydoc --environment production --since 1h --query "api.formBridge.submit.failed" --json --limit 100
+vercel logs --project findmydoc-portal --scope findmydoc --environment production --since 1h --query "auth.supabase.authenticate.failed" --json --limit 100
+vercel logs --project findmydoc-portal --scope findmydoc --environment production --since 1h --query "storage.media.upload_failed" --json --limit 100
+```
+
+For deploy and migration failures, inspect the matching GitHub Actions run first and then the related Vercel deployment logs:
+
+```bash
+gh run list --repo findmydoc-platform/website --branch main --limit 10
+vercel ls findmydoc-portal --scope findmydoc
+vercel inspect <deployment-url-or-id> --scope findmydoc --logs
+```
+
+## Critical Monitoring Flows
+
+| Flow | Primary signals | Where to inspect | Risk | First response | Escalation | Privacy boundary |
+| --- | --- | --- | --- | --- | --- | --- |
+| Public marketing and contact forms | `api.formBridge.submit.failed`; PostHog `patient_inquiry_created` and `clinic_onboarding_interest_created` when consent allows capture | Vercel runtime logs; Payload form submissions; PostHog only for governed aggregate analysis | P1 when accepted submissions fail or users cannot submit; P2 when only analytics capture fails | Check Vercel error logs for the event string, confirm whether Payload submissions were persisted, and verify whether user-facing responses returned 4xx or 5xx | Technical owner leads triage; business-risk reader receives context when lead capture may be affected | Do not log or copy names, emails, phone numbers, raw messages, preferred appointment details, medical free text, request bodies, cookies, or headers |
+| Auth and Supabase | `auth.supabase.*`, `auth.admin_login.*`, password reset and registration route events | Vercel runtime logs; Supabase operational view when needed; GitHub/Vercel deploy logs for configuration regressions | P1 for login, registration, password reset, platform admin access, or provisioning failures; P2 for isolated rejected requests with expected generic user response | Filter `auth.supabase.*`, check route-specific event names, and verify whether failures are expected denials or system errors | Technical owner leads triage; business-risk reader is informed when admin or user onboarding risk is material; consulted RACI roles are added only when their area is affected | Hash email-derived identifiers. Do not expose passwords, tokens, Supabase service role keys, cookies, auth sessions, raw emails, or raw user profiles |
+| Storage and media uploads | `storage.media.upload_failed`, `storage.media.upload_recovery_needed`, `storage.media.path_resolution_failed` | Vercel runtime logs; Payload media collection state; object storage provider only when the app receives enough context | P1 when public or admin media workflows are blocked; P2 when a seed/media recovery path is expected and contained | Filter storage events, confirm collection and storage prefix, and distinguish app-level failures from Vercel request-size rejection | Technical owner leads triage; affected content or operations owners are consulted based on the collection involved | Do not copy raw files, private media, signed URLs, storage credentials, request bodies, or unrelated CMS field payloads |
+| Runtime and request errors | Next.js `onRequestError`; PostHog `exception`; Vercel 5xx/runtime logs | PostHog error tracking; Vercel runtime logs; deployment logs when errors start after release | P1 for repeated 5xx, admin route failures, form route failures, or production-only regressions; P2 for isolated non-critical exceptions | Check Vercel error logs for the time window, then inspect the grouped PostHog error record without copying raw user data into docs or tickets | Technical owner leads triage; business-risk reader receives operational-risk summary for visible production impact | Do not expose raw stack traces containing secrets, request headers, cookies, auth data, URL query strings with sensitive values, or private route payloads |
+| Deployments and migrations | GitHub Actions failure, Vercel deploy failure, Payload migration failure, alias failure | GitHub Actions run logs; Vercel inspect logs; deployment runbook | P1 when production deploy, migration, or aliasing is blocked; P2 for preview-only deploy failures without user impact | Inspect the failed run, identify whether failure is build, migration, environment, or aliasing, and avoid manual production schema repair | Release owner leads triage; business-risk reader is informed when release timing or production availability is affected | Do not paste secrets, Vercel tokens, database URLs, migration data dumps, or private deployment environment values into tickets or docs |
+| Public discovery monitoring | `public_discovery.crawler.requested`; `pnpm discovery:health` results; sitemap and robots route status | Vercel runtime logs; local or production discovery health check; public discovery docs | P2 for crawler/discovery drift; P1 only when production indexing behavior is actively broken | Filter crawler events, run discovery health, and check whether sitemap/robots/llms endpoints return expected public responses | Technical owner leads triage; SEO/content stakeholders are consulted only when indexability or public visibility is affected | Logs must not include cookies, auth data, contact details, medical free text, private content, draft content, admin-only content, IP-based profiles, or individual identities |
+
+## Escalation Rules
+
+The technical owner is accountable and responsible for this monitoring topic and for the first technical triage path. The business-risk reader is informed when an incident can affect lead capture, onboarding, public trust, admin access, or production availability.
+
+Use the broader RACI roles as consulted or informed only when their area is affected. Do not infer hidden technical ownership from planning metadata.
+
+Escalate immediately when one of these conditions is true:
+
+- public form submissions fail or appear to be accepted without being persisted
+- production returns repeated 5xx responses on public, auth, or admin routes
+- login, registration, password reset, or platform admin access is materially blocked
+- production deploy, migration, or aliasing fails
+- logs suggest accidental exposure of personal data, secrets, auth state, or medical free text
+
+Keep routine warnings inside technical triage unless the same event repeats, affects a primary flow, or creates trust, privacy, or revenue risk.
+
+## Privacy And Logging Boundaries
+
+Logs and monitoring notes must use the minimum data needed to debug the operational signal.
+
+Never log or copy these values into tickets, Notion pages, PR descriptions, screenshots, or external artifacts:
+
+- passwords, tokens, cookies, secret keys, service role keys, authorization headers, database URLs, or webhook secrets
+- patient or contact names, email addresses, phone numbers, raw inquiry messages, appointment notes, medical details, or free text
+- raw request bodies, raw headers, auth sessions, private route data, draft content, preview-only content, or full Payload documents
+- private machine-specific network addresses, account-local routes, or private remote-access hostnames
+
+Use stable event names, hashed identifiers, collection names, route paths, deployment environment, request IDs, and Vercel IDs instead. If a raw value is required for a controlled local-only debugging session, do not promote it into repository files, Notion, tickets, PRs, or shared screenshots.
+
+## Known Gaps And Follow-Up
+
+Structured logs and PostHog error tracking are available, but the reliability operating surface is still mostly manual:
+
+- no confirmed PostHog log alerts are configured
+- no confirmed PostHog dashboard is dedicated to production reliability
+- no escalation automation is documented for repeated P1 events
+
+If active monitoring is required, open a separate website follow-up for a reliability dashboard and alerting setup. That follow-up should define alert thresholds, notification channels, ownership, data-retention expectations, and privacy review before any alert or dashboard is created.


### PR DESCRIPTION
## Management summary

### Deutsch

Das Team bekommt eine klare Betriebsbeschreibung für Produktionsfehler, kritische Monitoringpunkte und Eskalation. Dadurch ist nachvollziehbarer, welche Signale bei Formularen, Login, Uploads, Laufzeitfehlern und Deployments relevant sind, welche Rollen die erste Reaktion tragen und welche Daten aus Datenschutzgründen nicht in gemeinsame Artefakte gehören.

### English

The team gets a clear operating description for production errors, critical monitoring points, and escalation. This makes it easier to understand which signals matter for forms, login, uploads, runtime errors, and deployments, which roles own first response, and which data must stay out of shared artifacts for privacy reasons.

## What changed

- Added [Monitoring and Error Logic](https://github.com/findmydoc-platform/website/blob/feature/monitoring-error-logic-docs/docs/monitoring-and-error-logic.md) as the technical operating map for production monitoring, escalation, and privacy boundaries.
- Linked the new documentation from the docs index and feature overview.
- Aligned the logging guide with the existing `api.formBridge.submit.failed` event and pointed readers to the flow-level operating map.
- Updated the companion Notion page with absolute source links and topic-adjacent cross-links to the ADR index, compliance checklist, and public-discovery/localization context.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `docs/monitoring-and-error-logic.md` | Documents escalation, logging, and privacy boundaries for production operations. | Confirm the flow risks, role-based RACI wording, and no-raw-data boundaries are accurate and not overclaiming active dashboards or alerts. | `pnpm format`, `pnpm docs:check`, Notion fetch/search verification |
| P2 | `docs/logging.md` | Corrects the public form failure event name and links to the operating map. | Confirm the event family matches the route implementation and remains useful as a Vercel filter. | `pnpm format`, `pnpm docs:check` |

## Validation

- [x] `pnpm format`: passed
- [ ] `pnpm check`: not run; docs-only and Notion-only change, no runtime code or lint-relevant implementation files changed.
- [ ] `pnpm build`: not run; docs-only and Notion-only change, no build-relevant source changed.
- [ ] Focused tests: not run; no runtime behavior changed.
- [ ] UI/mobile QA: not applicable; no UI changed.
- [ ] Security/privacy review: not run; recommend `security-reviewer` before merge because the docs define logging, privacy, and escalation boundaries.
- [ ] Migration/schema check: not applicable; no schema, collection, or migration changes.
- [x] Documentation/instructions check: `pnpm docs:check` passed; Notion page and cross-links verified by fetch/search.

## Risk and rollout

Docs-only change. No runtime, API, schema, migration, environment, or cache behavior changes. The documented gap remains intentional: structured logs and PostHog Error Tracking exist, but active reliability dashboards and log alerts are separate follow-up work.

## Development

Closes findmydoc-platform/management#307
