### PR TITLE
fix(collections): enforce clinic trust boundaries

### DIFF
--- a/src/collections/Clinics.ts
+++ b/src/collections/Clinics.ts
@@ -4,11 +4,31 @@ import { slugField } from 'payload'
 import { clinicContactRoleOptions, languageOptions } from './common/selectionOptions'
 import { isPlatformBasicUser } from '@/access/isPlatformBasicUser'
 import { platformOrOwnClinicProfile, platformOnlyOrApproved } from '@/access/scopeFilters'
-import { platformClinicTrustAccess, platformClinicTrustFieldAccess } from '@/access/fieldAccess'
+import {
+  platformClinicTrustAccess,
+  platformClinicTrustFieldAccess,
+  platformOnlyFieldAccess,
+} from '@/access/fieldAccess'
 import { stableIdBeforeChangeHook, stableIdField } from './common/stableIdField'
 import { revalidateClinicChange, revalidateClinicDelete } from '@/hooks/revalidateClinicSurfaces'
 
 const INTERNAL_PRIMARY_CONTACT_REQUIRED_MESSAGE = 'Internal primary contact is required.'
+const GALLERY_ENTRIES_SAME_CLINIC_MESSAGE = 'Gallery entries must belong to this clinic.'
+
+const getRelationshipId = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isSafeInteger(value)) return value
+
+  if (typeof value === 'string') {
+    const numericId = Number(value)
+    return Number.isSafeInteger(numericId) ? numericId : null
+  }
+
+  if (value && typeof value === 'object' && 'id' in value) {
+    return getRelationshipId((value as { id?: unknown }).id)
+  }
+
+  return null
+}
 
 const hasCompleteInternalPrimaryContact = (value: unknown): boolean => {
   if (!value || typeof value !== 'object') return false
@@ -67,6 +87,55 @@ const validateInternalPrimaryContactBeforeValidate: CollectionBeforeValidateHook
   return data
 }
 
+const validateGalleryEntriesBeforeValidate: CollectionBeforeValidateHook<Clinic> = async ({
+  data,
+  originalDoc,
+  req,
+}) => {
+  if (!data || !Object.prototype.hasOwnProperty.call(data, 'galleryEntries')) return data
+
+  const incomingEntries = data.galleryEntries
+  if (incomingEntries === null || incomingEntries === undefined || incomingEntries.length === 0) return data
+
+  const clinicId = getRelationshipId(originalDoc?.id)
+  const entryIds = Array.from(new Set(incomingEntries.map(getRelationshipId)))
+
+  if (!clinicId || entryIds.some((id) => id === null)) {
+    throw new Error(GALLERY_ENTRIES_SAME_CLINIC_MESSAGE)
+  }
+
+  const normalizedEntryIds = entryIds as number[]
+  const entries = await req.payload.find({
+    collection: 'clinicGalleryEntries',
+    depth: 0,
+    limit: normalizedEntryIds.length,
+    pagination: false,
+    overrideAccess: true,
+    req,
+    select: {
+      id: true,
+      clinic: true,
+    },
+    where: {
+      id: {
+        in: normalizedEntryIds,
+      },
+    },
+  })
+
+  const validEntryIds = new Set(
+    entries.docs
+      .filter((entry) => getRelationshipId(entry.clinic) === clinicId)
+      .map((entry) => getRelationshipId(entry.id)),
+  )
+
+  if (normalizedEntryIds.some((id) => !validEntryIds.has(id))) {
+    throw new Error(GALLERY_ENTRIES_SAME_CLINIC_MESSAGE)
+  }
+
+  return data
+}
+
 export const Clinics: CollectionConfig<'clinics'> = {
   slug: 'clinics',
   // This config controls what's populated by default when a clinic is referenced
@@ -95,7 +164,7 @@ export const Clinics: CollectionConfig<'clinics'> = {
     delete: isPlatformBasicUser, // Only Platform can delete clinics
   },
   hooks: {
-    beforeValidate: [validateInternalPrimaryContactBeforeValidate],
+    beforeValidate: [validateInternalPrimaryContactBeforeValidate, validateGalleryEntriesBeforeValidate],
     beforeChange: [stableIdBeforeChangeHook],
     afterChange: [revalidateClinicChange],
     afterDelete: [revalidateClinicDelete],
@@ -116,6 +185,10 @@ export const Clinics: CollectionConfig<'clinics'> = {
       type: 'number',
       min: 0,
       max: 5,
+      access: {
+        create: platformOnlyFieldAccess,
+        update: platformOnlyFieldAccess,
+      },
       admin: {
         description: 'Average patient rating',
         readOnly: true,

--- a/tests/integration/access/clinics-access.test.ts
+++ b/tests/integration/access/clinics-access.test.ts
@@ -247,4 +247,46 @@ describe('Clinics access', () => {
       }),
     ).rejects.toThrow()
   })
+
+  it('keeps derived clinic ratings platform-controlled', async () => {
+    const clinic = await payload.create({
+      collection: 'clinics',
+      data: buildClinicData(`${slugPrefix}-rating`, cityId, 'approved'),
+      draft: false,
+      overrideAccess: true,
+      depth: 0,
+    })
+
+    const { basicUser: clinicUser, clinicStaff } = await createClinicUserWithStaff(payload, {
+      slugPrefix,
+      suffix: 'rating-staff',
+      createdBasicUserIds,
+      createdClinicStaffIds,
+    })
+    await approveClinicStaff(payload, clinicStaff.id, clinic.id as number)
+
+    const clinicUpdated = await payload.update({
+      collection: 'clinics',
+      id: clinic.id,
+      data: { averageRating: 5 },
+      user: asPayloadBasicUser(clinicUser),
+      overrideAccess: false,
+      depth: 0,
+    })
+    expect(clinicUpdated.averageRating).not.toBe(5)
+
+    const platformUser = await createPlatformTestUser(payload, {
+      emailPrefix: `${slugPrefix}-rating-platform`,
+      createdBasicUserIds,
+    })
+    const platformUpdated = await payload.update({
+      collection: 'clinics',
+      id: clinic.id,
+      data: { averageRating: 4.6 },
+      user: asPayloadBasicUser(platformUser),
+      overrideAccess: false,
+      depth: 0,
+    })
+    expect(platformUpdated.averageRating).toBe(4.6)
+  })
 })

