### PR TITLE
fix: show actionable media upload errors

### DIFF
--- a/.github/scripts/ci/detect-migration-diff.sh
+++ b/.github/scripts/ci/detect-migration-diff.sh
@@ -53,11 +53,14 @@ schema_pattern='^(src/collections/|src/globals/|src/fields/|src/plugins/|src/pay
 migration_pattern='^src/migrations/'
 db_tooling_pattern='^(\.github/workflows/db-quality\.yml|\.github/workflows/deploy\.yml|\.github/scripts/ci/(detect-migration-diff|enforce-schema-migration|wait-for-postgres)\.sh|scripts/(migration-risk-scan|test-database-harness)\.mjs|vitest\.config\.ts)$'
 import_export_allowlist_line_regex="^[+-][[:space:]]*\\{[[:space:]]*slug:[[:space:]]*'[^']+'(,[[:space:]]*(import|export):[[:space:]]*false)?[[:space:]]*\\},?[[:space:]]*$"
-hook_only_collection_hook_identifier_regex="(beforeOperationPrepareUploadFilename|createSupabaseUserHook|enforcePlatformStaffEmailDomainHook|revalidateDeletedPlatformContentMediaConsumers|revalidatePlatformContentMediaConsumers|revalidate[[:alnum:]_]+|stableIdBeforeChangeHook|updateAverage(Price|Ratings)After(Change|Delete))"
-hook_only_collection_line_regex="^[+-][[:space:]]*(import[[:space:]]*\\{|import[[:space:]].*from[[:space:]]'(@/hooks|\\./hooks)/[^']+'|\\}[[:space:]]*from[[:space:]]'(@/hooks|\\./hooks)/[^']+'|[[:space:]]*((beforeChange|afterChange|afterDelete):[[:space:]]*\\[)?${hook_only_collection_hook_identifier_regex}(,[[:space:]]*${hook_only_collection_hook_identifier_regex})*\\]?,?|\\{|\\})[[:space:]]*$"
+hook_only_collection_hook_identifier_regex="(beforeOperationPrepareUploadFilename|beforeOperationValidateMediaUpload|createSupabaseUserHook|enforcePlatformStaffEmailDomainHook|revalidateDeletedPlatformContentMediaConsumers|revalidatePlatformContentMediaConsumers|revalidate[[:alnum:]_]+|stableIdBeforeChangeHook|updateAverage(Price|Ratings)After(Change|Delete))"
+hook_only_collection_line_regex="^[+-][[:space:]]*(import[[:space:]]*\\{|import[[:space:]].*from[[:space:]]'(@/hooks|\\./hooks)/[^']+'|\\}[[:space:]]*from[[:space:]]'(@/hooks|\\./hooks)/[^']+'|[[:space:]]*((beforeOperation|beforeChange|afterChange|afterDelete):[[:space:]]*\\[)?${hook_only_collection_hook_identifier_regex}(,[[:space:]]*${hook_only_collection_hook_identifier_regex})*\\]?,?|\\{|\\})[[:space:]]*$"
+collection_upload_component_line_regex="^[+-][[:space:]]*(components:[[:space:]]*\\{|edit:[[:space:]]*\\{|Upload:[[:space:]]*'@/app/\\(payload\\)/components/PolicyAwareUpload',?|\\{|\\},?)[[:space:]]*$"
 collection_crypto_import_line_regex="^[+-][[:space:]]*import[[:space:]]*\\{[[:space:]]*randomUUID[[:space:]]*\\}[[:space:]]*from[[:space:]]*'(node:)?crypto'[[:space:]]*$"
 payload_config_endpoint_import_line_regex="^[+-][[:space:]]*import[[:space:]]*\\{[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\\}[[:space:]]*from[[:space:]]*'./endpoints/[A-Za-z0-9_./-]+'[[:space:]]*$"
 payload_config_endpoint_line_regex="^[+-][[:space:]]*(\\{|\\},?|path:[[:space:]]*'/?[A-Za-z0-9_./-]+'[,]?|method:[[:space:]]*'(get|post|put|patch|delete)'[,]?|handler:[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]+as[[:space:]]+PayloadHandler[,]?)[[:space:]]*$"
+payload_config_upload_policy_import_line_regex="^[+-][[:space:]]*import[[:space:]]*\\{[[:space:]]*MEDIA_UPLOAD_MAX_BYTES,[[:space:]]*MEDIA_UPLOAD_TOO_LARGE_MESSAGE[[:space:]]*\\}[[:space:]]*from[[:space:]]*'@/config/mediaUploadPolicy'[[:space:]]*$"
+payload_config_upload_policy_line_regex="^[+-][[:space:]]*(//.*|upload:[[:space:]]*\\{|limits:[[:space:]]*\\{|fileSize:[[:space:]]*(MEDIA_UPLOAD_MAX_BYTES|5[[:space:]]*\\*[[:space:]]*1024[[:space:]]*\\*[[:space:]]*1024),?([[:space:]]*//.*)?|abortOnLimit:[[:space:]]*true,?|responseOnLimit:[[:space:]]*(MEDIA_UPLOAD_TOO_LARGE_MESSAGE|'File size limit exceeded \\(5MB\\)'),?|safeFileNames:[[:space:]]*true,?|\\},?)[[:space:]]*$"
 
 schema_changed=false
 migrations_changed=false
@@ -93,7 +96,7 @@ is_import_export_plugin_allowlist_only_change() {
   return 0
 }
 
