### PR TITLE
feat: expose public blog during holding mode

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -7,3 +7,4 @@ Use these roadmap notes for planned work that has real future implementation or 
   [Direct Staff Authentication Implementation Plan](./clinic-dashboard/direct-staff-auth-implementation-plan.md)
 - [Localization Planning](./localization/README.md)
 - [Patient Favorites Roadmap](./patient-favorites/README.md)
+- [Temporary Landing Public Blog](./temporary-landing-public-blog.md)

--- a/docs/roadmap/temporary-landing-public-blog.md
+++ b/docs/roadmap/temporary-landing-public-blog.md
@@ -1,0 +1,253 @@
+# Temporary Landing Public Blog
+
+> Reviewed design and implementation record. This roadmap file preserves scope, decisions, and verification expectations; repository code and its tests remain authoritative for runtime behavior.
+
+## Decision Evidence
+
+- Visual truth: the versioned Storybook scenarios in `src/stories/templates/HoldingPageConcept.stories.tsx`, `src/stories/templates/BlogListing.stories.tsx`, and `src/stories/organisms/BlogCardCollection.stories.tsx`.
+- Selected direction: insert a compact three-card blog section after the temporary landing signals and before the footer, using the existing `BlogCard.Simple` card from the public blog listing.
+- Decision status: implemented and locally verified on `feature/public-blog-holding-page`.
+- Current implementation evidence:
+  - `src/app/(frontend)/page.tsx` returns the temporary landing page before loading the normal homepage blog data.
+  - `src/features/temporaryLandingMode/index.ts` does not currently classify `/posts` as publicly reachable in temporary landing mode.
+  - `src/components/templates/HoldingPageConcept/index.tsx` renders the immersive holding sequence as hero, founder/contact content, signals, and footer.
+  - `src/app/(frontend)/posts/page.tsx` composes the public listing from `BlogHero`, `BlogCard.Overlay`, and `BlogCard.Simple`.
+  - `src/utilities/content/serverData/posts.ts` already provides cached public post-list and latest-post reads.
+- Implementation note: existing production posts remain untouched and are removed or unpublished manually by an authorized Payload editor.
+
+## Product Decision
+
+The temporary landing page reuses the public blog listing's simple cards instead of introducing a new card style or embedding the complete homepage `BlogCardCollection` unchanged.
+
+The `BlogCard.Simple` direction is preferred because it:
+
+- preserves the holding page's restrained light visual rhythm
+- avoids a second dominant hero-like surface below the immersive hero
+- removes author-avatar and arrow density that is not needed for a three-post teaser
+- already has a whole-card link, an accessible label, and an explicit keyboard focus treatment
+- can reuse the public listing's one-, two-, and three-column responsive behavior
+
+The complete `BlogCardCollection` remains a valid implementation reference, but its full-width section ownership, container, vertical spacing, author treatment, and CTA make direct nesting in the holding template unnecessarily heavy.
+
+## Scope
+
+### Must
+
+- Keep the temporary landing root page publicly reachable as it is today.
+- Make `/posts`, `/posts/page/:pageNumber`, and `/posts/:slug` reachable without platform login while temporary landing mode is active.
+- Keep unrelated protected product routes unavailable to anonymous visitors.
+- Render up to three latest published posts after the holding-page signal cards and before the footer.
+- Reuse `BlogCard.Simple`, `Heading`, and `UiLink` rather than duplicating their markup or visual rules; inherit the holding template's existing outer `Container` instead of nesting another one.
+- Hide the complete teaser section when no published posts are available.
+- Preserve draft, preview, admin, auth, and personalized data as live/private data.
+- Keep deletion or unpublishing of existing production posts as a manual Payload operation.
+
+### Should
+
+- Keep the heading, introduction, and CTA labels in the temporary landing locale copy.
+- Carry the supported content locale into the post cards, listing CTA, and detail links.
+- Use English post content as the explicit fallback for the Turkish holding locale until Turkish CMS content localization exists.
+- Keep the current temporary-landing `X-Robots-Tag` behavior unless a separate SEO decision explicitly opens blog indexation and discovery surfaces.
+
+### Must Not
+
+- Add a new blog card visual language.
+- Copy card JSX from the listing or homepage into the holding template.
+- Use the large `BlogCard.Overlay` featured treatment on the holding page.
+- Add a new Payload collection, field, migration, cache class, cache tag family, or invalidation owner.
+- Delete or unpublish production posts from application code, a migration, a seed, or deployment automation.
+- Expose other routes merely because the blog becomes public.
+
+### Out of Scope
+
+- Writing or publishing replacement blog content.
+- Automated production-content deletion.
+- Turkish CMS content localization.
+- Changing post schemas, post-detail design, or the full blog-listing design.
+- Opening `robots.txt`, sitemap output, or blog routes for search indexing during temporary landing mode.
+- Reworking the temporary landing hero, contact form, signal cards, or footer.
+
+## Visible UI Contract
+
+Anything not listed here is out of implementation scope.
+
+| UI element | User value | Data source | Component ownership | Allowed behavior |
+| --- | --- | --- | --- | --- |
+| Blog section heading | Explains that current editorial content is already available | Temporary landing locale copy | `Heading` in a small temporary-landing blog section | Static localized text |
+| Blog section introduction | Sets expectations for the three articles | Temporary landing locale copy | Temporary-landing blog section | Static localized text; may be omitted if copy remains concise without it |
+| Three article cards | Gives anonymous visitors direct access to useful public content | Latest published `posts` documents | Existing `BlogCard.Simple` | Whole card navigates to the localized post detail path |
+| Category badge | Helps visitors scan article topics | Existing normalized post category | Existing `BlogCard.Simple` | Display only when present |
+| Article metadata | Provides source and publication context | Existing normalized author and publication date | Existing `BlogCard.Simple` | Use current truncation and fallback behavior |
+| All-articles CTA | Opens the complete public blog listing | Existing post path builder plus temporary landing locale mapping | Existing `UiLink` | Navigate to the localized `/posts` index |
+| Empty state | Avoids an empty section when no content is publishable | Published-post query result | Route composition | Render no blog section |
+
+## Data and Permissions
+
+| Collection or source | Fields or capability | Relationship | Permission | Provenance or freshness | Status |
+| --- | --- | --- | --- | --- | --- |
+| `posts` | Title, slug, excerpt, category, author, publication date, hero image | Latest three published records | Public read only; drafts excluded | Payload source, existing cached server-data loader | Available |
+| Temporary landing locale | `en`, `de`, `tr` | Selects section copy and supported post content locale | Public query parameter | Code-owned locale map | Available |
+| Blog content locale | `en`, `de` | Controls normalized post copy and generated paths | Public query parameter with English fallback | Existing content-localization utilities | Available |
+| Turkish blog content | Localized post fields | Would map holding locale `tr` to post content | Public | No Turkish CMS content locale exists | Data Gap |
+| Production post removal | Delete or unpublish records | Removes cards, listing entries, and detail routes | Authorized Payload editor only | Manual production operation with existing revalidation hooks | User-owned operation |
+
+## Component Plan
+
+| Feature | Reuse, change, or new | Candidate component or module | Notes |
+| --- | --- | --- | --- |
+| Article cards | Reuse | `src/components/organisms/Blog/BlogCard/Simple.tsx` | Use unchanged unless composed-route QA proves a real defect |
+| Blog grid | Reuse pattern | `src/app/(frontend)/posts/page.tsx` | Reuse its responsive grid behavior for three cards |
+| Holding insertion point | Small change | `src/components/templates/HoldingPageConcept/index.tsx` | Add one optional post-signals composition slot before `FooterBlock`; do not fetch data here |
+| Temporary blog section | New composition only | `src/components/templates/TemporaryLandingPage/` or a colocated child module | Own heading, grid, CTA, and empty rendering; remain Payload-free |
+| Post loading | Extend existing read | `src/utilities/content/serverData/posts.ts` | Make latest-post caching content-locale-aware without changing tags or policy |
+| Route composition | Change | `src/app/(frontend)/page.tsx` | Resolve locale, load latest public posts, normalize them, and pass presentation data down |
+| Public route boundary | Change | `src/features/temporaryLandingMode/index.ts`, `src/proxy.ts` | Allow only `/posts`, `/posts/:singleSlug`, and `/posts/page/:positiveInteger`; preserve all other restrictions |
+| Localized copy | Change | `src/features/temporaryLandingMode/content.ts` | Add section heading, introduction if retained, and CTA label for `en`, `de`, and `tr` |
+
+## Cache Impact
+
+### Decision
+
+`public-cached` applies because the holding page adds another public rendering of cached published post data. The existing `aggregated-public` policy and invalidation vocabulary already cover the required read and write paths.
+
+### Dependency Map
+
+- Public reads: latest three published posts for `/`; paginated published posts for `/posts`; published post detail for `/posts/:slug`.
+- Rendered surfaces: temporary landing `home` teaser, posts listing, posts pagination, and post detail.
+- Write events: post publish, update, slug change, unpublish, and delete.
+- Existing discovery dependencies: posts sitemap and posts-list surfaces remain governed by the current policy even though temporary landing mode keeps search indexation out of this scope.
+- Excluded inputs: draft, preview, admin, auth, private, personalized, cookie-bound, and request-bound data.
+
+### Read/Write Symmetry
+
+- Cache class: `aggregated-public` for list and landing aggregations; existing `critical-public` behavior remains on detail routes.
+- Policy entry: existing `route:posts:list`.
+- Latest-post cache key: use the shared post-list key builder with limit, content-locale, and fallback-locale dimensions.
+- Read tags: existing `collection:posts`, `surface:posts-list`, `surface:home`, `surface:partners-clinics`, and `surface:sitemap:posts` tag builders.
+- Normalized event: existing post collection change and delete events.
+- Invalidation owner: existing Posts collection hooks through the central revalidation adapter, planner, and executor.
+- Planner outcome: invalidate post entity/slug state, post collection/list/home surfaces, post sitemap, `/posts`, and bounded old/new post detail paths.
+- New cache semantics: none.
+
+### Cache Tests
+
+- Prove locale dimensions produce distinct latest-post cache keys.
+- Prove latest-post reads retain the existing canonical tag set.
+- Preserve planner coverage for publish, slug change, unpublish, and delete.
+- Prove the holding teaser refreshes through the existing `surface:home` invalidation path rather than a new tag.
+
+### Stop Conditions
+
+Stop for an ADR or explicit work order if implementation requires a new cache class, tag family, owner, freshness expectation, route family, Redis or remote cache, custom cache handler, Cache Components, or changed invalidation semantics.
+
+## Implementation Sequence
+
+1. Add localized blog-section copy and an explicit holding-to-content-locale mapping.
+2. Extend the latest-post cached read with locale-aware cache-key dimensions while retaining its existing tags and invalidation owner.
+3. Add the small presentation-only temporary blog section using `BlogCard.Simple`.
+4. Add the optional post-signals composition slot to the immersive holding layout and inject the blog section from `TemporaryLandingPage`.
+5. Open the exact blog index, single-segment detail, and positive-integer pagination route shapes to anonymous temporary-landing visitors.
+6. Add focused unit, proxy, route, Storybook, and cache-contract coverage.
+7. Complete mobile-first route QA and capture ignored Playwright screenshots.
+8. After replacement content is published and verified, let an authorized editor manually delete or unpublish the existing production posts.
+9. Verify the teaser, listing, detail routes, and removal of stale links after the manual content operation.
+
+## Acceptance Criteria
+
+- Product behavior:
+  - Anonymous visitors in temporary landing mode can open `/`, `/posts`, paginated blog listing paths, and published post detail paths.
+  - Unrelated product routes remain unavailable.
+  - The landing page shows at most three latest published posts after the signals and before the footer.
+  - Every card and the all-articles CTA navigate to a public blog route.
+  - No published posts results in no blog section.
+- Responsive behavior:
+  - Verify `320`, `375`, `640`, `768`, `1024`, and `1280` widths.
+  - Preserve one-column mobile order, expand deliberately to two and then three columns, and prevent horizontal overflow or clipped labels.
+  - Verify realistic long titles, long categories, missing excerpts, missing dates, and missing authors.
+- Accessibility:
+  - Preserve whole-card accessible names and visible keyboard focus.
+  - Keep heading order coherent after the signals.
+  - Do not rely on hover for navigation or article discovery.
+  - Verify keyboard traversal from the signal section through all cards, the CTA, and the footer.
+- Data and permissions:
+  - Query only published public posts.
+  - Force draft access off when the temporary-landing request header is present, even if an anonymous request carries a stale draft cookie.
+  - Keep drafts and preview reads outside the public cache.
+  - Do not automate production post deletion.
+- Verification evidence:
+  - Storybook covers default, empty, long-content, and responsive teaser states.
+  - Unit tests cover locale mapping, route-prefix boundaries, empty rendering, and cache-key/tag contracts.
+  - Proxy tests cover anonymous access with temporary landing mode alone and with preview guard also active.
+  - Composed-route Playwright checks cover `/`, `/posts`, and one post detail at the required viewport matrix.
+  - Required repository validation is `pnpm format`, `pnpm check`, and `pnpm build` with the documented Payload secret and database prerequisites.
+
+## Production Content Removal
+
+Existing production posts are removed manually in Payload after replacement content and public routing are verified.
+
+Recommended operator order:
+
+1. Publish replacement posts.
+2. Verify the three teaser cards, listing, and detail routes.
+3. Unpublish or delete the existing posts in Payload.
+4. Confirm the existing post hooks revalidate the teaser, listing, sitemap tags, and old detail paths.
+5. Confirm no deleted post remains linked or publicly reachable.
+
+If all posts are removed before replacements exist, the teaser intentionally disappears and the listing remains available without article cards.
+
+## Assumptions and Data Gaps
+
+### Assumptions
+
+- “Publicly visible” means reachable without login; it does not automatically mean indexable by search engines during temporary landing mode.
+- The selected visual direction is the existing simple blog-listing card, not a new mockup and not the complete homepage blog section.
+- English is the temporary fallback for Turkish blog content.
+- The existing `X-Robots-Tag` behavior remains unchanged until SEO indexation is separately approved.
+
+### Data Gaps
+
+- Turkish localized blog fields are not available.
+- Replacement production post content and its publication schedule are not part of this plan.
+- The future authoritative GitHub issue does not yet exist.
+
+## Revalidated Existing-Code Findings
+
+The implementation review confirmed that the following gaps predated this feature plan. They are fixed in the same change because the new public surface would otherwise inherit or amplify them:
+
+- The temporary-landing public-route helper had no exact blog route contract; a generic prefix would have widened access to non-blog paths.
+- Post detail draft access trusted `draftMode()` without a temporary-landing anonymous boundary.
+- The existing Storybook and live blog grid evidence used conflicting responsive breakpoints.
+- The existing central `blogCard` image `sizes` policy did not match the live `sm` and `xl` grid breakpoints.
+- The existing latest-post loader selected full rich-text content even though the teaser cards do not render read time.
+- The public posts index had no visible localized empty state after all posts are removed.
+
+These are repository-level corrections to existing components and loaders, not deficiencies invented by the implementation plan.
+
+## Implementation Verification
+
+- `pnpm format`: passed.
+- `pnpm check`: passed.
+- Unit test suite: 287 files and 2,181 tests passed.
+- Story governance: 109 story files and 6 MDX documents passed validation.
+- Storybook production build: passed.
+- Playwright Storybook QA: `320`, `375`, `640`, `768`, `1024`, and `1280` widths showed no horizontal overflow; visual screenshots cover the holding insertion at `375` and `1280`.
+- Security, SEO, accessibility, Web Vitals, cache architecture, and Storybook reviews: no findings at `5/10` or higher.
+- Next.js production build: compilation and TypeScript passed; page-data collection could not finish because Docker Desktop could not start the required local Postgres service.
+- Route-level runtime QA remains unconfirmed for the same local database limitation; Storybook evidence is supporting rather than a substitute for that check.
+
+## Review Handoff
+
+- Expected implementation surfaces:
+  - temporary landing route composition and locale copy
+  - public route access boundary in the proxy
+  - existing cached post loader and cache-key contract
+  - a small image-heavy responsive teaser composition
+  - Storybook, unit, proxy, and route-level UI coverage
+- Required reviewers and rationale:
+  - Product Design audit: verify that the selected existing card treatment fits the current holding-page hierarchy without introducing a competing visual language.
+  - Mobile UI reviewer: verify hierarchy, card stacking, image sizing, overflow, and CTA placement across the required matrix.
+  - Accessibility reviewer: verify heading structure, card naming, keyboard focus, and link traversal.
+  - Security reviewer: verify that the new public prefix does not widen access beyond published blog routes.
+  - SEO reviewer: verify the deliberate boundary between public reachability and continued temporary-mode noindex behavior.
+  - Web Vitals reviewer: verify image sizing, loading behavior, and landing-page impact.
+  - Cache architecture reviewer: verify public read/write symmetry and the absence of new cache semantics.

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -17,6 +17,7 @@ import {
   buildTemporaryLandingLanguageOptions,
   getTemporaryLandingPageContent,
   isTemporaryLandingModeRequest,
+  resolveTemporaryLandingContentLocale,
   resolveTemporaryLandingLocale,
 } from '@/features/temporaryLandingMode'
 import { getPayload } from 'payload'