--- a/tests/integration/clinicGalleryEntries.lifecycle.test.ts
+++ b/tests/integration/clinicGalleryEntries.lifecycle.test.ts
@@ -7,7 +7,7 @@ import { createClinicFixture } from '../fixtures/createClinicFixture'
 import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
 import { testSlug } from '../fixtures/testSlug'
 import { runBaselineContract } from './contracts/baselineContract'
-import type { BasicUser, ClinicGalleryEntry, ClinicGalleryMedia, ClinicStaff } from '@/payload-types'
+import type { BasicUser, Clinic, ClinicGalleryEntry, ClinicGalleryMedia, ClinicStaff } from '@/payload-types'
 
 vi.mock('@payloadcms/storage-s3', () => ({
   s3Storage: () => (incomingConfig: unknown) => incomingConfig,
@@ -368,6 +368,43 @@ describe('ClinicGalleryEntries integration - lifecycle', () => {
         depth: 0,
       } as PayloadCreateArgs),
     ).rejects.toThrow(/same clinic/i)
+  })
+
+  it('rejects gallery entries from a different clinic on clinic profiles', async () => {
+    const { clinic: clinicA } = await createClinicFixture(payload, cityId, {
+      slugPrefix: `${slugPrefix}-profile-gallery-a`,
+    })
+    const { clinic: clinicB } = await createClinicFixture(payload, cityId, {
+      slugPrefix: `${slugPrefix}-profile-gallery-b`,
+    })
+
+    const { basicUser: clinicUserA, clinicStaff: staffA } = await createClinicUser('profile-gallery-a')
+    await approveClinicStaff(staffA.id, clinicA.id as number)
+
+    const { basicUser: clinicUserB, clinicStaff: staffB } = await createClinicUser('profile-gallery-b')
+    await approveClinicStaff(staffB.id, clinicB.id as number)
+
+    const beforeB = await createGalleryMedia(clinicB.id as number, clinicUserB, 'profile-gallery-before-b', 'published')
+    const afterB = await createGalleryMedia(clinicB.id as number, clinicUserB, 'profile-gallery-after-b', 'published')
+    const entryB = await createEntry({
+      clinicId: clinicB.id as number,
+      user: clinicUserB,
+      beforeMediaId: beforeB.id,
+      afterMediaId: afterB.id,
+      status: 'published',
+      titleSuffix: 'profile-gallery-entry-b',
+    })
+
+    await expect(
+      payload.update({
+        collection: 'clinics',
+        id: clinicA.id,
+        data: { galleryEntries: [entryB.id] } as Partial<Clinic>,
+        user: asClinicUser(clinicUserA),
+        overrideAccess: false,
+        depth: 0,
+      } as PayloadUpdateArgs),
+    ).rejects.toThrow(/belong to this clinic/i)
   })
 
   it('scopes reads to published for public, clinic for staff, and all for platform', async () => {


### PR DESCRIPTION
## Management summary

### Deutsch

Kliniken können ihre veröffentlichten Vertrauenssignale nicht mehr eigenmächtig verfälschen oder Inhalte anderer Kliniken verwenden. Öffentliche Profile bleiben dadurch nachvollziehbar und voneinander getrennt.

### English

Clinics can no longer alter their published trust signals on their own or use content from other clinics. Public profiles therefore remain traceable and separated from one another.

## What changed

- Restrict direct writes to calculated clinic average ratings.
- Validate that every referenced gallery entry belongs to the clinic being saved.
- Add integration coverage for rating and cross-clinic gallery attempts.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `src/collections/Clinics.ts` | Enforces public trust data and tenant ownership. | Rating writes are restricted and every gallery relation resolves to the same clinic. | Integration tests: 10 passed. |

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed.
- [ ] `pnpm build`: not required; no build entry point, route, or Payload config changed.
- [x] Focused tests: 2 integration files, 10 tests passed.
- [x] UI/mobile QA: not applicable; no user-facing UI changed.
- [ ] Security/privacy review: not run; security reviewer recommended before merge.
- [x] Migration/schema check: not applicable.
- [x] Documentation/instructions check: no instruction sources changed.

## Risk and rollout

No migration and no new cache policy. Existing clinic revalidation remains responsible for public profile freshness.

## Development

Closes #1513