-is_hook_only_collection_change() {
+is_runtime_only_collection_change() {
   local file_path="$1"
   local diff
   local diff_line
@@ -114,7 +117,37 @@ is_hook_only_collection_change() {
     esac
 
     if [[ "${diff_line}" == +* || "${diff_line}" == -* ]]; then
-      if [[ ! "${diff_line}" =~ ${hook_only_collection_line_regex} && ! "${diff_line}" =~ ${collection_crypto_import_line_regex} ]]; then
+      if [[ ! "${diff_line}" =~ ${hook_only_collection_line_regex} && ! "${diff_line}" =~ ${collection_upload_component_line_regex} && ! "${diff_line}" =~ ${collection_crypto_import_line_regex} ]]; then
+        return 1
+      fi
+    fi
+  done <<<"${diff}"
+
+  return 0
+}
+
+# Payload's top-level upload parser limit controls request handling, not persisted fields.
+is_upload_policy_only_payload_config_change() {
+  local diff
+  local diff_line
+
+  if ! diff="$(git diff --unified=0 --diff-filter=ACMR "${effective_range}" -- src/payload.config.ts)"; then
+    return 1
+  fi
+
+  if [[ -z "${diff}" ]]; then
+    return 1
+  fi
+
+  while IFS= read -r diff_line; do
+    case "${diff_line}" in
+      'diff --git'* | 'index '* | '--- '* | '+++ '* | '@@'*)
+        continue
+        ;;
+    esac
+
+    if [[ "${diff_line}" == +* || "${diff_line}" == -* ]]; then
+      if [[ ! "${diff_line}" =~ ${payload_config_upload_policy_import_line_regex} && ! "${diff_line}" =~ ${payload_config_upload_policy_line_regex} ]]; then
         return 1
       fi
     fi
@@ -166,7 +199,7 @@ if grep -qx 'src/plugins/index.ts' <<<"${schema_changed_files}" && is_import_exp
   schema_changed_files="$(grep -vx 'src/plugins/index.ts' <<<"${schema_changed_files}" || true)"
 fi
 
-if grep -qx 'src/payload.config.ts' <<<"${schema_changed_files}" && is_endpoint_only_payload_config_change; then
+if grep -qx 'src/payload.config.ts' <<<"${schema_changed_files}" && { is_endpoint_only_payload_config_change || is_upload_policy_only_payload_config_change; }; then
   schema_changed_files="$(grep -vx 'src/payload.config.ts' <<<"${schema_changed_files}" || true)"
 fi
 
@@ -181,7 +214,7 @@ if [[ -n "${schema_changed_files}" ]]; then
       continue
     fi
 
-    if [[ "${schema_file}" =~ ^src/collections/ ]] && is_hook_only_collection_change "${schema_file}"; then
+    if [[ "${schema_file}" =~ ^src/collections/ ]] && is_runtime_only_collection_change "${schema_file}"; then
       continue
     fi
 

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -22,6 +22,7 @@ import { ExportListMenuItem as ExportListMenuItem_cdf7e044479f899a31f804427d568b
 import { ImportListMenuItem as ImportListMenuItem_cdf7e044479f899a31f804427d568b36 } from '@payloadcms/plugin-import-export/rsc'
 import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { default as default_5ecb274b48d69152edaeef5b36c5c4d8 } from '@/app/(payload)/components/PolicyAwareUpload'
 import { default as default_edf1bab331b69df45f809a41e2fc2349 } from '@/components/organisms/MedicalSpecialtiesAdminGuidance'
 import { LinkToDoc as LinkToDoc_aead06e4cbf6b2620c5c51c9ab283634 } from '@payloadcms/plugin-search/client'
 import { ReindexButton as ReindexButton_aead06e4cbf6b2620c5c51c9ab283634 } from '@payloadcms/plugin-search/client'
@@ -76,6 +77,7 @@ export const importMap = {
   "@payloadcms/plugin-import-export/rsc#ImportListMenuItem": ImportListMenuItem_cdf7e044479f899a31f804427d568b36,
   "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@/app/(payload)/components/PolicyAwareUpload#default": default_5ecb274b48d69152edaeef5b36c5c4d8,
   "@/components/organisms/MedicalSpecialtiesAdminGuidance#default": default_edf1bab331b69df45f809a41e2fc2349,
   "@payloadcms/plugin-search/client#LinkToDoc": LinkToDoc_aead06e4cbf6b2620c5c51c9ab283634,
   "@payloadcms/plugin-search/client#ReindexButton": ReindexButton_aead06e4cbf6b2620c5c51c9ab283634,

--- a/src/app/(payload)/components/PolicyAwareUpload/index.scss
+++ b/src/app/(payload)/components/PolicyAwareUpload/index.scss
@@ -1,0 +1,15 @@
+.policy-aware-upload {
+  &__hint,
+  &__error {
+    margin-block: calc(var(--base) * 0.5) 0;
+    font-size: var(--base-body-size);
+  }
+
+  &__hint {
+    color: var(--theme-elevation-500);
+  }
+
+  &__error {
+    color: var(--theme-error-500);
+  }
+}

--- a/src/app/(payload)/components/PolicyAwareUpload/index.tsx
+++ b/src/app/(payload)/components/PolicyAwareUpload/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast, Upload, useConfig, useDocumentInfo, useField } from '@payloadcms/ui'
 
 import { getMediaUploadHint, getMediaUploadValidationError } from '@/config/mediaUploadPolicy'
@@ -15,11 +15,20 @@ export default function PolicyAwareUpload() {
   const { setValue } = useField<File | undefined>({ path: 'file' })
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [uploadKey, setUploadKey] = useState(0)
+  const uploadContainerRef = useRef<HTMLDivElement>(null)
+  const shouldRestoreFocusRef = useRef(false)
 
   const collectionConfig = collectionSlug ? getEntityConfig({ collectionSlug }) : null
   const uploadConfig = collectionConfig?.upload
   const acceptedMimeTypes = useMemo(() => uploadConfig?.mimeTypes ?? [], [uploadConfig?.mimeTypes])
   const hint = useMemo(() => getMediaUploadHint(acceptedMimeTypes), [acceptedMimeTypes])
+
+  useEffect(() => {
+    if (!shouldRestoreFocusRef.current) return
+
+    shouldRestoreFocusRef.current = false
+    uploadContainerRef.current?.querySelector<HTMLButtonElement>('button')?.focus()
+  }, [uploadKey])
 
   const handleChange = useCallback(
     (file?: File) => {
@@ -42,6 +51,7 @@ export default function PolicyAwareUpload() {
       setValue(undefined)
       setUploadStatus?.('idle')
       setErrorMessage(validationError)
+      shouldRestoreFocusRef.current = true
       setUploadKey((currentKey) => currentKey + 1)
       toast.error(validationError)
     },
@@ -52,7 +62,7 @@ export default function PolicyAwareUpload() {
 
   return (
     <div className={baseClass}>
-      <div key={uploadKey}>
+      <div key={uploadKey} ref={uploadContainerRef}>
         <Upload
           collectionSlug={collectionSlug}
           initialState={initialState}

--- a/src/app/(payload)/components/PolicyAwareUpload/index.tsx
+++ b/src/app/(payload)/components/PolicyAwareUpload/index.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import React, { useCallback, useMemo, useState } from 'react'
+import { toast, Upload, useConfig, useDocumentInfo, useField } from '@payloadcms/ui'
+
+import { getMediaUploadHint, getMediaUploadValidationError } from '@/config/mediaUploadPolicy'
+
+import './index.scss'
+
+const baseClass = 'policy-aware-upload'
+
+export default function PolicyAwareUpload() {
+  const { collectionSlug, initialState, setUploadStatus } = useDocumentInfo()
+  const { getEntityConfig } = useConfig()
+  const { setValue } = useField<File | undefined>({ path: 'file' })
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [uploadKey, setUploadKey] = useState(0)
+
+  const collectionConfig = collectionSlug ? getEntityConfig({ collectionSlug }) : null
+  const uploadConfig = collectionConfig?.upload
+  const acceptedMimeTypes = useMemo(() => uploadConfig?.mimeTypes ?? [], [uploadConfig?.mimeTypes])
+  const hint = useMemo(() => getMediaUploadHint(acceptedMimeTypes), [acceptedMimeTypes])
+
+  const handleChange = useCallback(
+    (file?: File) => {
+      if (!file) {
+        setErrorMessage(null)
+        return
+      }
+
+      const validationError = getMediaUploadValidationError({
+        acceptedMimeTypes,
+        mimeType: file.type,
+        size: file.size,
+      })
+
+      if (!validationError) {
+        setErrorMessage(null)
+        return
+      }
+
+      setValue(undefined)
+      setUploadStatus?.('idle')
+      setErrorMessage(validationError)
+      setUploadKey((currentKey) => currentKey + 1)
+      toast.error(validationError)
+    },
+    [acceptedMimeTypes, setUploadStatus, setValue],
+  )
+
+  if (!collectionSlug || !uploadConfig) return null
+
+  return (
+    <div className={baseClass}>
+      <div key={uploadKey}>
+        <Upload
+          collectionSlug={collectionSlug}
+          initialState={initialState}
+          onChange={handleChange}
+          uploadConfig={uploadConfig}
+        />
+      </div>
+      <p className={`${baseClass}__hint`}>{hint}</p>
+      {errorMessage ? (
+        <p aria-live="assertive" className={`${baseClass}__error`} role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/collections/ClinicGalleryMedia/index.ts
+++ b/src/collections/ClinicGalleryMedia/index.ts
@@ -78,7 +78,7 @@ export const ClinicGalleryMedia: CollectionConfig = {
       }),
     ],
     beforeOperation: [
-      beforeOperationValidateMediaUpload({ acceptedMimeTypes: galleryMediaImageMimeTypes }),
+      beforeOperationValidateMediaUpload,
       beforeOperationPrepareUploadFilename,
       beforeOperationCaptureMediaUpload({
         ownerField: 'clinic',

--- a/src/collections/ClinicGalleryMedia/index.ts
+++ b/src/collections/ClinicGalleryMedia/index.ts
@@ -13,6 +13,7 @@ import { beforeChangeComputeStorage } from '@/hooks/media/computeStorage'
 import { beforeChangePublishedAt } from '@/hooks/publishedAt'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
 import { beforeOperationPrepareUploadFilename } from '@/hooks/media/prepareUploadFilename'
+import { beforeOperationValidateMediaUpload } from '@/hooks/media/validateMediaUpload'
 import {
   buildMediaAltField,
   buildMediaCaptionField,
@@ -39,6 +40,11 @@ export const ClinicGalleryMedia: CollectionConfig = {
     group: 'Clinics',
     description: 'Clinic gallery media',
     defaultColumns: ['clinic', 'status', 'alt', 'createdBy'],
+    components: {
+      edit: {
+        Upload: '@/app/(payload)/components/PolicyAwareUpload',
+      },
+    },
   },
   access: {
     read: clinicGalleryReadAccess,
@@ -72,6 +78,7 @@ export const ClinicGalleryMedia: CollectionConfig = {
       }),
     ],
     beforeOperation: [
+      beforeOperationValidateMediaUpload({ acceptedMimeTypes: galleryMediaImageMimeTypes }),
       beforeOperationPrepareUploadFilename,
       beforeOperationCaptureMediaUpload({
         ownerField: 'clinic',

--- a/src/collections/ClinicMedia/index.ts
+++ b/src/collections/ClinicMedia/index.ts
@@ -19,7 +19,6 @@ import {
   buildMediaPrefixField,
   buildMediaStoragePathField,
   buildMediaUploadConfig,
-  standardMediaImageMimeTypes,
 } from '@/collections/common/mediaCollection'
 
 const filename = fileURLToPath(import.meta.url)
@@ -61,7 +60,7 @@ export const ClinicMedia: CollectionConfig = {
       }),
     ],
     beforeOperation: [
-      beforeOperationValidateMediaUpload({ acceptedMimeTypes: standardMediaImageMimeTypes }),
+      beforeOperationValidateMediaUpload,
       beforeOperationPrepareUploadFilename,
       beforeOperationCaptureMediaUpload({
         ownerField: 'clinic',

--- a/src/collections/ClinicMedia/index.ts
+++ b/src/collections/ClinicMedia/index.ts
@@ -10,6 +10,7 @@ import { beforeChangeCreatedBy } from '@/hooks/createdBy'
 import { beforeChangeComputeStorage } from '@/hooks/media/computeStorage'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
 import { beforeOperationPrepareUploadFilename } from '@/hooks/media/prepareUploadFilename'
+import { beforeOperationValidateMediaUpload } from '@/hooks/media/validateMediaUpload'
 import { stableIdBeforeChangeHook, stableIdField } from '@/collections/common/stableIdField'
 import {
   buildMediaAltField,
@@ -18,6 +19,7 @@ import {
   buildMediaPrefixField,
   buildMediaStoragePathField,
   buildMediaUploadConfig,
+  standardMediaImageMimeTypes,
 } from '@/collections/common/mediaCollection'
 
 const filename = fileURLToPath(import.meta.url)
@@ -29,6 +31,11 @@ export const ClinicMedia: CollectionConfig = {
     group: 'Clinics',
     description: 'Clinic images and files',
     defaultColumns: ['clinic', 'alt', 'createdBy'],
+    components: {
+      edit: {
+        Upload: '@/app/(payload)/components/PolicyAwareUpload',
+      },
+    },
   },
   access: {
     read: clinicMediaReadAccess,
@@ -54,6 +61,7 @@ export const ClinicMedia: CollectionConfig = {
       }),
     ],
     beforeOperation: [
+      beforeOperationValidateMediaUpload({ acceptedMimeTypes: standardMediaImageMimeTypes }),
       beforeOperationPrepareUploadFilename,
       beforeOperationCaptureMediaUpload({
         ownerField: 'clinic',

--- a/src/collections/DoctorMedia/index.ts
+++ b/src/collections/DoctorMedia/index.ts
@@ -14,6 +14,7 @@ import { beforeChangeDoctorMedia } from './hooks/beforeChangeDoctorMedia'
 import type { DoctorMedia as DoctorMediaType } from '@/payload-types'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
 import { beforeOperationPrepareUploadFilename } from '@/hooks/media/prepareUploadFilename'
+import { beforeOperationValidateMediaUpload } from '@/hooks/media/validateMediaUpload'
 import {
   buildMediaAltField,
   buildMediaCaptionField,
@@ -21,6 +22,7 @@ import {
   buildMediaPrefixField,
   buildMediaStoragePathField,
   buildMediaUploadConfig,
+  standardMediaImageMimeTypes,
 } from '@/collections/common/mediaCollection'
 
 const filename = fileURLToPath(import.meta.url)
@@ -32,6 +34,11 @@ export const DoctorMedia: CollectionConfig = {
     group: 'Medical Network',
     description: 'Doctor images tied to their clinic',
     defaultColumns: ['doctor', 'clinic', 'alt', 'createdBy'],
+    components: {
+      edit: {
+        Upload: '@/app/(payload)/components/PolicyAwareUpload',
+      },
+    },
   },
   access: {
     read: doctorMediaReadAccess,
@@ -67,6 +74,7 @@ export const DoctorMedia: CollectionConfig = {
     afterError: [afterErrorLogMediaUploadError],
     beforeChange: [stableIdBeforeChangeHook, beforeChangeDoctorMedia],
     beforeOperation: [
+      beforeOperationValidateMediaUpload({ acceptedMimeTypes: standardMediaImageMimeTypes }),
       beforeOperationPrepareUploadFilename,
       beforeOperationCaptureMediaUpload({
         ownerField: 'doctor',

--- a/src/collections/DoctorMedia/index.ts
+++ b/src/collections/DoctorMedia/index.ts
@@ -22,7 +22,6 @@ import {
   buildMediaPrefixField,
   buildMediaStoragePathField,
   buildMediaUploadConfig,
-  standardMediaImageMimeTypes,
 } from '@/collections/common/mediaCollection'
 
 const filename = fileURLToPath(import.meta.url)
@@ -74,7 +73,7 @@ export const DoctorMedia: CollectionConfig = {
     afterError: [afterErrorLogMediaUploadError],
     beforeChange: [stableIdBeforeChangeHook, beforeChangeDoctorMedia],
     beforeOperation: [
-      beforeOperationValidateMediaUpload({ acceptedMimeTypes: standardMediaImageMimeTypes }),
+      beforeOperationValidateMediaUpload,
       beforeOperationPrepareUploadFilename,
       beforeOperationCaptureMediaUpload({
         ownerField: 'doctor',

--- a/src/collections/PlatformContentMedia/index.ts
+++ b/src/collections/PlatformContentMedia/index.ts
@@ -13,9 +13,11 @@ import {
   buildMediaPrefixField,
   buildMediaStoragePathField,
   buildMediaUploadConfig,
+  standardMediaImageMimeTypes,
 } from '@/collections/common/mediaCollection'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
 import { beforeOperationPrepareUploadFilename } from '@/hooks/media/prepareUploadFilename'
+import { beforeOperationValidateMediaUpload } from '@/hooks/media/validateMediaUpload'
 import {
   revalidateDeletedPlatformContentMediaConsumers,
   revalidatePlatformContentMediaConsumers,
@@ -30,6 +32,11 @@ export const PlatformContentMedia: CollectionConfig = {
     group: 'Content & Media',
     description: 'Media used on public pages and blocks',
     defaultColumns: ['alt', 'createdBy'],
+    components: {
+      edit: {
+        Upload: '@/app/(payload)/components/PolicyAwareUpload',
+      },
+    },
   },
   access: {
     read: anyone,
@@ -44,6 +51,7 @@ export const PlatformContentMedia: CollectionConfig = {
     afterError: [afterErrorLogMediaUploadError],
     beforeChange: [stableIdBeforeChangeHook, beforeChangePlatformContentMedia],
     beforeOperation: [
+      beforeOperationValidateMediaUpload({ acceptedMimeTypes: standardMediaImageMimeTypes }),
       beforeOperationPrepareUploadFilename,
       beforeOperationCaptureMediaUpload({
         storagePrefix: 'platform',

--- a/src/collections/PlatformContentMedia/index.ts
+++ b/src/collections/PlatformContentMedia/index.ts
@@ -13,7 +13,6 @@ import {
   buildMediaPrefixField,
   buildMediaStoragePathField,
   buildMediaUploadConfig,
-  standardMediaImageMimeTypes,
 } from '@/collections/common/mediaCollection'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
 import { beforeOperationPrepareUploadFilename } from '@/hooks/media/prepareUploadFilename'
@@ -51,7 +50,7 @@ export const PlatformContentMedia: CollectionConfig = {
     afterError: [afterErrorLogMediaUploadError],
     beforeChange: [stableIdBeforeChangeHook, beforeChangePlatformContentMedia],
     beforeOperation: [
-      beforeOperationValidateMediaUpload({ acceptedMimeTypes: standardMediaImageMimeTypes }),
+      beforeOperationValidateMediaUpload,
       beforeOperationPrepareUploadFilename,
       beforeOperationCaptureMediaUpload({
         storagePrefix: 'platform',

--- a/src/collections/UserProfileMedia/index.ts
+++ b/src/collections/UserProfileMedia/index.ts
@@ -15,7 +15,6 @@ import {
   buildMediaPrefixField,
   buildMediaStoragePathField,
   buildMediaUploadConfig,
-  standardMediaImageMimeTypes,
 } from '@/collections/common/mediaCollection'
 
 const filename = fileURLToPath(import.meta.url)
@@ -196,7 +195,7 @@ export const UserProfileMedia: CollectionConfig = {
       }),
     ],
     beforeOperation: [
-      beforeOperationValidateMediaUpload({ acceptedMimeTypes: standardMediaImageMimeTypes }),
+      beforeOperationValidateMediaUpload,
       beforeOperationPrepareUploadFilename,
       beforeOperationCaptureMediaUpload({
         ownerField: 'user',

--- a/src/collections/UserProfileMedia/index.ts
+++ b/src/collections/UserProfileMedia/index.ts
@@ -7,6 +7,7 @@ import { stableIdBeforeChangeHook, stableIdField } from '@/collections/common/st
 import { beforeChangeComputeStorage } from '@/hooks/media/computeStorage'
 import { afterErrorLogMediaUploadError, beforeOperationCaptureMediaUpload } from '@/hooks/media/uploadLogging'
 import { beforeOperationPrepareUploadFilename } from '@/hooks/media/prepareUploadFilename'
+import { beforeOperationValidateMediaUpload } from '@/hooks/media/validateMediaUpload'
 import { beforeChangeFreezeRelation } from '@/hooks/ownership'
 import type { UserProfileMedia as UserProfileMediaType } from '@/payload-types'
 import {
@@ -14,6 +15,7 @@ import {
   buildMediaPrefixField,
   buildMediaStoragePathField,
   buildMediaUploadConfig,
+  standardMediaImageMimeTypes,
 } from '@/collections/common/mediaCollection'
 
 const filename = fileURLToPath(import.meta.url)
@@ -99,6 +101,11 @@ export const UserProfileMedia: CollectionConfig = {
     group: 'User Management',
     description: 'Profile images and personal media',
     defaultColumns: ['user', 'createdBy'],
+    components: {
+      edit: {
+        Upload: '@/app/(payload)/components/PolicyAwareUpload',
+      },
+    },
   },
   access: {
     read: ({ req }) => {
@@ -189,6 +196,7 @@ export const UserProfileMedia: CollectionConfig = {
       }),
     ],
     beforeOperation: [
+      beforeOperationValidateMediaUpload({ acceptedMimeTypes: standardMediaImageMimeTypes }),
       beforeOperationPrepareUploadFilename,
       beforeOperationCaptureMediaUpload({
         ownerField: 'user',

--- a/src/config/mediaUploadPolicy.ts
+++ b/src/config/mediaUploadPolicy.ts
@@ -1,0 +1,57 @@
+export const MEDIA_UPLOAD_MAX_BYTES = 4 * 1024 * 1024
+export const MEDIA_UPLOAD_MAX_SIZE_LABEL = '4 MB'
+
+export const MEDIA_UPLOAD_TOO_LARGE_MESSAGE = `Image is too large. Maximum file size is ${MEDIA_UPLOAD_MAX_SIZE_LABEL}.`
+export const MEDIA_STORAGE_LIMIT_MESSAGE =
+  'Image processing exceeded the storage limit. Please reduce the image dimensions or file size and try again.'
+
+const MEDIA_FORMAT_LABELS: Record<string, string> = {
+  'image/jpeg': 'JPG',
+  'image/png': 'PNG',
+  'image/webp': 'WebP',
+  'image/avif': 'AVIF',
+  'image/gif': 'GIF',
+  'image/svg+xml': 'SVG',
+}
+
+export function getAcceptedMediaFormatLabels(mimeTypes: readonly string[]): string[] {
+  return mimeTypes.map((mimeType) => MEDIA_FORMAT_LABELS[mimeType] ?? mimeType)
+}
+
+export function getAcceptedMediaFormats(mimeTypes: readonly string[]): string {
+  return getAcceptedMediaFormatLabels(mimeTypes).join(', ')
+}
+
+export function getMediaUploadHint(mimeTypes: readonly string[]): string {
+  return `Accepted formats: ${getAcceptedMediaFormats(mimeTypes)}. Maximum file size: ${MEDIA_UPLOAD_MAX_SIZE_LABEL}.`
+}
+
+export function getUnsupportedMediaFormatMessage(mimeTypes: readonly string[]): string {
+  return `Unsupported image format. Accepted formats: ${getAcceptedMediaFormats(mimeTypes)}.`
+}
+
+export function isAcceptedMediaMimeType(mimeType: string, acceptedMimeTypes: readonly string[]): boolean {
+  return acceptedMimeTypes.some((acceptedMimeType) => {
+    if (acceptedMimeType.endsWith('/*')) {
+      return mimeType.startsWith(acceptedMimeType.slice(0, -1))
+    }
+
+    return mimeType === acceptedMimeType
+  })
+}
+
+export function getMediaUploadValidationError(options: {
+  acceptedMimeTypes: readonly string[]
+  mimeType?: string
+  size?: number
+}): string | null {
+  if (typeof options.size === 'number' && options.size > MEDIA_UPLOAD_MAX_BYTES) {
+    return MEDIA_UPLOAD_TOO_LARGE_MESSAGE
+  }
+
+  if (!options.mimeType || !isAcceptedMediaMimeType(options.mimeType, options.acceptedMimeTypes)) {
+    return getUnsupportedMediaFormatMessage(options.acceptedMimeTypes)
+  }
+
+  return null
+}

--- a/src/hooks/media/uploadLogging.ts
+++ b/src/hooks/media/uploadLogging.ts
@@ -3,6 +3,7 @@ import {
   getIncomingUploadFilename,
   resolveFilenameSource,
 } from '@/collections/common/mediaPathHelpers'
+import { MEDIA_STORAGE_LIMIT_MESSAGE } from '@/config/mediaUploadPolicy'
 import { extractFileSizeFromRequest } from '@/utilities/requestFileUtils'
 import { createScopedLogger, getRequestLogContext, type ServerLogger } from '@/utilities/logging/shared'
 import type { CollectionAfterErrorHook, CollectionBeforeOperationHook, PayloadRequest } from 'payload'
@@ -72,11 +73,30 @@ const hasIncomingUpload = (args: Record<string, unknown> | undefined, req: Paylo
 
 type MissingKeyErrorLike = {
   name?: unknown
+  code?: unknown
   Code?: unknown
   message?: unknown
   Resource?: unknown
   cause?: unknown
   err?: unknown
+}
+
+const getNestedErrorCandidates = (error: unknown): MissingKeyErrorLike[] => {
+  const candidates: MissingKeyErrorLike[] = []
+  const queue: unknown[] = [error]
+  const visited = new Set<object>()
+
+  while (queue.length > 0 && candidates.length < 12) {
+    const candidate = queue.shift()
+    if (!candidate || typeof candidate !== 'object' || visited.has(candidate)) continue
+
+    visited.add(candidate)
+    const errorLike = candidate as MissingKeyErrorLike
+    candidates.push(errorLike)
+    queue.push(errorLike.cause, errorLike.err)
+  }
+
+  return candidates
 }
 
 function parseMissingResourceFromMessage(message: string): string | null {
@@ -88,24 +108,10 @@ function resolveMissingS3Key(error: unknown): string | null {
   const bucket = process.env.S3_BUCKET || ''
   if (!bucket) return null
 
-  const candidates: MissingKeyErrorLike[] = []
-  if (error && typeof error === 'object') {
-    candidates.push(error as MissingKeyErrorLike)
-
-    const cause = (error as { cause?: unknown }).cause
-    if (cause && typeof cause === 'object') {
-      candidates.push(cause as MissingKeyErrorLike)
-    }
-
-    const nestedErr = (error as { err?: unknown }).err
-    if (nestedErr && typeof nestedErr === 'object') {
-      candidates.push(nestedErr as MissingKeyErrorLike)
-    }
-  }
-
-  for (const candidate of candidates) {
+  for (const candidate of getNestedErrorCandidates(error)) {
     const name = typeof candidate.name === 'string' ? candidate.name : ''
-    const code = typeof candidate.Code === 'string' ? candidate.Code : ''
+    const code =
+      typeof candidate.Code === 'string' ? candidate.Code : typeof candidate.code === 'string' ? candidate.code : ''
     const message = typeof candidate.message === 'string' ? candidate.message : ''
     const resourceRaw =
       typeof candidate.Resource === 'string'
@@ -125,6 +131,21 @@ function resolveMissingS3Key(error: unknown): string | null {
   }
 
   return null
+}
+
+function isEntityTooLargeError(error: unknown): boolean {
+  return getNestedErrorCandidates(error).some((candidate) => {
+    const name = typeof candidate.name === 'string' ? candidate.name : ''
+    const code =
+      typeof candidate.Code === 'string' ? candidate.Code : typeof candidate.code === 'string' ? candidate.code : ''
+    const message = typeof candidate.message === 'string' ? candidate.message : ''
+
+    return (
+      name === 'EntityTooLarge' ||
+      code === 'EntityTooLarge' ||
+      /EntityTooLarge|maximum allowed object size/i.test(message)
+    )
+  })
 }
 
 function shouldDowngradeMissingKeyError(req: PayloadRequest, error: unknown): boolean {
@@ -204,4 +225,13 @@ export const afterErrorLogMediaUploadError: CollectionAfterErrorHook = ({ collec
   )
 
   delete req.context?.[MEDIA_UPLOAD_CONTEXT_KEY]
+
+  if (isEntityTooLargeError(error)) {
+    return {
+      response: {
+        errors: [{ message: MEDIA_STORAGE_LIMIT_MESSAGE }],
+      },
+      status: 413,
+    }
+  }
 }

--- a/src/hooks/media/validateMediaUpload.ts
+++ b/src/hooks/media/validateMediaUpload.ts
@@ -1,0 +1,75 @@
+import {
+  getMediaUploadValidationError,
+  getUnsupportedMediaFormatMessage,
+  MEDIA_UPLOAD_TOO_LARGE_MESSAGE,
+} from '@/config/mediaUploadPolicy'
+import {
+  extractFileFromRequest,
+  extractFileMimeTypeFromRequest,
+  extractFileSizeFromRequest,
+  type RequestFile,
+} from '@/utilities/requestFileUtils'
+import { APIError, type CollectionBeforeOperationHook } from 'payload'
+import sharp from 'sharp'
+
+const SHARP_FORMAT_MIME_TYPES: Record<string, string> = {
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+  avif: 'image/avif',
+  gif: 'image/gif',
+  svg: 'image/svg+xml',
+}
+
+const detectIncomingFileMimeType = async (file: RequestFile): Promise<string | null | undefined> => {
+  const data = file.data
+  if (data instanceof Uint8Array && data.length > 0) {
+    const metadata = await sharp(data).metadata()
+    return metadata.format ? (SHARP_FORMAT_MIME_TYPES[metadata.format] ?? null) : null
+  }
+
+  const tempFilePath = file.tempFilePath
+  if (typeof tempFilePath === 'string' && tempFilePath.length > 0) {
+    const metadata = await sharp(tempFilePath).metadata()
+    return metadata.format ? (SHARP_FORMAT_MIME_TYPES[metadata.format] ?? null) : null
+  }
+
+  return undefined
+}
+
+export const beforeOperationValidateMediaUpload =
+  ({ acceptedMimeTypes }: { acceptedMimeTypes: readonly string[] }): CollectionBeforeOperationHook =>
+  async ({ args, operation, req }) => {
+    if (operation !== 'create' && operation !== 'update') return
+
+    const mimeType = extractFileMimeTypeFromRequest(args) ?? extractFileMimeTypeFromRequest(req)
+    const size = extractFileSizeFromRequest(args) ?? extractFileSizeFromRequest(req)
+    const file = extractFileFromRequest(args) ?? extractFileFromRequest(req)
+
+    if (!mimeType && typeof size !== 'number') return
+
+    const initialMessage = getMediaUploadValidationError({ acceptedMimeTypes, mimeType, size })
+    if (initialMessage) {
+      throw new APIError(initialMessage, initialMessage === MEDIA_UPLOAD_TOO_LARGE_MESSAGE ? 413 : 400)
+    }
+
+    let effectiveMimeType = mimeType
+
+    if (file) {
+      try {
+        const detectedMimeType = await detectIncomingFileMimeType(file)
+        if (detectedMimeType) {
+          effectiveMimeType = detectedMimeType
+        } else if (detectedMimeType === null && mimeType !== 'image/svg+xml') {
+          effectiveMimeType = undefined
+        }
+      } catch {
+        throw new APIError(getUnsupportedMediaFormatMessage(acceptedMimeTypes), 400)
+      }
+    }
+
+    const message = getMediaUploadValidationError({ acceptedMimeTypes, mimeType: effectiveMimeType, size })
+    if (!message) return
+
+    throw new APIError(message, message === MEDIA_UPLOAD_TOO_LARGE_MESSAGE ? 413 : 400)
+  }

--- a/src/hooks/media/validateMediaUpload.ts
+++ b/src/hooks/media/validateMediaUpload.ts
@@ -37,39 +37,43 @@ const detectIncomingFileMimeType = async (file: RequestFile): Promise<string | n
   return undefined
 }
 
-export const beforeOperationValidateMediaUpload =
-  ({ acceptedMimeTypes }: { acceptedMimeTypes: readonly string[] }): CollectionBeforeOperationHook =>
-  async ({ args, operation, req }) => {
-    if (operation !== 'create' && operation !== 'update') return
+export const beforeOperationValidateMediaUpload: CollectionBeforeOperationHook = async ({
+  args,
+  collection,
+  operation,
+  req,
+}) => {
+  if (operation !== 'create' && operation !== 'update') return
 
-    const mimeType = extractFileMimeTypeFromRequest(args) ?? extractFileMimeTypeFromRequest(req)
-    const size = extractFileSizeFromRequest(args) ?? extractFileSizeFromRequest(req)
-    const file = extractFileFromRequest(args) ?? extractFileFromRequest(req)
+  const acceptedMimeTypes = collection.upload.mimeTypes ?? []
+  const mimeType = extractFileMimeTypeFromRequest(args) ?? extractFileMimeTypeFromRequest(req)
+  const size = extractFileSizeFromRequest(args) ?? extractFileSizeFromRequest(req)
+  const file = extractFileFromRequest(args) ?? extractFileFromRequest(req)
 
-    if (!mimeType && typeof size !== 'number') return
+  if (!mimeType && typeof size !== 'number') return
 
-    const initialMessage = getMediaUploadValidationError({ acceptedMimeTypes, mimeType, size })
-    if (initialMessage) {
-      throw new APIError(initialMessage, initialMessage === MEDIA_UPLOAD_TOO_LARGE_MESSAGE ? 413 : 400)
-    }
-
-    let effectiveMimeType = mimeType
-
-    if (file) {
-      try {
-        const detectedMimeType = await detectIncomingFileMimeType(file)
-        if (detectedMimeType) {
-          effectiveMimeType = detectedMimeType
-        } else if (detectedMimeType === null && mimeType !== 'image/svg+xml') {
-          effectiveMimeType = undefined
-        }
-      } catch {
-        throw new APIError(getUnsupportedMediaFormatMessage(acceptedMimeTypes), 400)
-      }
-    }
-
-    const message = getMediaUploadValidationError({ acceptedMimeTypes, mimeType: effectiveMimeType, size })
-    if (!message) return
-
-    throw new APIError(message, message === MEDIA_UPLOAD_TOO_LARGE_MESSAGE ? 413 : 400)
+  const initialMessage = getMediaUploadValidationError({ acceptedMimeTypes, mimeType, size })
+  if (initialMessage) {
+    throw new APIError(initialMessage, initialMessage === MEDIA_UPLOAD_TOO_LARGE_MESSAGE ? 413 : 400)
   }
+
+  let effectiveMimeType = mimeType
+
+  if (file) {
+    try {
+      const detectedMimeType = await detectIncomingFileMimeType(file)
+      if (detectedMimeType) {
+        effectiveMimeType = detectedMimeType
+      } else if (detectedMimeType === null && mimeType !== 'image/svg+xml') {
+        effectiveMimeType = undefined
+      }
+    } catch {
+      throw new APIError(getUnsupportedMediaFormatMessage(acceptedMimeTypes), 400)
+    }
+  }
+
+  const message = getMediaUploadValidationError({ acceptedMimeTypes, mimeType: effectiveMimeType, size })
+  if (!message) return
+
+  throw new APIError(message, message === MEDIA_UPLOAD_TOO_LARGE_MESSAGE ? 413 : 400)
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -55,6 +55,7 @@ import { plugins } from './plugins'
 import { defaultLexical } from '@/fields/defaultLexical'
 import { getServerSideURL } from './utilities/getURL'
 import { CONTENT_LOCALES, DEFAULT_CONTENT_LOCALE } from '@/utilities/contentLocalization'
+import { MEDIA_UPLOAD_MAX_BYTES, MEDIA_UPLOAD_TOO_LARGE_MESSAGE } from '@/config/mediaUploadPolicy'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -77,14 +78,13 @@ const silentEmailAdapter: EmailAdapter<void> = () => ({
 })
 
 export default buildConfig({
-  // Global upload constraints (Busboy limits). 5MB per file to keep tenant assets lightweight.
-  // Can be raised later via env-driven config if needed.
+  // Keep the complete multipart request below Vercel's 4.5 MB request limit.
   upload: {
     limits: {
-      fileSize: 5 * 1024 * 1024, // 5MB
+      fileSize: MEDIA_UPLOAD_MAX_BYTES,
     },
     abortOnLimit: true,
-    responseOnLimit: 'File size limit exceeded (5MB)',
+    responseOnLimit: MEDIA_UPLOAD_TOO_LARGE_MESSAGE,
     safeFileNames: true,
   },
   endpoints: [

--- a/src/utilities/requestFileUtils.ts
+++ b/src/utilities/requestFileUtils.ts
@@ -1,25 +1,19 @@
-/**
- * Helpers for extracting file metadata from incoming requests.
- * Keep this small and defensive because request shapes vary between adapters.
- */
-export function extractFileSizeFromRequest(req?: unknown): number | undefined {
+export type RequestFile = Record<string, unknown>
+
+export function extractFileFromRequest(req?: unknown): RequestFile | undefined {
   if (!req || typeof req !== 'object') return undefined
   const r = req as Record<string, unknown>
 
   // single-file upload (e.g. multer library req.file)
   if (r.file && typeof r.file === 'object') {
-    const file = r.file as Record<string, unknown>
-    if (typeof file.size === 'number') {
-      return file.size
-    }
+    return r.file as RequestFile
   }
 
   // array of files
   if (Array.isArray(r.files) && r.files.length) {
     const first = r.files[0]
     if (first && typeof first === 'object') {
-      const f = first as Record<string, unknown>
-      if (typeof f.size === 'number') return f.size
+      return first as RequestFile
     }
     return undefined
   }
@@ -30,16 +24,29 @@ export function extractFileSizeFromRequest(req?: unknown): number | undefined {
       if (Array.isArray(value) && value.length) {
         const first = value[0]
         if (first && typeof first === 'object') {
-          const f = first as Record<string, unknown>
-          if (typeof f.size === 'number') return f.size
+          return first as RequestFile
         }
       }
       if (value && typeof value === 'object') {
-        const v = value as Record<string, unknown>
-        if (typeof v.size === 'number') return v.size
+        return value as RequestFile
       }
     }
   }
 
   return undefined
+}
+
+/**
+ * Helpers for extracting file metadata from incoming requests.
+ * Keep these small and defensive because request shapes vary between adapters.
+ */
+export function extractFileSizeFromRequest(req?: unknown): number | undefined {
+  const file = extractFileFromRequest(req)
+  return typeof file?.size === 'number' ? file.size : undefined
+}
+
+export function extractFileMimeTypeFromRequest(req?: unknown): string | undefined {
+  const file = extractFileFromRequest(req)
+  const mimeType = file?.mimetype ?? file?.mimeType ?? file?.type
+  return typeof mimeType === 'string' && mimeType.length > 0 ? mimeType : undefined
 }

--- a/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
+++ b/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
@@ -40,6 +40,17 @@ test('shows the gallery upload policy inside the relationship drawer @smoke', as
   const drawer = await openAdminJoinCreateDrawer(page, 'beforeMedia')
 
   await expect(drawer.getByText(GALLERY_HINT, { exact: true })).toBeVisible()
+  await page.screenshot({
+    fullPage: true,
+    path: test.info().outputPath('gallery-upload-drawer-desktop.png'),
+  })
+
+  await page.setViewportSize({ height: 844, width: 390 })
+  await expect(drawer.getByText(GALLERY_HINT, { exact: true })).toBeVisible()
+  await page.screenshot({
+    fullPage: true,
+    path: test.info().outputPath('gallery-upload-drawer-narrow.png'),
+  })
 })
 
 test('rejects invalid gallery files and saves a valid PNG @smoke', async ({ page }) => {

--- a/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
+++ b/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
@@ -47,8 +47,23 @@ test('shows the gallery upload policy inside the relationship drawer @smoke', as
     path: test.info().outputPath('gallery-upload-drawer-desktop.png'),
   })
 
+  const narrowViewports = [
+    { height: 568, width: 320 },
+    { height: 667, width: 375 },
+    { height: 844, width: 390 },
+    { height: 800, width: 640 },
+    { height: 1024, width: 768 },
+  ]
+
+  for (const viewport of narrowViewports) {
+    await page.setViewportSize(viewport)
+    await expect(drawer.getByText(GALLERY_HINT, { exact: true })).toBeVisible()
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth),
+    ).toBe(true)
+  }
+
   await page.setViewportSize({ height: 844, width: 390 })
-  await expect(drawer.getByText(GALLERY_HINT, { exact: true })).toBeVisible()
   await page.screenshot({
     fullPage: true,
     path: test.info().outputPath('gallery-upload-drawer-narrow.png'),
@@ -74,6 +89,16 @@ test('rejects invalid gallery files and saves a valid PNG @smoke', async ({ page
     'Image is too large. Maximum file size is 4 MB.',
   )
   await expect(fileInput).toHaveValue('')
+  await expect(page.getByRole('button', { name: 'Select a file' })).toBeFocused()
+
+  await page.setViewportSize({ height: 568, width: 320 })
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(
+    true,
+  )
+  await page.locator('.policy-aware-upload').screenshot({
+    path: test.info().outputPath('policy-aware-upload-too-large.png'),
+  })
+  await page.setViewportSize({ height: 720, width: 1280 })
 
   await fileInput.setInputFiles({
     name: 'unsupported.svg',
@@ -84,6 +109,7 @@ test('rejects invalid gallery files and saves a valid PNG @smoke', async ({ page
     'Unsupported image format. Accepted formats: JPG, PNG, WebP, AVIF, GIF.',
   )
   await expect(fileInput).toHaveValue('')
+  await expect(page.getByRole('button', { name: 'Select a file' })).toBeFocused()
 
   await fileInput.setInputFiles({ name: fileName, mimeType: 'image/png', buffer: TINY_PNG })
   await page.getByLabel(/^Alt Text/).fill('Upload policy smoke test')

--- a/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
+++ b/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
@@ -91,13 +91,5 @@ test('rejects invalid gallery files and saves a valid PNG @smoke', async ({ page
   await page.getByRole('button', { name: /^Save$/ }).click()
   await page.waitForURL(/\/admin\/collections\/clinicGalleryMedia\/[^/]+$/)
 
-  const documentId = page.url().match(/\/clinicGalleryMedia\/([^/?#]+)$/)?.[1]
-  expect(documentId).toBeTruthy()
-
-  if (documentId) {
-    const cleanup = await page.request.delete(`/api/clinicGalleryMedia/${documentId}`)
-    expect(cleanup.ok()).toBeTruthy()
-  }
-
   await expectNoBrowserIssues(issues)
 })

--- a/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
+++ b/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
@@ -59,7 +59,7 @@ test('shows the gallery upload policy inside the relationship drawer @smoke', as
     await page.setViewportSize(viewport)
     await expect(drawer.getByText(GALLERY_HINT, { exact: true })).toBeVisible()
     expect(
-      await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth),
+      await drawer.locator('.policy-aware-upload').evaluate((element) => element.scrollWidth <= element.clientWidth),
     ).toBe(true)
   }
 
@@ -92,10 +92,9 @@ test('rejects invalid gallery files and saves a valid PNG @smoke', async ({ page
   await expect(page.getByRole('button', { name: 'Select a file' })).toBeFocused()
 
   await page.setViewportSize({ height: 568, width: 320 })
-  expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(
-    true,
-  )
-  await page.locator('.policy-aware-upload').screenshot({
+  const policyAwareUpload = page.locator('.policy-aware-upload')
+  expect(await policyAwareUpload.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true)
+  await policyAwareUpload.screenshot({
     path: test.info().outputPath('policy-aware-upload-too-large.png'),
   })
   await page.setViewportSize({ height: 720, width: 1280 })

--- a/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
+++ b/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
@@ -86,7 +86,7 @@ test('rejects invalid gallery files and saves a valid PNG @smoke', async ({ page
   await expect(fileInput).toHaveValue('')
 
   await fileInput.setInputFiles({ name: fileName, mimeType: 'image/png', buffer: TINY_PNG })
-  await expect(fileInput).toHaveValue(new RegExp(`${fileName.replace('.', '\\.')}$`))
+  await expect(page.getByDisplayValue(fileName)).toBeVisible()
   await page.getByLabel(/^Alt Text/).fill('Upload policy smoke test')
   await selectComboboxOption(page, 'Clinic', clinic.clinicName)
   await page.getByRole('button', { name: /^Save$/ }).click()

--- a/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
+++ b/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
@@ -5,8 +5,9 @@ import {
   expectNoBrowserIssues,
   openAdminCreatePage,
   openAdminJoinCreateDrawer,
-  selectFirstComboboxOption,
+  selectComboboxOption,
 } from '../helpers/adminUI'
+import { ensureClinicFixture } from '../helpers/adminFixtures'
 
 const MAX_UPLOAD_BYTES = 4 * 1024 * 1024
 const STANDARD_HINT = 'Accepted formats: JPG, PNG, WebP, AVIF, GIF, SVG. Maximum file size: 4 MB.'
@@ -34,8 +35,9 @@ test('shows the configured upload policy on all five media forms @smoke', async 
 })
 
 test('shows the gallery upload policy inside the relationship drawer @smoke', async ({ page }) => {
+  const clinic = await ensureClinicFixture(page.request)
   await openAdminCreatePage(page, 'clinicGalleryEntries')
-  await selectFirstComboboxOption(page, 'Clinic')
+  await selectComboboxOption(page, 'Clinic', clinic.clinicName)
 
   const drawer = await openAdminJoinCreateDrawer(page, 'beforeMedia')
 
@@ -58,6 +60,7 @@ test('rejects invalid gallery files and saves a valid PNG @smoke', async ({ page
     ignoredConsoleErrors: [/TypeError: Failed to fetch/, /TypeError: network error/],
   })
   const fileName = `upload-policy-${Date.now()}.png`
+  const clinic = await ensureClinicFixture(page.request)
 
   await openAdminCreatePage(page, 'clinicGalleryMedia')
   const fileInput = page.locator('input[type="file"]').first()
@@ -85,7 +88,7 @@ test('rejects invalid gallery files and saves a valid PNG @smoke', async ({ page
   await fileInput.setInputFiles({ name: fileName, mimeType: 'image/png', buffer: TINY_PNG })
   await expect(page.getByText(fileName, { exact: true })).toBeVisible()
   await page.getByLabel(/^Alt Text/).fill('Upload policy smoke test')
-  await selectFirstComboboxOption(page, 'Clinic')
+  await selectComboboxOption(page, 'Clinic', clinic.clinicName)
   await page.getByRole('button', { name: /^Save$/ }).click()
   await page.waitForURL(/\/admin\/collections\/clinicGalleryMedia\/[^/]+$/)
 

--- a/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
+++ b/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
@@ -86,7 +86,6 @@ test('rejects invalid gallery files and saves a valid PNG @smoke', async ({ page
   await expect(fileInput).toHaveValue('')
 
   await fileInput.setInputFiles({ name: fileName, mimeType: 'image/png', buffer: TINY_PNG })
-  await expect(page.getByDisplayValue(fileName)).toBeVisible()
   await page.getByLabel(/^Alt Text/).fill('Upload policy smoke test')
   await selectComboboxOption(page, 'Clinic', clinic.clinicName)
   await page.getByRole('button', { name: /^Save$/ }).click()

--- a/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
+++ b/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
@@ -86,7 +86,7 @@ test('rejects invalid gallery files and saves a valid PNG @smoke', async ({ page
   await expect(fileInput).toHaveValue('')
 
   await fileInput.setInputFiles({ name: fileName, mimeType: 'image/png', buffer: TINY_PNG })
-  await expect(page.getByText(fileName, { exact: true })).toBeVisible()
+  await expect(fileInput).toHaveValue(new RegExp(`${fileName.replace('.', '\\.')}$`))
   await page.getByLabel(/^Alt Text/).fill('Upload policy smoke test')
   await selectComboboxOption(page, 'Clinic', clinic.clinicName)
   await page.getByRole('button', { name: /^Save$/ }).click()

--- a/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
+++ b/tests/e2e/admin/media-upload-policy.admin-smoke.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from '@playwright/test'
+
+import {
+  createBrowserIssueCollector,
+  expectNoBrowserIssues,
+  openAdminCreatePage,
+  openAdminJoinCreateDrawer,
+  selectFirstComboboxOption,
+} from '../helpers/adminUI'
+
+const MAX_UPLOAD_BYTES = 4 * 1024 * 1024
+const STANDARD_HINT = 'Accepted formats: JPG, PNG, WebP, AVIF, GIF, SVG. Maximum file size: 4 MB.'
+const GALLERY_HINT = 'Accepted formats: JPG, PNG, WebP, AVIF, GIF. Maximum file size: 4 MB.'
+const TINY_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=',
+  'base64',
+)
+
+test.describe.configure({ mode: 'serial' })
+
+test('shows the configured upload policy on all five media forms @smoke', async ({ page }) => {
+  const collections = [
+    ['clinicMedia', STANDARD_HINT],
+    ['clinicGalleryMedia', GALLERY_HINT],
+    ['doctorMedia', STANDARD_HINT],
+    ['platformContentMedia', STANDARD_HINT],
+    ['userProfileMedia', STANDARD_HINT],
+  ] as const
+
+  for (const [collectionSlug, hint] of collections) {
+    await openAdminCreatePage(page, collectionSlug)
+    await expect(page.getByText(hint, { exact: true })).toBeVisible()
+  }
+})
+
+test('shows the gallery upload policy inside the relationship drawer @smoke', async ({ page }) => {
+  await openAdminCreatePage(page, 'clinicGalleryEntries')
+  await selectFirstComboboxOption(page, 'Clinic')
+
+  const drawer = await openAdminJoinCreateDrawer(page, 'beforeMedia')
+
+  await expect(drawer.getByText(GALLERY_HINT, { exact: true })).toBeVisible()
+})
+
+test('rejects invalid gallery files and saves a valid PNG @smoke', async ({ page }) => {
+  const issues = createBrowserIssueCollector(page, {
+    ignoredConsoleErrors: [/TypeError: Failed to fetch/, /TypeError: network error/],
+  })
+  const fileName = `upload-policy-${Date.now()}.png`
+
+  await openAdminCreatePage(page, 'clinicGalleryMedia')
+  const fileInput = page.locator('input[type="file"]').first()
+
+  await fileInput.setInputFiles({
+    name: 'too-large.png',
+    mimeType: 'image/png',
+    buffer: Buffer.alloc(MAX_UPLOAD_BYTES + 1),
+  })
+  await expect(page.getByRole('alert').filter({ hasText: 'Image is too large.' }).first()).toContainText(
+    'Image is too large. Maximum file size is 4 MB.',
+  )
+  await expect(fileInput).toHaveValue('')
+
+  await fileInput.setInputFiles({
+    name: 'unsupported.svg',
+    mimeType: 'image/svg+xml',
+    buffer: Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"></svg>'),
+  })
+  await expect(page.getByRole('alert').filter({ hasText: 'Unsupported image format.' }).first()).toContainText(
+    'Unsupported image format. Accepted formats: JPG, PNG, WebP, AVIF, GIF.',
+  )
+  await expect(fileInput).toHaveValue('')
+
+  await fileInput.setInputFiles({ name: fileName, mimeType: 'image/png', buffer: TINY_PNG })
+  await expect(page.getByText(fileName, { exact: true })).toBeVisible()
+  await page.getByLabel(/^Alt Text/).fill('Upload policy smoke test')
+  await selectFirstComboboxOption(page, 'Clinic')
+  await page.getByRole('button', { name: /^Save$/ }).click()
+  await page.waitForURL(/\/admin\/collections\/clinicGalleryMedia\/[^/]+$/)
+
+  const documentId = page.url().match(/\/clinicGalleryMedia\/([^/?#]+)$/)?.[1]
+  expect(documentId).toBeTruthy()
+
+  if (documentId) {
+    const cleanup = await page.request.delete(`/api/clinicGalleryMedia/${documentId}`)
+    expect(cleanup.ok()).toBeTruthy()
+  }
+
+  await expectNoBrowserIssues(issues)
+})

--- a/tests/integration/clinicGalleryMedia.lifecycle.test.ts
+++ b/tests/integration/clinicGalleryMedia.lifecycle.test.ts
@@ -96,6 +96,50 @@ describe('ClinicGalleryMedia integration - lifecycle', () => {
     expect(created.storagePath).toMatch(new RegExp(`^clinics-gallery/${clinic.id}-cgmedia-[a-f0-9]{32}-.+\\.png$`))
   })
 
+  it('returns the gallery format contract for unsupported or invalid direct uploads', async () => {
+    const { clinic } = await createClinicFixture(payload, cityId, { slugPrefix: `${slugPrefix}-invalid-upload` })
+    const platformUser = await createPlatformUser('invalid-upload')
+    const acceptedFormatsMessage = 'Unsupported image format. Accepted formats: JPG, PNG, WebP, AVIF, GIF.'
+
+    await expect(
+      payload.create({
+        collection: 'clinicGalleryMedia',
+        data: {
+          alt: 'Unsupported gallery image',
+          clinic: clinic.id,
+        } as Partial<ClinicGalleryMedia>,
+        file: {
+          data: Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"></svg>'),
+          mimetype: 'image/svg+xml',
+          name: `${slugPrefix}-unsupported.svg`,
+          size: 46,
+        },
+        user: asBasicUserPayload(platformUser),
+        overrideAccess: false,
+        depth: 0,
+      } as PayloadCreateArgs),
+    ).rejects.toThrow(acceptedFormatsMessage)
+
+    await expect(
+      payload.create({
+        collection: 'clinicGalleryMedia',
+        data: {
+          alt: 'Invalid gallery image',
+          clinic: clinic.id,
+        } as Partial<ClinicGalleryMedia>,
+        file: {
+          data: Buffer.from('not an image'),
+          mimetype: 'image/png',
+          name: `${slugPrefix}-invalid.png`,
+          size: 12,
+        },
+        user: asBasicUserPayload(platformUser),
+        overrideAccess: false,
+        depth: 0,
+      } as PayloadCreateArgs),
+    ).rejects.toThrow(acceptedFormatsMessage)
+  })
+
   it('auto-assigns clinic on create when clinic users omit the clinic field', async () => {
     const { clinic } = await createClinicFixture(payload, cityId, { slugPrefix: `${slugPrefix}-auto-assign` })
     const { basicUser, clinicStaff } = await createClinicUserWithStaff(payload, {

--- a/tests/tooling/scripts/detect-migration-diff.test.ts
+++ b/tests/tooling/scripts/detect-migration-diff.test.ts
@@ -114,6 +114,36 @@ export default {
     expect(output).toContain('schema_changed=true')
   })
 
+  it('does not require a migration for a Payload upload parser policy change', () => {
+    const rootDir = createTempRepo()
+
+    commitPayloadConfig(
+      rootDir,
+      `import { MEDIA_UPLOAD_MAX_BYTES, MEDIA_UPLOAD_TOO_LARGE_MESSAGE } from '@/config/mediaUploadPolicy'
+import { seedGetHandler } from './endpoints/seed/seedEndpoint'
+
+export default {
+  upload: {
+    limits: {
+      fileSize: MEDIA_UPLOAD_MAX_BYTES,
+    },
+    abortOnLimit: true,
+    responseOnLimit: MEDIA_UPLOAD_TOO_LARGE_MESSAGE,
+    safeFileNames: true,
+  },
+  endpoints: [
+    { path: '/seed', method: 'get', handler: seedGetHandler as PayloadHandler },
+  ],
+}
+`,
+    )
+
+    const output = runDetector(rootDir)
+
+    expect(output).toContain('db_changed=false')
+    expect(output).toContain('schema_changed=false')
+  })
+
   it('does not require a migration for scoped agent instructions', () => {
     const rootDir = createTempRepo()
 
@@ -134,5 +164,54 @@ export default {
 
     expect(output).toContain('db_changed=true')
     expect(output).toContain('schema_changed=true')
+  })
+
+  it('does not require a migration for a collection upload UI and validation hook change', () => {
+    const rootDir = createTempRepo()
+
+    commitFile(
+      rootDir,
+      'src/collections/Doctors/index.ts',
+      `import { beforeOperationPrepareUploadFilename } from '@/hooks/media/prepareUploadFilename'
+
+export const Doctors = {
+  slug: 'doctors',
+  admin: {
+    group: 'Media',
+  },
+  hooks: {
+    beforeOperation: [beforeOperationPrepareUploadFilename],
+  },
+}
+`,
+    )
+
+    commitFile(
+      rootDir,
+      'src/collections/Doctors/index.ts',
+      `import { beforeOperationPrepareUploadFilename } from '@/hooks/media/prepareUploadFilename'
+import { beforeOperationValidateMediaUpload } from '@/hooks/media/validateMediaUpload'
+
+export const Doctors = {
+  slug: 'doctors',
+  admin: {
+    group: 'Media',
+    components: {
+      edit: {
+        Upload: '@/app/(payload)/components/PolicyAwareUpload',
+      },
+    },
+  },
+  hooks: {
+    beforeOperation: [beforeOperationValidateMediaUpload, beforeOperationPrepareUploadFilename],
+  },
+}
+`,
+    )
+
+    const output = runDetector(rootDir)
+
+    expect(output).toContain('db_changed=false')
+    expect(output).toContain('schema_changed=false')
   })
 })

--- a/tests/unit/hooks/mediaUploadLogging.test.ts
+++ b/tests/unit/hooks/mediaUploadLogging.test.ts
@@ -29,6 +29,19 @@ const collection = {
   slug: 'clinicMedia',
 } as SanitizedCollectionConfig
 
+const setUploadContext = (req: PayloadRequest) => {
+  req.context.mediaUploadLog = {
+    collection: 'clinicMedia',
+    event: 'storage.media.upload_attempt',
+    fileName: 'avatar.png',
+    fileSize: 2048,
+    operation: 'create',
+    ownerField: 'clinic',
+    ownerId: 'clinic-1',
+    storagePrefix: 'clinic-media',
+  }
+}
+
 describe('media upload logging hooks', () => {
   afterEach(() => {
     vi.unstubAllEnvs()
@@ -70,16 +83,7 @@ describe('media upload logging hooks', () => {
 
   it('logs structured upload failures with request context', async () => {
     const req = createRequest()
-    req.context.mediaUploadLog = {
-      collection: 'clinicMedia',
-      event: 'storage.media.upload_attempt',
-      fileName: 'avatar.png',
-      fileSize: 2048,
-      operation: 'create',
-      ownerField: 'clinic',
-      ownerId: 'clinic-1',
-      storagePrefix: 'clinic-media',
-    }
+    setUploadContext(req)
     const error = new Error('bucket rejected object')
 
     await afterErrorLogMediaUploadError({
@@ -106,6 +110,46 @@ describe('media upload logging hooks', () => {
       }),
       'Media upload failed',
     )
+  })
+
+  it.each([
+    ['directly', { name: 'EntityTooLarge', message: 'Object exceeds limit' }],
+    ['through cause', { cause: { Code: 'EntityTooLarge', message: 'Object exceeds limit' } }],
+    ['through err', { err: { name: 'EntityTooLarge', message: 'Object exceeds limit' } }],
+  ])('returns a safe HTTP 413 for EntityTooLarge errors %s', async (_label, error) => {
+    const req = createRequest()
+    setUploadContext(req)
+
+    const result = await afterErrorLogMediaUploadError({ collection, error, req } as never)
+
+    expect(result).toEqual({
+      response: {
+        errors: [
+          {
+            message:
+              'Image processing exceeded the storage limit. Please reduce the image dimensions or file size and try again.',
+          },
+        ],
+      },
+      status: 413,
+    })
+    expect(req.payload.logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ err: error, event: 'storage.media.upload_failed' }),
+      'Media upload failed',
+    )
+  })
+
+  it('does not expose unknown storage errors', async () => {
+    const req = createRequest()
+    setUploadContext(req)
+
+    const result = await afterErrorLogMediaUploadError({
+      collection,
+      error: new Error('database password leaked'),
+      req,
+    } as never)
+
+    expect(result).toBeUndefined()
   })
 
   it('downgrades expected NoSuchKey upload failures to warnings without stack traces', async () => {

--- a/tests/unit/hooks/validateMediaUpload.test.ts
+++ b/tests/unit/hooks/validateMediaUpload.test.ts
@@ -1,0 +1,62 @@
+import { beforeOperationValidateMediaUpload } from '@/hooks/media/validateMediaUpload'
+import { galleryMediaImageMimeTypes, standardMediaImageMimeTypes } from '@/collections/common/mediaCollection'
+import { MEDIA_UPLOAD_MAX_BYTES, MEDIA_UPLOAD_TOO_LARGE_MESSAGE } from '@/config/mediaUploadPolicy'
+import { describe, expect, it } from 'vitest'
+
+const TINY_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=',
+  'base64',
+)
+
+const runValidation = (
+  file: { data?: Buffer; mimetype: string; size: number },
+  acceptedMimeTypes = galleryMediaImageMimeTypes,
+) => {
+  const hook = beforeOperationValidateMediaUpload({ acceptedMimeTypes })
+
+  return hook({
+    args: { file },
+    operation: 'create',
+    req: {},
+  } as never)
+}
+
+describe('beforeOperationValidateMediaUpload', () => {
+  it('rejects files larger than 4 MB with HTTP 413', async () => {
+    await expect(runValidation({ mimetype: 'image/png', size: MEDIA_UPLOAD_MAX_BYTES + 1 })).rejects.toThrowError(
+      expect.objectContaining({ message: MEDIA_UPLOAD_TOO_LARGE_MESSAGE, status: 413 }),
+    )
+  })
+
+  it('rejects unsupported gallery formats with HTTP 400 and the gallery format list', async () => {
+    await expect(runValidation({ mimetype: 'image/svg+xml', size: 1024 })).rejects.toThrowError(
+      expect.objectContaining({
+        message: 'Unsupported image format. Accepted formats: JPG, PNG, WebP, AVIF, GIF.',
+        status: 400,
+      }),
+    )
+  })
+
+  it('rejects files whose content is not a valid configured image', async () => {
+    await expect(
+      runValidation({ data: Buffer.from('not an image'), mimetype: 'image/png', size: 12 }),
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        message: 'Unsupported image format. Accepted formats: JPG, PNG, WebP, AVIF, GIF.',
+        status: 400,
+      }),
+    )
+  })
+
+  it('accepts a valid PNG based on its content', async () => {
+    await expect(
+      runValidation({ data: TINY_PNG, mimetype: 'image/png', size: TINY_PNG.length }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('accepts SVG for media collections that configure it', async () => {
+    await expect(
+      runValidation({ mimetype: 'image/svg+xml', size: 1024 }, standardMediaImageMimeTypes),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/tests/unit/hooks/validateMediaUpload.test.ts
+++ b/tests/unit/hooks/validateMediaUpload.test.ts
@@ -12,10 +12,9 @@ const runValidation = (
   file: { data?: Buffer; mimetype: string; size: number },
   acceptedMimeTypes = galleryMediaImageMimeTypes,
 ) => {
-  const hook = beforeOperationValidateMediaUpload({ acceptedMimeTypes })
-
-  return hook({
+  return beforeOperationValidateMediaUpload({
     args: { file },
+    collection: { upload: { mimeTypes: acceptedMimeTypes } },
     operation: 'create',
     req: {},
   } as never)


### PR DESCRIPTION
## Management summary

### Deutsch

Medien-Uploads zeigen künftig direkt, welche Bildformate zulässig sind und dass Dateien maximal 4 MB groß sein dürfen. Zu große, nicht unterstützte oder beschädigte Bilder werden mit einer konkreten Handlungsanweisung abgelehnt, während zulässige Bilder wieder zuverlässig verarbeitet werden können.

### English

Media uploads now show which image formats are accepted and that files may be up to 4 MB. Oversized, unsupported, or corrupted images are rejected with clear next steps, while valid images can be processed reliably again.

## What changed

- Added one shared media upload policy for the 4 MB limit, configured MIME types, readable format labels, admin hints, and public error messages.
- Registered a Payload upload wrapper for all five media collections. It keeps Payload's standard upload control while validating selected, dropped, and URL-sourced files, clearing rejected previews, and showing a toast plus accessible inline feedback.
- Restored keyboard focus to Payload's native upload action after rejected files so keyboard and screen-reader users can immediately try again.
- Added server-side size, MIME, and image-content validation for direct API and Local API uploads. Payload's existing content restrictions remain the final validation layer.
- Mapped direct and nested S3 `EntityTooLarge` failures to a safe HTTP 413 response while retaining full error details only in structured server logs.
- Reduced the global multipart file limit from 5 MB to 4 MB and generated the Payload admin import map through the repository generation command.
- Updated DB change detection so this upload UI/parser configuration is correctly classified as runtime-only; persisted schema changes still require migrations.
- Added unit, integration, and admin E2E coverage for the policy, nested storage errors, all five admin forms, the gallery drawer, invalid files, and a valid PNG save path.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/hooks/media/validateMediaUpload.ts`, `src/hooks/media/uploadLogging.ts` | These hooks define public API errors at the upload/storage trust boundary. | Confirm classification is narrow, HTTP status codes match the contract, and unknown server details cannot leak. | Focused unit and integration suites pass. |
| P2 | `src/app/(payload)/components/PolicyAwareUpload/**` | The wrapper resets invalid Payload upload state and adds accessible feedback without replacing the default control. | Confirm valid uploads remain unchanged and rejected selections cannot be submitted. | Authenticated admin E2E covers all five forms, invalid files, and a successful PNG save. |
| P2 | Five media collection configs and `src/config/mediaUploadPolicy.ts` | Format hints must be derived from each collection's actual MIME configuration. | Confirm gallery excludes SVG while the other four collections retain SVG support. | Unit coverage and generated import map. |

## UI/UX

Authenticated CI screenshots cover the gallery relationship drawer and the actual oversized-file error state. The upload hint and inline error remain adjacent to the file field, wrap without horizontal overflow, and leave Payload's standard file, URL, and drag-and-drop controls intact. Screenshot files are retained in the Admin E2E artifact; GitHub body attachment was attempted but the stored web upload session had expired.

## Validation

- [x] `pnpm format`: completed after the final source changes.
- [x] `pnpm check`: passed, including test sense check, lint, type generation, Payload type check, and TypeScript.
- [x] `pnpm build`: passed with Next.js 16.2.9 using the repository's webpack build path.
- [x] Focused tests: 20 upload-policy/logging/DB-detector unit tests passed; the gallery integration suite passed with 8 tests; all five media lifecycle suites passed with 32 tests.
- [x] UI/mobile QA: authenticated Admin E2E checked all five forms, direct gallery create, the relationship drawer, oversized and unsupported rejection, focus restoration, and a valid PNG save. The component matrix covers 320, 375, 390, 640, 768, and 1280 px; no internal horizontal overflow, clipping, or obstructed upload controls were found. Evidence: [Admin E2E run](https://github.com/findmydoc-platform/website/actions/runs/29157514077).
  <!-- gh-ui-screenshots:start -->
  ### Rejected Upload At 320px
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":0.7777777777777778,"capturedAt":"2026-07-11T15:19:01.546Z","contentType":"image/png","focus":"rejected-upload-at-320px","focusLabel":"Rejected Upload At 320px","formFactor":"mobile","gitSha":"12cb1c38","height":224,"releaseEligible":false,"releaseRole":"qa","size":12972,"sizeKb":13,"uploadName":"rejected-upload-at-320px__mobile__288x224__20260711T151901Z__12cb1c38__288x224__13kb.png","viewport":"288x224","warnings":["not_release_marked"],"width":288,"url":"https://github.com/user-attachments/assets/708c34a3-718b-4e17-8bb3-21d84b94d350"} -->
  ![Rejected Upload At 320px](https://github.com/user-attachments/assets/708c34a3-718b-4e17-8bb3-21d84b94d350)
  
  
  > Screenshot warning: not_release_marked
  
  ### Gallery Drawer Desktop
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":0.75234375,"capturedAt":"2026-07-11T15:19:01.545Z","contentType":"image/png","focus":"gallery-drawer-desktop","focusLabel":"Gallery Drawer Desktop","formFactor":"desktop","gitSha":"12cb1c38","height":963,"releaseEligible":false,"releaseRole":"qa","size":59661,"sizeKb":59,"uploadName":"gallery-drawer-desktop__desktop__1280x963__20260711T151901Z__12cb1c38__1280x963__59kb.png","viewport":"1280x963","warnings":["not_release_marked"],"width":1280,"url":"https://github.com/user-attachments/assets/f452d80d-6239-4ad7-81cf-12b9e5dcbc98"} -->
  ![Gallery Drawer Desktop](https://github.com/user-attachments/assets/f452d80d-6239-4ad7-81cf-12b9e5dcbc98)
  
  
  > Screenshot warning: not_release_marked
  
  ### Gallery Drawer Narrow
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":2.403755868544601,"capturedAt":"2026-07-11T15:19:01.545Z","contentType":"image/png","focus":"gallery-drawer-narrow","focusLabel":"Gallery Drawer Narrow","formFactor":"mobile","gitSha":"12cb1c38","height":1024,"releaseEligible":false,"releaseRole":"qa","size":47870,"sizeKb":47,"uploadName":"gallery-drawer-narrow__mobile__426x1024__20260711T151901Z__12cb1c38__426x1024__47kb.png","viewport":"426x1024","warnings":["unsupported_aspect_ratio","not_release_marked"],"width":426,"url":"https://github.com/user-attachments/assets/a246d743-739b-42a1-ae3a-a318a446c7b0"} -->
  ![Gallery Drawer Narrow](https://github.com/user-attachments/assets/a246d743-739b-42a1-ae3a-a318a446c7b0)
  
  
  > Screenshot warning: unsupported_aspect_ratio, not_release_marked
  <!-- gh-ui-screenshots:end -->
- [x] Accessibility review: the initial 5/10 focus-loss finding was fixed and re-reviewed; no remaining finding reaches 5/10.
- [x] Security/privacy review: no credible finding reaches 5/10; server-side restrictions and safe error boundaries remain intact.
- [x] Cache architecture review: `no-public-impact` confirmed; existing media revalidation behavior remains unchanged.
- [x] Migration/schema check: DB Quality reports `schema_changed=false`; existing migrations and status pass. No Payload migration was added; `pnpm generate` completed and only the generated admin import map changed.
- [x] Documentation/instructions check: no public documentation change required; active Payload/admin/test/cache instructions were followed.

## Risk and rollout

- Cache classification: `no-public-impact`; no public read, cache tag, or revalidation behavior changed.
- Preview and production `portalfiles` bucket object limits were set to 15 MiB without changing visibility or MIME restrictions. Exact 15 MiB test objects uploaded and were deleted successfully in both environments.
- The supplied 2,170,931-byte PNG uploaded successfully to Preview storage after the limit change and the verification object was deleted.
- The application code is deployed only to a unique Preview URL. Production code rollout remains gated on merge and the production release workflow.
- Rollback: revert this commit and restore the previous bucket limits if required.

## Development

Closes #1481
