### PR TITLE
fix: protect computed rating fields

### DIFF
--- a/.github/scripts/ci/detect-migration-diff.sh
+++ b/.github/scripts/ci/detect-migration-diff.sh
@@ -65,6 +65,7 @@ hook_only_collection_hook_expression_regex="(${hook_only_collection_hook_identif
 hook_only_collection_line_regex="^[+-][[:space:]]*(import[[:space:]]*\\{|import[[:space:]].*from[[:space:]]'(@/hooks|\\./hooks)/[^']+'|\\}[[:space:]]*from[[:space:]]'(@/hooks|\\./hooks)/[^']+'|(beforeOperation|beforeChange|afterChange|afterDelete):[[:space:]]*\\[|\\],?|[[:space:]]*((beforeOperation|beforeChange|afterChange|afterDelete):[[:space:]]*\\[)?${hook_only_collection_hook_expression_regex}(,[[:space:]]*${hook_only_collection_hook_expression_regex})*\\]?,?|\\{|\\})[[:space:]]*$"
 collection_upload_component_line_regex="^[+-][[:space:]]*(components:[[:space:]]*\\{|edit:[[:space:]]*\\{|Upload:[[:space:]]*'@/app/\\(payload\\)/components/PolicyAwareUpload',?|\\{|\\},?)[[:space:]]*$"
 collection_crypto_import_line_regex="^[+-][[:space:]]*import[[:space:]]*\\{[[:space:]]*randomUUID[[:space:]]*\\}[[:space:]]*from[[:space:]]*'(node:)?crypto'[[:space:]]*$"
+collection_field_access_import_line_regex="^[+-][[:space:]]*(import[[:space:]]+\\{[[:space:]]*([A-Za-z_][A-Za-z0-9_]*Access[[:space:]]*,?[[:space:]]*)+\\}[[:space:]]+from[[:space:]]+'@/access/fieldAccess'|import[[:space:]]+\\{|\\}[[:space:]]+from[[:space:]]+'@/access/fieldAccess'|[A-Za-z_][A-Za-z0-9_]*Access,?)[[:space:]]*$"
 collection_field_access_line_regex="^[+-][[:space:]]*(//.*|access:[[:space:]]*\\{|(create|read|update):[[:space:]]*[A-Za-z_][A-Za-z0-9_]*FieldAccess,?)[[:space:]]*$"
 payload_config_endpoint_import_line_regex="^[+-][[:space:]]*import[[:space:]]*\\{[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\\}[[:space:]]*from[[:space:]]*'./endpoints/[A-Za-z0-9_./-]+'[[:space:]]*$"
 payload_config_endpoint_line_regex="^[+-][[:space:]]*(\\{|\\},?|path:[[:space:]]*'/?[A-Za-z0-9_./-]+'[,]?|method:[[:space:]]*'(get|post|put|patch|delete)'[,]?|handler:[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]+as[[:space:]]+PayloadHandler[,]?)[[:space:]]*$"
