### PR TITLE
fix: harden clinic staff assignments

### DIFF
--- a/.github/scripts/ci/detect-migration-diff.sh
+++ b/.github/scripts/ci/detect-migration-diff.sh
@@ -58,6 +58,7 @@ hook_only_collection_hook_expression_regex="(${hook_only_collection_hook_identif
 hook_only_collection_line_regex="^[+-][[:space:]]*(import[[:space:]]*\\{|import[[:space:]].*from[[:space:]]'(@/hooks|\\./hooks)/[^']+'|\\}[[:space:]]*from[[:space:]]'(@/hooks|\\./hooks)/[^']+'|(beforeOperation|beforeChange|afterChange|afterDelete):[[:space:]]*\\[|\\],?|[[:space:]]*((beforeOperation|beforeChange|afterChange|afterDelete):[[:space:]]*\\[)?${hook_only_collection_hook_expression_regex}(,[[:space:]]*${hook_only_collection_hook_expression_regex})*\\]?,?|\\{|\\})[[:space:]]*$"
 collection_upload_component_line_regex="^[+-][[:space:]]*(components:[[:space:]]*\\{|edit:[[:space:]]*\\{|Upload:[[:space:]]*'@/app/\\(payload\\)/components/PolicyAwareUpload',?|\\{|\\},?)[[:space:]]*$"
 collection_crypto_import_line_regex="^[+-][[:space:]]*import[[:space:]]*\\{[[:space:]]*randomUUID[[:space:]]*\\}[[:space:]]*from[[:space:]]*'(node:)?crypto'[[:space:]]*$"
+collection_field_access_line_regex="^[+-][[:space:]]*(//.*|access:[[:space:]]*\\{|(create|read|update):[[:space:]]*[A-Za-z_][A-Za-z0-9_]*FieldAccess,?)[[:space:]]*$"
 payload_config_endpoint_import_line_regex="^[+-][[:space:]]*import[[:space:]]*\\{[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\\}[[:space:]]*from[[:space:]]*'./endpoints/[A-Za-z0-9_./-]+'[[:space:]]*$"
 payload_config_endpoint_line_regex="^[+-][[:space:]]*(\\{|\\},?|path:[[:space:]]*'/?[A-Za-z0-9_./-]+'[,]?|method:[[:space:]]*'(get|post|put|patch|delete)'[,]?|handler:[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]+as[[:space:]]+PayloadHandler[,]?)[[:space:]]*$"
 payload_config_upload_policy_import_line_regex="^[+-][[:space:]]*import[[:space:]]*\\{[[:space:]]*MEDIA_UPLOAD_MAX_BYTES,[[:space:]]*MEDIA_UPLOAD_TOO_LARGE_MESSAGE[[:space:]]*\\}[[:space:]]*from[[:space:]]*'@/config/mediaUploadPolicy'[[:space:]]*$"
