### PR TITLE
chore: enforce cache architecture extension guardrails

### DIFF
--- a/.codex/agents/cache-architecture-reviewer.toml
+++ b/.codex/agents/cache-architecture-reviewer.toml
@@ -1,0 +1,28 @@
+name = "cache_architecture_reviewer"
+description = "Read-only reviewer for cache policy, revalidation ownership, and public freshness boundaries in this repository."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+nickname_candidates = ["Cache Cartographer", "Freshness Auditor", "Invalidation Gate"]
+developer_instructions = """
+Read the repository root AGENTS.md and the closest path-local AGENTS.md files before drawing conclusions. Read docs/engineering/cache-revalidation-runtime.md, ADR 023, and the relevant cachePolicy/cacheRevalidation modules when cache behavior is in scope.
+
+Stay strictly inside cache architecture, public freshness, and invalidation ownership. Do not drift into generic code quality, UI, accessibility, product strategy, or storage implementation unless the changed cache behavior creates a concrete risk there.
+
+Review these concerns when the diff is relevant:
+- cache-policy catalog coverage and use of existing cache classes, tag families, and owner types
+- read/write tag symmetry between cached reads, planner output, and executor invalidation
+- public versus draft, preview, private, auth-bound, cookie-bound, and request-bound data boundaries
+- old and new slugs, IDs, statuses, and relations for public changes
+- aggregate, list, sitemap, discovery, and seed-final-flush dependencies
+- bounded path fanout and tag-first behavior for shared or query-variant surfaces
+- direct next/cache bypasses, legacy exceptions, and Cache Components or remote-storage architecture changes
+
+Working style:
+- Ground every finding in the changed file and its direct policy or planner path.
+- Separate confirmed drift from assumptions or deferred work.
+- Score findings on the repository absolute 1-10 severity scale.
+- Treat a new cache class, tag family, owner type, route family, Cache Components primitive, remote store, or invalidation semantic as an architecture decision gate, not a local refactor.
+- If no credible cache-architecture issue is present, say so explicitly.
+- Do not make code changes.
+"""

--- a/.codex/skills/cache-impact-planner/SKILL.md
+++ b/.codex/skills/cache-impact-planner/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: cache-impact-planner
+description: Classify cache impact before planning or implementing a collection, global, public page, route, server-data loader, hook, sitemap, discovery flow, or seed flow. Use it when a change could affect public freshness, cache tags, invalidation, or the public/private data boundary.
+---
+
+# Cache Impact Planner
+
+## Overview
+
+Use this workflow before an implementation plan makes cache or revalidation decisions. It converts a proposed data or public-surface change into one explicit cache-impact decision without inventing architecture locally.
+
+## Workflow
+
+1. Read the repository root and closest path-local `AGENTS.md` files.
+2. Locate and read the accepted cache ADR, runtime guide, policy catalog, planner/executor boundary, and the touched source area. Treat those local sources as the architecture contract.
+3. Map the changed source to public reads, public outputs, hooks or write events, aggregate/list/sitemap/discovery dependencies, and private or request-bound inputs.
+4. Choose exactly one decision:
+   - `no-public-impact`: no public cache or revalidation wiring
+   - `public-live`: deliberately uncached public data; private, draft, preview, and request-bound data stays live
+   - `public-cached`: existing cache class, policy entry, canonical read tags, invalidation owner, normalized planner event, and focused tests are required
+5. For `public-cached`, prove read/write symmetry: identify the cache key and tags, the source event, old and new identities or relations, planner output, bounded path fanout, and the tests that cover the boundary.
+6. For a new collection or global, require an explicit policy-catalog classification even for `no-public-impact` or `public-live`. Static pages do not need a catalog entry.
+7. Record the decision in the plan or PR notes. Keep only local implementation mechanics autonomous when existing vocabulary and boundaries already fit.
+
+## Output Contract
+
+Return these sections before an implementation plan is finalized:
+
+- `Decision`: one of the three cache-impact outcomes and why it applies.
+- `Dependency map`: public reads, rendered or discovery surfaces, write events, and excluded private/request-bound inputs.
+- `Read/write symmetry`: cache class, policy entry, read tags, normalized event, owner, planner outcome, and bounded paths when cached.
+- `Tests`: focused contract, hook, loader, route, sitemap/discovery, or seed coverage needed for the decision.
+- `Stop conditions`: any architecture decision that cannot be made locally.
+
+## Stop Conditions
+
+Stop and request an ADR or explicit work order when the change needs a new cache class, tag family, owner type, freshness expectation, route family, Redis or remote cache, custom cache handler, `cacheComponents`, `'use cache'`, `cacheTag`, `cacheLife`, or changed invalidation semantics.

--- a/.codex/skills/cache-impact-planner/agents/openai.yaml
+++ b/.codex/skills/cache-impact-planner/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Cache Impact Planner'
+  short_description: 'Classify cache impact before implementation'
+  default_prompt: 'Use $cache-impact-planner to classify cache impact before planning or implementing a collection, global, public route, loader, hook, sitemap, discovery, or seed-flow change.'

--- a/.codex/skills/findmydoc-collection-planner/SKILL.md
+++ b/.codex/skills/findmydoc-collection-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: findmydoc-collection-planner
-description: Plan and safely implement Payload CMS collections for the findmydoc website. Use when Codex is asked to create, change, evaluate, or implement a new Payload collection, join collection, media collection, collection access model, permission-matrix row, collection tests, Payload migration, or CMS/admin data model in this repository. Default to discovery, questions, recommendation, and a proposed plan before editing unless the user explicitly provides an approved plan and asks for implementation.
+description: Plan and safely implement Payload CMS collections and globals for the findmydoc website. Use when Codex is asked to create, change, evaluate, or implement a new Payload collection, global, join collection, media collection, collection access model, permission-matrix row, collection tests, Payload migration, or CMS/admin data model in this repository. Default to discovery, questions, recommendation, and a proposed plan before editing unless the user explicitly provides an approved plan and asks for implementation.
 ---
 
 # findmydoc Collection Planner
@@ -16,6 +16,7 @@ This skill does not require or activate the technical Plan Mode. It works as a n
 - Do not edit files when the user asks for a new or unclear collection design and no approved plan exists.
 - Treat technical Plan Mode as optional. If it is not active, keep using this planning-first workflow in the current session.
 - First run repo discovery, then summarize facts, ask targeted questions, recommend an approach, and produce one `<proposed_plan>`.
+- Before finalizing a plan for a new or changed collection or global, run `$cache-impact-planner` and incorporate its decision. Stop rather than choosing a new cache architecture locally.
 - After the proposed plan, ask in normal prose whether the user wants it implemented.
 - If the user explicitly provides an approved plan or says to implement a previously proposed plan, proceed to implementation using the checklist in `references/collection-planning-playbook.md`.
 - If the requested change is obviously tiny and fully specified, still run discovery and state why no questions are needed before proposing or implementing.
@@ -35,21 +36,22 @@ This skill does not require or activate the technical Plan Mode. It works as a n
    - existing hooks and lifecycle utilities
    - permission matrix entries and unit access matrix tests
    - integration contract registry, lifecycle tests, and seeds
-5. Summarize discovery in concrete facts:
+5. Run `$cache-impact-planner` for every new or materially changed collection or global. Keep its three-way decision, dependency map, read/write symmetry, tests, and stop conditions in the proposed plan.
+6. Summarize discovery in concrete facts:
    - existing patterns that fit
    - likely affected domains
    - whether the feature looks like a new collection, field, join collection, global, media collection, or extension of an existing collection
-6. Ask questions only when answers would change schema, access, lifecycle, migration, tests, or docs:
+7. Ask questions only when answers would change schema, access, lifecycle, migration, tests, docs, or the cache-impact decision:
    - ask at most 3 questions per round
    - include a recommended default for each question
    - do not ask questions answerable from repo inspection