@@ -205,7 +206,11 @@ is_runtime_only_collection_change() {
     esac
 
     if [[ "${diff_line}" == +* || "${diff_line}" == -* ]]; then
-      if [[ ! "${diff_line}" =~ ${hook_only_collection_line_regex} && ! "${diff_line}" =~ ${collection_upload_component_line_regex} && ! "${diff_line}" =~ ${collection_crypto_import_line_regex} && ! "${diff_line}" =~ ${collection_field_access_line_regex} ]]; then
+      if [[ "${diff_line}" =~ ^[+-][[:space:]]*$ ]]; then
+        continue
+      fi
+
+      if [[ ! "${diff_line}" =~ ${hook_only_collection_line_regex} && ! "${diff_line}" =~ ${collection_upload_component_line_regex} && ! "${diff_line}" =~ ${collection_crypto_import_line_regex} && ! "${diff_line}" =~ ${collection_field_access_import_line_regex} && ! "${diff_line}" =~ ${collection_field_access_line_regex} ]]; then
         return 1
       fi
     fi

--- a/docs/security/permission-matrix.generated.md
+++ b/docs/security/permission-matrix.generated.md
@@ -54,14 +54,14 @@
 - **Patients**: Patients can update own profile; no self-create/delete
 - **Posts**: Blog content - platform write, published content readable by all
 - **Pages**: Static pages - platform write, published content readable by all
-- **Doctors**: Platform RWDA, clinic RWA own clinic, patients/anonymous R
-- **Clinics**: Platform admin/support create, platform read/update/delete, clinic RW own profile, patients/anonymous R approved
+- **Doctors**: Platform RWDA, clinic RWA own clinic, patients/anonymous R; averageRating is computed-only
+- **Clinics**: Platform admin/support create, platform read/update/delete, clinic RW own profile, patients/anonymous R approved; averageRating is computed-only
 - **DoctorSpecialties**: Platform RWDA, clinic RWA own clinic, patients/anonymous R
 - **DoctorTreatments**: Platform RWDA, clinic RWA own clinic, patients/anonymous R
 - **ClinicTreatments**: Platform RWDA, clinic RWA own clinic, patients/anonymous R
 - **FavoriteClinics**: Platform RWDA, patients RWDA own list only
 - **Reviews**: Platform RWDA moderation, patients W create own pending reviews only, all R approved
-- **Treatments**: Master data - platform write, everyone read
+- **Treatments**: Master data - platform write, everyone read; averageRating is computed-only
 - **MedicalSpecialties**: Master data - platform write, everyone read
 - **Countries**: Geographic data - platform write, everyone read
 - **Cities**: Geographic data - platform write, everyone read

--- a/src/access/fieldAccess.ts
+++ b/src/access/fieldAccess.ts
@@ -55,6 +55,12 @@ export const platformOnlyFieldAccess: FieldAccess = ({ req }) => {
 }
 
 /**
+ * Computed fields reject all access-controlled writes.
+ * Trusted internal writers must opt into Payload's access override explicitly.
+ */
+export const computedOnlyFieldAccess: FieldAccess = () => false
+
+/**
  * Only Platform Staff with clinic trust management roles can create clinic records.
  */
 export const platformClinicTrustAccess: Access = async ({ req }) => {

--- a/src/collections/Clinics.ts
+++ b/src/collections/Clinics.ts
@@ -4,7 +4,11 @@ import { slugField } from 'payload'
 import { clinicContactRoleOptions, languageOptions } from './common/selectionOptions'
 import { isPlatformBasicUser } from '@/access/isPlatformBasicUser'
 import { platformOrOwnClinicProfile, platformOnlyOrApproved } from '@/access/scopeFilters'
-import { platformClinicTrustAccess, platformClinicTrustFieldAccess } from '@/access/fieldAccess'
+import {
+  computedOnlyFieldAccess,
+  platformClinicTrustAccess,
+  platformClinicTrustFieldAccess,
+} from '@/access/fieldAccess'
 import { stableIdBeforeChangeHook, stableIdField } from './common/stableIdField'
 import { revalidateClinicChange, revalidateClinicDelete } from '@/hooks/revalidateClinicSurfaces'
 
@@ -116,6 +120,10 @@ export const Clinics: CollectionConfig<'clinics'> = {
       type: 'number',
       min: 0,
       max: 5,
+      access: {
+        create: computedOnlyFieldAccess,
+        update: computedOnlyFieldAccess,
+      },
       admin: {
         description: 'Average patient rating',
         readOnly: true,

--- a/src/collections/Doctors.ts
+++ b/src/collections/Doctors.ts
@@ -1,6 +1,7 @@
 import { CollectionConfig, slugField } from 'payload'
 import { languageOptions } from './common/selectionOptions'
 import { generateFullName } from '@/utilities/nameUtils'
+import { computedOnlyFieldAccess } from '@/access/fieldAccess'
 import { isPlatformBasicUser } from '@/access/isPlatformBasicUser'
 import { anyone } from '@/access/anyone'
 import { platformOrAssignedClinicMutation, platformOrOwnClinicResource } from '@/access/scopeFilters'
@@ -72,6 +73,10 @@ export const Doctors: CollectionConfig<'doctors'> = {
       type: 'number',
       min: 0,
       max: 5,
+      access: {
+        create: computedOnlyFieldAccess,
+        update: computedOnlyFieldAccess,
+      },
       admin: {
         description: 'Average patient rating',
         readOnly: true,

--- a/src/collections/Treatments.ts
+++ b/src/collections/Treatments.ts
@@ -1,4 +1,5 @@
 import { CollectionConfig } from 'payload'
+import { computedOnlyFieldAccess } from '@/access/fieldAccess'
 import { anyone } from '@/access/anyone'
 import { isPlatformBasicUser } from '@/access/isPlatformBasicUser'
 import { stableIdBeforeChangeHook, stableIdField } from './common/stableIdField'
@@ -89,6 +90,10 @@ export const Treatments: CollectionConfig<'treatments'> = {
               type: 'number',
               min: 0,
               max: 5,
+              access: {
+                create: computedOnlyFieldAccess,
+                update: computedOnlyFieldAccess,
+              },
               admin: {
                 description: 'Average patient rating',
                 readOnly: true,

--- a/src/hooks/calculations/updateAverageRatings.ts
+++ b/src/hooks/calculations/updateAverageRatings.ts
@@ -83,6 +83,7 @@ async function updateEntityRating(
         ...context,
         skipHooks: true, // Prevent infinite loops
       },
+      overrideAccess: true,
       req,
     })
   } catch (error) {

--- a/src/security/permission-matrix.config.ts
+++ b/src/security/permission-matrix.config.ts
@@ -322,7 +322,7 @@ export const permissionMatrix: PermissionMatrix = {
           admin: { kind: 'clinic-scope', path: 'clinic' },
         },
       },
-      notes: 'Platform RWDA, clinic RWA own clinic, patients/anonymous R',
+      notes: 'Platform RWDA, clinic RWA own clinic, patients/anonymous R; averageRating is computed-only',
     },
     clinics: {
       slug: 'clinics',
@@ -342,7 +342,7 @@ export const permissionMatrix: PermissionMatrix = {
         },
       },
       notes:
-        'Platform admin/support create, platform read/update/delete, clinic RW own profile, patients/anonymous R approved',
+        'Platform admin/support create, platform read/update/delete, clinic RW own profile, patients/anonymous R approved; averageRating is computed-only',
     },
     doctorspecialties: {
       slug: 'doctorspecialties',
@@ -459,7 +459,7 @@ export const permissionMatrix: PermissionMatrix = {
         delete: { type: 'platform' },
         admin: { type: 'platform' },
       },
-      notes: 'Master data - platform write, everyone read',
+      notes: 'Master data - platform write, everyone read; averageRating is computed-only',
     },
     'medical-specialties': {
       slug: 'medical-specialties',

--- a/tests/integration/reviews.averageRatings.test.ts
+++ b/tests/integration/reviews.averageRatings.test.ts
@@ -6,10 +6,16 @@ import { ensureBaseline } from '../fixtures/ensureBaseline'
 import { createClinicFixture } from '../fixtures/createClinicFixture'
 import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
 import { testSlug } from '../fixtures/testSlug'
-import { createPatientTestUser } from '../fixtures/testUsers'
+import {
+  asPayloadBasicUser,
+  cleanupTrackedUsers,
+  createPatientTestUser,
+  createPlatformTestUser,
+} from '../fixtures/testUsers'
 import type { Review } from '@/payload-types'
 
 const createdPatientIds: Array<string | number> = []
+const createdBasicUserIds: Array<string | number> = []
 type PayloadCreateArgs = Parameters<Payload['create']>[0]
 
 async function createReviewPatient(payload: Payload) {
@@ -40,13 +46,7 @@ describe('Review average ratings hooks', () => {
   }, 60000)
 
   afterEach(async () => {
-    while (createdPatientIds.length) {
-      const id = createdPatientIds.pop()
-      if (!id) continue
-      try {
-        await payload.delete({ collection: 'patients', id, overrideAccess: true })
-      } catch {}
-    }
+    await cleanupTrackedUsers(payload, { basicUserIds: createdBasicUserIds, patientIds: createdPatientIds })
 
     await cleanupTestEntities(payload, 'doctors', slugPrefix)
     await cleanupTestEntities(payload, 'clinics', slugPrefix)
@@ -66,6 +66,12 @@ describe('Review average ratings hooks', () => {
     })
     const medicalSpecialty = medicalSpecialtyRes.docs[0]
     if (!medicalSpecialty) throw new Error('Expected baseline medical specialty for review rating tests')
+
+    const platformUser = await createPlatformTestUser(payload, {
+      emailPrefix: `${slugPrefix}-platform`,
+      createdBasicUserIds,
+    })
+    const platformPayloadUser = asPayloadBasicUser(platformUser)
 
     const treatment = await payload.create({
       collection: 'treatments',
@@ -88,10 +94,14 @@ describe('Review average ratings hooks', () => {
           },
         },
         medicalSpecialty: medicalSpecialty.id,
+        averageRating: 1,
       },
-      overrideAccess: true,
+      user: platformPayloadUser,
+      overrideAccess: false,
       depth: 0,
     })
+
+    expect(treatment.averageRating ?? null).toBeNull()
 
     const patient = await createReviewPatient(payload)
 
@@ -121,6 +131,51 @@ describe('Review average ratings hooks', () => {
     expect(clinicAfterCreate.averageRating).toBeCloseTo(4, 5)
     expect(doctorAfterCreate.averageRating).toBeCloseTo(4, 5)
     expect(treatmentAfterCreate.averageRating).toBeCloseTo(4, 5)
+
+    await payload.update({
+      collection: 'clinics',
+      id: clinic.id,
+      data: { averageRating: 1 },
+      user: platformPayloadUser,
+      overrideAccess: false,
+      depth: 0,
+    })
+    await payload.update({
+      collection: 'doctors',
+      id: doctor.id,
+      data: { averageRating: 1 },
+      user: platformPayloadUser,
+      overrideAccess: false,
+      depth: 0,
+    })
+    await payload.update({
+      collection: 'treatments',
+      id: treatment.id,
+      data: { averageRating: 1 },
+      user: platformPayloadUser,
+      overrideAccess: false,
+      depth: 0,
+    })
+
+    const clinicAfterDirectWrite = await payload.findByID({
+      collection: 'clinics',
+      id: clinic.id,
+      overrideAccess: true,
+    })
+    const doctorAfterDirectWrite = await payload.findByID({
+      collection: 'doctors',
+      id: doctor.id,
+      overrideAccess: true,
+    })
+    const treatmentAfterDirectWrite = await payload.findByID({
+      collection: 'treatments',
+      id: treatment.id,
+      overrideAccess: true,
+    })
+
+    expect(clinicAfterDirectWrite.averageRating).toBeCloseTo(4, 5)
+    expect(doctorAfterDirectWrite.averageRating).toBeCloseTo(4, 5)
+    expect(treatmentAfterDirectWrite.averageRating).toBeCloseTo(4, 5)
 
     const reviewAfterUpdate = await payload.update({
       collection: 'reviews',

--- a/tests/tooling/scripts/detect-migration-diff.test.ts
+++ b/tests/tooling/scripts/detect-migration-diff.test.ts
@@ -296,7 +296,9 @@ export default {
     commitFile(
       rootDir,
       'src/collections/ClinicStaff.ts',
-      `export const ClinicStaff = {
+      `import { platformOnlyFieldAccess } from '@/access/fieldAccess'
+
+export const ClinicStaff = {
   fields: [
     {
       name: 'clinic',
@@ -306,6 +308,55 @@ export default {
         // Clinic assignment defines tenant access and may only be changed by Platform Staff.
         create: platformOnlyFieldAccess,
         update: platformOnlyFieldAccess,
+      },
+    },
+  ],
+}
+`,
+    )
+
+    const output = runDetector(rootDir)
+
+    expect(output).toContain('db_changed=false')
+    expect(output).toContain('schema_changed=false')
+  })
+
+  it('does not require a migration when a field access import expands across lines', () => {
+    const rootDir = createTempRepo()
+
+    commitFile(
+      rootDir,
+      'src/collections/Clinics.ts',
+      `import { platformClinicTrustAccess, platformClinicTrustFieldAccess } from '@/access/fieldAccess'
+
+export const Clinics = {
+  fields: [
+    {
+      name: 'averageRating',
+      type: 'number',
+    },
+  ],
+}
+`,
+    )
+
+    commitFile(
+      rootDir,
+      'src/collections/Clinics.ts',
+      `import {
+  computedOnlyFieldAccess,
+  platformClinicTrustAccess,
+  platformClinicTrustFieldAccess,
+} from '@/access/fieldAccess'
+
+export const Clinics = {
+  fields: [
+    {
+      name: 'averageRating',
+      type: 'number',
+      access: {
+        create: computedOnlyFieldAccess,
+        update: computedOnlyFieldAccess,
       },
     },
   ],

--- a/tests/unit/access/fieldAccess.test.ts
+++ b/tests/unit/access/fieldAccess.test.ts
@@ -9,6 +9,7 @@ import { describe, test, beforeEach, expect } from 'vitest'
 import { createAccessArgs, expectAccess, clearAllMocks, createMockPayload } from '../helpers/testHelpers'
 import { mockUsers } from '../helpers/mockUsers'
 import {
+  computedOnlyFieldAccess,
   platformClinicTrustAccess,
   platformClinicTrustFieldAccess,
   platformOnlyFieldAccess,
@@ -17,6 +18,17 @@ import {
 describe('Field Access Control', () => {
   beforeEach(() => {
     clearAllMocks()
+  })
+
+  describe('computedOnlyFieldAccess', () => {
+    test.each([
+      { userType: 'Platform Staff', user: () => mockUsers.platform() },
+      { userType: 'Clinic Staff', user: () => mockUsers.clinic() },
+      { userType: 'Patient', user: () => mockUsers.patient() },
+      { userType: 'Anonymous', user: () => mockUsers.anonymous() },
+    ])('denies $userType writes', ({ user }) => {
+      expectAccess.none(computedOnlyFieldAccess(createAccessArgs(user())))
+    })
   })
 
   describe('platformOnlyFieldAccess', () => {

--- a/tests/unit/collections/computedRatingFields.test.ts
+++ b/tests/unit/collections/computedRatingFields.test.ts
@@ -1,0 +1,70 @@
+import type { FieldAccess } from 'payload'
+import { describe, expect, test } from 'vitest'
+
+import { Clinics } from '@/collections/Clinics'
+import { Doctors } from '@/collections/Doctors'
+import { Treatments } from '@/collections/Treatments'
+import { createAccessArgs } from '../helpers/testHelpers'
+import { mockUsers } from '../helpers/mockUsers'
+
+type FieldNode = {
+  name?: string
+  fields?: FieldNode[]
+  tabs?: Array<{ fields?: FieldNode[] }>
+  access?: {
+    create?: FieldAccess
+    read?: FieldAccess
+    update?: FieldAccess
+  }
+  admin?: {
+    readOnly?: boolean
+  }
+}
+
+const findFieldByName = (fields: FieldNode[] | undefined, name: string): FieldNode | null => {
+  if (!fields) return null
+
+  for (const field of fields) {
+    if (field.name === name) return field
+
+    const nestedField = findFieldByName(field.fields, name)
+    if (nestedField) return nestedField
+
+    for (const tab of field.tabs ?? []) {
+      const tabField = findFieldByName(tab.fields, name)
+      if (tabField) return tabField
+    }
+  }
+
+  return null
+}
+
+const collections = [
+  { slug: 'clinics', fields: Clinics.fields as FieldNode[] },
+  { slug: 'doctors', fields: Doctors.fields as FieldNode[] },
+  { slug: 'treatments', fields: Treatments.fields as FieldNode[] },
+]
+
+const roles = [
+  { role: 'platform', user: () => mockUsers.platform() },
+  { role: 'clinic', user: () => mockUsers.clinic() },
+  { role: 'patient', user: () => mockUsers.patient() },
+  { role: 'anonymous', user: () => mockUsers.anonymous() },
+]
+
+describe.each(collections)('$slug averageRating field', ({ fields }) => {
+  const averageRatingField = findFieldByName(fields, 'averageRating')
+
+  test.each(roles)('denies direct create and update writes for $role users', async ({ user }) => {
+    expect(averageRatingField?.access?.create).toBeTypeOf('function')
+    expect(averageRatingField?.access?.update).toBeTypeOf('function')
+
+    expect(await averageRatingField?.access?.create?.(createAccessArgs(user()))).toBe(false)
+    expect(await averageRatingField?.access?.update?.(createAccessArgs(user()))).toBe(false)
+  })
+
+  test('keeps reads unrestricted and the Admin field read-only', () => {
+    expect(averageRatingField?.access?.read).toBeUndefined()
+    expect(averageRatingField?.admin?.readOnly).toBe(true)
+  })
+})

--- a/tests/unit/hooks/updateAverageRatings.test.ts
+++ b/tests/unit/hooks/updateAverageRatings.test.ts
@@ -77,6 +77,8 @@ describe('updateAverageRatings hooks', () => {
         id: 'clinic-new',
         data: { averageRating: 3 },
         context: { skipHooks: true },
+        overrideAccess: true,
+        req,
       }),
     )
     expect(payload.update).toHaveBeenNthCalledWith(
@@ -85,6 +87,7 @@ describe('updateAverageRatings hooks', () => {
         collection: 'doctors',
         id: 'doctor-new',
         data: { averageRating: 5 },
+        overrideAccess: true,
       }),
     )
     expect(payload.update).toHaveBeenNthCalledWith(
@@ -93,6 +96,7 @@ describe('updateAverageRatings hooks', () => {
         collection: 'treatments',
         id: 301,
         data: { averageRating: 3 },
+        overrideAccess: true,
       }),
     )
     expect(payload.update).toHaveBeenNthCalledWith(
@@ -101,6 +105,7 @@ describe('updateAverageRatings hooks', () => {
         collection: 'clinics',
         id: 'clinic-old',
         data: { averageRating: 3 },
+        overrideAccess: true,
       }),
     )
     expect(payload.update).toHaveBeenNthCalledWith(
@@ -109,8 +114,15 @@ describe('updateAverageRatings hooks', () => {
         collection: 'treatments',
         id: 999,
         data: { averageRating: null },
+        overrideAccess: true,
       }),
     )
+
+    for (const [updateArgs] of payload.update.mock.calls) {
+      expect(Object.keys(updateArgs.data)).toEqual(['averageRating'])
+      expect(updateArgs.context).toEqual({ skipHooks: true })
+      expect(updateArgs.req).toBe(req)
+    }
   })
 
   it('skips all work when the hook context already disabled nested hooks', async () => {


### PR DESCRIPTION
## Management summary

### Deutsch

Bewertungen auf Klinik-, Arzt- und Behandlungsprofilen können nicht mehr manuell überschrieben werden. Sie bleiben ausschließlich das Ergebnis freigegebener Patientenbewertungen, sodass die Plattform verlässlichere und nachvollziehbare Rating-Werte zeigt.

### English

Ratings on clinic, doctor, and treatment profiles can no longer be overwritten manually. They remain exclusively derived from approved patient reviews, giving the platform more reliable and traceable rating values.

## What changed

- Added a reusable computed-only field access rule that rejects access-controlled create and update writes.
- Applied the rule to `averageRating` in Clinics, Doctors, and Treatments while preserving public reads and the existing read-only Admin presentation.
- Made the trusted review calculation path opt into Payload's access override explicitly while retaining its narrow `averageRating` payload and recursion guard.
- Added computed-only notes to the permission matrix and regenerated its documentation.
- Extended the fail-closed migration detector to recognize field-access imports and harmless blank diff lines without excluding mixed schema changes.
- Added role, collection-config, hook, real Payload, public default-populate, and migration-detector coverage.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/access/fieldAccess.ts`, `src/collections/Clinics.ts`, `src/collections/Doctors.ts`, `src/collections/Treatments.ts` | These rules protect publicly visible computed data from direct writes. | Verify create and update are denied for every role while reads and Admin presentation remain unchanged. | 39 focused field/config/hook tests and the broader 93-test regression set pass. |
| P1 | `src/hooks/calculations/updateAverageRatings.ts`, `tests/integration/reviews.averageRatings.test.ts` | The review hook is the only trusted writer for the protected fields. | Verify the internal update explicitly overrides access, writes only `averageRating`, preserves `skipHooks`, and still handles create, update, and delete review flows. | Real Payload integration coverage passes for blocked direct create/update writes and review-driven recalculation. |
| P1 | `.github/scripts/ci/detect-migration-diff.sh`, `tests/tooling/scripts/detect-migration-diff.test.ts` | Runtime-only field access must not request a migration, while schema changes must remain fail-closed. | Verify the import allowlist is limited to `@/access/fieldAccess`, blank lines are the only generic addition, and mixed field/schema changes remain schema-relevant. | 14 detector tests pass; the real PR diff reports `schema_changed=false`. |

## Validation

- [x] `pnpm format`: passed; `pnpm format:check` also passed afterward.
- [x] `pnpm check`: passed, including sense-check, lint, route type generation, Payload type drift check, and TypeScript.
- [x] `pnpm build`: passed with `PAYLOAD_SECRET=dev-secret`; Next.js compiled and generated 36 static pages, followed by sitemap generation.
- [x] Focused tests: 93 field-access, collection-config, permission-matrix, rating-hook, and cache-hook tests; three relevant Payload integration tests; and 14 migration-detector tests passed. `pnpm matrix:verify` reports all 34 collections and permission suites aligned.
- [x] GitHub CI: all required checks passed, including Build and the database quality gate; Semgrep and CodeQL analyses also passed.
- [ ] UI/mobile QA: not applicable because no UI, layout, responsive, or interaction implementation changed; the existing Admin read-only presentation remains configured.
- [ ] Security/privacy review: not run automatically; repository policy requires explicit confirmation before `security_reviewer` and `cache_architecture_reviewer` execution.
- [x] Migration/schema check: the real branch diff reports `schema_changed=false`, `migrations_changed=false`, and `risk_scan_needed=false`; no migration or Payload type generation is required.
- [x] Documentation/instructions check: permission-matrix documentation was regenerated and verified; no instruction source changed.

## Risk and rollout

The primary risk is blocking the trusted review calculation together with external writes. Unit and real Payload integration tests cover the explicit internal override, narrow update payload, recursion guard, and review create/update/delete behavior. There are no data, schema, environment, or migration changes. Cache impact is `no-public-impact`: public reads, cache tags, planner events, and existing revalidation behavior remain unchanged. Rollback is a code revert without data recovery.

## Development

Closes #1539
