### PR TITLE
fix(auth): allow direct platform staff in MCP

### DIFF
--- a/src/plugins/mcp.ts
+++ b/src/plugins/mcp.ts
@@ -103,7 +103,7 @@ export const createMcpPlugin = (): Plugin =>
       const isPlatformStaffUser = (user: unknown): boolean => {
         if (typeof user !== 'object' || user === null) return false
         const record = user as Record<string, unknown>
-        return record.collection === mcpUserCollection && record.userType === 'platform'
+        return record.collection === mcpUserCollection
       }
 
       if (!isPlatformStaffUser(mcpAccessSettings.user as unknown)) {


### PR DESCRIPTION
## Management summary

### Deutsch

Plattformmitarbeitende können die redaktionellen Automatisierungsfunktionen nach der Umstellung auf die neue direkte Anmeldung wieder verwenden. Der laufende Admin-Zugang und die übrigen Nutzerabläufe bleiben unverändert.

### English

Platform staff can use the editorial automation capabilities again after the switch to direct staff sign-in. The existing admin access and other user flows remain unchanged.

## What changed

- Updated the MCP authorization boundary to recognize the direct `platformStaff` principal collection without requiring the removed legacy `userType` field.
- Kept the existing collection-based platform staff boundary and all MCP read/write collection restrictions unchanged.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/plugins/mcp.ts` | MCP authorization moved to direct staff principals in the preceding auth switch. | Direct `platformStaff` principals are accepted while non-platform collections remain rejected. | `pnpm check` and `pnpm build` passed. |

## Validation

- [x] `pnpm format`: completed successfully.
- [x] `pnpm check`: completed successfully; existing sense-check warnings only.
- [x] `pnpm build`: completed successfully; Next reported compile warnings without failing.
- [ ] Focused tests: no dedicated MCP authorization test exists; the one-line predicate is covered by check/build only.
- [ ] UI/mobile QA: not applicable; no UI changes.
- [ ] Security/privacy review: not run automatically; recommend the security reviewer because this changes an authorization predicate.
- [ ] Migration/schema check: not applicable; no schema or migration changes.
- [ ] Documentation/instructions check: not applicable; no documentation or instruction changes.

## Risk and rollout

Low-risk authorization correction. Direct `platformStaff` remains the sole accepted MCP user collection; no database, environment, or public UI changes.

## Development

Closes #1548
