### PR TITLE
docs: fix ADR directory paths

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -4,10 +4,10 @@ This repository contains the Architecture Decision Records (ADRs) for the projec
 
 ## Repository Structure
 
-- **/adr/**: The main folder where all ADRs are stored.
-- **/adr/000x-decision-title.md**: Each ADR is numbered sequentially and includes a descriptive title.
-- **/archive/**: Deprecated or rejected ADRs are moved here to keep the main folder clean.
-- **/templates/**: This folder contains the template to create new ADRs.
+- **/adrs/**: The main folder where all ADRs are stored.
+- **/adrs/000x-decision-title.md**: Each ADR is numbered sequentially and includes a descriptive title.
+- **/adrs/archive/**: Deprecated or rejected ADRs are moved here to keep the main folder clean.
+- **/adrs/templates/**: This folder contains the template to create new ADRs.
 
 ## How to Create a New ADR
 


### PR DESCRIPTION
## Management summary

### Deutsch

Die ADR-Dokumentation verweist jetzt wieder auf die tatsächlich verwendeten Verzeichnisse. Dadurch bleiben interne Architekturentscheidungen für Mitarbeitende leichter auffindbar und Folgearbeit an ADRs läuft nicht in veraltete Pfade.

### English

The ADR documentation now points back to the directory structure that is actually used. This keeps architecture decisions easier to find for contributors and prevents follow-up ADR work from drifting into outdated paths.

## What changed

- Corrected the `Repository Structure` paths in `docs/adrs/README.md` from the outdated `/adr/**` naming to the live `docs/adrs/**` structure.
- Kept the change scoped to the incorrect path references only; no wording, formatting, or broader documentation refactors were introduced.

## Points to review

None beyond standard review.

## Validation

- [x] `pnpm format`: `rtk proxy /Users/razorspoint/Library/pnpm/pnpm format`
- [ ] `pnpm check`: not run because this is a docs-only path correction.
- [ ] `pnpm build`: not run because this change does not affect runtime code.
- [ ] Focused tests: not run because the change is documentation-only.
- [ ] UI/mobile QA: not applicable; no UI change.
- [ ] Security/privacy review: not run because the change is limited to ADR documentation paths.
- [ ] Migration/schema check: not applicable; no schema or collection change.
- [x] Documentation/instructions check: verified the documented ADR paths against the live `docs/adrs/` directory.

## Risk and rollout

None known. This is a documentation-only correction.

## Development

Closes #1473
