### PR TITLE
fix: revalidate doctor media after clinic reassignment

### DIFF
--- a/src/hooks/doctorProfileImageOwnership.ts
+++ b/src/hooks/doctorProfileImageOwnership.ts
@@ -12,9 +12,11 @@ export const beforeChangeValidateDoctorProfileImage: CollectionBeforeChangeHook<
   req,
 }) => {
   const draft = { ...(data || {}) } as Partial<Doctor>
-  if (!hasOwn(draft, 'profileImage')) return draft
+  const profileImageSubmitted = hasOwn(draft, 'profileImage')
+  const clinicSubmitted = hasOwn(draft, 'clinic')
+  if (!profileImageSubmitted && !(operation === 'update' && clinicSubmitted)) return draft
 
-  const profileImageId = extractRelationId(draft.profileImage)
+  const profileImageId = extractRelationId(profileImageSubmitted ? draft.profileImage : originalDoc?.profileImage)
   if (!profileImageId) return draft
 
   const doctorId = resolveDocumentId({

--- a/tests/unit/hooks/doctorProfileImageOwnership.test.ts
+++ b/tests/unit/hooks/doctorProfileImageOwnership.test.ts
@@ -43,6 +43,19 @@ describe('beforeChangeValidateDoctorProfileImage', () => {
     expect(req.payload.findByID).not.toHaveBeenCalled()
   })
 
+  it('revalidates existing media when the doctor clinic changes', async () => {
+    const req = createReq()
+    vi.mocked(req.payload.findByID).mockResolvedValue({ id: 20, doctor: 10, clinic: 4 } as never)
+
+    await expect(
+      runHook({
+        data: { clinic: 5 },
+        originalDoc: { id: 10, clinic: 4, profileImage: 20 },
+        req,
+      }),
+    ).rejects.toThrow("Selected profile image does not belong to this doctor's clinic")
+  })
+
   it('allows media owned by the same doctor and clinic', async () => {
     const req = createReq()
     vi.mocked(req.payload.findByID).mockResolvedValue({ id: 20, doctor: 10, clinic: 4 } as never)


### PR DESCRIPTION
## Management summary

### Deutsch

Ein Arztprofil kann nach einem Klinikwechsel kein Portrait aus der vorherigen Klinik weiterverwenden. Dadurch bleiben öffentliche Arztprofile und Klinikzuordnung konsistent.

### English

A doctor profile can no longer retain a portrait from its previous clinic after reassignment. This keeps public doctor profiles consistent with their clinic ownership.

## What changed

- Revalidate an existing `profileImage` when a Doctor update changes the `clinic` relationship.
- Keep partial updates that change neither `profileImage` nor `clinic` free of unnecessary media reads.
- Add a regression test for rejecting an existing image that belongs to the former clinic.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/hooks/doctorProfileImageOwnership.ts` | Existing media ownership must remain valid across clinic reassignment. | A clinic-only update validates the stored image against the incoming clinic while unrelated partial updates still short-circuit. | Focused hook test, 7/7 passed |

## Validation

- [x] `pnpm format`: Passed.
- [x] `pnpm check`: Passed.
- [x] `pnpm build`: Passed; existing build warnings only.
- [x] Focused tests: `tests/unit/hooks/doctorProfileImageOwnership.test.ts`, 7 passed.
- [ ] UI/mobile QA: Not applicable; no UI change.
- [ ] Security/privacy review: Not run; requires explicit reviewer confirmation.
- [x] Migration/schema check: No schema change; runtime hook only.
- [ ] Documentation/instructions check: Not applicable; no documentation or instruction source changed.

## Risk and rollout

No migration or configuration change. Clinic reassignment now fails closed when the existing portrait belongs to another clinic; clearing or replacing the portrait remains available. Rollback is limited to this commit.

## Development

Closes #1492