@@ -37,8 +38,18 @@ export default async function Home({
     const searchParams = (await searchParamsPromise) ?? {}
     const locale = resolveTemporaryLandingLocale(searchParams)
     const languageOptions = buildTemporaryLandingLanguageOptions(searchParams)
+    const contentLocale = resolveTemporaryLandingContentLocale(locale)
+    const posts = await getCachedLatestPosts(3, contentLocale)
+    const normalizedPosts = posts.map((post) => normalizePost(post, { contentLocale }))
 
-    return <TemporaryLandingPage locale={locale} languageOptions={languageOptions} />
+    return (
+      <TemporaryLandingPage
+        contentLocale={contentLocale}
+        locale={locale}
+        languageOptions={languageOptions}
+        posts={normalizedPosts}
+      />
+    )
   }
 
   const payload = await getPayload({ config: configPromise })

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { RelatedPosts } from '@/blocks/RelatedPosts/Component'
 import { PayloadRedirects } from '@/app/(frontend)/_components/PayloadRedirects'
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
-import { draftMode } from 'next/headers'
+import { draftMode, headers } from 'next/headers'
 import React, { cache } from 'react'
 import RichText from '@/blocks/_shared/RichText'
 
@@ -23,6 +23,7 @@ import { resolveContentLocaleContext, type ContentLocaleContext } from '@/utilit
 import { buildPostPath, buildPostsIndexPath } from '@/utilities/content/postPaths'
 import { createBlogBreadcrumb, HOME_BREADCRUMB } from '@/utilities/breadcrumbs'
 import { JsonLdScript, buildArticlePageJsonLd } from '@/utilities/structuredData'
+import { isTemporaryLandingModeRequest } from '@/features/temporaryLandingMode'
 
 export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
@@ -45,13 +46,13 @@ type Args = {
 }
 
 export default async function Post({ params: paramsPromise, searchParams: searchParamsPromise }: Args) {
-  const { isEnabled: draft } = await draftMode()
+  const draft = await resolveDraftAccess()
   const { slug = '' } = await paramsPromise
   const searchParams = await searchParamsPromise
   const contentLocale = resolveContentLocaleContext(searchParams.locale)
   const canonicalPostPath = buildPostPath(slug)
   const localizedPostPath = buildPostPath(slug, contentLocale)
-  const post = await queryPostBySlug({ contentLocale, slug })
+  const post = await queryPostBySlug({ contentLocale, draft, slug })
 
   if (!post) return <PayloadRedirects url={canonicalPostPath} />
 
@@ -166,19 +167,24 @@ export async function generateMetadata({
   const { slug = '' } = await paramsPromise
   const searchParams = await searchParamsPromise
   const contentLocale = resolveContentLocaleContext(searchParams.locale)
-  const post = await queryPostBySlug({ contentLocale, slug })
+  const draft = await resolveDraftAccess()
+  const post = await queryPostBySlug({ contentLocale, draft, slug })
 
   return generateMeta({ doc: post, path: buildPostPath(slug, contentLocale), sourceCollection: 'posts' })
 }
 
 const queryPostBySlug = cache(
-  async ({ slug, contentLocale }: { contentLocale?: ContentLocaleContext; slug: string }) => {
+  async ({ slug, contentLocale, draft }: { contentLocale?: ContentLocaleContext; draft: boolean; slug: string }) => {
     const normalizedContentLocale = contentLocale ?? {}
-
-    const { isEnabled: draft } = await draftMode()
 
     const payload = await getPayload({ config: configPromise })
 
     return findPostBySlug(payload, slug, draft, normalizedContentLocale)
   },
 )
+
+const resolveDraftAccess = async (): Promise<boolean> => {
+  const [{ isEnabled }, requestHeaders] = await Promise.all([draftMode(), headers()])
+
+  return isEnabled && !isTemporaryLandingModeRequest(requestHeaders)
+}

--- a/src/app/(frontend)/posts/page.tsx
+++ b/src/app/(frontend)/posts/page.tsx
@@ -18,6 +18,17 @@ import { PostsPagination } from './_components/PostsPagination'
 export const dynamic = 'force-static'
 export const revalidate = 600
 
+const EMPTY_POSTS_COPY = {
+  en: {
+    title: 'New articles are on the way',
+    description: 'We are preparing practical guidance about clinics, treatments, and informed comparisons.',
+  },
+  de: {
+    title: 'Neue Beiträge sind in Vorbereitung',
+    description: 'Wir bereiten praktische Orientierung zu Kliniken, Behandlungen und fundierten Vergleichen vor.',
+  },
+} as const
+
 type Args = {
   searchParams?: Promise<{
     locale?: string | string[]
@@ -37,6 +48,7 @@ export default async function Page({ searchParams: searchParamsPromise }: Args =
   const [featuredPost, ...gridPosts] = normalizedPosts
   const moreArticlesCount = Math.max((posts.totalDocs || 0) - (featuredPost ? 1 : 0), 0)
   const breadcrumbs = [HOME_BREADCRUMB, createBlogBreadcrumb(buildPostsIndexPath(contentLocale))]
+  const emptyCopy = contentLocale.locale === 'de' ? EMPTY_POSTS_COPY.de : EMPTY_POSTS_COPY.en
 
   return (
     <div className="pb-20 sm:pb-24">
@@ -45,6 +57,22 @@ export default async function Page({ searchParams: searchParamsPromise }: Args =
 
       {/* Hero Section */}
       <BlogHero breadcrumbs={breadcrumbs} />
+
+      {normalizedPosts.length === 0 ? (
+        <Container className="mt-6 mb-12 sm:mt-8 sm:mb-16">
+          <section
+            aria-labelledby="empty-posts-heading"
+            className="rounded-3xl border border-border bg-muted/30 px-5 py-10 text-center sm:px-8 sm:py-14"
+          >
+            <Heading id="empty-posts-heading" as="h2" size="h3" align="center">
+              {emptyCopy.title}
+            </Heading>
+            <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
+              {emptyCopy.description}
+            </p>
+          </section>
+        </Container>
+      ) : null}
 
       {/* Featured Post (Overlay Variant) */}
       {featuredPost && (

--- a/src/components/organisms/Blog/BlogCard/Simple.tsx
+++ b/src/components/organisms/Blog/BlogCard/Simple.tsx
@@ -23,10 +23,10 @@ export const Simple: React.FC<BlogCardBaseProps> = ({
   const resolvedImage = image ?? {
     src: '/images/blog-placeholder-1600-900.svg',
     alt: 'Blog placeholder',
-    sizes: '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw',
+    sizes: '(max-width: 639px) 100vw, (max-width: 1279px) 50vw, 33vw',
     quality: 70,
   }
-  const imageSizes = resolvedImage.sizes ?? '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
+  const imageSizes = resolvedImage.sizes ?? '(max-width: 639px) 100vw, (max-width: 1279px) 50vw, 33vw'
   const imageQuality = resolvedImage.quality ?? 70
   const authorName = author?.name || 'findmydoc Editorial Team'
 

--- a/src/components/templates/HoldingPageConcept/index.tsx
+++ b/src/components/templates/HoldingPageConcept/index.tsx
@@ -62,6 +62,7 @@ export type HoldingPageConceptVisualVariant =
   | 'videoImmersiveHero'
 
 export type HoldingPageConceptProps = {
+  afterSignals?: ReactNode
   backgroundImage: StaticImageData | string
   backgroundImageClassName?: string
   bestFor: string
@@ -551,6 +552,7 @@ function renderVariantLayout(
   isVideoLayout: boolean,
 ) {
   const {
+    afterSignals,
     backgroundImage,
     backgroundImageClassName,
     bestFor,
@@ -1441,6 +1443,8 @@ function renderVariantLayout(
                 </div>
               </div>
             </ScrollReveal>
+
+            {afterSignals ? <ScrollReveal preset="surface">{afterSignals}</ScrollReveal> : null}
           </div>
 
           <ScrollReveal>
@@ -1460,6 +1464,7 @@ function renderVariantLayout(
 }
 
 export function HoldingPageConcept({
+  afterSignals,
   backgroundImage,
   backgroundImageClassName,
   bestFor,
@@ -1498,6 +1503,7 @@ export function HoldingPageConcept({
   const showMetadataPills = visualVariant !== 'videoImmersiveHero'
 
   const sharedData: SharedConceptData = {
+    afterSignals,
     backgroundImage,
     backgroundImageClassName,
     bestFor,

--- a/src/components/templates/TemporaryLandingPage/TemporaryLandingBlogSection.tsx
+++ b/src/components/templates/TemporaryLandingPage/TemporaryLandingBlogSection.tsx
@@ -1,0 +1,58 @@
+import { Heading } from '@/components/atoms/Heading'
+import { UiLink } from '@/components/molecules/Link'
+import { BlogCard } from '@/components/organisms/Blog/BlogCard'
+import type { BlogCardBaseProps } from '@/utilities/blog/normalizePost'
+
+type TemporaryLandingBlogSectionProps = {
+  ctaHref: string
+  ctaLabel: string
+  description: string
+  posts: BlogCardBaseProps[]
+  title: string
+}
+
+export function TemporaryLandingBlogSection({
+  ctaHref,
+  ctaLabel,
+  description,
+  posts,
+  title,
+}: TemporaryLandingBlogSectionProps) {
+  if (posts.length === 0) {
+    return null
+  }
+
+  return (
+    <section
+      aria-labelledby="temporary-landing-blog-heading"
+      className="mt-6 rounded-[24px] border border-white/74 bg-white/84 p-4 shadow-[0_28px_90px_-48px_rgba(15,23,42,0.26)] backdrop-blur-xl sm:p-5 lg:p-6"
+    >
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between sm:gap-6">
+        <div className="max-w-2xl">
+          <Heading
+            id="temporary-landing-blog-heading"
+            as="h2"
+            align="left"
+            size="h4"
+            className="text-2xl text-slate-950 sm:text-3xl"
+          >
+            {title}
+          </Heading>
+          <p className="mt-2 text-sm leading-6 text-slate-700 sm:text-base">{description}</p>
+        </div>
+        <UiLink
+          appearance="outline"
+          className="w-full shrink-0 border-slate-300 bg-white/80 sm:w-auto"
+          href={ctaHref}
+          label={ctaLabel}
+        />
+      </div>
+
+      <div className="mt-6 grid gap-6 sm:grid-cols-2 sm:gap-8 xl:grid-cols-3">
+        {posts.map((post) => (
+          <BlogCard.Simple key={post.href} {...post} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/templates/TemporaryLandingPage/index.tsx
+++ b/src/components/templates/TemporaryLandingPage/index.tsx
@@ -1,22 +1,39 @@
 import { LanguageSwitcher } from '@/components/molecules/LanguageSwitcher'
 import { HoldingPageConcept } from '@/components/templates/HoldingPageConcept'
 import {
+  getTemporaryLandingBlogCopy,
   getTemporaryLandingPageContent,
   type TemporaryLandingLanguageOption,
   type TemporaryLandingLocale,
 } from '@/features/temporaryLandingMode'
+import type { BlogCardBaseProps } from '@/utilities/blog/normalizePost'
+import { buildPostsIndexPath } from '@/utilities/content/postPaths'
+import type { ContentLocaleContext } from '@/utilities/contentLocalization'
+import { TemporaryLandingBlogSection } from './TemporaryLandingBlogSection'
 
 type TemporaryLandingPageProps = {
+  contentLocale: ContentLocaleContext
   languageOptions: TemporaryLandingLanguageOption[]
   locale: TemporaryLandingLocale
+  posts: BlogCardBaseProps[]
 }
 
-export function TemporaryLandingPage({ languageOptions, locale }: TemporaryLandingPageProps) {
+export function TemporaryLandingPage({ contentLocale, languageOptions, locale, posts }: TemporaryLandingPageProps) {
   const content = getTemporaryLandingPageContent(locale)
+  const blogCopy = getTemporaryLandingBlogCopy(locale)
 
   return (
     <HoldingPageConcept
       {...content}
+      afterSignals={
+        <TemporaryLandingBlogSection
+          ctaHref={buildPostsIndexPath(contentLocale)}
+          ctaLabel={blogCopy.ctaLabel}
+          description={blogCopy.description}
+          posts={posts}
+          title={blogCopy.title}
+        />
+      }
       heroOverlay={
         <LanguageSwitcher
           ariaLabel="Landing page language"

--- a/src/endpoints/seed/tasks/seedChunkTask.ts
+++ b/src/endpoints/seed/tasks/seedChunkTask.ts
@@ -173,7 +173,8 @@ export const seedChunkTask = {
           throw new Error('Seed reset jobs require an authenticated platform user')
         }
 
-        await resetCollections(payload, input.type, { preservePlatformUserId })
+        const resetResult = await resetCollections(payload, input.type, { preservePlatformUserId })
+        const affectedPostSlugs = resetResult.affectedPostSlugs
 
         const next = await finishSeedRunJob(payload, runId, {
           jobId,
@@ -192,6 +193,7 @@ export const seedChunkTask = {
             updated: 0,
             warnings: [],
             failures: [],
+            affectedPostSlugs,
           },
         })
 
@@ -212,6 +214,7 @@ export const seedChunkTask = {
             updated: 0,
             warnings: [],
             failures: [],
+            affectedPostSlugs,
           },
         }
       }
@@ -403,6 +406,7 @@ export const seedChunkTask = {
           status: jobStatus,
           created: result.created,
           updated: result.updated,
+          affectedPostSlugs: result.affectedPostSlugs ?? [],
           warnings,
           failures,
         },
@@ -459,6 +463,7 @@ export const seedChunkTask = {
           status: 'succeeded',
           created: result.created,
           updated: result.updated,
+          affectedPostSlugs: result.affectedPostSlugs ?? [],
           warnings,
           failures,
           chunkIndex: input.chunkIndex,

--- a/src/endpoints/seed/utils/finalFlush.ts
+++ b/src/endpoints/seed/utils/finalFlush.ts
@@ -198,7 +198,12 @@ const hasCompletedOrWritten = (job: SeedRunJobRecord): boolean => {
 
 const buildScopeFromCompletedPublicJobs = (
   record: SeedRunRecord,
-): { completedJobCount: number; publicJobs: SeedRunJobRecord[]; scope: SeedFinalFlushScope } => {
+): {
+  affectedPostSlugs: string[]
+  completedJobCount: number
+  publicJobs: SeedRunJobRecord[]
+  scope: SeedFinalFlushScope
+} => {
   const scope = createScope()
   const completedJobs = record.jobs.filter(hasCompletedOrWritten)
   const publicJobs = completedJobs.filter((job) => isPublicAffectingJob(job))
@@ -207,7 +212,17 @@ const buildScopeFromCompletedPublicJobs = (
     addJobScope(scope, job, record.type)
   }
 
+  const affectedPostSlugs = [
+    ...new Set(
+      publicJobs.flatMap((job) => {
+        const slugs = job.output?.affectedPostSlugs
+        return Array.isArray(slugs) ? slugs.filter((slug): slug is string => typeof slug === 'string') : []
+      }),
+    ),
+  ].sort()
+
   return {
+    affectedPostSlugs,
     completedJobCount: completedJobs.length,
     publicJobs,
     scope,
@@ -345,7 +360,7 @@ export const finalizeSeedRunPublicCaches = async (payload: Payload, snapshot: Se
   if (!record || isFinalFlushComplete(record.finalFlush)) return
 
   const terminalStatus = snapshot.status as FlushableSeedRunStatus
-  const { completedJobCount, publicJobs, scope } = buildScopeFromCompletedPublicJobs(record)
+  const { affectedPostSlugs, completedJobCount, publicJobs, scope } = buildScopeFromCompletedPublicJobs(record)
 
   if (publicJobs.length === 0) {
     await markFinalFlush(payload, snapshot.runId, {
@@ -379,6 +394,7 @@ export const finalizeSeedRunPublicCaches = async (payload: Payload, snapshot: Se
         affectedSurfaces: [...scope.surfaces].sort(),
         affectedSitemaps: [...scope.sitemaps].sort(),
         affectedDiscovery: [],
+        affectedPostSlugs,
         completedJobCount,
         publicJobCount: publicJobs.length,
       },

--- a/src/endpoints/seed/utils/import-collection.ts
+++ b/src/endpoints/seed/utils/import-collection.ts
@@ -20,6 +20,7 @@ export type CollectionImportResult = {
   name: string
   created: number
   updated: number
+  affectedPostSlugs?: string[]
   warnings: string[]
   failures: string[]
 }
@@ -172,6 +173,7 @@ export async function importCollection(options: {
       : allRecords
   const warnings: string[] = []
   const failures: string[] = []
+  const affectedPostSlugs = new Set<string>()
   let created = 0
   let updated = 0
 
@@ -272,6 +274,8 @@ export async function importCollection(options: {
       })
       if (result.created) created += 1
       if (result.updated) updated += 1
+      if (result.previousSlug) affectedPostSlugs.add(result.previousSlug)
+      if (result.nextSlug) affectedPostSlugs.add(result.nextSlug)
 
       if (Object.keys(localizedUpdates).length > 0) {
         const docId = await resolvers.resolveIdByStableId(collection, record.stableId)
@@ -299,6 +303,7 @@ export async function importCollection(options: {
     name: fileName,
     created,
     updated,
+    affectedPostSlugs: [...affectedPostSlugs].sort(),
     warnings,
     failures,
   }

--- a/src/endpoints/seed/utils/plan.ts
+++ b/src/endpoints/seed/utils/plan.ts
@@ -165,6 +165,7 @@ export const demoPlan: SeedPlanStep[] = [
     name: 'posts',
     collection: 'posts',
     fileName: 'posts',
+    context: { resetSeedPublishedAt: true },
     localizedFields: ['title', 'content', 'excerpt', 'meta.title', 'meta.description'],
     mapping: [
       {

--- a/src/endpoints/seed/utils/reset.ts
+++ b/src/endpoints/seed/utils/reset.ts
@@ -42,6 +42,32 @@ type ResetCollectionsOptions = {
   preservePlatformUserId?: string | number
 }
 
+type ResetCollectionsResult = {
+  affectedPostSlugs: string[]
+}
+
+const collectPostSlugsBeforeReset = async (payload: Payload): Promise<string[]> => {
+  const posts = await payload.find({
+    collection: 'posts',
+    depth: 0,
+    overrideAccess: true,
+    pagination: false,
+    select: {
+      slug: true,
+    },
+    trash: true,
+  })
+
+  return [
+    ...new Set(
+      posts.docs
+        .map((post) => post.slug)
+        .filter((slug): slug is string => typeof slug === 'string' && slug.trim().length > 0)
+        .map((slug) => slug.trim()),
+    ),
+  ].sort()
+}
+
 const buildResetWhere = (collection: CollectionSlug, preservePlatformUserId?: string | number): Where => {
   const allDocuments: Where = {
     id: {
@@ -96,7 +122,7 @@ export async function resetCollections(
   payload: Payload,
   kind: 'baseline' | 'demo',
   options: ResetCollectionsOptions = {},
-) {
+): Promise<ResetCollectionsResult> {
   const runtimeEnv = resolveSeedRuntimeEnv(undefined, process.env)
   const policy = resolveSeedRuntimePolicy(runtimeEnv)
 
@@ -112,6 +138,8 @@ export async function resetCollections(
     throw new Error('Seed reset is disabled in this runtime')
   }
 
+  const affectedPostSlugs = await collectPostSlugsBeforeReset(payload)
+
   // Baseline reference data is commonly referenced by demo data (e.g. treatments
   // referenced by clinictreatments). To avoid FK / NOT NULL violations during
   // deletion, baseline resets must clear demo collections first.
@@ -120,4 +148,6 @@ export async function resetCollections(
     payload.logger.info(`Resetting ${collection} (${kind})`)
     await deleteCollection(payload, collection, options.preservePlatformUserId)
   }
+
+  return { affectedPostSlugs }
 }

--- a/src/endpoints/seed/utils/upsert.ts
+++ b/src/endpoints/seed/utils/upsert.ts
@@ -4,7 +4,12 @@ import path from 'path'
 import type { CollectionSlug, Payload, PayloadRequest } from 'payload'
 import { prepareUploadFilenameFromFilePathSync } from '@/hooks/media/prepareUploadFilename'
 
-export type UpsertResult = { created: boolean; updated: boolean }
+export type UpsertResult = {
+  created: boolean
+  updated: boolean
+  previousSlug?: string
+  nextSlug?: string
+}
 
 function buildOperationReq(
   req: Partial<PayloadRequest> | undefined,
@@ -483,10 +488,14 @@ export async function upsertByStableId<T extends Record<string, unknown>>(
         `retry create ${collection}:${stableId}`,
       )
     }
-    return { created: true, updated: false }
+    return {
+      created: true,
+      updated: false,
+      ...(collection === 'posts' && typeof data.slug === 'string' ? { nextSlug: data.slug } : {}),
+    }
   }
 
-  const current = existing.docs[0] as { id: string | number; deletedAt?: unknown }
+  const current = existing.docs[0] as { id: string | number; deletedAt?: unknown; slug?: unknown }
   const nextData: Record<string, unknown> = { ...data }
 
   // If found doc is trashed, restore it by clearing deletedAt.
@@ -518,5 +527,10 @@ export async function upsertByStableId<T extends Record<string, unknown>>(
     req: operationReq,
     filePath: options?.filePath,
   })
-  return { created: false, updated: true }
+  return {
+    created: false,
+    updated: true,
+    ...(collection === 'posts' && typeof current.slug === 'string' ? { previousSlug: current.slug } : {}),
+    ...(collection === 'posts' && typeof data.slug === 'string' ? { nextSlug: data.slug } : {}),
+  }
 }

--- a/src/features/temporaryLandingMode/content.ts
+++ b/src/features/temporaryLandingMode/content.ts
@@ -4,6 +4,9 @@ import { ArrowLeftRight, ShieldCheck, UserRoundSearch } from 'lucide-react'
 import { TEMPORARY_LANDING_DEFAULT_LOCALE, type TemporaryLandingLocale } from './i18n'
 
 type TemporaryLandingCopy = {
+  blogCtaLabel: string
+  blogDescription: string
+  blogTitle: string
   contactConsent: string
   contactDescription: string
   contactEyebrow: string
@@ -40,6 +43,9 @@ type TemporaryLandingCopy = {
 
 const copyByLocale: Record<TemporaryLandingLocale, TemporaryLandingCopy> = {
   en: {
+    blogCtaLabel: 'View all articles',
+    blogDescription: 'Practical guidance and clear context for comparing clinics, treatments, and quality signals.',
+    blogTitle: 'Latest insights',
     contactConsent: 'By sending this request, you agree that findmydoc may contact you about your inquiry.',
     contactDescription:
       'Use this contact form to send us a direct request. Include a short title, your message, and your email so we can reply.',
@@ -90,6 +96,10 @@ const copyByLocale: Record<TemporaryLandingLocale, TemporaryLandingCopy> = {
     whySectionHeading: 'Patients from the DACH region',
   },
   de: {
+    blogCtaLabel: 'Alle Beiträge ansehen',
+    blogDescription:
+      'Praktische Orientierung und verständlicher Kontext zum Vergleich von Kliniken, Behandlungen und Qualitätsmerkmalen.',
+    blogTitle: 'Aktuelle Einblicke',
     contactConsent: 'Mit dem Absenden stimmst du zu, dass findmydoc dich zu deiner Anfrage kontaktieren darf.',
     contactDescription:
       'Nutze dieses Kontaktformular für eine direkte Anfrage. Gib einen kurzen Titel, deine Nachricht und deine E-Mail an, damit wir antworten können.',
@@ -143,6 +153,10 @@ const copyByLocale: Record<TemporaryLandingLocale, TemporaryLandingCopy> = {
     whySectionHeading: 'Patient:innen DACH',
   },
   tr: {
+    blogCtaLabel: 'Tüm yazıları görüntüle',
+    blogDescription:
+      'Klinikleri, tedavileri ve kalite göstergelerini karşılaştırmak için pratik rehberler ve anlaşılır bilgiler.',
+    blogTitle: 'Güncel bilgiler',
     contactConsent:
       'Bu formu göndererek findmydoc’un talebinizle ilgili sizinle iletişime geçebileceğini kabul etmiş olursunuz.',
     contactDescription:
@@ -283,3 +297,19 @@ export const temporaryLandingPageContentByLocale: Record<TemporaryLandingLocale,
 
 export const getTemporaryLandingPageContent = (locale: TemporaryLandingLocale): HoldingPageConceptProps =>
   temporaryLandingPageContentByLocale[locale] ?? temporaryLandingPageContentByLocale[TEMPORARY_LANDING_DEFAULT_LOCALE]
+
+export type TemporaryLandingBlogCopy = {
+  ctaLabel: string
+  description: string
+  title: string
+}
+
+export const getTemporaryLandingBlogCopy = (locale: TemporaryLandingLocale): TemporaryLandingBlogCopy => {
+  const copy = copyByLocale[locale] ?? copyByLocale[TEMPORARY_LANDING_DEFAULT_LOCALE]
+
+  return {
+    ctaLabel: copy.blogCtaLabel,
+    description: copy.blogDescription,
+    title: copy.blogTitle,
+  }
+}

--- a/src/features/temporaryLandingMode/i18n.ts
+++ b/src/features/temporaryLandingMode/i18n.ts
@@ -93,3 +93,15 @@ export const buildTemporaryLandingLanguageOptions = (
     label: TEMPORARY_LANDING_LABELS[locale],
     href: buildTemporaryLandingLocaleHref(locale, searchParams),
   }))
+
+export const resolveTemporaryLandingContentLocale = (locale: TemporaryLandingLocale): ContentLocaleContext => {
+  if (locale === 'de') {
+    return {
+      locale: 'de',
+      fallbackLocale: 'en',
+    }
+  }
+
+  return {}
+}
+import type { ContentLocaleContext } from '@/utilities/contentLocalization'

--- a/src/features/temporaryLandingMode/index.ts
+++ b/src/features/temporaryLandingMode/index.ts
@@ -28,7 +28,21 @@ export const isTemporaryLandingModeExemptPath = (pathname: string): boolean => {
 }
 
 export const isTemporaryLandingPublicExemptPath = (pathname: string): boolean => {
-  return TEMPORARY_LANDING_PUBLIC_EXEMPT_PATHS.has(normalizePathname(pathname))
+  const normalizedPath = normalizePathname(pathname)
+
+  if (TEMPORARY_LANDING_PUBLIC_EXEMPT_PATHS.has(normalizedPath)) {
+    return true
+  }
+
+  if (normalizedPath === '/posts') {
+    return true
+  }
+
+  if (/^\/posts\/page\/[1-9]\d*$/.test(normalizedPath)) {
+    return true
+  }
+
+  return /^\/posts\/[^/]+$/.test(normalizedPath)
 }
 
 export const isTemporaryLandingRootPath = (pathname: string): boolean => {

--- a/src/hooks/publishedAt.ts
+++ b/src/hooks/publishedAt.ts
@@ -18,7 +18,15 @@ export function beforeChangePublishedAt(options?: {
   publishedValue?: string
 }) {
   const { statusKey = 'status', publishedAtKey = 'publishedAt', publishedValue = 'published' } = options || {}
-  return async ({ data, originalDoc }: { data: Record<string, unknown>; originalDoc?: Record<string, unknown> }) => {
+  return async ({
+    data,
+    originalDoc,
+    context,
+  }: {
+    data: Record<string, unknown>
+    originalDoc?: Record<string, unknown>
+    context?: Record<string, unknown>
+  }) => {
     const draft: Record<string, unknown> = { ...(data || {}) }
     const nextStatus = draft?.[statusKey] ?? originalDoc?.[statusKey] ?? 'draft'
     draft[statusKey] = nextStatus
@@ -29,6 +37,11 @@ export function beforeChangePublishedAt(options?: {
       incomingPublishedAt !== undefined && incomingPublishedAt !== null && incomingPublishedAt !== ''
     const hasPreviousPublishedAt =
       previousPublishedAt !== undefined && previousPublishedAt !== null && previousPublishedAt !== ''
+
+    if (context?.resetSeedPublishedAt === true && nextStatus !== publishedValue) {
+      draft[publishedAtKey] = null
+      return draft
+    }
 
     if (nextStatus === publishedValue && previousStatus !== publishedValue) {
       if (hasIncomingPublishedAt) {

--- a/src/stories/templates/HoldingPageConcept.stories.tsx
+++ b/src/stories/templates/HoldingPageConcept.stories.tsx
@@ -2,10 +2,40 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, userEvent, waitFor, within } from 'storybook/test'
 
 import { HoldingPageConcept } from '@/components/templates/HoldingPageConcept'
+import { TemporaryLandingBlogSection } from '@/components/templates/TemporaryLandingPage/TemporaryLandingBlogSection'
 import { holdingPageConcept } from '@/stories/fixtures/holdingPageConcepts'
 import { withViewportStory } from '../utils/viewportMatrix'
 
 const submitContact = () => new Promise<void>((resolve) => setTimeout(resolve, 120))
+
+const holdingBlogSection = (
+  <TemporaryLandingBlogSection
+    ctaHref="/posts"
+    ctaLabel="View all articles"
+    description="Practical guidance and clear context for comparing clinics, treatments, and quality signals."
+    posts={[
+      {
+        title: 'How to compare clinic quality signals',
+        excerpt: 'A practical guide to structured comparisons before contacting a clinic.',
+        href: '/posts/quality-signals',
+        category: 'Clinic comparison',
+      },
+      {
+        title: 'Questions to ask before treatment abroad',
+        excerpt: 'Prepare the first conversation and make expectations easier to compare.',
+        href: '/posts/questions-before-treatment',
+        category: 'Patient guidance',
+      },
+      {
+        title: 'Understanding treatment estimates',
+        excerpt: 'Put estimates, services, and follow-up details into context.',
+        href: '/posts/treatment-estimates',
+        category: 'Treatments',
+      },
+    ]}
+    title="Latest insights"
+  />
+)
 
 const meta = {
   title: 'Internal/Landing/Templates/HoldingPageConcept',
@@ -46,6 +76,7 @@ const meta = {
   tags: ['autodocs', 'domain:landing', 'layer:template', 'status:experimental', 'used-in:shared'],
   args: {
     ...holdingPageConcept,
+    afterSignals: holdingBlogSection,
     onSubmitContact: submitContact,
   },
 } satisfies Meta<typeof HoldingPageConcept>
@@ -56,6 +87,7 @@ type Story = StoryObj<typeof meta>
 
 const mobileStressArgs = {
   ...holdingPageConcept,
+  afterSignals: holdingBlogSection,
   onSubmitContact: submitContact,
   contactDescription:
     'Use this contact form to send us a direct request. Include a short title, your message, and your email so we can reply with launch timing and first-access details.',
@@ -75,6 +107,7 @@ const assertConceptFrame: Story['play'] = async ({ args, canvasElement }) => {
   await expect(canvas.getByLabelText('Email')).toBeInTheDocument()
   await expect(canvas.getByText('Why findmydoc')).toBeInTheDocument()
   await expect(canvas.getByText('What you get')).toBeInTheDocument()
+  await expect(canvas.getByRole('heading', { level: 2, name: 'Latest insights' })).toBeInTheDocument()
 
   if (args.contactMode === 'compact') {
     await expect(canvas.queryByLabelText('Name')).not.toBeInTheDocument()
@@ -128,6 +161,7 @@ const assertConceptFrame: Story['play'] = async ({ args, canvasElement }) => {
 export const HoldingPage: Story = {
   args: {
     ...holdingPageConcept,
+    afterSignals: holdingBlogSection,
     onSubmitContact: submitContact,
   },
   play: assertConceptFrame,

--- a/src/stories/templates/TemporaryLandingBlogSection.stories.tsx
+++ b/src/stories/templates/TemporaryLandingBlogSection.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, within } from 'storybook/test'
+
+import { TemporaryLandingBlogSection } from '@/components/templates/TemporaryLandingPage/TemporaryLandingBlogSection'
+import type { BlogCardBaseProps } from '@/utilities/blog/normalizePost'
+
+const posts: BlogCardBaseProps[] = [
+  {
+    title: 'How to compare clinic quality signals',
+    excerpt: 'A practical guide to structured comparisons before contacting a clinic.',
+    href: '/posts/quality-signals',
+    dateLabel: 'July 10, 2026',
+    category: 'Clinic comparison',
+  },
+  {
+    title: 'Questions to ask before treatment abroad',
+    excerpt: 'Prepare the first conversation and make expectations easier to compare.',
+    href: '/posts/questions-before-treatment',
+    dateLabel: 'July 8, 2026',
+    category: 'Patient guidance',
+  },
+  {
+    title: 'Understanding treatment estimates',
+    excerpt: 'Put estimates, services, and follow-up details into context.',
+    href: '/posts/treatment-estimates',
+    dateLabel: 'July 5, 2026',
+    category: 'Treatments',
+  },
+]
+
+const meta = {
+  title: 'Internal/Landing/Templates/TemporaryLandingBlogSection',
+  component: TemporaryLandingBlogSection,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Reuses the public BlogCard.Simple pattern for the temporary holding page. The section stays hidden when no published posts are available.',
+      },
+    },
+  },
+  tags: ['autodocs', 'domain:landing', 'layer:template', 'status:experimental', 'used-in:shared'],
+  args: {
+    ctaHref: '/posts',
+    ctaLabel: 'View all articles',
+    description: 'Practical guidance and clear context for comparing clinics, treatments, and quality signals.',
+    posts,
+    title: 'Latest insights',
+  },
+} satisfies Meta<typeof TemporaryLandingBlogSection>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const ThreePosts: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByRole('heading', { level: 2, name: 'Latest insights' })).toBeInTheDocument()
+    await expect(canvas.getAllByRole('link')).toHaveLength(4)
+  },
+}
+
+export const OnePost: Story = {
+  args: { posts: posts.slice(0, 1) },
+}
+
+export const TwoPosts: Story = {
+  args: { posts: posts.slice(0, 2) },
+}
+
+export const MissingImage: Story = {
+  args: {
+    posts: [
+      {
+        ...posts[0]!,
+        image: undefined,
+      },
+    ],
+  },
+}
+
+export const Empty: Story = {
+  args: { posts: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.queryByRole('region')).not.toBeInTheDocument()
+    await expect(canvas.queryByRole('link')).not.toBeInTheDocument()
+  },
+}

--- a/src/utilities/cacheRevalidation/planner.ts
+++ b/src/utilities/cacheRevalidation/planner.ts
@@ -639,6 +639,7 @@ const buildSeedFinalFlushPlan = (event: SeedFinalFlushRevalidationEvent): Revali
   const discovery = unique(
     event.subject.affectedDiscovery.map((discoveryId) => normalizeRequiredText(discoveryId, 'discovery')),
   )
+  const postSlugs = unique(event.subject.affectedPostSlugs.map((slug) => normalizeRequiredText(slug, 'post slug')))
   const tags = [
     ...collections.map((collection) => buildCollectionTag(collection)),
     ...globals.map((global) => buildGlobalTag(global)),
@@ -659,6 +660,7 @@ const buildSeedFinalFlushPlan = (event: SeedFinalFlushRevalidationEvent): Revali
       }
     }),
     ...sitemaps.map((sitemap) => buildSitemapPath(sitemap)),
+    ...postSlugs.map((slug) => buildPostPath(slug)),
   ]
 
   return createPlan({
@@ -678,6 +680,7 @@ const buildSeedFinalFlushPlan = (event: SeedFinalFlushRevalidationEvent): Revali
       affectedSurfaces: event.subject.affectedSurfaces,
       affectedSitemaps: event.subject.affectedSitemaps,
       affectedDiscovery: event.subject.affectedDiscovery,
+      affectedPostSlugs: postSlugs,
       completedJobCount: event.subject.completedJobCount,
       publicJobCount: event.subject.publicJobCount,
     },

--- a/src/utilities/cacheRevalidation/types.ts
+++ b/src/utilities/cacheRevalidation/types.ts
@@ -107,6 +107,7 @@ export interface SeedFinalFlushRevalidationSubject {
   readonly affectedSurfaces: readonly CacheTaggableSurfaceId[]
   readonly affectedSitemaps: readonly CacheSitemapId[]
   readonly affectedDiscovery: readonly CacheDiscoveryId[]
+  readonly affectedPostSlugs: readonly string[]
   readonly completedJobCount: number
   readonly publicJobCount: number
 }

--- a/src/utilities/content/serverData/posts.ts
+++ b/src/utilities/content/serverData/posts.ts
@@ -29,7 +29,7 @@ export type PostSummaryDoc = Pick<
   | 'meta'
 >
 
-export type PostLatestDoc = PostSummaryDoc & Pick<Post, 'content'>
+export type PostLatestDoc = PostSummaryDoc
 
 export type PostDetailDoc = Omit<
   Pick<
@@ -89,10 +89,7 @@ const POST_LIST_SELECT = {
   },
 } satisfies PostsSelect<true>
 
-const POST_LATEST_SELECT = {
-  ...POST_LIST_SELECT,
-  content: true,
-} satisfies PostsSelect<true>
+const POST_LATEST_SELECT = POST_LIST_SELECT
 
 const POST_RELATED_SELECT = {
   title: true,
@@ -264,8 +261,13 @@ async function queryPosts<TDoc>(
   return result as unknown as PagedResult<TDoc>
 }
 
-export async function findLatestPosts(payload: Payload, limit = 3): Promise<PostLatestDoc[]> {
+export async function findLatestPosts(
+  payload: Payload,
+  limit = 3,
+  contentLocale: LocalizedDocQuery = {},
+): Promise<PostLatestDoc[]> {
   const result = await queryPosts<PostLatestDoc>(payload, {
+    contentLocale,
     depth: 1,
     limit,
     pagination: false,
@@ -276,21 +278,28 @@ export async function findLatestPosts(payload: Payload, limit = 3): Promise<Post
   return result.docs
 }
 
-const getCachedLatestPostsByLimit = (limit: number) =>
+const getCachedLatestPostsByArgs = (limit: number, contentLocale: LocalizedDocQuery) =>
   unstable_cache(
     async () => {
       const payload = await getPayload({ config: configPromise })
 
-      return findLatestPosts(payload, limit)
+      return findLatestPosts(payload, limit, contentLocale)
     },
-    ['posts-latest', String(limit)],
+    [
+      'posts-latest',
+      buildPostListDataCacheKey({
+        contentLocale,
+        limit,
+        page: 1,
+      }),
+    ],
     {
       tags: buildPostListDataCacheTags(),
     },
   )
 
-export async function getCachedLatestPosts(limit = 3): Promise<PostLatestDoc[]> {
-  return getCachedLatestPostsByLimit(limit)()
+export async function getCachedLatestPosts(limit = 3, contentLocale: LocalizedDocQuery = {}): Promise<PostLatestDoc[]> {
+  return getCachedLatestPostsByArgs(limit, contentLocale)()
 }
 
 export async function findPublishedPostsPage(

--- a/src/utilities/media/resolveMediaImage.ts
+++ b/src/utilities/media/resolveMediaImage.ts
@@ -69,7 +69,7 @@ const MEDIA_IMAGE_POLICIES = {
   },
   blogCard: {
     payloadSizeOrder: ['large', 'medium', 'small', 'original', 'thumbnail'],
-    sizes: '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw',
+    sizes: '(max-width: 639px) 100vw, (max-width: 1279px) 50vw, 33vw',
     quality: 70,
   },
   content: {

--- a/tests/unit/app/frontend/home.page.test.ts
+++ b/tests/unit/app/frontend/home.page.test.ts
@@ -88,6 +88,7 @@ describe('frontend home page route', () => {
     const result = await pageModule.default({})
 
     expect(mocks.getPayloadMock).not.toHaveBeenCalled()
+    expect(mocks.getCachedLatestPostsMock).toHaveBeenCalledWith(3, {})
     expect(result.type).toBe(mocks.temporaryLandingPageComponent)
     expect(result.props.locale).toBe('en')
     expect(result.props.languageOptions).toEqual([
@@ -95,6 +96,8 @@ describe('frontend home page route', () => {
       { value: 'de', label: 'DE', href: '/?lang=de' },
       { value: 'tr', label: 'TR', href: '/?lang=tr' },
     ])
+    expect(result.props.contentLocale).toEqual({})
+    expect(result.props.posts).toEqual([])
   })
 
   it('passes resolved locale and language options to temporary landing page', async () => {
@@ -110,6 +113,11 @@ describe('frontend home page route', () => {
 
     expect(result.type).toBe(mocks.temporaryLandingPageComponent)
     expect(result.props.locale).toBe('de')
+    expect(mocks.getCachedLatestPostsMock).toHaveBeenCalledWith(3, {
+      locale: 'de',
+      fallbackLocale: 'en',
+    })
+    expect(result.props.contentLocale).toEqual({ locale: 'de', fallbackLocale: 'en' })
     expect(result.props.languageOptions).toEqual([
       { value: 'en', label: 'EN', href: '/?foo=bar&lang=en' },
       { value: 'de', label: 'DE', href: '/?foo=bar&lang=de' },

--- a/tests/unit/app/frontend/post.page.test.tsx
+++ b/tests/unit/app/frontend/post.page.test.tsx
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   buildArticlePageJsonLdMock: vi.fn(() => [{ '@type': 'Article' }]),
   calculateReadTimeMock: vi.fn(() => '5 min read'),
   draftModeMock: vi.fn(),
+  headersMock: vi.fn(),
   findPostBySlugMock: vi.fn(),
   findPostSlugsMock: vi.fn(),
   generateMetaMock: vi.fn((args: unknown) => args),
@@ -21,6 +22,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('next/headers', () => ({
   draftMode: mocks.draftModeMock,
+  headers: mocks.headersMock,
 }))
 
 vi.mock('@payload-config', () => ({
@@ -114,6 +116,7 @@ describe('frontend post detail route', () => {
     vi.clearAllMocks()
 
     mocks.draftModeMock.mockResolvedValue({ isEnabled: false })
+    mocks.headersMock.mockResolvedValue(new Headers())
     mocks.getPayloadMock.mockResolvedValue({})
     mocks.findPostSlugsMock.mockResolvedValue([{ slug: 'hello-world' }])
     mocks.resolveMediaImageMock.mockReturnValue({
@@ -261,5 +264,32 @@ describe('frontend post detail route', () => {
         path: '/posts/hello-world?locale=de',
       }),
     )
+  })
+
+  it('disables draft access for anonymous temporary landing requests', async () => {
+    mocks.draftModeMock.mockResolvedValue({ isEnabled: true })
+    mocks.headersMock.mockResolvedValue(new Headers({ 'x-temporary-landing-mode': '1' }))
+
+    const pageModule = await import('@/app/(frontend)/posts/[slug]/page')
+    const result = await pageModule.default({
+      params: Promise.resolve({ slug: 'hello-world' }),
+      searchParams: Promise.resolve({}),
+    })
+
+    expect(mocks.findPostBySlugMock).toHaveBeenCalledWith({}, 'hello-world', false, {})
+    expect(findElementByType(result, mocks.jsonLdScriptComponent)?.props.data).toEqual([{ '@type': 'Article' }])
+  })
+
+  it('keeps authorized draft access when temporary landing headers are absent', async () => {
+    mocks.draftModeMock.mockResolvedValue({ isEnabled: true })
+
+    const pageModule = await import('@/app/(frontend)/posts/[slug]/page')
+    const result = await pageModule.default({
+      params: Promise.resolve({ slug: 'hello-world' }),
+      searchParams: Promise.resolve({}),
+    })
+
+    expect(mocks.findPostBySlugMock).toHaveBeenCalledWith({}, 'hello-world', true, {})
+    expect(findElementByType(result, mocks.jsonLdScriptComponent)?.props.data).toBeNull()
   })
 })

--- a/tests/unit/app/frontend/posts.page.test.tsx
+++ b/tests/unit/app/frontend/posts.page.test.tsx
@@ -76,6 +76,14 @@ const findElementByType = (node: ReactNodeLike, type: unknown): React.ReactEleme
   return findElementByType(element.props.children, type)
 }
 
+const getTextContent = (node: ReactNodeLike): string => {
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(getTextContent).join(' ')
+  if (!React.isValidElement(node)) return ''
+
+  return getTextContent((node as React.ReactElement<{ children?: ReactNodeLike }>).props.children)
+}
+
 describe('frontend posts index route', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -157,5 +165,25 @@ describe('frontend posts index route', () => {
         path: '/posts?locale=de',
       }),
     )
+  })
+
+  it('renders a visible localized empty state when no posts are published', async () => {
+    mocks.getCachedPublishedPostsPageMock.mockResolvedValue({
+      docs: [],
+      totalDocs: 0,
+      totalPages: 0,
+      page: 1,
+    })
+
+    const pageModule = await import('@/app/(frontend)/posts/page')
+    const result = await pageModule.default({
+      searchParams: Promise.resolve({ locale: 'de' }),
+    })
+
+    const emptySection = findElementByType(result, 'section')
+    expect(emptySection?.props['aria-labelledby']).toBe('empty-posts-heading')
+    expect(getTextContent(emptySection)).toContain('Neue Beiträge sind in Vorbereitung')
+    expect(getTextContent(emptySection)).toContain('praktische Orientierung')
+    expect(mocks.normalizePostMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/app/frontend/previewLock.middleware.test.ts
+++ b/tests/unit/app/frontend/previewLock.middleware.test.ts
@@ -256,13 +256,43 @@ describe('preview lock proxy', () => {
 
   it('returns 404 for non-root routes in temporary landing mode', async () => {
     mockGuardFlags({ 'temporary-landing-mode': true })
-    const request = new NextRequest('https://findmydoc.eu/posts/example')
+    const request = new NextRequest('https://findmydoc.eu/clinics/example')
 
     const response = await proxy(request)
 
     expect(response.status).toBe(404)
     expect(response.headers.get('location')).toBeNull()
     expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
+  })
+
+  it('keeps only exact public blog route shapes reachable in temporary landing mode', async () => {
+    mockGuardFlags({ 'temporary-landing-mode': true })
+
+    const allowedPaths = ['/posts', '/posts/', '/posts/example', '/posts/page/2']
+    const blockedPaths = [
+      '/posts-admin',
+      '/postscript',
+      '/posts-sitemap.xml',
+      '/posts/foo/bar',
+      '/posts/page/0',
+      '/posts/page/2/extra',
+    ]
+
+    for (const path of allowedPaths) {
+      const response = await proxy(new NextRequest(`https://findmydoc.eu${path}`))
+      expect(response.status).toBe(200)
+      expect(response.headers.get('location')).toBeNull()
+      expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
+      expect(response.headers.get(`x-middleware-request-${TEMPORARY_LANDING_MODE_REQUEST_HEADER}`)).toBe('1')
+      expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBe('1')
+    }
+
+    for (const path of blockedPaths) {
+      const response = await proxy(new NextRequest(`https://findmydoc.eu${path}`))
+      expect(response.status).toBe(404)
+      expect(response.headers.get('location')).toBeNull()
+      expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
+    }
   })
 
   it('applies temporary landing mode to canonical crawl entrypoints', async () => {
@@ -395,9 +425,11 @@ describe('preview lock proxy', () => {
     const request = new NextRequest('https://preview.findmydoc.eu/posts/example')
     const response = await proxy(request)
 
-    expect(response.status).toBe(404)
+    expect(response.status).toBe(200)
     expect(response.headers.get('location')).toBeNull()
     expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
+    expect(response.headers.get(`x-middleware-request-${TEMPORARY_LANDING_MODE_REQUEST_HEADER}`)).toBe('1')
+    expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBe('1')
   })
 
   it('keeps preview guard restrictions on temporary landing exempt admin routes', async () => {

--- a/tests/unit/components/temporaryLandingBlogSection.test.tsx
+++ b/tests/unit/components/temporaryLandingBlogSection.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { TemporaryLandingBlogSection } from '@/components/templates/TemporaryLandingPage/TemporaryLandingBlogSection'
+
+const posts = [
+  {
+    title: 'How to compare clinic quality signals',
+    excerpt: 'A practical guide to structured comparisons.',
+    href: '/posts/quality-signals',
+    dateLabel: 'July 10, 2026',
+  },
+  {
+    title: 'Questions to ask before treatment abroad',
+    excerpt: 'Prepare your first conversation with a clinic.',
+    href: '/posts/questions-before-treatment',
+    dateLabel: 'July 8, 2026',
+  },
+  {
+    title: 'Understanding treatment estimates',
+    excerpt: 'Put estimates and included services into context.',
+    href: '/posts/treatment-estimates',
+    dateLabel: 'July 5, 2026',
+  },
+]
+
+const renderSection = (visiblePosts = posts) =>
+  render(
+    <TemporaryLandingBlogSection
+      ctaHref="/posts?locale=de"
+      ctaLabel="Alle Beiträge ansehen"
+      description="Praktische Orientierung zum Vergleich."
+      posts={visiblePosts}
+      title="Aktuelle Einblicke"
+    />,
+  )
+
+describe('TemporaryLandingBlogSection', () => {
+  it('renders a labelled section with named card links and a localized CTA', () => {
+    renderSection()
+
+    const heading = screen.getByRole('heading', { level: 2, name: 'Aktuelle Einblicke' })
+    expect(heading.getAttribute('id')).toBe('temporary-landing-blog-heading')
+    expect(heading.closest('section')?.getAttribute('aria-labelledby')).toBe('temporary-landing-blog-heading')
+    expect(screen.getByRole('link', { name: posts[0]!.title }).getAttribute('href')).toBe(posts[0]!.href)
+    expect(screen.getByRole('link', { name: posts[1]!.title }).getAttribute('href')).toBe(posts[1]!.href)
+    expect(screen.getByRole('link', { name: posts[2]!.title }).getAttribute('href')).toBe(posts[2]!.href)
+    expect(screen.getByRole('link', { name: 'Alle Beiträge ansehen' }).getAttribute('href')).toBe('/posts?locale=de')
+  })
+
+  it('keeps CTA and card links in a predictable tab order with visible focus styles', () => {
+    renderSection(posts.slice(0, 2))
+
+    const cta = screen.getByRole('link', { name: 'Alle Beiträge ansehen' })
+    const firstCard = screen.getByRole('link', { name: posts[0]!.title })
+    const secondCard = screen.getByRole('link', { name: posts[1]!.title })
+
+    expect(screen.getAllByRole('link')).toEqual([cta, firstCard, secondCard])
+
+    cta.focus()
+    expect(document.activeElement).toBe(cta)
+
+    firstCard.focus()
+    expect(document.activeElement).toBe(firstCard)
+    expect(firstCard.className).toContain('focus-visible:ring-2')
+
+    secondCard.focus()
+    expect(document.activeElement).toBe(secondCard)
+  })
+
+  it('renders nothing and exposes no focusable links when there are no posts', () => {
+    const { container } = renderSection([])
+
+    expect(container.innerHTML).toBe('')
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+})

--- a/tests/unit/endpoints/seed/import-collection.test.ts
+++ b/tests/unit/endpoints/seed/import-collection.test.ts
@@ -424,4 +424,29 @@ describe('importCollection', () => {
       req: undefined,
     })
   })
+
+  it('returns old and new post slugs for terminal cache invalidation', async () => {
+    mockLoadSeedFile.mockResolvedValueOnce([
+      {
+        stableId: 'post-1',
+        slug: 'new-editorial-post',
+      },
+    ])
+    mockUpsertByStableId.mockResolvedValueOnce({
+      created: false,
+      updated: true,
+      previousSlug: 'old-demo-post',
+      nextSlug: 'new-editorial-post',
+    })
+
+    const outcome = await importCollection({
+      payload: makePayload(),
+      kind: 'demo',
+      collection: 'posts',
+      fileName: 'posts',
+      resolvers: makeResolvers(),
+    })
+
+    expect(outcome.affectedPostSlugs).toEqual(['new-editorial-post', 'old-demo-post'])
+  })
 })

--- a/tests/unit/endpoints/seed/resolvers-upsert-reset.test.ts
+++ b/tests/unit/endpoints/seed/resolvers-upsert-reset.test.ts
@@ -104,6 +104,7 @@ describe('upsertByStableId', () => {
 })
 
 describe('resetCollections', () => {
+  const find = vi.fn().mockResolvedValue({ docs: [] })
   const deleteMany = vi.fn()
   const deleteVersions = vi.fn()
   const tableNameMap = {
@@ -111,6 +112,7 @@ describe('resetCollections', () => {
   }
 
   const payload = {
+    find,
     logger: {
       info: vi.fn(),
     },
@@ -124,6 +126,7 @@ describe('resetCollections', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+    find.mockResolvedValue({ docs: [] })
     vi.unstubAllEnvs()
   })
 
@@ -135,6 +138,7 @@ describe('resetCollections', () => {
     await expect(resetCollections(payload, 'baseline')).rejects.toThrow(/seed reset is disabled in this runtime/i)
     expect(deleteMany).not.toHaveBeenCalled()
     expect(deleteVersions).not.toHaveBeenCalled()
+    expect(find).not.toHaveBeenCalled()
   })
 
   it('throws for demo reset in production', async () => {
@@ -145,6 +149,30 @@ describe('resetCollections', () => {
     await expect(resetCollections(payload, 'demo')).rejects.toThrow(/demo reset is disabled in production/i)
     expect(deleteMany).not.toHaveBeenCalled()
     expect(deleteVersions).not.toHaveBeenCalled()
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('returns the post slugs that must be invalidated after reset', async () => {
+    vi.stubEnv('VERCEL_ENV', '')
+    vi.stubEnv('DEPLOYMENT_ENV', '')
+    vi.stubEnv('NODE_ENV', 'test')
+    find.mockResolvedValue({
+      docs: [{ slug: ' old-post ' }, { slug: 'another-post' }, { slug: 'old-post' }, { slug: null }],
+    })
+    deleteMany.mockResolvedValue(undefined)
+    deleteVersions.mockResolvedValue(undefined)
+
+    const result = await resetCollections(payload, 'demo')
+
+    expect(result).toEqual({ affectedPostSlugs: ['another-post', 'old-post'] })
+    expect(find).toHaveBeenCalledWith({
+      collection: 'posts',
+      depth: 0,
+      overrideAccess: true,
+      pagination: false,
+      select: { slug: true },
+      trash: true,
+    })
   })
 
   it('deletes demo collections in order for demo reset', async () => {

--- a/tests/unit/endpoints/seed/seedChunkTask.test.ts
+++ b/tests/unit/endpoints/seed/seedChunkTask.test.ts
@@ -30,6 +30,7 @@ describe('seedChunkTask', () => {
       failures: [],
     })
     resetCollections.mockReset()
+    resetCollections.mockResolvedValue({ affectedPostSlugs: [] })
   })
 
   afterEach(() => {
@@ -138,6 +139,8 @@ describe('seedChunkTask', () => {
       failures: [],
     })
 
+    resetCollections.mockResolvedValue({ affectedPostSlugs: ['retired-post'] })
+
     const result = await seedChunkTask.handler({
       input,
       job: { id: 'job-reset' },
@@ -151,6 +154,7 @@ describe('seedChunkTask', () => {
         jobId: 'job-reset',
         kind: 'reset',
         status: 'succeeded',
+        affectedPostSlugs: ['retired-post'],
       },
     })
   })

--- a/tests/unit/endpoints/seed/seedEndpoint-success.test.ts
+++ b/tests/unit/endpoints/seed/seedEndpoint-success.test.ts
@@ -182,6 +182,9 @@ describe('seed endpoints success paths', () => {
           updated: status === 'failed' || status === 'cancelled' ? 1 : 0,
           warnings: [],
           failures: status === 'failed' ? ['partial write failed'] : [],
+          output: {
+            affectedPostSlugs: ['old-demo-post', 'new-editorial-post'],
+          },
         },
       ]
       await saveSeedRunRecord(payload as unknown as Payload, record)
@@ -199,13 +202,15 @@ describe('seed endpoints success paths', () => {
       expect(body.finalFlush).toMatchObject({
         status: 'executed',
         tagCount: 5,
-        pathCount: 4,
+        pathCount: 6,
       })
       expect(revalidateTag).toHaveBeenCalledWith('collection:posts', { expire: 0 })
       expect(revalidateTag).toHaveBeenCalledWith('surface:posts-list', { expire: 0 })
       expect(revalidateTag).toHaveBeenCalledWith('surface:sitemap:posts', { expire: 0 })
       expect(revalidatePath).toHaveBeenCalledWith('/posts')
       expect(revalidatePath).toHaveBeenCalledWith('/posts-sitemap.xml')
+      expect(revalidatePath).toHaveBeenCalledWith('/posts/old-demo-post')
+      expect(revalidatePath).toHaveBeenCalledWith('/posts/new-editorial-post')
 
       const tagCallCount = vi.mocked(revalidateTag).mock.calls.length
       const secondRes = makeRes()

--- a/tests/unit/features/temporaryLandingMode/content.test.ts
+++ b/tests/unit/features/temporaryLandingMode/content.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  getTemporaryLandingBlogCopy,
   getTemporaryLandingPageContent,
   TEMPORARY_LANDING_LOCALES,
   type TemporaryLandingLocale,
@@ -154,5 +155,20 @@ describe('temporaryLandingMode content', () => {
 
     expect(fallbackContent.title).toBe(getTemporaryLandingPageContent('en').title)
     expect(fallbackContent.searchSnapshot.metaTitle).toBe(getTemporaryLandingPageContent('en').searchSnapshot.metaTitle)
+  })
+
+  it('returns localized blog teaser copy for every holding locale', () => {
+    expect(getTemporaryLandingBlogCopy('en')).toMatchObject({
+      ctaLabel: 'View all articles',
+      title: 'Latest insights',
+    })
+    expect(getTemporaryLandingBlogCopy('de')).toMatchObject({
+      ctaLabel: 'Alle Beiträge ansehen',
+      title: 'Aktuelle Einblicke',
+    })
+    expect(getTemporaryLandingBlogCopy('tr')).toMatchObject({
+      ctaLabel: 'Tüm yazıları görüntüle',
+      title: 'Güncel bilgiler',
+    })
   })
 })

--- a/tests/unit/features/temporaryLandingMode/i18n.test.ts
+++ b/tests/unit/features/temporaryLandingMode/i18n.test.ts
@@ -4,6 +4,7 @@ import {
   buildTemporaryLandingLanguageOptions,
   buildTemporaryLandingLocaleHref,
   getTemporaryLandingPageContent,
+  resolveTemporaryLandingContentLocale,
   resolveTemporaryLandingLocale,
   TEMPORARY_LANDING_LOCALES,
   type TemporaryLandingLocale,
@@ -36,6 +37,12 @@ describe('temporaryLandingMode i18n', () => {
       { value: 'de', label: 'DE', href: '/?source=hero&lang=de' },
       { value: 'tr', label: 'TR', href: '/?source=hero&lang=tr' },
     ])
+  })
+
+  it('maps holding locales to supported blog content locales', () => {
+    expect(resolveTemporaryLandingContentLocale('en')).toEqual({})
+    expect(resolveTemporaryLandingContentLocale('de')).toEqual({ locale: 'de', fallbackLocale: 'en' })
+    expect(resolveTemporaryLandingContentLocale('tr')).toEqual({})
   })
 
   it('returns localized content for every supported locale', () => {

--- a/tests/unit/features/temporaryLandingMode/index.test.ts
+++ b/tests/unit/features/temporaryLandingMode/index.test.ts
@@ -31,8 +31,18 @@ describe('temporaryLandingMode feature', () => {
     expect(isTemporaryLandingPublicExemptPath('/privacy-policy')).toBe(true)
     expect(isTemporaryLandingPublicExemptPath('/imprint')).toBe(true)
     expect(isTemporaryLandingPublicExemptPath('/contact')).toBe(true)
+    expect(isTemporaryLandingPublicExemptPath('/posts')).toBe(true)
+    expect(isTemporaryLandingPublicExemptPath('/posts/clinic-quality-signals')).toBe(true)
+    expect(isTemporaryLandingPublicExemptPath('/posts/page/2')).toBe(true)
+    expect(isTemporaryLandingPublicExemptPath('/posts/page/02')).toBe(false)
     expect(isTemporaryLandingPublicExemptPath('/admin/login')).toBe(false)
     expect(isTemporaryLandingPublicExemptPath('/login/patient')).toBe(false)
+    expect(isTemporaryLandingPublicExemptPath('/posts-admin')).toBe(false)
+    expect(isTemporaryLandingPublicExemptPath('/postscript')).toBe(false)
+    expect(isTemporaryLandingPublicExemptPath('/posts-sitemap.xml')).toBe(false)
+    expect(isTemporaryLandingPublicExemptPath('/posts/foo/bar')).toBe(false)
+    expect(isTemporaryLandingPublicExemptPath('/posts/page/0')).toBe(false)
+    expect(isTemporaryLandingPublicExemptPath('/posts/page/2/extra')).toBe(false)
   })
 
   it('recognizes temporary landing root paths', () => {

--- a/tests/unit/hooks/publishedAt.test.ts
+++ b/tests/unit/hooks/publishedAt.test.ts
@@ -5,14 +5,16 @@ import type { CollectionConfig, RequestContext } from 'payload'
 const makeArgs = ({
   data,
   originalDoc,
+  context,
 }: {
   data?: Record<string, unknown>
   originalDoc?: Record<string, unknown>
+  context?: Record<string, unknown>
 }) => ({
   data: { ...(data ?? {}) },
   originalDoc,
   collection: { slug: 'mock' } as unknown as CollectionConfig,
-  context: {} as unknown as RequestContext,
+  context: (context ?? {}) as unknown as RequestContext,
   req: undefined,
 })
 
@@ -77,5 +79,19 @@ describe('beforeChangePublishedAt', () => {
     )
 
     expect(result.publishedAt).toBe('2024-01-01T00:00:00.000Z')
+  })
+
+  it('clears an old publication date only for trusted seed draft replacement', async () => {
+    const hook = beforeChangePublishedAt({ statusKey: '_status' })
+
+    const result = await hook(
+      makeArgs({
+        data: { _status: 'draft', publishedAt: null },
+        originalDoc: { _status: 'published', publishedAt: '2023-10-10' },
+        context: { resetSeedPublishedAt: true },
+      }),
+    )
+
+    expect(result.publishedAt).toBeNull()
   })
 })

--- a/tests/unit/utilities/cacheRevalidation/plannerExecutor.test.ts
+++ b/tests/unit/utilities/cacheRevalidation/plannerExecutor.test.ts
@@ -171,6 +171,7 @@ describe('cache revalidation planner', () => {
         affectedSurfaces: ['posts-list', 'home', 'listing-comparison'],
         affectedSitemaps: ['posts', 'pages'],
         affectedDiscovery: [],
+        affectedPostSlugs: ['old-post-slug', 'new-post-slug'],
         completedJobCount: 4,
         publicJobCount: 3,
       },
@@ -186,7 +187,15 @@ describe('cache revalidation planner', () => {
       'surface:sitemap:posts',
       'surface:sitemap:pages',
     ])
-    expect(plan.paths).toEqual(['/posts', '/', '/listing-comparison', '/posts-sitemap.xml', '/pages-sitemap.xml'])
+    expect(plan.paths).toEqual([
+      '/posts',
+      '/',
+      '/listing-comparison',
+      '/posts-sitemap.xml',
+      '/pages-sitemap.xml',
+      '/posts/old-post-slug',
+      '/posts/new-post-slug',
+    ])
     expect(plan.logContext).toMatchObject({
       operation: 'seed-final-flush',
       sourceKind: 'seed-runner',
@@ -194,7 +203,7 @@ describe('cache revalidation planner', () => {
       subjectKind: 'seed-final-flush',
       subjectId: 'seed-run-1',
       tagCount: 8,
-      pathCount: 5,
+      pathCount: 7,
     })
   })
 

--- a/tests/unit/utilities/contentServerData.test.ts
+++ b/tests/unit/utilities/contentServerData.test.ts
@@ -56,6 +56,22 @@ describe('content server data helpers', () => {
         select: POST_LATEST_SELECT,
       }),
     )
+    expect(POST_LATEST_SELECT).toBe(POST_LIST_SELECT)
+  })
+
+  it('passes content locale through latest post queries', async () => {
+    const { payload, findMock } = createPayloadMock()
+    findMock.mockResolvedValue({ docs: [], totalDocs: 0, totalPages: 0 })
+
+    await findLatestPosts(payload, 3, { locale: 'de', fallbackLocale: 'en' })
+
+    expect(findMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fallbackLocale: 'en',
+        locale: 'de',
+        select: POST_LIST_SELECT,
+      }),
+    )
   })
 
   it('keeps the paginated post archive filter and count semantics intact', async () => {

--- a/tests/unit/utilities/normalizePost.test.ts
+++ b/tests/unit/utilities/normalizePost.test.ts
@@ -54,7 +54,7 @@ describe('normalizePost', () => {
       alt: 'Blog hero image',
       width: 576,
       height: 968,
-      sizes: '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw',
+      sizes: '(max-width: 639px) 100vw, (max-width: 1279px) 50vw, 33vw',
       quality: 70,
     })
   })

--- a/tests/unit/utilities/postsServerDataCache.test.ts
+++ b/tests/unit/utilities/postsServerDataCache.test.ts
@@ -43,21 +43,53 @@ describe('posts server data cache contract', () => {
 
     await expect(getCachedLatestPosts(3)).resolves.toEqual([{ id: 1, slug: 'latest-post' }])
 
-    expect(cacheMocks.unstableCache).toHaveBeenCalledWith(expect.any(Function), ['posts-latest', '3'], {
-      tags: [
-        'collection:posts',
-        'surface:posts-list',
-        'surface:home',
-        'surface:partners-clinics',
-        'surface:sitemap:posts',
-      ],
-    })
+    expect(cacheMocks.unstableCache).toHaveBeenCalledWith(
+      expect.any(Function),
+      ['posts-latest', buildPostListDataCacheKey({ contentLocale: {}, limit: 3, page: 1 })],
+      {
+        tags: [
+          'collection:posts',
+          'surface:posts-list',
+          'surface:home',
+          'surface:partners-clinics',
+          'surface:sitemap:posts',
+        ],
+      },
+    )
     expect(payload.find).toHaveBeenCalledWith(
       expect.objectContaining({
         collection: 'posts',
         draft: false,
         overrideAccess: false,
         pagination: false,
+      }),
+    )
+  })
+
+  it('couples latest post locale query options to the cache key', async () => {
+    const payload = {
+      find: vi.fn().mockResolvedValue({ docs: [{ id: 3, slug: 'deutscher-beitrag' }] }),
+    }
+    cacheMocks.getPayload.mockResolvedValue(payload)
+
+    await getCachedLatestPosts(3, { locale: 'de', fallbackLocale: 'en' })
+
+    expect(cacheMocks.unstableCache).toHaveBeenCalledWith(
+      expect.any(Function),
+      [
+        'posts-latest',
+        buildPostListDataCacheKey({
+          contentLocale: { locale: 'de', fallbackLocale: 'en' },
+          limit: 3,
+          page: 1,
+        }),
+      ],
+      expect.any(Object),
+    )
+    expect(payload.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fallbackLocale: 'en',
+        locale: 'de',
       }),
     )
   })

--- a/tests/unit/utilities/resolveMediaImage.test.ts
+++ b/tests/unit/utilities/resolveMediaImage.test.ts
@@ -4,6 +4,20 @@ import * as mediaImageModule from '@/utilities/media/resolveMediaImage'
 import { resolveMediaImage, type MediaImageUsage } from '@/utilities/media/resolveMediaImage'
 
 describe('resolveMediaImage', () => {
+  it('matches blog card image hints to the sm and xl grid breakpoints', () => {
+    const image = resolveMediaImage(
+      {
+        alt: 'Blog image',
+        url: '/api/platformContentMedia/file/blog.webp',
+        width: 1600,
+        height: 900,
+      },
+      { usage: 'blogCard' },
+    )
+
+    expect(image?.sizes).toBe('(max-width: 639px) 100vw, (max-width: 1279px) 50vw, 33vw')
+  })
+
   it('preserves intentionally empty alt text instead of replacing it with fallback text', () => {
     const image = resolveMediaImage(
       {


### PR DESCRIPTION
## Management summary

### Deutsch

Besucher der temporären findmydoc Holding Page können jetzt bereits veröffentlichte Blogbeiträge entdecken und ohne Plattform-Login lesen. Dadurch werden vorhandene Orientierungshilfen sichtbar, während der übrige Produktbereich und unveröffentlichte Inhalte weiterhin geschützt bleiben. Neue redaktionelle Blogartikel oder Produktionsinhalte sind ausdrücklich nicht Teil dieses PRs.

### English

Visitors to the temporary findmydoc holding page can now discover and read published blog articles without a platform login. This makes existing guidance accessible while the rest of the product and all unpublished content remain protected. New editorial articles and production content are explicitly outside this PR's scope.

## What changed

- Added a localized three-post teaser to the existing temporary holding-page composition using `BlogCard.Simple`.
- Opened only the exact public blog index, single-segment detail, and positive-integer pagination route shapes during temporary landing mode.
- Forced anonymous temporary-mode post reads to published-only even when a draft cookie is present.
- Coupled latest-post cache entries and Payload queries to the same content-locale context while removing unused rich-text content from teaser reads.
- Added a localized empty state to the public posts index and kept the holding teaser hidden when no posts are published.
- Aligned blog-card responsive image hints with the existing `sm` and `xl` grid breakpoints.
- Hardened seed cache invalidation so reset and upsert flows cover both previous and current post-detail slugs.
- Added a trusted seed context for clearing stale `publishedAt` values when an existing seeded post is intentionally returned to draft state.
- Kept all new editorial source content, translations, generated article fixtures, authors, and publication schedules out of the repository.
- Documented the reviewed product, cache, access, locale, and manual production-content removal contracts.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/features/temporaryLandingMode/index.ts`, `src/app/(frontend)/posts/[slug]/page.tsx` | Anonymous access widens only for published blog routes | Exact allowlist remains fail-closed and stale draft cookies cannot expose drafts | Proxy, route, and security-review coverage |
| P2 | `src/utilities/content/serverData/posts.ts` | The holding page adds a locale-aware cached post aggregation | Cache key inputs match the Payload locale query and existing tags retain invalidation symmetry | Cache contract tests and cache-architecture review |
| P2 | `src/endpoints/seed/utils/**`, `src/utilities/cacheRevalidation/**` | Reset and upsert flows can replace post slugs | Old and new detail paths are included in the final invalidation scope without adding editorial content | Focused seed/cache tests |
| P2 | `src/components/templates/TemporaryLandingPage/**`, `src/components/templates/HoldingPageConcept/index.tsx` | New visible section enters the production holding sequence | Existing visual language, responsive grid, empty rendering, heading order, and CTA placement remain coherent | Storybook states and Chromium screenshots at mobile and desktop widths |

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed.
- [ ] `pnpm build`: webpack compilation and TypeScript passed; page-data collection could not finish because no local Postgres service was available (`ECONNREFUSED` on port 5432).
- [x] Focused seed/cache tests: 66 tests passed after the editorial seed-content removal.
- [x] Existing demo-post data-integrity tests: 6 tests passed with the original fixtures restored.
- [x] UI/mobile QA: Chromium Storybook checks at 320, 375, 640, 768, 1024, and 1280 px showed no horizontal overflow; route-level runtime QA remains unconfirmed because the local database was unavailable.
  <!-- gh-ui-screenshots:start -->
  ### Holding Page Blog Mobile
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":4.614678899082569,"capturedAt":"2026-07-15T18:38:54.942Z","contentType":"image/png","focus":"holding-page-blog-mobile","focusLabel":"Holding Page Blog Mobile","formFactor":"mobile","gitSha":"e1458169","height":1509,"releaseEligible":false,"releaseRole":"qa","size":91225,"sizeKb":90,"uploadName":"holding-page-blog-mobile__mobile__327x1509__20260715T183854Z__e1458169__327x1509__90kb.png","viewport":"327x1509","warnings":["too_tall","unsupported_aspect_ratio","not_release_marked"],"width":327,"url":"https://github.com/user-attachments/assets/e3b7ec70-4641-43be-b0f0-c13601716ec2"} -->
  ![Holding Page Blog Mobile](https://github.com/user-attachments/assets/e3b7ec70-4641-43be-b0f0-c13601716ec2)
  
  > Screenshot warning: too_tall, unsupported_aspect_ratio, not_release_marked
  
  ### Holding Page Blog Desktop
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":0.5116071428571428,"capturedAt":"2026-07-15T18:39:16.815Z","contentType":"image/png","focus":"holding-page-blog-desktop","focusLabel":"Holding Page Blog Desktop","formFactor":"desktop","gitSha":"e1458169","height":573,"releaseEligible":false,"releaseRole":"qa","size":85586,"sizeKb":84,"uploadName":"holding-page-blog-desktop__desktop__1120x573__20260715T183916Z__e1458169__1120x573__84kb.png","viewport":"1120x573","warnings":["not_release_marked"],"width":1120,"url":"https://github.com/user-attachments/assets/641a5bc3-3d68-47ea-b906-d643b7d0f267"} -->
  ![Holding Page Blog Desktop](https://github.com/user-attachments/assets/641a5bc3-3d68-47ea-b906-d643b7d0f267)
  
  > Screenshot warning: not_release_marked
  <!-- gh-ui-screenshots:end -->
- [x] Reviews: security, accessibility, mobile UI, web vitals, SEO, and cache reviewers reported no remaining findings at 5/10 or higher after fixes.
- [x] Migration/schema check: not applicable; no Payload schema or migration changes.
- [x] Documentation/instructions check: roadmap restored to the implementation scope; no instruction sources changed.

## Risk and rollout

No migration, new editorial seed content, or automated production-content change is included. Existing production posts remain untouched and must be unpublished or deleted manually by an authorized Payload editor when replacement content is ready and verified. Rollback is a code revert.

## Development

Closes #1556