-7. Recommend the smallest coherent solution:
+8. Recommend the smallest coherent solution:
    - name the preferred model
    - briefly name rejected alternatives
    - call out hooks or helpers that would reduce custom logic
    - mark unresolved assumptions explicitly
-8. Produce a `<proposed_plan>` with implementation changes, validation, and assumptions.
-9. After the plan, ask whether to implement it.
+9. Produce a `<proposed_plan>` with implementation changes, cache impact, validation, and assumptions.
+10. After the plan, ask whether to implement it.
 
 ## Anti-Overengineering Check
 

--- a/.codex/skills/findmydoc-collection-planner/agents/openai.yaml
+++ b/.codex/skills/findmydoc-collection-planner/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: 'findmydoc Collection Planner'
-  short_description: 'Plan findmydoc Payload collections'
-  default_prompt: 'Use $findmydoc-collection-planner to evaluate, question, recommend, and plan a new findmydoc Payload collection before implementation.'
+  short_description: 'Plan findmydoc Payload collections and globals'
+  default_prompt: 'Use $findmydoc-collection-planner to evaluate, question, recommend, and plan a new or changed findmydoc Payload collection or global before implementation. Run $cache-impact-planner before plan finalization.'

--- a/.github/scripts/ci/detect-migration-diff.sh
+++ b/.github/scripts/ci/detect-migration-diff.sh
@@ -153,7 +153,8 @@ is_endpoint_only_payload_config_change() {
   return 0
 }
 
