### PR TITLE
fix(seeding): preserve seed reset operator

### DIFF
--- a/src/endpoints/seed/tasks/seedChunkTask.ts
+++ b/src/endpoints/seed/tasks/seedChunkTask.ts
@@ -67,6 +67,24 @@ const resolveSeedReqForJob = async (
   }
 }
 
+const resolveAuthenticatedPlatformUserId = (req: PayloadRequest): string | number | null => {
+  const user = req.user
+  if (!user || typeof user !== 'object') return null
+
+  const candidate = user as { collection?: unknown; id?: unknown; userType?: unknown }
+  if (candidate.collection !== 'basicUsers' || candidate.userType !== 'platform') return null
+
+  if (typeof candidate.id === 'number' && Number.isFinite(candidate.id)) {
+    return candidate.id
+  }
+
+  if (typeof candidate.id === 'string' && candidate.id.trim().length > 0) {
+    return candidate.id
+  }
+
+  return null
+}
+
 const getLogContext = (
   input: SeedQueueJobInput,
   jobId: string,
@@ -151,7 +169,12 @@ export const seedChunkTask = {
       }
 
       if (input.kind === 'reset') {
-        await resetCollections(payload, input.type)
+        const preservePlatformUserId = resolveAuthenticatedPlatformUserId(req)
+        if (preservePlatformUserId === null) {
+          throw new Error('Seed reset jobs require an authenticated platform user')
+        }
+
+        await resetCollections(payload, input.type, { preservePlatformUserId })
 
         const next = await finishSeedRunJob(payload, runId, {
           jobId,

--- a/src/endpoints/seed/utils/finalFlush.ts
+++ b/src/endpoints/seed/utils/finalFlush.ts
@@ -239,10 +239,10 @@ const acquireDatabaseFinalFlushLock = async (
   payload: Payload,
   runId: string,
 ): Promise<(() => Promise<void>) | null | undefined> => {
-  const connect = (payload as PayloadWithOptionalPostgresPool).db?.pool?.connect
-  if (typeof connect !== 'function') return undefined
+  const pool = (payload as PayloadWithOptionalPostgresPool).db?.pool
+  if (typeof pool?.connect !== 'function') return undefined
 
-  const client = await connect()
+  const client = await pool.connect()
 
   try {
     const result = await client.query('select pg_try_advisory_lock(hashtext($1), hashtext($2)) as acquired', [

--- a/src/endpoints/seed/utils/reset.ts
+++ b/src/endpoints/seed/utils/reset.ts
@@ -1,4 +1,4 @@
-import type { CollectionSlug, Payload } from 'payload'
+import type { CollectionSlug, Payload, Where } from 'payload'
 import { resolveSeedRuntimeEnv } from './runtime'
 import { resolveSeedRuntimePolicy } from '@/features/runtimePolicy'
 
@@ -39,17 +39,48 @@ const baselineResetOrder: CollectionSlug[] = [
   'countries',
 ]
 
-async function deleteCollection(payload: Payload, collection: CollectionSlug) {
+type ResetCollectionsOptions = {
+  preservePlatformUserId?: string | number
+}
+
+const buildResetWhere = (collection: CollectionSlug, preservePlatformUserId?: string | number): Where => {
+  const allDocuments: Where = {
+    id: {
+      exists: true,
+    },
+  }
+
+  if (typeof preservePlatformUserId === 'undefined') {
+    return allDocuments
+  }
+
+  if (collection === 'platformStaff') {
+    return {
+      and: [allDocuments, { user: { not_equals: preservePlatformUserId } }],
+    }
+  }
+
+  if (collection === 'basicUsers') {
+    return {
+      and: [allDocuments, { id: { not_equals: preservePlatformUserId } }],
+    }
+  }
+
+  return allDocuments
+}
+
+async function deleteCollection(
+  payload: Payload,
+  collection: CollectionSlug,
+  preservePlatformUserId?: string | number,
+) {
   const req = { payload }
+  const where = buildResetWhere(collection, preservePlatformUserId)
 
   await payload.db.deleteMany({
     collection,
     req,
-    where: {
-      id: {
-        exists: true,
-      },
-    },
+    where,
   })
 
   const versionTableName = payload.db.tableNameMap.get(`_${toSnakeCaseKey(collection)}${payload.db.versionsSuffix}`)
@@ -68,7 +99,11 @@ async function deleteCollection(payload: Payload, collection: CollectionSlug) {
   })
 }
 
-export async function resetCollections(payload: Payload, kind: 'baseline' | 'demo') {
+export async function resetCollections(
+  payload: Payload,
+  kind: 'baseline' | 'demo',
+  options: ResetCollectionsOptions = {},
+) {
   const runtimeEnv = resolveSeedRuntimeEnv(undefined, process.env)
   const policy = resolveSeedRuntimePolicy(runtimeEnv)
 
@@ -90,6 +125,6 @@ export async function resetCollections(payload: Payload, kind: 'baseline' | 'dem
   const order = kind === 'demo' ? demoResetOrder : [...demoResetOrder, ...baselineResetOrder]
   for (const collection of order) {
     payload.logger.info(`Resetting ${collection} (${kind})`)
-    await deleteCollection(payload, collection)
+    await deleteCollection(payload, collection, options.preservePlatformUserId)
   }
 }

--- a/tests/unit/endpoints/seed/resolvers-upsert-reset.test.ts
+++ b/tests/unit/endpoints/seed/resolvers-upsert-reset.test.ts
@@ -191,6 +191,32 @@ describe('resetCollections', () => {
     expect(versionOrder).toEqual(['posts'])
   })
 
+  it('preserves the active platform user and linked staff profile during reset', async () => {
+    vi.stubEnv('VERCEL_ENV', '')
+    vi.stubEnv('DEPLOYMENT_ENV', 'test')
+    vi.stubEnv('NODE_ENV', 'test')
+
+    deleteMany.mockResolvedValue(undefined)
+    deleteVersions.mockResolvedValue(undefined)
+
+    await resetCollections(payload, 'demo', { preservePlatformUserId: 42 })
+
+    const deleteArgsByCollection = new Map(
+      deleteMany.mock.calls.map((call: unknown[]) => {
+        const args = call[0] as { collection: string; where: unknown }
+        return [args.collection, args] as const
+      }),
+    )
+
+    expect(deleteArgsByCollection.get('platformStaff')?.where).toEqual({
+      and: [{ id: { exists: true } }, { user: { not_equals: 42 } }],
+    })
+    expect(deleteArgsByCollection.get('basicUsers')?.where).toEqual({
+      and: [{ id: { exists: true } }, { id: { not_equals: 42 } }],
+    })
+    expect(deleteArgsByCollection.get('clinics')?.where).toEqual({ id: { exists: true } })
+  })
+
   it('deletes demo then baseline collections for baseline reset', async () => {
     vi.stubEnv('VERCEL_ENV', '')
     vi.stubEnv('DEPLOYMENT_ENV', '')

--- a/tests/unit/endpoints/seed/seedChunkTask.test.ts
+++ b/tests/unit/endpoints/seed/seedChunkTask.test.ts
@@ -6,6 +6,7 @@ import { createMockPayload, createMockReq } from '../../helpers/testHelpers'
 import { mockUsers } from '../../helpers/mockUsers'
 
 const importCollection = vi.hoisted(() => vi.fn<() => Promise<CollectionImportResult>>())
+const resetCollections = vi.hoisted(() => vi.fn())
 
 vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
@@ -13,6 +14,7 @@ vi.mock('next/cache', () => ({
 }))
 
 vi.mock('@/endpoints/seed/utils/import-collection', () => ({ importCollection }))
+vi.mock('@/endpoints/seed/utils/reset', () => ({ resetCollections }))
 
 import { seedChunkTask } from '@/endpoints/seed/tasks/seedChunkTask'
 import { createSeedRunRecord, registerSeedRunJob, saveSeedRunRecord } from '@/endpoints/seed/utils/state'
@@ -27,6 +29,7 @@ describe('seedChunkTask', () => {
       warnings: [],
       failures: [],
     })
+    resetCollections.mockReset()
   })
 
   afterEach(() => {
@@ -91,6 +94,65 @@ describe('seedChunkTask', () => {
         localizedFields,
       }),
     )
+  })
+
+  it('preserves the authenticated platform identity during reset jobs', async () => {
+    vi.stubEnv('VERCEL_ENV', '')
+    vi.stubEnv('DEPLOYMENT_ENV', 'test')
+    vi.stubEnv('NODE_ENV', 'test')
+
+    const payload = createMockPayload()
+    const runId = 'seed-run-reset-preserve-actor'
+    const queue = `seed:${runId}`
+    const input: SeedQueueJobInput = {
+      runId,
+      type: 'demo',
+      reset: true,
+      queue,
+      title: 'Reset demo data',
+      stepName: 'reset',
+      kind: 'reset',
+    }
+
+    const record = createSeedRunRecord({
+      runId,
+      type: 'demo',
+      reset: true,
+      queue,
+      totalJobs: 1,
+    })
+    await saveSeedRunRecord(payload as unknown as Payload, record)
+    await registerSeedRunJob(payload as unknown as Payload, runId, {
+      id: 'job-reset',
+      order: 1,
+      status: 'queued',
+      input,
+      queue,
+      title: 'Reset demo data',
+      stepName: 'reset',
+      kind: 'reset',
+      createdAt: '2026-07-13T10:00:00.000Z',
+      created: 0,
+      updated: 0,
+      warnings: [],
+      failures: [],
+    })
+
+    const result = await seedChunkTask.handler({
+      input,
+      job: { id: 'job-reset' },
+      req: createMockReq(mockUsers.platform(42), payload) as PayloadRequest,
+    })
+
+    expect(resetCollections).toHaveBeenCalledWith(payload, 'demo', { preservePlatformUserId: 42 })
+    expect(result).toMatchObject({
+      output: {
+        runId,
+        jobId: 'job-reset',
+        kind: 'reset',
+        status: 'succeeded',
+      },
+    })
   })
 
   it('blocks demo chunk execution in production before importing records', async () => {

--- a/tests/unit/endpoints/seed/seedEndpoint-success.test.ts
+++ b/tests/unit/endpoints/seed/seedEndpoint-success.test.ts
@@ -622,7 +622,7 @@ describe('seed endpoints success paths', () => {
     expect(release).toHaveBeenCalledTimes(1)
   })
 
-  it('holds and releases the database final-flush lock around execution when available', async () => {
+  it('binds the pool while holding and releasing the database final-flush lock', async () => {
     const { payload } = makePayloadReq({})
     const runId = 'seed-run-database-final-flush-lock'
     const queue = `seed:${runId}`
@@ -672,10 +672,17 @@ describe('seed endpoints success paths', () => {
     const query = vi.fn(async (text: string) => ({
       rows: text.includes('pg_try_advisory_lock') ? [{ acquired: true }] : [],
     }))
+    const poolMarker = Symbol('seed-final-flush-pool')
+    const connect = vi.fn(async function (this: { marker?: symbol }) {
+      if (this.marker !== poolMarker) {
+        throw new Error('Database pool context was not preserved')
+      }
+
+      return { query, release }
+    })
+    const pool = { marker: poolMarker, connect }
     ;(payload as typeof payload & { db: { pool: { connect: ReturnType<typeof vi.fn> } } }).db = {
-      pool: {
-        connect: vi.fn(async () => ({ query, release })),
-      },
+      pool,
     }
 
     await finalizeSeedRunPublicCaches(payload as unknown as Payload, {
@@ -686,6 +693,7 @@ describe('seed endpoints success paths', () => {
     })
 
     expect(revalidateTag).toHaveBeenCalled()
+    expect(connect).toHaveBeenCalledTimes(1)
     expect(query).toHaveBeenCalledWith('select pg_try_advisory_lock(hashtext($1), hashtext($2)) as acquired', [
       'seed-final-flush',
       runId,


### PR DESCRIPTION
## Management summary

### Deutsch

Seed-Resets können den ausführenden Plattformadministrator nicht mehr selbst aussperren und schließen wieder zuverlässig ab. Das reduziert manuelle Eingriffe bei der Wiederherstellung von Test- und Vorschau-Daten.

### English

Seed resets can no longer lock out the platform administrator who started them and now complete reliably. This reduces manual intervention when restoring test and preview data.

## What changed

- Preserve the authenticated platform user and profile during reset deletion.
- Reject reset jobs without an authenticated platform user.
- Keep the database pool context intact during the final cache flush.
- Add focused regression coverage for reset and flush behavior.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `src/endpoints/seed/tasks/seedChunkTask.ts`, `src/endpoints/seed/utils/reset.ts` | Reset authorization and deletion scope affect operational recovery. | Only the executing platform identity is preserved; all intended seed data still resets. | Unit tests: 28 passed. |
| P1 | `src/endpoints/seed/utils/finalFlush.ts` | Finalization controls post-reset visibility. | The database client is acquired with the correct pool context. | Unit tests: 28 passed. |

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed.
- [ ] `pnpm build`: not required; no build entry point, route, or Payload config changed.
- [x] Focused tests: 3 unit files, 28 tests passed.
- [x] UI/mobile QA: not applicable; no user-facing UI changed.
- [ ] Security/privacy review: not run; no new public trust boundary.
- [x] Migration/schema check: not applicable.
- [x] Documentation/instructions check: no instruction sources changed.

## Risk and rollout

No schema or cache-policy change. Reset behavior intentionally fails closed when no authenticated platform user is available.

## Development

Closes #1510