### PR TITLE
docs: align doctor media permission matrix

### DIFF
--- a/docs/security/permission-matrix.generated.md
+++ b/docs/security/permission-matrix.generated.md
@@ -26,7 +26,7 @@
 | ClinicMedia `(clinicMedia)` | Conditional<br/><sub>platform full + clinic allowed (hook assigns clinic ownership)</sub> | Conditional<br/><sub>document read scoped; static file read allows approved clinics</sub> | Conditional<br/><sub>platform full + clinic own clinic</sub> | Conditional<br/><sub>platform full + clinic own clinic</sub> | Platform |
 | ClinicGalleryMedia `(clinicGalleryMedia)` | Conditional<br/><sub>platform full + clinic allowed (hook assigns clinic ownership)</sub> | Conditional<br/><sub>platform full + clinic scoped; patients/anonymous published only</sub> | Conditional<br/><sub>platform full + clinic own clinic</sub> | Conditional<br/><sub>platform full + clinic own clinic</sub> | Platform |
 | ClinicGalleryEntries `(clinicGalleryEntries)` | Conditional<br/><sub>platform full + clinic allowed (hook assigns clinic ownership)</sub> | Conditional<br/><sub>platform full + clinic scoped; patients/anonymous published only</sub> | Conditional<br/><sub>platform full + clinic own clinic</sub> | Conditional<br/><sub>platform full + clinic own clinic</sub> | Platform |
-| DoctorMedia `(doctorMedia)` | Conditional<br/><sub>platform full + clinic own clinic</sub> | Conditional<br/><sub>served when referenced</sub> | Conditional<br/><sub>platform full + clinic own clinic</sub> | Conditional<br/><sub>platform full + clinic own clinic</sub> | Platform |
+| DoctorMedia `(doctorMedia)` | Conditional<br/><sub>platform full + clinic own clinic</sub> | Conditional<br/><sub>served when referenced</sub> | Conditional<br/><sub>platform full + clinic own clinic</sub> | Conditional<br/><sub>platform full + clinic own clinic</sub> | Conditional<br/><sub>platform full + clinic own clinic</sub> |
 | UserProfileMedia `(userProfileMedia)` | Conditional<br/><sub>platform full + user own profile (auto owner when omitted)</sub> | Conditional<br/><sub>platform full + staff profiles in own clinic + patient own</sub> | Conditional<br/><sub>platform full + user own profile</sub> | Conditional<br/><sub>platform full + user own profile</sub> | Platform |
 | Tags `(tags)` | Platform | Anyone | Platform | Platform | Platform |
 | Categories `(categories)` | Platform | Anyone | Platform | Platform | Platform |
@@ -57,8 +57,8 @@
 - **ClinicMedia**: Clinic-owned files - scoped document read, approved static file read for public listing images
 - **ClinicGalleryMedia**: Clinic gallery assets with publication control; platform RWDA, clinic RWD own clinic, others published only
 - **ClinicGalleryEntries**: Structured gallery stories referencing clinic gallery media; publication gates public visibility
-- **DoctorMedia**: Doctor-owned images - similar scoping to ClinicMedia
-- **UserProfileMedia**: User & patient avatars - self or platform management; owner + createdBy auto-stamped for requesters
+- **DoctorMedia**: Platform full + clinic-managed doctor images scoped to the assigned clinic
+- **UserProfileMedia**: User &amp; patient avatars - self or platform management; owner + createdBy auto-stamped for requesters
 - **Tags**: Supporting data - platform write, everyone read
 - **Categories**: Supporting data - platform write, everyone read
 - **Accreditation**: Supporting data - platform write, everyone read

--- a/src/security/permission-matrix.config.ts
+++ b/src/security/permission-matrix.config.ts
@@ -488,7 +488,7 @@ export const permissionMatrix: PermissionMatrix = {
         read: { type: 'conditional', details: 'served when referenced' },
         update: { type: 'conditional', details: 'platform full + clinic own clinic' },
         delete: { type: 'conditional', details: 'platform full + clinic own clinic' },
-        admin: { type: 'platform' },
+        admin: { type: 'conditional', details: 'platform full + clinic own clinic' },
       },
       meta: {
         conditional: {
@@ -496,9 +496,10 @@ export const permissionMatrix: PermissionMatrix = {
           read: { kind: 'clinic-scope', path: 'clinic' },
           update: { kind: 'clinic-scope', path: 'clinic' },
           delete: { kind: 'clinic-scope', path: 'clinic' },
+          admin: { kind: 'clinic-scope', path: 'clinic' },
         },
       },
-      notes: 'Doctor-owned images - similar scoping to ClinicMedia',
+      notes: 'Platform full + clinic-managed doctor images scoped to the assigned clinic',
     },
     userProfileMedia: {
       slug: 'userProfileMedia',


### PR DESCRIPTION
## Management summary

### Deutsch

Die Berechtigungsübersicht beschreibt jetzt korrekt, dass Klinikteams ihre eigenen Arztbilder verwalten dürfen, während der Zugriff weiterhin auf die zugewiesene Klinik begrenzt bleibt.

### English

The permission overview now correctly states that clinic teams can manage their own doctor images while access remains limited to their assigned clinic.

## What changed

- Align the DoctorMedia admin classification with the existing clinic-scoped CRUD model.
- Add the matching clinic-scope metadata for the admin classification.
- Regenerate the human-readable permission matrix from its canonical configuration.
- Cache impact: `no-public-impact`; no runtime data or public cache behavior changed.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `src/security/permission-matrix.config.ts` | This is the permission documentation source of truth used by generated artifacts and tests. | DoctorMedia admin classification matches the existing clinic-scoped management model. | Matrix verification passed |
| P2 | `docs/security/permission-matrix.generated.md` | Reviewers and operators consume this generated view. | The rendered DoctorMedia row and note communicate the same scope as the source config. | Generated through `pnpm matrix:derive` |

## Validation

- [x] `pnpm format`: Passed.
- [ ] `pnpm check`: Skipped as requested; only fast focused tests were run.
- [ ] `pnpm build`: Skipped as requested; only fast focused tests were run.
- [x] Focused tests: DoctorMedia matrix and matrix generator tests; 18 passed.
- [ ] UI/mobile QA: Not applicable; no UI change.
- [ ] Security/privacy review: Not run; security reviewer requires explicit confirmation.
- [x] Migration/schema check: No schema change; no migration required.
- [x] Documentation/instructions check: `pnpm matrix:verify` passed with all 28 collections and tests aligned.

## Risk and rollout

Documentation and permission-classification metadata only. Runtime DoctorMedia CRUD permissions are unchanged. Rollback is the single commit on this branch.

## Development

Closes #1487