-schema_changed_files="$(grep -E "${schema_pattern}" <<<"${changed_files}" || true)"
+# Scoped agent instructions guide tooling but never change the Payload schema.
+schema_changed_files="$(grep -E "${schema_pattern}" <<<"${changed_files}" | grep -Ev '(^|/)AGENTS(\.override)?\.md$' || true)"
 
 is_dedicated_payload_hook_file() {
   local file_path="$1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 - Read-only specialist agents live under `.codex/agents/`; after local validation and before final handoff, identify every matching reviewer and recommend that set briefly to the user instead of running it automatically: instruction quality for `AGENTS.md`, `.codex/agents`, `.codex/rules`, `.codex/skills`, and AI governance docs; mobile UI for frontend UI/responsive/touch changes; accessibility for semantics/keyboard/focus/forms/dialogs/ARIA; security for access/auth/secrets/hooks/API/server trust boundaries; SEO for metadata/headings/canonicals/robots/sitemap/redirects/structured data/indexation; web vitals for image-heavy/animation-heavy/landing-page/bundle/hydration/LCP/INP/CLS-sensitive frontend changes; and Storybook for `.storybook/**`, story files, Storybook MSW handlers, Storybook Vitest config, or story-governance changes.
 - Run those reviewers only after explicit user confirmation, and after a reviewer run, present all findings before making fixes so the user can confirm the fixing step.
 - Treat findings with severity `6/10` or higher as fix-before-handoff; treat `5/10` as a documented user decision gate; document skipped or declined reviewers with concrete reasons.
-- When instruction surfaces change, include `agent_instruction_reviewer` in the recommended reviewer set after `pnpm ai:slop-check` and before PR/final handoff; skip it for ordinary app-code changes with no instruction surface.
+- When instruction surfaces change, include `agent_instruction_reviewer` after `pnpm ai:slop-check` and before PR/final handoff; for cache/revalidation, collection/global, public route or loader, hook, sitemap/discovery, or seed-flow diffs, also recommend `cache_architecture_reviewer`; skip each for unrelated changes.
 
 ## Layered Instruction Map
 

--- a/docs/engineering/cache-revalidation-runtime.md
+++ b/docs/engineering/cache-revalidation-runtime.md
@@ -151,6 +151,30 @@ Sitemaps and public discovery outputs participate in the same cache model as oth
 
 `/llms.txt` and `/.well-known/llms.txt` remain static public-discovery contract routes unless a future ADR or work order assigns CMS-backed dependencies. Search indexing and canonical/noindex policy remain route/config policy, not ad hoc document invalidation.
 
+## Extending The Cache Stack
+
+Every new or materially changed collection, global, public page, route, server-data loader, hook, sitemap, discovery flow, or seed flow receives one explicit cache-impact decision:
+
+| Decision | Required treatment |
+| --- | --- |
+| `no-public-impact` | No public cache or revalidation wiring. Collections and globals still receive an explicit policy-catalog classification. |
+| `public-live` | Public data remains deliberately uncached. Draft, preview, private, authenticated, cookie-bound, and request-bound data remains live. |
+| `public-cached` | Reuse an accepted cache class, policy-catalog entry, canonical read tags, planner event and owner, and focused read/write-symmetry tests. |
+
+Static public pages do not need a catalog entry. New surface IDs and catalog entries are local implementation decisions only when the existing cache classes, tag families, owner types, and public/private boundary already fit.
+
+Cached reads and writes stay symmetric: every read-side `unstable_cache` tag comes from `cachePolicy`, and the matching write-side event reaches the planner before the executor invalidates tags and then paths. Hook adapters preserve stable old and new identities or relations and honor `context.disableRevalidate`.
+
+Direct `revalidateTag` and `revalidatePath` calls belong to the executor. `src/hooks/media/revalidateMediaConsumers.ts` is the one temporary legacy exception while [issue #1468](https://github.com/findmydoc-platform/website/issues/1468) owns the bounded media dependency resolver.
+
+Stop for an ADR decision when a change needs a new cache class, tag family, owner type, freshness expectation, route family, Redis or another remote store, custom cache handler, or changed invalidation semantics.
+
+## Framework Compatibility
+
+The runtime uses `unstable_cache`, canonical cache tags, `revalidateTag`, and `revalidatePath`. Next.js Cache Components are not enabled in this stack: `cacheComponents`, `'use cache'`, `cacheTag`, and `cacheLife` are not implementation choices for ordinary feature work.
+
+Adopting Cache Components changes cache ownership, keying, lifetime, and invalidation semantics. It requires a dedicated ADR and migration plan that preserves the policy-first architecture before any runtime primitive is introduced.
+
 ## Deferred Boundaries
 
 Direct media dependency resolution remains a bounded follow-up. Media inherits the cache class of the surface where it appears, and referencing documents or relations own invalidation in the first stack.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -37,6 +37,13 @@ This guide defines shared defaults for `src/**`. Nested `AGENTS.md` files overri
 7. Do not hard-code secrets; only read from environment variables.
 8. Keep `.secrets.baseline` synchronized with branch changes; when `detect-secrets` updates the baseline, commit it with the related change.
 
+### Cache And Revalidation Boundary
+
+- Before finalizing a change to a collection, global, public route, server-data loader, hook, sitemap, discovery flow, or seed flow, use `$cache-impact-planner`.
+- Record exactly one decision: `no-public-impact`, `public-live`, or `public-cached`. New collections and globals require a cache-policy catalog classification; static public pages do not.
+- `public-cached` work uses existing cache classes, policy builders, canonical read tags, a planner event and owner, and focused read/write-symmetry tests. Draft, preview, private, and request-bound data stays live.
+- Do not invent cache classes, tag families, owner types, or direct invalidation. Stop for unclear freshness, a new route family, remote storage, or Cache Components primitives that need an ADR decision.
+
 ### Validation Policy
 
 - Follow the repository-level validation policy in `AGENTS.md`; this section is only a `src/**` routing summary.

--- a/src/app/(frontend)/AGENTS.md
+++ b/src/app/(frontend)/AGENTS.md
@@ -52,6 +52,8 @@
 - Business validation belongs in Payload hooks/access logic.
 - Public UI forms must suppress browser validation bubbles with the shared `PublicFormValidation` + `FieldError` pattern. Keep native control constraints in place, but expose failures inline with `data-invalid`, `aria-invalid`, and `aria-describedby`.
 - Prefer server-side data fetching in App Router unless client reactivity is required.
+- For every new or materially changed public page, route, or server-data loader, record one cache-impact decision in the plan or PR notes. Static pages need no catalog entry; public cached output must use the existing policy and planner boundary.
+- Keep draft, preview, private, cookie-bound, auth-bound, and request-bound reads live. Do not add direct revalidation, Cache Components primitives, or new cache semantics without an ADR decision.
 - For local verification of authenticated admin-facing routes under `src/app/(frontend)/admin/**`, prefer the shared Playwright session `output/playwright/sessions/admin.local.json` instead of redoing login in each browser run.
 - If local verification of public frontend routes is blocked by Temporary Landing Mode, disable the PostHog `temporary-landing-mode` flag for the local host before accepting proxy-level `404` responses as route evidence. Mention the flag state in the QA note.
 - For route-level mobile work, apply the canonical mobile matrix from `docs/frontend/mobile-ai-playbook.md`; include the additional `1280px` check only when the playbook marks it as required.

--- a/src/collections/AGENTS.md
+++ b/src/collections/AGENTS.md
@@ -16,6 +16,9 @@
 - For field labels and descriptions, keep copy short, plain, and self-contained for first-time clinic users.
 - Explain what a field is for and what to enter, but do not add history, implementation notes, or status-quo wording.
 - Prefer leaving already clear copy unchanged over rewriting for style.
+- Run `$cache-impact-planner` before finalizing a new or materially changed collection or global. Add its catalog classification even when the result is `no-public-impact` or `public-live`.
+- When a collection owns public cached output, its hook adapter builds a normalized planner event from stable old and new identities or relations and respects `context.disableRevalidate`.
+- Do not import `next/cache` or construct cache tags in collection code.
 
 ## Alignment Requirements
 

--- a/src/hooks/AGENTS.md
+++ b/src/hooks/AGENTS.md
@@ -12,6 +12,8 @@
 - Reuse `src/access/**` helpers; avoid duplicated role logic.
 - Maintain soft-delete behavior unless destructive semantics are explicitly required.
 - Keep hook logic deterministic, testable, and scoped to the owning collection/global.
+- Cache-affecting hooks use normalized planner events, preserve old and new identities or relations when they affect public output, and return early for `context.disableRevalidate`.
+- Hooks do not import `next/cache` or build tags and paths directly. The legacy media exception is limited to `src/hooks/media/revalidateMediaConsumers.ts` until issue `#1468`; do not extend it.
 
 ## Alignment Requirements
 

--- a/src/hooks/media/revalidateMediaConsumers.ts
+++ b/src/hooks/media/revalidateMediaConsumers.ts
@@ -1,3 +1,4 @@
+// Temporary direct invalidation exception. Remove this legacy path-level behavior with #1468.
 import { revalidatePath, revalidateTag } from 'next/cache.js'
 import type { CollectionAfterChangeHook, CollectionAfterDeleteHook, PayloadRequest } from 'payload'
 

--- a/src/stories/organisms/PostHero.stories.tsx
+++ b/src/stories/organisms/PostHero.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect, waitFor, within } from 'storybook/test'
+import { expect, fireEvent, waitFor, within } from 'storybook/test'
 import { PostHero } from '@/components/organisms/Heroes/PostHero'
 import { getStoryImageSrc, storyClinicImages, storyPortraits } from '../fixtures/assets'
 import { samplePost } from './fixtures'
@@ -153,6 +153,10 @@ const brokenHeroImageBase: Story = {
     const canvas = within(canvasElement)
     const heroImage = canvas.getByAltText('Broken post hero image')
 
+    if (!heroImage.getAttribute('src')?.includes('blog-placeholder-1600-900')) {
+      fireEvent.error(heroImage)
+    }
+
     await waitFor(() => {
       const imageSources = [
         heroImage.getAttribute('src') ?? '',
@@ -177,6 +181,10 @@ const brokenAuthorAvatarBase: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const avatarImage = canvas.getByAltText('Dr. Sarah Weber')
+
+    if (!avatarImage.getAttribute('src')?.includes('avatar-placeholder')) {
+      fireEvent.error(avatarImage)
+    }
 
     await waitFor(() => {
       const src = avatarImage.getAttribute('src') ?? ''

--- a/src/utilities/cachePolicy/index.ts
+++ b/src/utilities/cachePolicy/index.ts
@@ -312,6 +312,17 @@ export const CACHE_POLICY_CATALOG = [
     surfaces: ['clinic-detail'],
   },
   {
+    id: 'collection:doctor-treatments-deferred',
+    kind: 'collection',
+    cacheClass: 'critical-public',
+    boundary: 'public',
+    owner: 'collection-hook',
+    tagFamilies: [],
+    pathRelationship: 'deferred',
+    pathFamilies: ['none'],
+    collections: ['doctortreatments'],
+  },
+  {
     id: 'route:home',
     kind: 'public-route',
     cacheClass: 'aggregated-public',

--- a/tests/integration/contracts/cacheArchitectureCoverage.test.ts
+++ b/tests/integration/contracts/cacheArchitectureCoverage.test.ts
@@ -1,0 +1,870 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+import {
+  CACHE_POLICY_CATALOG,
+  CACHE_POLICY_COLLECTIONS,
+  CACHE_POLICY_GLOBALS,
+  type CachePolicyCatalogEntry,
+} from '@/utilities/cachePolicy'
+
+const repositoryRoot = process.cwd()
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'])
+const NEXT_CACHE_MODULES = new Set(['next/cache', 'next/cache.js'])
+const DIRECT_INVALIDATION_IMPORTS = new Set(['revalidateTag', 'revalidatePath'])
+const CACHE_COMPONENT_FUNCTIONS = new Set(['cacheTag', 'cacheLife'])
+const EXECUTOR_RELATIVE_PATH = 'src/utilities/cacheRevalidation/executor.ts'
+const MEDIA_EXCEPTION_RELATIVE_PATH = 'src/hooks/media/revalidateMediaConsumers.ts'
+const MEDIA_EXCEPTION_ISSUE = '#1468'
+
+type RepositorySource = {
+  readonly relativePath: string
+  readonly source: string
+}
+
+type SourceSlug = {
+  readonly location: string
+  readonly slug: string
+}
+
+type PayloadConfigKind = 'collection' | 'global'
+
+type PayloadConfigSlugScan = {
+  readonly slugs: readonly SourceSlug[]
+  readonly violations: readonly string[]
+}
+
+type SourceSlugScan = {
+  readonly slugs: readonly string[]
+  readonly violations: readonly string[]
+}
+
+type CatalogCoverageEntry = {
+  readonly boundary?: CachePolicyCatalogEntry['boundary']
+  readonly cacheClass?: CachePolicyCatalogEntry['cacheClass']
+  readonly collections?: readonly string[]
+  readonly globals?: readonly string[]
+}
+
+type LocalTagFunction = ts.ArrowFunction | ts.FunctionDeclaration | ts.FunctionExpression
+
+type LocalTagDefinitions = {
+  readonly expressions: ReadonlyMap<string, ts.Expression>
+  readonly functions: ReadonlyMap<string, LocalTagFunction>
+}
+
+type TagExpressionAnalysis = {
+  readonly containsLiteral: boolean
+  readonly isPolicyDerived: boolean
+}
+
+const normalizeRelativePath = (filePath: string): string => filePath.split(path.sep).join('/')
+
+const toRepositoryRelativePath = (filePath: string): string =>
+  normalizeRelativePath(path.relative(repositoryRoot, filePath))
+
+const isSourceFilePath = (filePath: string): boolean =>
+  SOURCE_EXTENSIONS.has(path.extname(filePath)) && !filePath.endsWith('.d.ts')
+
+const walkSourceFiles = (directory: string): string[] => {
+  const files: string[] = []
+  const entries = fs
+    .readdirSync(directory, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name))
+
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...walkSourceFiles(entryPath))
+      continue
+    }
+
+    if (entry.isFile() && isSourceFilePath(entryPath)) {
+      files.push(entryPath)
+    }
+  }
+
+  return files
+}
+
+const readSourcesUnder = (relativeDirectory: string): RepositorySource[] => {
+  const directory = path.join(repositoryRoot, relativeDirectory)
+
+  return walkSourceFiles(directory).map((filePath) => ({
+    relativePath: toRepositoryRelativePath(filePath),
+    source: fs.readFileSync(filePath, 'utf8'),
+  }))
+}
+
+const readNextConfigSources = (): RepositorySource[] =>
+  fs
+    .readdirSync(repositoryRoot)
+    .filter((name) => name.startsWith('next.config.') && isSourceFilePath(name))
+    .sort()
+    .map((name) => {
+      const filePath = path.join(repositoryRoot, name)
+
+      return {
+        relativePath: name,
+        source: fs.readFileSync(filePath, 'utf8'),
+      }
+    })
+
+const scriptKindFor = (filePath: string): ts.ScriptKind => {
+  const extension = path.extname(filePath)
+
+  if (extension === '.tsx') return ts.ScriptKind.TSX
+  if (extension === '.jsx') return ts.ScriptKind.JSX
+  if (extension === '.js' || extension === '.mjs' || extension === '.cjs') return ts.ScriptKind.JS
+
+  return ts.ScriptKind.TS
+}
+
+const parseSource = ({ relativePath, source }: RepositorySource): ts.SourceFile =>
+  ts.createSourceFile(relativePath, source, ts.ScriptTarget.Latest, true, scriptKindFor(relativePath))
+
+const visitNodes = (sourceFile: ts.SourceFile, visitor: (node: ts.Node) => void): void => {
+  const visit = (node: ts.Node): void => {
+    visitor(node)
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+}
+
+const getPropertyName = (name: ts.PropertyName): string | null => {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text
+  }
+
+  if (ts.isComputedPropertyName(name) && ts.isStringLiteral(name.expression)) {
+    return name.expression.text
+  }
+
+  return null
+}
+
+const getObjectPropertyInitializer = (object: ts.ObjectLiteralExpression, name: string): ts.Expression | undefined => {
+  for (const property of object.properties) {
+    if (ts.isPropertyAssignment(property) && getPropertyName(property.name) === name) {
+      return property.initializer
+    }
+
+    if (ts.isShorthandPropertyAssignment(property) && getPropertyName(property.name) === name) {
+      return property.name
+    }
+  }
+
+  return undefined
+}
+
+const getTypeReferenceName = (type: ts.TypeNode | undefined): string | null => {
+  if (!type || !ts.isTypeReferenceNode(type)) {
+    return null
+  }
+
+  return ts.isIdentifier(type.typeName) ? type.typeName.text : type.typeName.right.text
+}
+
+const unwrapExpression = (expression: ts.Expression): ts.Expression => {
+  if (ts.isParenthesizedExpression(expression)) return unwrapExpression(expression.expression)
+  if (ts.isAsExpression(expression)) return unwrapExpression(expression.expression)
+  if (ts.isTypeAssertionExpression(expression)) return unwrapExpression(expression.expression)
+  if (ts.isSatisfiesExpression(expression)) return unwrapExpression(expression.expression)
+
+  return expression
+}
+
+const getPayloadConfigTypeName = (declaration: ts.VariableDeclaration): string | null => {
+  const annotatedTypeName = getTypeReferenceName(declaration.type)
+  if (annotatedTypeName) {
+    return annotatedTypeName
+  }
+
+  let expression = declaration.initializer
+  while (expression) {
+    if (
+      ts.isSatisfiesExpression(expression) ||
+      ts.isAsExpression(expression) ||
+      ts.isTypeAssertionExpression(expression)
+    ) {
+      const assertedTypeName = getTypeReferenceName(expression.type)
+      if (assertedTypeName) {
+        return assertedTypeName
+      }
+
+      expression = expression.expression
+      continue
+    }
+
+    if (ts.isParenthesizedExpression(expression)) {
+      expression = expression.expression
+      continue
+    }
+
+    return null
+  }
+
+  return null
+}
+
+const getSourceLocation = (sourceFile: ts.SourceFile, node: ts.Node, relativePath: string): string => {
+  const location = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+
+  return `${relativePath}:${location.line + 1}`
+}
+
+const readPayloadConfigSlugs = ({
+  relativePath,
+  source,
+  kind,
+}: RepositorySource & { readonly kind: PayloadConfigKind }): PayloadConfigSlugScan => {
+  const sourceFile = parseSource({ relativePath, source })
+  const configTypeName = kind === 'collection' ? 'CollectionConfig' : 'GlobalConfig'
+  const slugs: SourceSlug[] = []
+  const violations: string[] = []
+
+  visitNodes(sourceFile, (node) => {
+    if (!ts.isVariableDeclaration(node) || !node.initializer || getPayloadConfigTypeName(node) !== configTypeName) {
+      return
+    }
+
+    const location = getSourceLocation(sourceFile, node, relativePath)
+    const config = unwrapExpression(node.initializer)
+    if (!ts.isObjectLiteralExpression(config)) {
+      violations.push(`${location} uses a non-literal ${kind} config; cache policy coverage requires a static slug.`)
+      return
+    }
+
+    const slug = getObjectPropertyInitializer(config, 'slug')
+    if (!slug) {
+      violations.push(`${location} is missing a static ${kind} slug.`)
+      return
+    }
+
+    const normalizedSlug = unwrapExpression(slug)
+    if (!ts.isStringLiteral(normalizedSlug) && !ts.isNoSubstitutionTemplateLiteral(normalizedSlug)) {
+      violations.push(`${location} has a non-literal ${kind} slug; cache policy coverage requires a static slug.`)
+      return
+    }
+
+    slugs.push({ location, slug: normalizedSlug.text })
+  })
+
+  return { slugs, violations: sortedUnique(violations) }
+}
+
+const sortedUnique = (values: readonly string[]): string[] => [...new Set(values)].sort()
+
+const readSourceSlugScan = (relativeDirectory: string, kind: PayloadConfigKind): SourceSlugScan => {
+  const scans = readSourcesUnder(relativeDirectory).map((source) => readPayloadConfigSlugs({ ...source, kind }))
+
+  return {
+    slugs: sortedUnique(scans.flatMap((scan) => scan.slugs.map((record) => record.slug))),
+    violations: sortedUnique(scans.flatMap((scan) => scan.violations)),
+  }
+}
+
+const catalogValues = (catalog: readonly CatalogCoverageEntry[], key: 'collections' | 'globals'): string[] =>
+  sortedUnique(catalog.flatMap((entry) => entry[key] ?? []))
+
+const getPolicyCoverageViolations = ({
+  catalog,
+  knownCollections,
+  knownGlobals,
+  sourceCollections,
+  sourceGlobals,
+}: {
+  readonly catalog: readonly CatalogCoverageEntry[]
+  readonly knownCollections: readonly string[]
+  readonly knownGlobals: readonly string[]
+  readonly sourceCollections: readonly string[]
+  readonly sourceGlobals: readonly string[]
+}): string[] => {
+  const knownCollectionSet = new Set(knownCollections)
+  const knownGlobalSet = new Set(knownGlobals)
+  const catalogCollectionValues = catalogValues(catalog, 'collections')
+  const catalogGlobalValues = catalogValues(catalog, 'globals')
+  const catalogCollectionSet = new Set(catalogCollectionValues)
+  const catalogGlobalSet = new Set(catalogGlobalValues)
+  const violations: string[] = []
+
+  for (const slug of sourceCollections) {
+    if (!knownCollectionSet.has(slug)) {
+      violations.push(`Collection "${slug}" is missing from CACHE_POLICY_COLLECTIONS.`)
+      continue
+    }
+
+    if (!catalogCollectionSet.has(slug)) {
+      violations.push(`Collection "${slug}" is missing from CACHE_POLICY_CATALOG.`)
+    }
+  }
+
+  for (const slug of sourceGlobals) {
+    if (!knownGlobalSet.has(slug)) {
+      violations.push(`Global "${slug}" is missing from CACHE_POLICY_GLOBALS.`)
+      continue
+    }
+
+    if (!catalogGlobalSet.has(slug)) {
+      violations.push(`Global "${slug}" is missing from CACHE_POLICY_CATALOG.`)
+    }
+  }
+
+  for (const slug of knownCollections) {
+    if (!catalogCollectionSet.has(slug)) {
+      violations.push(`CACHE_POLICY_COLLECTIONS contains "${slug}" without a CACHE_POLICY_CATALOG classification.`)
+    }
+  }
+
+  for (const slug of knownGlobals) {
+    if (!catalogGlobalSet.has(slug)) {
+      violations.push(`CACHE_POLICY_GLOBALS contains "${slug}" without a CACHE_POLICY_CATALOG classification.`)
+    }
+  }
+
+  for (const slug of catalogCollectionValues) {
+    if (!knownCollectionSet.has(slug)) {
+      violations.push(`CACHE_POLICY_CATALOG references unknown collection "${slug}".`)
+    }
+  }
+
+  for (const slug of catalogGlobalValues) {
+    if (!knownGlobalSet.has(slug)) {
+      violations.push(`CACHE_POLICY_CATALOG references unknown global "${slug}".`)
+    }
+  }
+
+  return sortedUnique(violations)
+}
+
+const getModuleSpecifierText = (node: ts.ImportDeclaration | ts.ExportDeclaration): string | null =>
+  node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier) ? node.moduleSpecifier.text : null
+
+const isNextCacheModule = (node: ts.ImportDeclaration | ts.ExportDeclaration): boolean => {
+  const moduleSpecifier = getModuleSpecifierText(node)
+
+  return Boolean(moduleSpecifier && NEXT_CACHE_MODULES.has(moduleSpecifier))
+}
+
+const allowsDirectInvalidation = (relativePath: string): boolean =>
+  relativePath === EXECUTOR_RELATIVE_PATH || relativePath === MEDIA_EXCEPTION_RELATIVE_PATH
+
+const directInvalidationBoundaryMessage = (relativePath: string): string =>
+  `${relativePath} bypasses the planner/executor boundary. Direct revalidation belongs in ${EXECUTOR_RELATIVE_PATH}; ${MEDIA_EXCEPTION_RELATIVE_PATH} is the only temporary exception until ${MEDIA_EXCEPTION_ISSUE}.`
+
+const cacheComponentsBoundaryMessage = (relativePath: string, primitive: string): string =>
+  `${relativePath} uses ${primitive}, but ADR 023 keeps Cache Components out of the first stack. Add an ADR and migration work order before introducing this primitive.`
+
+const findNextCacheViolations = ({ relativePath, source }: RepositorySource): string[] => {
+  const sourceFile = parseSource({ relativePath, source })
+  const directInvalidationLocalNames = new Set(DIRECT_INVALIDATION_IMPORTS)
+  const violations: string[] = []
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isExportDeclaration(statement) && isNextCacheModule(statement)) {
+      violations.push(`${relativePath} re-exports next/cache and bypasses the executor boundary.`)
+      continue
+    }
+
+    if (!ts.isImportDeclaration(statement) || !isNextCacheModule(statement)) {
+      continue
+    }
+
+    const importClause = statement.importClause
+    if (!importClause) {
+      violations.push(`${relativePath} uses a side-effect next/cache import, which is not allowed.`)
+      continue
+    }
+
+    if (importClause.name) {
+      violations.push(`${relativePath} uses a default next/cache import, which is not allowed.`)
+    }
+
+    if (importClause.namedBindings && ts.isNamespaceImport(importClause.namedBindings)) {
+      violations.push(`${relativePath} uses a namespace next/cache import, which is not allowed.`)
+      continue
+    }
+
+    if (!importClause.namedBindings || !ts.isNamedImports(importClause.namedBindings)) {
+      continue
+    }
+
+    for (const element of importClause.namedBindings.elements) {
+      const importedName = element.propertyName?.text ?? element.name.text
+      if (DIRECT_INVALIDATION_IMPORTS.has(importedName)) {
+        directInvalidationLocalNames.add(element.name.text)
+
+        if (!allowsDirectInvalidation(relativePath)) {
+          violations.push(directInvalidationBoundaryMessage(relativePath))
+        }
+      }
+
+      if (CACHE_COMPONENT_FUNCTIONS.has(importedName)) {
+        violations.push(cacheComponentsBoundaryMessage(relativePath, importedName))
+      }
+    }
+  }
+
+  visitNodes(sourceFile, (node) => {
+    if (!ts.isCallExpression(node)) {
+      return
+    }
+
+    const firstArgument = node.arguments[0]
+    const isDynamicImport = node.expression.kind === ts.SyntaxKind.ImportKeyword
+    const isRequireCall = ts.isIdentifier(node.expression) && node.expression.text === 'require'
+    if (
+      (isDynamicImport || isRequireCall) &&
+      firstArgument &&
+      ts.isStringLiteral(firstArgument) &&
+      NEXT_CACHE_MODULES.has(firstArgument.text)
+    ) {
+      violations.push(`${relativePath} loads next/cache dynamically, which is not allowed.`)
+    }
+
+    if (
+      ts.isIdentifier(node.expression) &&
+      directInvalidationLocalNames.has(node.expression.text) &&
+      !allowsDirectInvalidation(relativePath)
+    ) {
+      violations.push(directInvalidationBoundaryMessage(relativePath))
+    }
+  })
+
+  return sortedUnique(violations)
+}
+
+const collectLocalTagDefinitions = (sourceFile: ts.SourceFile): LocalTagDefinitions => {
+  const expressions = new Map<string, ts.Expression>()
+  const functions = new Map<string, LocalTagFunction>()
+
+  visitNodes(sourceFile, (node) => {
+    if (ts.isFunctionDeclaration(node) && node.name) {
+      functions.set(node.name.text, node)
+      return
+    }
+
+    if (!ts.isVariableDeclaration(node) || !ts.isIdentifier(node.name) || !node.initializer) {
+      return
+    }
+
+    if (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer)) {
+      functions.set(node.name.text, node.initializer)
+      return
+    }
+
+    expressions.set(node.name.text, node.initializer)
+  })
+
+  return { expressions, functions }
+}
+
+const getNamedImportLocalNames = (
+  sourceFile: ts.SourceFile,
+  importedName: string,
+  moduleMatcher: (value: string) => boolean,
+) => {
+  const localNames = new Set<string>()
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement)) continue
+
+    const moduleSpecifier = getModuleSpecifierText(statement)
+    if (!moduleSpecifier || !moduleMatcher(moduleSpecifier)) continue
+
+    const bindings = statement.importClause?.namedBindings
+    if (!bindings || !ts.isNamedImports(bindings)) continue
+
+    for (const element of bindings.elements) {
+      const imported = element.propertyName?.text ?? element.name.text
+      if (imported === importedName) {
+        localNames.add(element.name.text)
+      }
+    }
+  }
+
+  return localNames
+}
+
+const getPolicyBuilderLocalNames = (sourceFile: ts.SourceFile): Set<string> => {
+  const localNames = new Set<string>()
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement)) continue
+
+    const moduleSpecifier = getModuleSpecifierText(statement)
+    if (!moduleSpecifier || !moduleSpecifier.includes('cachePolicy')) continue
+
+    const bindings = statement.importClause?.namedBindings
+    if (!bindings || !ts.isNamedImports(bindings)) continue
+
+    for (const element of bindings.elements) {
+      const imported = element.propertyName?.text ?? element.name.text
+      if (imported.startsWith('build') && imported.endsWith('Tag')) {
+        localNames.add(element.name.text)
+      }
+    }
+  }
+
+  return localNames
+}
+
+const getFunctionReturnExpressions = (functionLike: LocalTagFunction): ts.Expression[] => {
+  if (ts.isArrowFunction(functionLike) && !ts.isBlock(functionLike.body)) {
+    return [functionLike.body]
+  }
+
+  if (!functionLike.body || !ts.isBlock(functionLike.body)) {
+    return []
+  }
+
+  return functionLike.body.statements.flatMap((statement) =>
+    ts.isReturnStatement(statement) && statement.expression ? [statement.expression] : [],
+  )
+}
+
+const mergeTagExpressionAnalyses = (analyses: readonly TagExpressionAnalysis[]): TagExpressionAnalysis => ({
+  containsLiteral: analyses.some((analysis) => analysis.containsLiteral),
+  isPolicyDerived: analyses.length > 0 && analyses.every((analysis) => analysis.isPolicyDerived),
+})
+
+const analyzeTagExpression = (
+  expression: ts.Expression,
+  definitions: LocalTagDefinitions,
+  policyBuilderLocalNames: ReadonlySet<string>,
+  visiting: ReadonlySet<string> = new Set(),
+): TagExpressionAnalysis => {
+  const unwrapped = unwrapExpression(expression)
+
+  if (ts.isStringLiteral(unwrapped) || ts.isNoSubstitutionTemplateLiteral(unwrapped)) {
+    return { containsLiteral: true, isPolicyDerived: false }
+  }
+
+  if (ts.isArrayLiteralExpression(unwrapped)) {
+    if (unwrapped.elements.length === 0) {
+      return { containsLiteral: false, isPolicyDerived: false }
+    }
+
+    return mergeTagExpressionAnalyses(
+      unwrapped.elements.map((element) =>
+        ts.isSpreadElement(element)
+          ? analyzeTagExpression(element.expression, definitions, policyBuilderLocalNames, visiting)
+          : analyzeTagExpression(element, definitions, policyBuilderLocalNames, visiting),
+      ),
+    )
+  }
+
+  if (ts.isConditionalExpression(unwrapped)) {
+    return mergeTagExpressionAnalyses([
+      analyzeTagExpression(unwrapped.whenTrue, definitions, policyBuilderLocalNames, visiting),
+      analyzeTagExpression(unwrapped.whenFalse, definitions, policyBuilderLocalNames, visiting),
+    ])
+  }
+
+  if (ts.isCallExpression(unwrapped) && ts.isIdentifier(unwrapped.expression)) {
+    const name = unwrapped.expression.text
+    if (policyBuilderLocalNames.has(name)) {
+      return { containsLiteral: false, isPolicyDerived: true }
+    }
+
+    const functionLike = definitions.functions.get(name)
+    if (functionLike) {
+      const reference = `function:${name}`
+      if (visiting.has(reference)) return { containsLiteral: false, isPolicyDerived: false }
+
+      const nextVisiting = new Set(visiting)
+      nextVisiting.add(reference)
+      return mergeTagExpressionAnalyses(
+        getFunctionReturnExpressions(functionLike).map((result) =>
+          analyzeTagExpression(result, definitions, policyBuilderLocalNames, nextVisiting),
+        ),
+      )
+    }
+  }
+
+  if (ts.isIdentifier(unwrapped)) {
+    const initializer = definitions.expressions.get(unwrapped.text)
+    if (initializer) {
+      const reference = `expression:${unwrapped.text}`
+      if (visiting.has(reference)) return { containsLiteral: false, isPolicyDerived: false }
+
+      const nextVisiting = new Set(visiting)
+      nextVisiting.add(reference)
+      return analyzeTagExpression(initializer, definitions, policyBuilderLocalNames, nextVisiting)
+    }
+  }
+
+  return { containsLiteral: false, isPolicyDerived: false }
+}
+
+const findUnstableCacheTagViolations = ({ relativePath, source }: RepositorySource): string[] => {
+  const sourceFile = parseSource({ relativePath, source })
+  const unstableCacheLocalNames = getNamedImportLocalNames(sourceFile, 'unstable_cache', (moduleSpecifier) =>
+    NEXT_CACHE_MODULES.has(moduleSpecifier),
+  )
+  const policyBuilderLocalNames = getPolicyBuilderLocalNames(sourceFile)
+  const definitions = collectLocalTagDefinitions(sourceFile)
+  const violations: string[] = []
+
+  visitNodes(sourceFile, (node) => {
+    if (
+      !ts.isCallExpression(node) ||
+      !ts.isIdentifier(node.expression) ||
+      !unstableCacheLocalNames.has(node.expression.text)
+    ) {
+      return
+    }
+
+    const options = node.arguments[2]
+    const unwrappedOptions = options ? unwrapExpression(options) : undefined
+    if (!unwrappedOptions || !ts.isObjectLiteralExpression(unwrappedOptions)) {
+      violations.push(`${relativePath} calls unstable_cache without an analyzable tags configuration.`)
+      return
+    }
+
+    const tags = getObjectPropertyInitializer(unwrappedOptions, 'tags')
+    if (!tags) {
+      violations.push(`${relativePath} calls unstable_cache without cachePolicy-derived tags.`)
+      return
+    }
+
+    const analysis = analyzeTagExpression(tags, definitions, policyBuilderLocalNames)
+    if (analysis.containsLiteral) {
+      violations.push(`${relativePath} uses a literal unstable_cache tag. Use cachePolicy builders instead.`)
+    }
+
+    if (!analysis.isPolicyDerived) {
+      violations.push(`${relativePath} uses unstable_cache tags that do not derive from cachePolicy builders.`)
+    }
+  })
+
+  return sortedUnique(violations)
+}
+
+const findCacheComponentsViolations = ({ relativePath, source }: RepositorySource): string[] => {
+  const sourceFile = parseSource({ relativePath, source })
+  const violations: string[] = []
+
+  visitNodes(sourceFile, (node) => {
+    if (ts.isPropertyAssignment(node) && getPropertyName(node.name) === 'cacheComponents') {
+      violations.push(cacheComponentsBoundaryMessage(relativePath, 'cacheComponents'))
+      return
+    }
+
+    if (ts.isExpressionStatement(node) && ts.isStringLiteral(node.expression) && node.expression.text === 'use cache') {
+      violations.push(cacheComponentsBoundaryMessage(relativePath, "'use cache'"))
+      return
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      CACHE_COMPONENT_FUNCTIONS.has(node.expression.text)
+    ) {
+      violations.push(cacheComponentsBoundaryMessage(relativePath, node.expression.text))
+    }
+  })
+
+  return sortedUnique(violations)
+}
+
+describe('Cache architecture coverage gate', () => {
+  it('uses the TypeScript AST to read configured slugs without matching comments', () => {
+    const scan = readPayloadConfigSlugs({
+      kind: 'collection',
+      relativePath: 'src/collections/Example.ts',
+      source:
+        "import type { CollectionConfig } from 'payload'\n// slug: 'ignored'\nexport const Example: CollectionConfig<'example'> = { slug: 'example' }\n",
+    })
+
+    expect(scan).toEqual({
+      slugs: [{ location: 'src/collections/Example.ts:3', slug: 'example' }],
+      violations: [],
+    })
+  })
+
+  it('rejects a dynamic collection or global slug before it can bypass policy coverage', () => {
+    const collectionScan = readPayloadConfigSlugs({
+      kind: 'collection',
+      relativePath: 'src/collections/Example.ts',
+      source:
+        "import type { CollectionConfig } from 'payload'\nconst slug = 'example'\nexport const Example: CollectionConfig = { slug }\n",
+    })
+    const globalScan = readPayloadConfigSlugs({
+      kind: 'global',
+      relativePath: 'src/globals/Example.ts',
+      source:
+        "import type { GlobalConfig } from 'payload'\nconst slug = 'example'\nexport const Example: GlobalConfig = { slug }\n",
+    })
+
+    expect(collectionScan.slugs).toEqual([])
+    expect(collectionScan.violations).toContain(
+      'src/collections/Example.ts:3 has a non-literal collection slug; cache policy coverage requires a static slug.',
+    )
+    expect(globalScan.slugs).toEqual([])
+    expect(globalScan.violations).toContain(
+      'src/globals/Example.ts:3 has a non-literal global slug; cache policy coverage requires a static slug.',
+    )
+  })
+
+  it('keeps every collection and global source slug classified by the policy catalog', () => {
+    const collectionScan = readSourceSlugScan('src/collections', 'collection')
+    const globalScan = readSourceSlugScan('src/globals', 'global')
+
+    expect([...collectionScan.violations, ...globalScan.violations]).toEqual([])
+    expect(
+      getPolicyCoverageViolations({
+        catalog: CACHE_POLICY_CATALOG,
+        knownCollections: CACHE_POLICY_COLLECTIONS,
+        knownGlobals: CACHE_POLICY_GLOBALS,
+        sourceCollections: collectionScan.slugs,
+        sourceGlobals: globalScan.slugs,
+      }),
+    ).toEqual([])
+  })
+
+  it('fails for a new collection or global without a catalog classification', () => {
+    const violations = getPolicyCoverageViolations({
+      catalog: [],
+      knownCollections: ['new-collection'],
+      knownGlobals: ['new-global'],
+      sourceCollections: ['new-collection'],
+      sourceGlobals: ['new-global'],
+    })
+
+    expect(violations).toContain('Collection "new-collection" is missing from CACHE_POLICY_CATALOG.')
+    expect(violations).toContain('Global "new-global" is missing from CACHE_POLICY_CATALOG.')
+  })
+
+  it('accepts private and no-public-impact catalog classifications', () => {
+    const catalog = [
+      {
+        boundary: 'private',
+        cacheClass: 'private-live',
+        collections: ['private-document'],
+      },
+      {
+        boundary: 'public',
+        cacheClass: 'critical-public',
+        collections: ['no-public-impact-document'],
+      },
+    ] as const satisfies readonly CatalogCoverageEntry[]
+
+    expect(
+      getPolicyCoverageViolations({
+        catalog,
+        knownCollections: ['private-document', 'no-public-impact-document'],
+        knownGlobals: [],
+        sourceCollections: ['private-document', 'no-public-impact-document'],
+        sourceGlobals: [],
+      }),
+    ).toEqual([])
+  })
+
+  it('fails when catalog vocabulary has no matching policy classification', () => {
+    expect(
+      getPolicyCoverageViolations({
+        catalog: [{ collections: ['unknown-collection'] }],
+        knownCollections: ['known-collection'],
+        knownGlobals: [],
+        sourceCollections: ['known-collection'],
+        sourceGlobals: [],
+      }),
+    ).toContain('CACHE_POLICY_CATALOG references unknown collection "unknown-collection".')
+  })
+
+  it('blocks direct next/cache invalidation outside the executor boundary', () => {
+    const violations = findNextCacheViolations({
+      relativePath: 'src/hooks/revalidateSomething.ts',
+      source: "import { revalidateTag } from 'next/cache'\nrevalidateTag('collection:pages')\n",
+    })
+
+    expect(violations).toContain(directInvalidationBoundaryMessage('src/hooks/revalidateSomething.ts'))
+  })
+
+  it('allows only the executor and exact media exception path to import direct invalidation', () => {
+    const executorSource = {
+      relativePath: EXECUTOR_RELATIVE_PATH,
+      source:
+        "import { revalidatePath, revalidateTag } from 'next/cache'\nrevalidateTag('collection:pages')\nrevalidatePath('/')\n",
+    }
+    const mediaExceptionSource = {
+      relativePath: MEDIA_EXCEPTION_RELATIVE_PATH,
+      source:
+        "import { revalidatePath, revalidateTag } from 'next/cache.js'\nrevalidateTag('collection:pages')\nrevalidatePath('/')\n",
+    }
+    const similarPathSource = {
+      relativePath: 'src/hooks/media/revalidateMediaConsumersCopy.ts',
+      source: mediaExceptionSource.source,
+    }
+
+    expect(findNextCacheViolations(executorSource)).toEqual([])
+    expect(findNextCacheViolations(mediaExceptionSource)).toEqual([])
+    expect(findNextCacheViolations(similarPathSource)).toContain(
+      directInvalidationBoundaryMessage(similarPathSource.relativePath),
+    )
+  })
+
+  it('blocks namespace and default next/cache imports', () => {
+    const namespaceViolations = findNextCacheViolations({
+      relativePath: 'src/utilities/cacheNamespace.ts',
+      source: "import * as cache from 'next/cache'\nvoid cache\n",
+    })
+    const defaultViolations = findNextCacheViolations({
+      relativePath: 'src/utilities/cacheDefault.ts',
+      source: "import cache from 'next/cache'\nvoid cache\n",
+    })
+
+    expect(namespaceViolations).toContain(
+      'src/utilities/cacheNamespace.ts uses a namespace next/cache import, which is not allowed.',
+    )
+    expect(defaultViolations).toContain(
+      'src/utilities/cacheDefault.ts uses a default next/cache import, which is not allowed.',
+    )
+  })
+
+  it('blocks literal unstable_cache tags and accepts cachePolicy builder tags', () => {
+    const literalViolations = findUnstableCacheTagViolations({
+      relativePath: 'src/utilities/literalCache.ts',
+      source:
+        "import { unstable_cache } from 'next/cache'\nconst cached = unstable_cache(async () => null, [], { tags: ['pages-sitemap'] })\nvoid cached\n",
+    })
+    const builderViolations = findUnstableCacheTagViolations({
+      relativePath: 'src/utilities/policyCache.ts',
+      source:
+        "import { unstable_cache } from 'next/cache'\nimport { buildCollectionTag } from '@/utilities/cachePolicy'\nconst cached = unstable_cache(async () => null, [], { tags: [buildCollectionTag('pages')] })\nvoid cached\n",
+    })
+
+    expect(literalViolations).toContain(
+      'src/utilities/literalCache.ts uses a literal unstable_cache tag. Use cachePolicy builders instead.',
+    )
+    expect(builderViolations).toEqual([])
+  })
+
+  it('blocks Cache Components primitives with ADR guidance', () => {
+    const violations = findCacheComponentsViolations({
+      relativePath: 'next.config.ts',
+      source: "'use cache'\nexport default { cacheComponents: true }\ncacheTag('pages')\ncacheLife('hours')\n",
+    })
+
+    expect(violations).toHaveLength(4)
+    expect(violations.every((violation) => violation.includes('ADR 023'))).toBe(true)
+  })
+
+  it('keeps the repository inside the accepted cache architecture', () => {
+    const runtimeSources = readSourcesUnder('src')
+    const frameworkSources = [...runtimeSources, ...readNextConfigSources()]
+
+    for (const source of runtimeSources) {
+      expect(findNextCacheViolations(source), source.relativePath).toEqual([])
+      expect(findUnstableCacheTagViolations(source), source.relativePath).toEqual([])
+    }
+
+    for (const source of frameworkSources) {
+      expect(findCacheComponentsViolations(source), source.relativePath).toEqual([])
+    }
+  })
+})