@@ -118,7 +119,7 @@ is_runtime_only_collection_change() {
     esac
 
     if [[ "${diff_line}" == +* || "${diff_line}" == -* ]]; then
-      if [[ ! "${diff_line}" =~ ${hook_only_collection_line_regex} && ! "${diff_line}" =~ ${collection_upload_component_line_regex} && ! "${diff_line}" =~ ${collection_crypto_import_line_regex} ]]; then
+      if [[ ! "${diff_line}" =~ ${hook_only_collection_line_regex} && ! "${diff_line}" =~ ${collection_upload_component_line_regex} && ! "${diff_line}" =~ ${collection_crypto_import_line_regex} && ! "${diff_line}" =~ ${collection_field_access_line_regex} ]]; then
         return 1
       fi
     fi

--- a/docs/security/permission-matrix.generated.md
+++ b/docs/security/permission-matrix.generated.md
@@ -7,7 +7,7 @@
 | --- | --- | --- | --- | --- | --- |
 | BasicUsers `(basicUsers)` | Platform | Platform | Platform | Platform | Platform |
 | PlatformStaff `(platformStaff)` | Conditional<br/><sub>disabled API create; managed via provisioning</sub> | Platform | Platform | Conditional<br/><sub>disabled API delete; managed via provisioning</sub> | Platform |
-| ClinicStaff `(clinicStaff)` | Conditional<br/><sub>disabled API create; managed via provisioning</sub> | Conditional<br/><sub>platform full + clinic own clinic</sub> | Conditional<br/><sub>platform + own profile only after approval</sub> | Conditional<br/><sub>disabled API delete; managed via provisioning</sub> | Platform |
+| ClinicStaff `(clinicStaff)` | Conditional<br/><sub>disabled API create; managed via provisioning</sub> | Conditional<br/><sub>platform full + clinic own clinic</sub> | Conditional<br/><sub>platform + own profile after approval; user, clinic, and status fields are platform-only</sub> | Conditional<br/><sub>disabled API delete; managed via provisioning</sub> | Platform |
 | Patients `(patients)` | Platform | Conditional<br/><sub>platform full + patient own profile</sub> | Conditional<br/><sub>platform full + own profile only</sub> | Platform | Platform |
 | Posts `(posts)` | Platform | Published (approved) | Platform | Platform | Platform |
 | Pages `(pages)` | Platform | Published (approved) | Platform | Platform | Platform |
@@ -38,7 +38,7 @@
 
 - **BasicUsers**: User management restricted to platform staff
 - **PlatformStaff**: Platform staff management - indirect via BasicUsers lifecycle
-- **ClinicStaff**: Authentication denied until approval; RW post-approval own clinic + own profile update
+- **ClinicStaff**: Authentication denied until approval; clinic staff read their clinic and update only non-authorization fields on their own profile
 - **Patients**: Patients can update own profile; no self-create/delete
 - **Posts**: Blog content - platform write, published content readable by all
 - **Pages**: Static pages - platform write, published content readable by all

--- a/docs/security/permission-matrix.md
+++ b/docs/security/permission-matrix.md
@@ -62,7 +62,7 @@ Human-readable and machine-readable views are generated from the config on deman
 If you need to change permissions, update `src/security/permission-matrix.config.ts` and regenerate as needed.
 
 ### Notes on Specific Rows
-* ClinicStaff: Authentication is denied entirely until the staff profile is approved. After approval, Clinic Staff can read all staff in their own clinic and update only their own profile. Create/Delete operations occur exclusively via the BasicUsers lifecycle (no direct create/delete even for Platform Staff) †‡.
+* ClinicStaff: Authentication is denied entirely until the staff profile is approved. After approval, Clinic Staff can read all staff in their own clinic and target only their own profile for updates; `user`, `clinic`, and `status` remain Platform-only at field level. Create/Delete operations occur exclusively via the BasicUsers lifecycle (no direct create/delete even for Platform Staff) †‡.
 * Patients: Patients can update their own profile but cannot create or delete their patient record (provisioned via Supabase/Auth).
 * Reviews: Patients can create reviews. Only Platform can edit or delete reviews. Non-platform users only read approved reviews.
 * PlatformContentMedia: Publicly readable marketing / page assets. Write restricted to Platform.

--- a/src/collections/ClinicStaff.ts
+++ b/src/collections/ClinicStaff.ts
@@ -45,6 +45,11 @@ export const ClinicStaff: CollectionConfig = {
       required: true,
       unique: true,
       hasMany: false,
+      access: {
+        // Identity linkage controls authorization and may only be reassigned by Platform Staff.
+        create: platformOnlyFieldAccess,
+        update: platformOnlyFieldAccess,
+      },
       admin: {
         position: 'sidebar',
         description: 'Login account for this staff member',
@@ -61,6 +66,11 @@ export const ClinicStaff: CollectionConfig = {
       relationTo: 'clinics',
       required: false, // Allow staff registration without immediate clinic assignment (assigned by Platform staff)
       hasMany: false,
+      access: {
+        // Clinic assignment defines tenant access and may only be changed by Platform Staff.
+        create: platformOnlyFieldAccess,
+        update: platformOnlyFieldAccess,
+      },
       admin: {
         position: 'sidebar',
         description: 'Clinic this staff member belongs to',

--- a/src/security/permission-matrix.config.ts
+++ b/src/security/permission-matrix.config.ts
@@ -50,7 +50,7 @@ export type ConditionalScenarioKind =
   | 'clinic-approved'
   // Clinic scope: response must scope by clinic identifier for non-platform users.
   | 'clinic-scope'
-  // Clinic staff update: clinic staff can update only their own profile user relation.
+  // Clinic staff update: clinic staff can target only their own profile; field access protects authorization data.
   | 'clinic-staff-update'
   // Patient scope: restricts non-platform reads/writes to documents owned by the patient user.
   | 'patient-scope'
@@ -153,7 +153,10 @@ export const permissionMatrix: PermissionMatrix = {
       operations: {
         create: { type: 'conditional', details: 'disabled API create; managed via provisioning' },
         read: { type: 'conditional', details: 'platform full + clinic own clinic' },
-        update: { type: 'conditional', details: 'platform + own profile only after approval' },
+        update: {
+          type: 'conditional',
+          details: 'platform + own profile after approval; user, clinic, and status fields are platform-only',
+        },
         delete: { type: 'conditional', details: 'disabled API delete; managed via provisioning' },
         admin: { type: 'platform' },
       },
@@ -165,7 +168,8 @@ export const permissionMatrix: PermissionMatrix = {
           delete: { kind: 'always-false' },
         },
       },
-      notes: 'Authentication denied until approval; RW post-approval own clinic + own profile update',
+      notes:
+        'Authentication denied until approval; clinic staff read their clinic and update only non-authorization fields on their own profile',
     },
     patients: {
       slug: 'patients',

--- a/tests/integration/access/clinicStaff-access.test.ts
+++ b/tests/integration/access/clinicStaff-access.test.ts
@@ -73,7 +73,7 @@ describe('ClinicStaff access', () => {
     expect(results.docs[0]?.clinic).toBe(clinicA.id)
   })
 
-  it('allows clinic staff to update their own profile but not others', async () => {
+  it('keeps authorization fields immutable for clinic staff', async () => {
     const { clinic: clinicA } = await createClinicFixture(payload, cityId, { slugPrefix: `${slugPrefix}-update-a` })
     const { clinic: clinicB } = await createClinicFixture(payload, cityId, { slugPrefix: `${slugPrefix}-update-b` })
 
@@ -83,7 +83,7 @@ describe('ClinicStaff access', () => {
       createdBasicUserIds,
       createdClinicStaffIds,
     })
-    const { clinicStaff: staffB } = await createClinicUserWithStaff(payload, {
+    const { basicUser: clinicUserB, clinicStaff: staffB } = await createClinicUserWithStaff(payload, {
       slugPrefix,
       suffix: 'update-b',
       createdBasicUserIds,
@@ -96,13 +96,25 @@ describe('ClinicStaff access', () => {
     const updated = await payload.update({
       collection: 'clinicStaff',
       id: staffA.id,
-      data: { clinic: clinicA.id },
+      data: { clinic: clinicB.id, user: clinicUserB.id },
       user: asBasicUserPayload(clinicUserA),
       overrideAccess: false,
       depth: 0,
     })
 
     expect(updated.id).toBe(staffA.id)
+    expect(updated.clinic).toBe(clinicA.id)
+    expect(updated.user).toBe(clinicUserA.id)
+
+    const persisted = await payload.findByID({
+      collection: 'clinicStaff',
+      id: staffA.id,
+      overrideAccess: true,
+      depth: 0,
+    })
+
+    expect(persisted.clinic).toBe(clinicA.id)
+    expect(persisted.user).toBe(clinicUserA.id)
 
     await expect(
       payload.update({
@@ -120,7 +132,7 @@ describe('ClinicStaff access', () => {
       createdBasicUserIds,
     })
 
-    await payload.update({
+    const platformUpdated = await payload.update({
       collection: 'clinicStaff',
       id: staffB.id,
       data: { clinic: clinicA.id },
@@ -128,6 +140,8 @@ describe('ClinicStaff access', () => {
       overrideAccess: false,
       depth: 0,
     })
+
+    expect(platformUpdated.clinic).toBe(clinicA.id)
 
     await expect(
       payload.delete({

--- a/tests/tooling/scripts/detect-migration-diff.test.ts
+++ b/tests/tooling/scripts/detect-migration-diff.test.ts
@@ -166,6 +166,94 @@ export default {
     expect(output).toContain('schema_changed=true')
   })
 
+  it('does not require a migration for collection field access-only changes', () => {
+    const rootDir = createTempRepo()
+
+    commitFile(
+      rootDir,
+      'src/collections/ClinicStaff.ts',
+      `export const ClinicStaff = {
+  fields: [
+    {
+      name: 'clinic',
+      type: 'relationship',
+      relationTo: 'clinics',
+    },
+  ],
+}
+`,
+    )
+
+    commitFile(
+      rootDir,
+      'src/collections/ClinicStaff.ts',
+      `export const ClinicStaff = {
+  fields: [
+    {
+      name: 'clinic',
+      type: 'relationship',
+      relationTo: 'clinics',
+      access: {
+        // Clinic assignment defines tenant access and may only be changed by Platform Staff.
+        create: platformOnlyFieldAccess,
+        update: platformOnlyFieldAccess,
+      },
+    },
+  ],
+}
+`,
+    )
+
+    const output = runDetector(rootDir)
+
+    expect(output).toContain('db_changed=false')
+    expect(output).toContain('schema_changed=false')
+  })
+
+  it('keeps mixed field access and schema changes schema-relevant', () => {
+    const rootDir = createTempRepo()
+
+    commitFile(
+      rootDir,
+      'src/collections/ClinicStaff.ts',
+      `export const ClinicStaff = {
+  fields: [
+    {
+      name: 'clinic',
+      type: 'relationship',
+      relationTo: 'clinics',
+    },
+  ],
+}
+`,
+    )
+
+    commitFile(
+      rootDir,
+      'src/collections/ClinicStaff.ts',
+      `export const ClinicStaff = {
+  fields: [
+    {
+      name: 'clinic',
+      type: 'relationship',
+      relationTo: 'clinics',
+      required: true,
+      access: {
+        create: platformOnlyFieldAccess,
+        update: platformOnlyFieldAccess,
+      },
+    },
+  ],
+}
+`,
+    )
+
+    const output = runDetector(rootDir)
+
+    expect(output).toContain('db_changed=true')
+    expect(output).toContain('schema_changed=true')
+  })
+
   it('does not require a migration for a collection upload UI and validation hook change', () => {
     const rootDir = createTempRepo()
 


### PR DESCRIPTION
## Management summary

### Deutsch

Klinikzugänge können ihre Klinikzuordnung und die verknüpfte Identität nicht mehr selbst verändern. Dadurch bleibt der Zugriff zuverlässig auf die freigegebene Klinik begrenzt, während das Plattformteam Zuordnungen weiterhin verwalten kann.

### English

Clinic accounts can no longer change their own clinic assignment or linked identity. This keeps access reliably limited to the approved clinic while allowing the platform team to continue managing assignments.

## What changed

- Restricted the `clinicStaff.user` identity link and `clinicStaff.clinic` tenant assignment to platform-only field writes.
- Preserved existing platform management and explicit internal provisioning paths.
- Added an integration regression covering combined clinic and identity reassignment attempts, persisted state, foreign-profile denial, and platform updates.
- Aligned the permission-matrix source and generated security documentation with the field-level authorization contract.
- Classified the change as `no-public-impact`; `clinicStaff` remains `private-live` without public cache or revalidation wiring.
- Updated DB-quality change detection so field-access-only collection changes skip schema migration generation while mixed or real schema changes remain fail-closed.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/collections/ClinicStaff.ts`, `tests/integration/access/clinicStaff-access.test.ts` | These fields define identity and tenant authorization boundaries. | Clinic users cannot persist either protected field, while platform and internal provisioning flows remain functional. | Focused integration test; security reviewer reported no findings. |
| P1 | `.github/scripts/ci/detect-migration-diff.sh`, `tests/tooling/scripts/detect-migration-diff.test.ts` | Migration enforcement must distinguish runtime authorization rules from persisted schema without weakening the gate. | Access-only diffs are exempt while any mixed schema line still triggers enforcement. | Tooling regression suite passed 9/9; full-diff detector reports `schema_changed=false`; CI security reviewer reported no findings. |
| P2 | `src/security/permission-matrix.config.ts`, `docs/security/permission-matrix*` | Documentation and generated policy must describe the same access contract. | The collection-level own-profile rule and field-level platform-only restrictions are represented consistently. | `pnpm matrix:verify`; cache reviewer confirmed `no-public-impact`. |

## Validation

- [x] `pnpm format`: completed successfully after rebasing onto current `origin/main`.
- [x] `pnpm check`: passed, including test sense check, lint, route type generation, Payload type check, and TypeScript.
- [x] `pnpm build`: production build and sitemap generation passed.
- [x] Focused tests: permission matrix verification passed; ClinicStaff permission suite passed 16/16; ClinicStaff access integration passed 2/2; DB-quality detector tooling suite passed 9/9.
- [ ] UI/mobile QA: not applicable; no UI or frontend behavior was changed.
- [x] Security/privacy review: repository security reviewers reported no findings at or above 5/10 for the authorization or CI changes; cache architecture reviewer reported no findings and confirmed `no-public-impact`.
- [x] Migration/schema check: field access only; no schema, data migration, or generated Payload type change required.
- [x] Documentation/instructions check: source and generated permission-matrix documentation updated and verified.

## Risk and rollout

Existing clinic users lose write access only to the identity and clinic-assignment fields that authorize them. Platform management and explicit internal provisioning remain unchanged. DB-quality detection skips migration generation only when every changed collection line is runtime-only; mixed or persisted schema changes still trigger the enforcement gate. No environment, schema, data migration, cache, or deployment configuration changes are required.

## Development

Closes #1483
