### PR TITLE
fix: derive doctor media clinic ownership

### DIFF
--- a/src/collections/DoctorMedia/hooks/beforeChangeDoctorMedia.ts
+++ b/src/collections/DoctorMedia/hooks/beforeChangeDoctorMedia.ts
@@ -41,10 +41,7 @@ export const beforeChangeDoctorMedia: CollectionBeforeChangeHook<DoctorMedia> = 
 
   draft.doctor = draft.doctor ?? doctorId
 
-  let clinicId = extractRelationId(draft.clinic) ?? extractRelationId(originalDoc?.clinic)
-  if (!clinicId) {
-    clinicId = await getDoctorClinicId(doctorId, req.payload)
-  }
+  const clinicId = await getDoctorClinicId(doctorId, req.payload)
 
   const numericClinicId = Number(clinicId)
   if (!clinicId || !Number.isFinite(numericClinicId)) {

--- a/tests/unit/hooks/doctorMediaBeforeChange.test.ts
+++ b/tests/unit/hooks/doctorMediaBeforeChange.test.ts
@@ -77,6 +77,22 @@ describe('beforeChangeDoctorMedia', () => {
     expect(result.createdBy).toBe(5)
   })
 
+  test('overwrites client-supplied clinic with the doctor clinic on create', async () => {
+    const req = baseReq({ id: 5, collection: 'basicUsers' })
+    vi.mocked(req.payload.findByID).mockResolvedValue({ clinic: 8 } as unknown as Doctor)
+
+    const result = (await beforeChangeDoctorMedia({
+      data: { doctor: 3, clinic: 99, filename: 'portraits/doc.png' } as Partial<DoctorMedia>,
+      operation: 'create',
+      req,
+      originalDoc: undefined,
+      collection: mockCollection,
+      context: emptyContext,
+    })) as Record<string, unknown>
+
+    expect(result.clinic).toBe(8)
+  })
+
   test('prevents doctor change on update', async () => {
     const req = baseReq({ id: 2, collection: 'basicUsers' })
 
@@ -115,6 +131,7 @@ describe('beforeChangeDoctorMedia', () => {
 
   test('preserves createdBy when updating other fields', async () => {
     const req = baseReq({ id: 2, collection: 'basicUsers' })
+    vi.mocked(req.payload.findByID).mockResolvedValue({ clinic: 12 } as unknown as Doctor)
 
     const result = (await beforeChangeDoctorMedia({
       data: { alt: 'Updated' } as Partial<DoctorMedia>,
@@ -132,5 +149,27 @@ describe('beforeChangeDoctorMedia', () => {
     })) as Record<string, unknown>
 
     expect(result.createdBy).toBe(2)
+  })
+
+  test('restores doctor clinic ownership when an update submits another clinic', async () => {
+    const req = baseReq({ id: 2, collection: 'basicUsers' })
+    vi.mocked(req.payload.findByID).mockResolvedValue({ clinic: 12 } as unknown as Doctor)
+
+    const result = (await beforeChangeDoctorMedia({
+      data: { clinic: 99 } as Partial<DoctorMedia>,
+      operation: 'update',
+      req,
+      originalDoc: {
+        doctor: 9,
+        clinic: 12,
+        createdBy: 2,
+        filename: '9-aaaaaaaaaa-doc.png',
+        storagePath: 'doctors/9-aaaaaaaaaa-doc.png',
+      } as DoctorMedia,
+      collection: mockCollection,
+      context: emptyContext,
+    })) as Record<string, unknown>
+
+    expect(result.clinic).toBe(12)
   })
 })


### PR DESCRIPTION
## Management summary

### Deutsch

Arztbilder bleiben zuverlässig der Klinik des ausgewählten Arztes zugeordnet. Dadurch können Bilder nicht versehentlich unter einer anderen Klinik verwaltet werden, und Klinikteams behalten klare Verantwortungsbereiche.

### English

Doctor images now remain reliably assigned to the selected doctor's clinic. This prevents images from being managed under the wrong clinic and keeps responsibilities clear for clinic teams.

## What changed

- Derive DoctorMedia clinic ownership from the immutable doctor relationship on every create and update.
- Ignore client-supplied clinic relationship values instead of using them as authorization ownership input.
- Add focused hook coverage for forged clinic values on create and update.
- Cache impact: `public-cached`; the existing inherited media policy and Clinic Detail cache ownership remain unchanged.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `src/collections/DoctorMedia/hooks/beforeChangeDoctorMedia.ts` | The derived clinic is an authorization and tenant-ownership boundary. | Clinic ownership always follows the immutable doctor relationship for platform and clinic callers. | Focused hook and access tests |
| P1 | `tests/unit/hooks/doctorMediaBeforeChange.test.ts` | Regression coverage must include direct API payload manipulation. | Forged clinic IDs are overwritten on create and update. | 25 focused tests passed |

## Validation

- [x] `pnpm format`: Passed.
- [ ] `pnpm check`: Skipped as requested; only fast focused tests were run.
- [ ] `pnpm build`: Skipped as requested; only fast focused tests were run.
- [x] Focused tests: `doctorMediaBeforeChange.test.ts` and `DoctorMedia.access.test.ts`; 25 passed.
- [ ] UI/mobile QA: Not applicable; no UI change.
- [ ] Security/privacy review: Not run; security reviewer requires explicit confirmation.
- [x] Migration/schema check: No schema change; no migration required.
- [ ] Documentation/instructions check: Not applicable; no documentation or instruction source changed.

## Risk and rollout

Existing records with inconsistent clinic ownership are not backfilled automatically. Future creates and updates restore the doctor-derived clinic. Rollback is the single commit on this branch.

## Development

Closes #1485