--- a/tests/tooling/scripts/detect-migration-diff.test.ts
+++ b/tests/tooling/scripts/detect-migration-diff.test.ts
@@ -52,6 +52,15 @@ const commitPayloadConfig = (rootDir: string, source: string) => {
   runGit(rootDir, ['commit', '--message', 'update payload config'])
 }
 
+const commitFile = (rootDir: string, relativePath: string, source: string) => {
+  const filePath = path.join(rootDir, relativePath)
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, source, 'utf8')
+  runGit(rootDir, ['add', relativePath])
+  runGit(rootDir, ['commit', '--message', `update ${relativePath}`])
+}
+
 const runDetector = (rootDir: string) => {
   const outputPath = path.join(rootDir, 'github-output')
   execFileSync('bash', [path.join(repositoryRoot, '.github/scripts/ci/detect-migration-diff.sh'), 'push', ''], {
@@ -98,6 +107,28 @@ export default {
       rootDir,
       `${initialPayloadConfig}\nexport const generatedTypes = { outputFile: 'src/payload-types.ts' }\n`,
     )
+
+    const output = runDetector(rootDir)
+
+    expect(output).toContain('db_changed=true')
+    expect(output).toContain('schema_changed=true')
+  })
+
+  it('does not require a migration for scoped agent instructions', () => {
+    const rootDir = createTempRepo()
+
+    commitFile(rootDir, 'src/collections/AGENTS.md', '# Collection instructions\n')
+
+    const output = runDetector(rootDir)
+
+    expect(output).toContain('db_changed=false')
+    expect(output).toContain('schema_changed=false')
+  })
+
+  it('keeps collection config changes schema-relevant', () => {
+    const rootDir = createTempRepo()
+
+    commitFile(rootDir, 'src/collections/Doctors/index.ts', "export const Doctors = { slug: 'doctors' }\n")
 
     const output = runDetector(rootDir)
 

--- a/tests/unit/utilities/cachePolicy.test.ts
+++ b/tests/unit/utilities/cachePolicy.test.ts
@@ -186,6 +186,7 @@ describe('cache policy contract', () => {
       'route:posts:list',
       'route:clinics:detail',
       'route:clinic-detail:related-data',
+      'collection:doctor-treatments-deferred',
       'route:home',
       'route:about',
       'route:partners-clinics',
@@ -229,6 +230,17 @@ describe('cache policy contract', () => {
       tagFamilies: ['global', 'collection', 'surface', 'surface:sitemap'],
       surfaces: ['home'],
       sitemapSurfaces: ['pages'],
+    })
+
+    expect(getCachePolicyEntry('collection:doctor-treatments-deferred')).toMatchObject({
+      kind: 'collection',
+      cacheClass: 'critical-public',
+      boundary: 'public',
+      owner: 'collection-hook',
+      tagFamilies: [],
+      pathRelationship: 'deferred',
+      pathFamilies: ['none'],
+      collections: ['doctortreatments'],
     })
 
     expect(getCachePolicyEntry('route:about')).toMatchObject({


### PR DESCRIPTION
## Management summary

### Deutsch

Neue Inhalte können künftig nur mit einer klaren Entscheidung zur Aktualität der öffentlichen Website ergänzt werden. Das senkt das Risiko, dass Besucher oder Suchmaschinen nach redaktionellen Änderungen veraltete Inhalte sehen, ohne die bestehende Laufzeitlogik zu verändern.

### English

New content can now be extended only with a clear decision about public website freshness. This reduces the risk that visitors or search engines see stale content after editorial changes without changing the existing runtime behavior.

## What changed

- Added an AST-backed integration contract for collection/global policy coverage, direct `next/cache` bypasses, raw `unstable_cache` tags, and unsupported Cache Components primitives.
- Added the generic `cache-impact-planner` skill, integrated it into the existing collection/global planning workflow, and added scoped cache-impact guidance.
- Added a read-only cache architecture reviewer and extended the runtime guide with extension and framework-compatibility boundaries.
- Hardened Payload collection/global source coverage so dynamic slugs cannot bypass the policy catalog.
- Updated schema-diff detection so scoped `AGENTS.md` changes do not trigger a Payload migration check.
- Stabilized the existing PostHero fallback-story interaction by explicitly exercising the image-error path, matching the established BlogCard story pattern.
- Classified the already deferred `doctortreatments` dependency in the policy catalog without adding runtime invalidation behavior.
- Kept `src/hooks/media/revalidateMediaConsumers.ts` as the exact temporary legacy exception tracked by #1468.

This PR targets `main` after the cache stack documentation merge.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `tests/integration/contracts/cacheArchitectureCoverage.test.ts` | This is the PR-blocking architecture contract. | AST coverage is strict enough to prevent bypasses without blocking the permitted executor and exact media exception. | Focused integration test: 12/12 passed. |
| P2 | `src/utilities/cachePolicy/index.ts`, `src/hooks/media/revalidateMediaConsumers.ts` | The contract needs a complete catalog and one bounded legacy exception. | The deferred DoctorTreatments classification adds no runtime invalidation and the exception remains limited to #1468. | Cache policy unit test: 9/9 passed. |
| P2 | `.github/scripts/ci/detect-migration-diff.sh`, `tests/tooling/scripts/detect-migration-diff.test.ts` | Instruction files inside collection paths must not be treated as persisted-schema changes. | Scoped `AGENTS.md` is ignored while actual collection config remains schema-relevant. | Tooling test: 4/4 passed. |
| P2 | `AGENTS.md`, `src/**/AGENTS.md`, `.codex/skills/**`, `.codex/agents/cache-architecture-reviewer.toml` | Instruction hierarchy governs future architecture decisions. | The three-way decision, stop conditions, and reviewer trigger stay concise and consistent with ADR 023. | `pnpm ai:slop-check` and both skill validators passed. |

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed.
- [ ] `pnpm build`: not run; no routing, Payload config, output, or rendering behavior changed.
- [x] Focused tests: `vitest tests/integration/contracts/cacheArchitectureCoverage.test.ts --project integration` (12/12), `vitest tests/unit/utilities/cachePolicy.test.ts --project unit` (9/9), `vitest tests/tooling/scripts/detect-migration-diff.test.ts --project tooling` (4/4), and `vitest src/stories/organisms/PostHero.stories.tsx --project storybook --run` (26/26, three consecutive runs).
- [ ] UI/mobile QA: not applicable; no rendered UI behavior changed, only existing Storybook interaction-test instrumentation.
- [ ] Security/privacy review: not run; explicit reviewer confirmation is required.
- [x] Migration/schema guard: the focused detector test and the current PR diff both report `schema_changed=false`.
- [x] Documentation/instructions check: `pnpm ai:slop-check`, `pnpm docs:check`, and both skill validators passed.

## Risk and rollout

None known. The PR adds planning and mechanical guardrails only. It does not add cache storage, change public cache behavior, or introduce new runtime cache APIs. The generated Payload type drift from stacked PR8 remains outside this PR because no schema source changes here require a Payload type comparison.

## Development

Closes #1476

