### PR TITLE
feat: add clinic dashboard bootstrap

### DIFF
--- a/docs/integrations/clinic-dashboard-api.md
+++ b/docs/integrations/clinic-dashboard-api.md
@@ -109,7 +109,7 @@ The bootstrap always returns one of these stable Payload status and code pairs:
 
 | Payload or upstream condition | Payload result | Session effect |
 | --- | --- | --- |
-| Missing or invalid explicit Bearer token, non-clinic principal, or valid identity without matching clinic staff | `401` with `CLINIC_DASHBOARD_UNAUTHORIZED` | Dashboard may attempt one controlled refresh; persistent failure clears invalid cookies. Staff is never created during authentication. |
+| Missing or invalid explicit Bearer token, non-clinic principal, conflicting identity mapping, or valid identity without matching clinic staff | `401` with `CLINIC_DASHBOARD_UNAUTHORIZED` | Dashboard may attempt one controlled refresh; persistent failure clears invalid cookies. Staff is never created during authentication. |
 | Principal not approved or missing a current clinic assignment | `403` with `CLINIC_DASHBOARD_ACCESS_DENIED` | Preserve the session so the Dashboard can render an access-state explanation. |
 | Supabase or Payload temporarily unavailable | `503` with `CLINIC_DASHBOARD_TEMPORARILY_UNAVAILABLE` | Preserve the session; do not present an upstream outage as logout. |
 

--- a/docs/integrations/clinic-dashboard-api.md
+++ b/docs/integrations/clinic-dashboard-api.md
@@ -16,13 +16,13 @@
 
 ## Runtime Status and Scope
 
-> **Temporary runtime notice:** The website does not yet expose the Dashboard bootstrap and capability
-> contracts described here. This notice must be removed when those runtime contracts are deployed.
-
 This document records the approved server-to-server integration contract for the standalone Clinic Dashboard. It is
 durable architecture documentation, not an execution plan. The contract does not add browser access to Payload,
 Payload CORS origins, a Dashboard database, service-role credentials, public cache behavior, or clinic login UI to the
 website.
+
+Payload exposes the initial private bootstrap contract. The Clinic Dashboard session and BFF runtime remain separate
+work owned by the Dashboard repository.
 
 ## Boundary and Ownership
 
@@ -52,6 +52,8 @@ The endpoint:
 The initial response shape is owned by the website repository:
 
 ```ts
+type ClinicDashboardCapability = 'clinic-profile:view' | 'clinic-profile:edit'
+
 type ClinicDashboardBootstrapDTO = {
   principal: {
     id: string
@@ -67,9 +69,14 @@ type ClinicDashboardBootstrapDTO = {
 }
 ```
 
+The two initial capabilities are returned exactly once in the order shown above for every approved clinic principal
+with a current clinic assignment. They support profile display and editing controls already backed by current access
+rules. A successful bootstrap implies Dashboard access, so there is no separate `dashboard:access` capability.
+
 `ClinicDashboardCapability` is a closed, version-controlled string union. It describes user-visible operations, not
-Payload collection names or field-level access details. New capability values require synchronized type, endpoint,
-Dashboard behavior, and permission tests.
+Payload collection names or field-level access details. It is a UI projection and never replaces Payload authorization:
+each later read or mutation must authorize the current principal, clinic, document, and fields again. New capability
+values require synchronized type, endpoint, Dashboard behavior, and permission tests.
 
 The DTO deliberately omits Supabase identifiers, tokens, internal roles, access-control metadata, Payload timestamps,
 and unrelated clinic fields. Later capability endpoints may add their own DTOs without expanding this bootstrap into a
@@ -98,17 +105,33 @@ Dashboard BFF and requires no Payload change.
 
 ## Error Mapping
 
+The bootstrap always returns one of these stable Payload status and code pairs:
+
+| Payload or upstream condition | Payload result | Session effect |
+| --- | --- | --- |
+| Missing or invalid explicit Bearer token, non-clinic principal, or valid identity without matching clinic staff | `401` with `CLINIC_DASHBOARD_UNAUTHORIZED` | Dashboard may attempt one controlled refresh; persistent failure clears invalid cookies. Staff is never created during authentication. |
+| Principal not approved or missing a current clinic assignment | `403` with `CLINIC_DASHBOARD_ACCESS_DENIED` | Preserve the session so the Dashboard can render an access-state explanation. |
+| Supabase or Payload temporarily unavailable | `503` with `CLINIC_DASHBOARD_TEMPORARILY_UNAVAILABLE` | Preserve the session; do not present an upstream outage as logout. |
+
+Later capability routes may additionally use these general semantics:
+
 | Payload or upstream condition | Dashboard BFF result | Session effect |
 | --- | --- | --- |
-| Missing or invalid Supabase access token | `401 Unauthorized` | Dashboard may attempt one controlled refresh; persistent failure clears invalid cookies. |
-| Valid identity without a matching clinic principal | `401 Unauthorized` | Fail closed; do not create staff during authentication. |
-| Principal not approved, missing clinic, or forbidden capability | `403 Forbidden` | Preserve the session so the Dashboard can render an access-state explanation. |
 | Invalid request input | `400 Bad Request` with a stable error code | Preserve the session. |
 | Conflict with current business state | `409 Conflict` with a stable error code | Preserve the session and allow a controlled refresh. |
 | Payload unavailable or timed out | `502 Bad Gateway` or `504 Gateway Timeout` | Preserve the session; do not present an upstream outage as logout. |
 
 Error bodies expose stable machine-readable codes and safe user-facing categories. They do not expose tokens, raw
 Payload errors, SQL details, stack traces, clinic data from a denied request, or Supabase response bodies.
+
+Every bootstrap response, including errors, carries:
+
+```text
+Cache-Control: private, no-store
+Pragma: no-cache
+Expires: 0
+Vary: Authorization
+```
 
 ## Environment Matrix
 

--- a/docs/roadmap/clinic-dashboard/application-api-architecture.md
+++ b/docs/roadmap/clinic-dashboard/application-api-architecture.md
@@ -14,8 +14,9 @@
 
 ## Status and Scope
 
-Status: planned. This roadmap document owns implementation order and acceptance evidence only. Durable API, security,
-environment, DTO, error, and cache contracts live in the paired architecture documents and must not be redefined here.
+Status: initial Payload bootstrap implemented; Dashboard BFF integration and later capability contracts planned. This
+roadmap document owns implementation order and acceptance evidence only. Durable API, security, environment, DTO,
+error, and cache contracts live in the paired architecture documents and must not be redefined here.
 
 The website work exposes the focused Payload contracts required by the standalone Clinic Dashboard. It does not add
 browser access to Payload, Dashboard CORS origins, a Dashboard database, service-role credentials, public cache
@@ -23,11 +24,13 @@ behavior, or clinic login UI to the website.
 
 ## Implementation Order
 
-1. Add contract tests for clinic Bearer authentication, principal resolution, approval, clinic assignment, and denied
-   states.
-2. Implement and register the bootstrap DTO and endpoint without changing Payload CORS.
-3. Add permission and response-projection tests, including PII and raw-document leak assertions.
-4. Coordinate the Dashboard server-only client and same-origin routes against the exact website branch and DTO
+1. **Implemented:** Contract tests cover explicit clinic Bearer authentication, principal resolution, approval, clinic
+   assignment, tenant derivation, private response headers, upstream failure classification, and denied states.
+2. **Implemented:** Payload exposes `GET /api/clinic-dashboard/bootstrap` without changing Payload CORS. Its initial
+   projection contains only `clinic-profile:view` and `clinic-profile:edit`.
+3. **Implemented:** The bootstrap returns a purpose-limited DTO and stable error codes without raw principals, clinic
+   documents, Supabase identifiers, tokens, roles, or timestamps.
+4. Coordinate the Dashboard server-only client and same-origin routes against the exact website contract and DTO
    contract.
 5. Validate local and trusted preview authentication against Staging before activating the exact production callback.
 6. Add later capability endpoints one bounded user operation at a time.
@@ -45,6 +48,8 @@ behavior, or clinic login UI to the website.
 
 - Payload resolves clinic, status, and capabilities from the current principal for every request.
 - Bootstrap and capability DTOs contain no unapproved internal fields.
+- The initial capability projection contains exactly `clinic-profile:view` and `clinic-profile:edit`; later values wait
+  for their own data and permission contracts.
 - Invalid, missing, conflicting, and ineligible principals fail closed with the documented status mapping.
 - The Payload API remains inaccessible from the Dashboard browser and requires no Dashboard CORS origin.
 - Local, preview, and production configurations reject cross-environment combinations.

--- a/docs/roadmap/clinic-dashboard/capability-matrix.md
+++ b/docs/roadmap/clinic-dashboard/capability-matrix.md
@@ -17,9 +17,11 @@
 [ADR 025](../../adrs/025-adr-direct-staff-auth-collections.md), and the standalone application boundary is defined by
 [ADR 026](../../adrs/026-adr-standalone-clinic-dashboard-bff-architecture.md).
 
-The first remaining runtime gate is [website#1524](https://github.com/findmydoc-platform/website/issues/1524): Payload
-must expose the focused, server-authenticated self-and-capability bootstrap required by the Dashboard BFF. The browser
-does not call Payload and Payload CORS is not expanded.
+The initial runtime handoff is implemented by
+[website#1524](https://github.com/findmydoc-platform/website/issues/1524): this matrix defines the full product and
+capability inventory, while the first Payload bootstrap projects only `clinic-profile:view` and
+`clinic-profile:edit`. Later capabilities remain owned by their listed data and permission contracts. The browser does
+not call Payload and Payload CORS is not expanded.
 
 The standalone app shell in
 [clinic-dashboard#1](https://github.com/findmydoc-platform/clinic-dashboard/issues/1) can proceed in parallel using only
@@ -125,7 +127,7 @@ Cache labels used below:
 | Staff identity | `platformStaff`, `clinicStaff`, and `patients` are direct auth principals under ADR 025. | Dashboard authorization resolves `clinicStaff` directly and never grants clinic access to Payload Admin. |
 | Clinic authorization | Access helpers resolve the authenticated direct principal and require current approval plus clinic assignment. | Dashboard requests must use the same server-derived tenant boundary. |
 | Session and token mechanics | ADR 026 assigns Supabase session cookies to the Dashboard BFF and Bearer transport to its server-to-server Payload requests. | The Dashboard owns no database or browser-readable token; Payload remains the current authorization boundary. |
-| Dashboard API | There is no focused clinic self/capability endpoint yet. | #1524 owns the private-live bootstrap and related Payload contracts. Browser CORS is not part of that work. |
+| Dashboard API | Payload exposes the private-live `GET /api/clinic-dashboard/bootstrap` contract with the two initial profile capabilities. | The Dashboard may integrate this focused contract server-side. Later actions require their owning API and permission work; browser CORS remains unnecessary. |
 | Payload API | Current collections expose Payload REST according to collection access rules; Payload remains the intended business API and authorization boundary. | The dashboard must not query Postgres directly or bypass collection/endpoint access. |
 | Analytics reporting | Typed PostHog events already carry `clinic_id` for profile views, CTA clicks, and inquiries, but no tenant-safe reporting endpoint exists. PostHog documents its Query API for embedded, aggregated analytics. | #1531 owns a server-only reporting facade that derives the clinic from the authenticated principal, composes approved PostHog and Payload aggregates, and returns dashboard-shaped data. |
 | Public freshness | Clinic detail and listing reads use canonical cache tags; clinic-related hooks normalize events into the central planner/executor. | New or changed public data in #1527–#1529 must prove read/write symmetry under ADR 023. |

--- a/src/auth/utilities/jwtValidation.ts
+++ b/src/auth/utilities/jwtValidation.ts
@@ -15,6 +15,27 @@ type SupabaseAuthErrorLike = {
   code?: string
   message?: string
   name?: string
+  status?: number
+}
+
+export type SupabaseBearerValidationResult =
+  { status: 'authenticated'; authData: AuthData } | { status: 'invalid' } | { status: 'unavailable' }
+
+const isTemporarySupabaseError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') return false
+
+  const authError = error as SupabaseAuthErrorLike
+  const normalizedMessage = authError.message?.toLowerCase() ?? ''
+
+  return (
+    authError.name === 'AuthRetryableFetchError' ||
+    authError.status === 0 ||
+    authError.status === 429 ||
+    (typeof authError.status === 'number' && authError.status >= 500) ||
+    normalizedMessage.includes('fetch failed') ||
+    normalizedMessage.includes('network error') ||
+    normalizedMessage.includes('timed out')
+  )
 }
 
 const isExpectedMissingSessionError = (error: unknown): boolean => {
@@ -43,9 +64,9 @@ export function extractTokenFromHeader(headers?: Headers): string | undefined {
   if (!authHeader) return undefined
 
   const [scheme, ...rest] = authHeader.trim().split(/\s+/)
-  if (scheme?.toLowerCase() !== 'bearer' || rest.length === 0) return undefined
+  if (scheme?.toLowerCase() !== 'bearer' || rest.length !== 1) return undefined
 
-  return rest.join(' ')
+  return rest[0]
 }
 
 /**
@@ -82,6 +103,64 @@ export function transformSupabaseUser(user: User): AuthData {
 }
 
 /**
+ * Validates one explicit Supabase Bearer token without consulting cookie state.
+ */
+export async function validateSupabaseBearerToken({
+  token,
+  headers,
+  logger,
+}: {
+  token: string
+  headers?: Headers
+  logger?: ServerLogger
+}): Promise<SupabaseBearerValidationResult> {
+  const activeLogger = await getSupabaseLogger({ headers, logger })
+
+  try {
+    const supabaseClient = await createClient()
+    const {
+      data: { user },
+      error,
+    } = await supabaseClient.auth.getUser(token)
+
+    if (error) {
+      const unavailable = isTemporarySupabaseError(error)
+      activeLogger[unavailable ? 'error' : 'warn'](
+        {
+          event: unavailable ? 'auth.supabase.token.unavailable' : 'auth.supabase.token.invalid',
+          err: error,
+        },
+        unavailable ? 'Supabase bearer validation is temporarily unavailable' : 'Supabase bearer token is invalid',
+      )
+      return { status: unavailable ? 'unavailable' : 'invalid' }
+    }
+
+    if (!user || !validateSupabaseUser(user)) {
+      activeLogger.warn(
+        {
+          event: 'auth.supabase.user.invalid',
+          supabaseUserIdHash: user?.id ? hashLogValue(user.id) : undefined,
+          userEmailHash: user?.email ? hashLogValue(user.email) : undefined,
+        },
+        'Supabase user payload is missing required fields',
+      )
+      return { status: 'invalid' }
+    }
+
+    return { status: 'authenticated', authData: transformSupabaseUser(user) }
+  } catch (error: unknown) {
+    activeLogger.error(
+      {
+        err: toLoggedError(error),
+        event: 'auth.supabase.token.unavailable',
+      },
+      'Supabase bearer validation is temporarily unavailable',
+    )
+    return { status: 'unavailable' }
+  }
+}
+
+/**
  * Extracts and validates user data from Supabase authentication.
  * Supports both header-based tokens (API calls) and cookie-based sessions (Admin UI).
  * @param headers - Request headers
@@ -98,28 +177,14 @@ export async function extractSupabaseUserData({
   const activeLogger = await getSupabaseLogger({ headers, logger })
 
   try {
-    const supabaseClient = await createClient()
     let user: User | null
 
     if (token) {
-      // Validate specific token (for API requests)
-      const {
-        data: { user: tokenUser },
-        error,
-      } = await supabaseClient.auth.getUser(token)
-      if (error) {
-        activeLogger.warn(
-          {
-            event: 'auth.supabase.token.invalid',
-            err: error,
-          },
-          'Supabase bearer token validation failed',
-        )
-      }
-      if (error || !tokenUser) return null
-      user = tokenUser
+      const result = await validateSupabaseBearerToken({ token, headers, logger: activeLogger })
+      return result.status === 'authenticated' ? result.authData : null
     } else {
       // Fallback to session-based authentication (for Admin UI)
+      const supabaseClient = await createClient()
       const {
         data: { user: sessionUser },
         error,
@@ -155,7 +220,7 @@ export async function extractSupabaseUserData({
       activeLogger.warn(
         {
           event: 'auth.supabase.user.invalid',
-          supabaseUserId: user?.id,
+          supabaseUserIdHash: user?.id ? hashLogValue(user.id) : undefined,
           userEmailHash: user?.email ? hashLogValue(user.email) : undefined,
         },
         'Supabase user payload is missing required fields',

--- a/src/auth/utilities/userLookup.ts
+++ b/src/auth/utilities/userLookup.ts
@@ -74,7 +74,7 @@ export async function findUserBySupabaseId(
         err: error instanceof Error ? error : new Error(message),
         event: 'auth.supabase.user.lookup_failed',
         userType: authData.userType,
-        supabaseUserId: authData.supabaseUserId,
+        supabaseUserIdHash: hashLogValue(authData.supabaseUserId),
         userEmailHash: hashLogValue(normalizeEmail(authData.userEmail)),
       },
       'Failed to find payload user during Supabase authentication',

--- a/src/auth/utilities/userLookup.ts
+++ b/src/auth/utilities/userLookup.ts
@@ -5,7 +5,7 @@
 
 import type { AuthData } from '@/auth/types/authTypes'
 import { getUserConfig as getAuthConfig } from '@/auth/config/authConfig'
-import { AUTH_FLOW_ERROR_CODES, AuthFlowError, toErrorMessage } from '@/auth/errors/authFlowError'
+import { AUTH_FLOW_ERROR_CODES, AuthFlowError, isAuthFlowError, toErrorMessage } from '@/auth/errors/authFlowError'
 import { normalizeEmail } from '@/auth/utilities/emailNormalization'
 import type { Payload, PayloadRequest } from 'payload'
 import type { ClinicStaff, Patient, PlatformStaff } from '@/payload-types'
@@ -79,6 +79,11 @@ export async function findUserBySupabaseId(
       },
       'Failed to find payload user during Supabase authentication',
     )
+
+    if (isAuthFlowError(error)) {
+      throw error
+    }
+
     throw new AuthFlowError({
       code: AUTH_FLOW_ERROR_CODES.USER_LOOKUP_FAILED,
       message: `User lookup failed: ${message}`,

--- a/src/endpoints/clinicDashboardBootstrap.ts
+++ b/src/endpoints/clinicDashboardBootstrap.ts
@@ -1,0 +1,33 @@
+import type { PayloadHandler } from 'payload'
+import { resolveClinicDashboardBootstrap } from '@/features/clinicDashboard/bootstrap'
+
+export const CLINIC_DASHBOARD_ERROR_CODES = {
+  accessDenied: 'CLINIC_DASHBOARD_ACCESS_DENIED',
+  temporarilyUnavailable: 'CLINIC_DASHBOARD_TEMPORARILY_UNAVAILABLE',
+  unauthorized: 'CLINIC_DASHBOARD_UNAUTHORIZED',
+} as const
+
+const PRIVATE_LIVE_HEADERS = {
+  'Cache-Control': 'private, no-store',
+  Expires: '0',
+  Pragma: 'no-cache',
+  Vary: 'Authorization',
+} as const
+
+const jsonResponse = (body: unknown, status: number): Response =>
+  Response.json(body, { status, headers: PRIVATE_LIVE_HEADERS })
+
+export const clinicDashboardBootstrapGetHandler: PayloadHandler = async (req) => {
+  const result = await resolveClinicDashboardBootstrap(req)
+
+  switch (result.status) {
+    case 'success':
+      return jsonResponse(result.data, 200)
+    case 'access-denied':
+      return jsonResponse({ error: { code: CLINIC_DASHBOARD_ERROR_CODES.accessDenied } }, 403)
+    case 'unavailable':
+      return jsonResponse({ error: { code: CLINIC_DASHBOARD_ERROR_CODES.temporarilyUnavailable } }, 503)
+    case 'unauthorized':
+      return jsonResponse({ error: { code: CLINIC_DASHBOARD_ERROR_CODES.unauthorized } }, 401)
+  }
+}

--- a/src/features/clinicDashboard/bootstrap.ts
+++ b/src/features/clinicDashboard/bootstrap.ts
@@ -1,4 +1,5 @@
 import type { Clinic, ClinicStaff } from '@/payload-types'
+import { AUTH_FLOW_ERROR_CODES, isAuthFlowError } from '@/auth/errors/authFlowError'
 import { extractTokenFromHeader, validateSupabaseBearerToken } from '@/auth/utilities/jwtValidation'
 import { findUserBySupabaseId } from '@/auth/utilities/userLookup'
 import type { PayloadRequest } from 'payload'
@@ -93,7 +94,11 @@ export async function resolveClinicDashboardBootstrap(req: PayloadRequest): Prom
         return { status: 'unauthorized' }
       }
       principalId = principal.id
-    } catch {
+    } catch (error: unknown) {
+      if (isAuthFlowError(error) && error.code === AUTH_FLOW_ERROR_CODES.USER_LOOKUP_FAILED && !error.retryable) {
+        return { status: 'unauthorized' }
+      }
+
       return { status: 'unavailable' }
     }
   }

--- a/src/features/clinicDashboard/bootstrap.ts
+++ b/src/features/clinicDashboard/bootstrap.ts
@@ -1,0 +1,137 @@
+import type { Clinic, ClinicStaff } from '@/payload-types'
+import { extractTokenFromHeader, validateSupabaseBearerToken } from '@/auth/utilities/jwtValidation'
+import { findUserBySupabaseId } from '@/auth/utilities/userLookup'
+import type { PayloadRequest } from 'payload'
+import { toLoggedError } from '@/utilities/logging/shared'
+
+export const CLINIC_DASHBOARD_CAPABILITIES = ['clinic-profile:view', 'clinic-profile:edit'] as const
+
+export type ClinicDashboardCapability = (typeof CLINIC_DASHBOARD_CAPABILITIES)[number]
+
+export type ClinicDashboardBootstrapDTO = {
+  principal: {
+    id: string
+    displayName: string
+    email: string
+  }
+  clinic: {
+    id: string
+    name: string
+  }
+  status: 'approved'
+  capabilities: ClinicDashboardCapability[]
+}
+
+export type ClinicDashboardBootstrapResult =
+  | { status: 'success'; data: ClinicDashboardBootstrapDTO }
+  | { status: 'unauthorized' }
+  | { status: 'access-denied' }
+  | { status: 'unavailable' }
+
+const relationId = (relation: ClinicStaff['clinic']): number | string | null => {
+  if (typeof relation === 'number' || typeof relation === 'string') return relation
+  if (relation && typeof relation === 'object' && 'id' in relation) return relation.id
+  return null
+}
+
+const displayName = (staff: ClinicStaff): string => {
+  const name = [staff.firstName, staff.lastName]
+    .map((value) => value?.trim())
+    .filter(Boolean)
+    .join(' ')
+
+  return name || staff.email?.trim() || ''
+}
+
+const readCurrentClinicStaff = async (req: PayloadRequest, id: number | string): Promise<ClinicStaff | null> => {
+  const result = await req.payload.find({
+    collection: 'clinicStaff',
+    depth: 0,
+    limit: 1,
+    overrideAccess: true,
+    pagination: false,
+    req,
+    where: { id: { equals: id } },
+  })
+
+  return (result.docs[0] as ClinicStaff | undefined) ?? null
+}
+
+const readAssignedClinic = async (req: PayloadRequest, id: number | string): Promise<Clinic | null> => {
+  const result = await req.payload.find({
+    collection: 'clinics',
+    depth: 0,
+    limit: 1,
+    overrideAccess: true,
+    pagination: false,
+    req,
+    where: { id: { equals: id } },
+  })
+
+  return (result.docs[0] as Clinic | undefined) ?? null
+}
+
+export async function resolveClinicDashboardBootstrap(req: PayloadRequest): Promise<ClinicDashboardBootstrapResult> {
+  const token = extractTokenFromHeader(req.headers)
+  if (!token) return { status: 'unauthorized' }
+
+  let principalId: number | string
+
+  if (req.user) {
+    if (req.user.collection !== 'clinicStaff') return { status: 'unauthorized' }
+    principalId = req.user.id
+  } else {
+    const validation = await validateSupabaseBearerToken({ token, headers: req.headers, logger: req.payload.logger })
+    if (validation.status === 'unavailable') return { status: 'unavailable' }
+    if (validation.status === 'invalid' || validation.authData.userType !== 'clinic') {
+      return { status: 'unauthorized' }
+    }
+
+    try {
+      const principal = await findUserBySupabaseId(req.payload, validation.authData, req, req.payload.logger)
+      if (!principal || !('collection' in principal) || principal.collection !== 'clinicStaff') {
+        return { status: 'unauthorized' }
+      }
+      principalId = principal.id
+    } catch {
+      return { status: 'unavailable' }
+    }
+  }
+
+  try {
+    const staff = await readCurrentClinicStaff(req, principalId)
+    if (!staff?.id || !staff.email) return { status: 'unauthorized' }
+
+    const clinicId = relationId(staff.clinic)
+    if (staff.status !== 'approved' || clinicId === null) return { status: 'access-denied' }
+
+    const clinic = await readAssignedClinic(req, clinicId)
+    if (!clinic?.id || !clinic.name?.trim()) return { status: 'access-denied' }
+
+    return {
+      status: 'success',
+      data: {
+        principal: {
+          id: String(staff.id),
+          displayName: displayName(staff),
+          email: staff.email,
+        },
+        clinic: {
+          id: String(clinic.id),
+          name: clinic.name,
+        },
+        status: 'approved',
+        capabilities: [...CLINIC_DASHBOARD_CAPABILITIES],
+      },
+    }
+  } catch (error: unknown) {
+    req.payload.logger.error(
+      {
+        err: toLoggedError(error),
+        event: 'clinic_dashboard.bootstrap.read_failed',
+      },
+      'Clinic Dashboard bootstrap state could not be read',
+    )
+    return { status: 'unavailable' }
+  }
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -5,6 +5,7 @@ import sharp from 'sharp'
 import path from 'path'
 import { buildConfig, PayloadHandler, type EmailAdapter } from 'payload'
 import { cacheRevalidationVisibilityGetHandler } from './endpoints/cacheRevalidationVisibility'
+import { clinicDashboardBootstrapGetHandler } from './endpoints/clinicDashboardBootstrap'
 import { seedPostHandler, seedGetHandler, seedAdvanceHandler, seedRetryHandler } from './endpoints/seed/seedEndpoint'
 import { seedChunkTask } from './endpoints/seed/tasks/seedChunkTask'
 import { fileURLToPath } from 'url'
@@ -87,6 +88,11 @@ export default buildConfig({
     safeFileNames: true,
   },
   endpoints: [
+    {
+      path: '/clinic-dashboard/bootstrap',
+      method: 'get',
+      handler: clinicDashboardBootstrapGetHandler as PayloadHandler,
+    },
     { path: '/seed', method: 'post', handler: seedPostHandler as PayloadHandler },
     { path: '/seed', method: 'get', handler: seedGetHandler as PayloadHandler },
     { path: '/seed/retry', method: 'post', handler: seedRetryHandler as PayloadHandler },

--- a/tests/unit/auth/utilities/jwtValidation.edge-cases.test.ts
+++ b/tests/unit/auth/utilities/jwtValidation.edge-cases.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { extractSupabaseUserData } from '@/auth/utilities/jwtValidation'
+import { extractSupabaseUserData, validateSupabaseBearerToken } from '@/auth/utilities/jwtValidation'
 import type { User } from '@supabase/supabase-js'
 
 // Mock the supabase client
@@ -49,6 +49,56 @@ describe('jwtValidation edge cases', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(createClient).mockResolvedValue(mockSupabaseClient as unknown as Awaited<ReturnType<typeof createClient>>)
+  })
+
+  describe('validateSupabaseBearerToken', () => {
+    it('returns authenticated data for a valid explicit token', async () => {
+      mockSupabaseClient.auth.getUser.mockResolvedValue({
+        data: { user: makeSupabaseUser() },
+        error: null,
+      })
+
+      await expect(validateSupabaseBearerToken({ token: 'valid-token', logger })).resolves.toEqual({
+        status: 'authenticated',
+        authData: {
+          supabaseUserId: 'user-123',
+          userEmail: 'test@example.com',
+          userType: 'clinic',
+          firstName: 'John',
+          lastName: 'Doe',
+        },
+      })
+    })
+
+    it('classifies an invalid token separately from an upstream outage', async () => {
+      mockSupabaseClient.auth.getUser.mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Invalid JWT', name: 'AuthApiError', status: 401 },
+      })
+
+      await expect(validateSupabaseBearerToken({ token: 'invalid-token', logger })).resolves.toEqual({
+        status: 'invalid',
+      })
+    })
+
+    it.each([429, 500, 503])('classifies Supabase status %s as temporarily unavailable', async (status) => {
+      mockSupabaseClient.auth.getUser.mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Temporary error', name: 'AuthApiError', status },
+      })
+
+      await expect(validateSupabaseBearerToken({ token: 'valid-token', logger })).resolves.toEqual({
+        status: 'unavailable',
+      })
+    })
+
+    it('classifies network failures as temporarily unavailable', async () => {
+      mockSupabaseClient.auth.getUser.mockRejectedValue(new TypeError('fetch failed'))
+
+      await expect(validateSupabaseBearerToken({ token: 'valid-token', logger })).resolves.toEqual({
+        status: 'unavailable',
+      })
+    })
   })
 
   afterEach(() => {

--- a/tests/unit/auth/utilities/jwtValidation.test.ts
+++ b/tests/unit/auth/utilities/jwtValidation.test.ts
@@ -49,6 +49,12 @@ describe('jwtValidation utilities', () => {
       const result = extractTokenFromHeader(headers)
       expect(result).toBe('test-token-123')
     })
+
+    it('should reject a Bearer value containing multiple token segments', () => {
+      const headers = new Headers([['authorization', 'Bearer token unexpected']])
+
+      expect(extractTokenFromHeader(headers)).toBeUndefined()
+    })
   })
 
   describe('validateSupabaseUser', () => {

--- a/tests/unit/auth/utilities/userLookup.test.ts
+++ b/tests/unit/auth/utilities/userLookup.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { findUserBySupabaseId, isClinicUserApproved } from '@/auth/utilities/userLookup'
+import { AUTH_FLOW_ERROR_CODES } from '@/auth/errors/authFlowError'
 import { getUserConfig } from '@/auth/config/authConfig'
 import { createMockPayload } from '../../helpers/testHelpers'
 import type { Payload } from 'payload'
@@ -41,7 +42,11 @@ describe('userLookup utilities', () => {
         userType: 'clinic',
         userEmail: 'clinic@example.com',
       }),
-    ).rejects.toThrow(/more than one Payload principal/i)
+    ).rejects.toMatchObject({
+      code: AUTH_FLOW_ERROR_CODES.USER_LOOKUP_FAILED,
+      message: expect.stringMatching(/more than one Payload principal/i),
+      retryable: false,
+    })
   })
 
   it('requires approved clinic staff with a clinic assignment', async () => {

--- a/tests/unit/endpoints/clinicDashboardBootstrap.test.ts
+++ b/tests/unit/endpoints/clinicDashboardBootstrap.test.ts
@@ -1,0 +1,304 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { clinicDashboardBootstrapGetHandler } from '@/endpoints/clinicDashboardBootstrap'
+import { CLINIC_DASHBOARD_CAPABILITIES } from '@/features/clinicDashboard/bootstrap'
+import { createMockPayload, createMockReq, type MockPayload } from '../helpers/testHelpers'
+import { mockUsers } from '../helpers/mockUsers'
+
+const mocks = vi.hoisted(() => ({
+  findUserBySupabaseId: vi.fn(),
+  validateSupabaseBearerToken: vi.fn(),
+}))
+
+vi.mock('@/auth/utilities/jwtValidation', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/auth/utilities/jwtValidation')>()),
+  validateSupabaseBearerToken: mocks.validateSupabaseBearerToken,
+}))
+
+vi.mock('@/auth/utilities/userLookup', () => ({
+  findUserBySupabaseId: mocks.findUserBySupabaseId,
+}))
+
+const bearerHeaders = new Headers({ Authorization: 'Bearer clinic-token' })
+
+const staffDocument = {
+  id: 22,
+  collection: 'clinicStaff' as const,
+  stableId: 'staff-stable-id',
+  supabaseUserId: 'supabase-secret-id',
+  email: 'clinic@example.com',
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  clinic: 8,
+  status: 'approved' as const,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-02T00:00:00.000Z',
+}
+
+const clinicDocument = {
+  id: 8,
+  name: 'Berlin Clinic',
+  stableId: 'clinic-stable-id',
+  internalNotes: 'must not leak',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-02T00:00:00.000Z',
+}
+
+const arrangeCurrentDocuments = (
+  payload: MockPayload,
+  staff: Record<string, unknown> | null = staffDocument,
+  clinic: Record<string, unknown> | null = clinicDocument,
+) => {
+  payload.find.mockImplementation(async ({ collection }: { collection: string }) => ({
+    docs: collection === 'clinicStaff' ? (staff ? [staff] : []) : clinic ? [clinic] : [],
+  }))
+}
+
+const request = (
+  payload: MockPayload,
+  user:
+    | ReturnType<typeof mockUsers.clinic>
+    | ReturnType<typeof mockUsers.platform>
+    | ReturnType<typeof mockUsers.patient>
+    | null,
+  overrides: Record<string, unknown> = {},
+) =>
+  createMockReq(user, payload, {
+    headers: bearerHeaders,
+    ...overrides,
+  })
+
+const readResponse = async (response: Response) => ({
+  body: await response.json(),
+  status: response.status,
+})
+
+const expectPrivateLiveHeaders = (response: Response) => {
+  expect(response.headers.get('cache-control')).toBe('private, no-store')
+  expect(response.headers.get('pragma')).toBe('no-cache')
+  expect(response.headers.get('expires')).toBe('0')
+  expect(response.headers.get('vary')).toBe('Authorization')
+}
+
+describe('Clinic Dashboard bootstrap endpoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.validateSupabaseBearerToken.mockResolvedValue({ status: 'invalid' })
+    mocks.findUserBySupabaseId.mockResolvedValue(null)
+  })
+
+  it('returns only the safe, stable DTO for an approved clinic principal', async () => {
+    const payload = createMockPayload()
+    arrangeCurrentDocuments(payload)
+
+    const response = await clinicDashboardBootstrapGetHandler(request(payload, mockUsers.clinic(22, 8)))
+
+    expect(await readResponse(response)).toEqual({
+      status: 200,
+      body: {
+        principal: {
+          id: '22',
+          displayName: 'Ada Lovelace',
+          email: 'clinic@example.com',
+        },
+        clinic: {
+          id: '8',
+          name: 'Berlin Clinic',
+        },
+        status: 'approved',
+        capabilities: [...CLINIC_DASHBOARD_CAPABILITIES],
+      },
+    })
+    expectPrivateLiveHeaders(response)
+    expect(mocks.validateSupabaseBearerToken).not.toHaveBeenCalled()
+    expect(payload.create).not.toHaveBeenCalled()
+  })
+
+  it('rejects cookie-only authentication before trusting the resolved principal', async () => {
+    const payload = createMockPayload()
+    arrangeCurrentDocuments(payload)
+    const req = request(payload, mockUsers.clinic(22, 8), { headers: new Headers() })
+
+    const response = await clinicDashboardBootstrapGetHandler(req)
+
+    expect(await readResponse(response)).toEqual({
+      status: 401,
+      body: { error: { code: 'CLINIC_DASHBOARD_UNAUTHORIZED' } },
+    })
+    expect(payload.find).not.toHaveBeenCalled()
+    expectPrivateLiveHeaders(response)
+  })
+
+  it.each([
+    ['platform', mockUsers.platform()],
+    ['patient', mockUsers.patient()],
+  ])('rejects a resolved %s principal', async (_label, user) => {
+    const payload = createMockPayload()
+
+    const response = await clinicDashboardBootstrapGetHandler(request(payload, user))
+
+    expect(response.status).toBe(401)
+    expect(payload.find).not.toHaveBeenCalled()
+    expectPrivateLiveHeaders(response)
+  })
+
+  it('returns 401 for an invalid Bearer token', async () => {
+    const payload = createMockPayload()
+
+    const response = await clinicDashboardBootstrapGetHandler(request(payload, null))
+
+    expect(response.status).toBe(401)
+    expect(mocks.findUserBySupabaseId).not.toHaveBeenCalled()
+    expectPrivateLiveHeaders(response)
+  })
+
+  it('returns 401 without creating staff when the valid identity has no principal', async () => {
+    const payload = createMockPayload()
+    mocks.validateSupabaseBearerToken.mockResolvedValue({
+      status: 'authenticated',
+      authData: {
+        supabaseUserId: 'missing-staff',
+        userEmail: 'missing@example.com',
+        userType: 'clinic',
+      },
+    })
+
+    const response = await clinicDashboardBootstrapGetHandler(request(payload, null))
+
+    expect(response.status).toBe(401)
+    expect(payload.create).not.toHaveBeenCalled()
+    expectPrivateLiveHeaders(response)
+  })
+
+  it('uses the focused fallback resolver when the global strategy yields no principal', async () => {
+    const payload = createMockPayload()
+    arrangeCurrentDocuments(payload)
+    mocks.validateSupabaseBearerToken.mockResolvedValue({
+      status: 'authenticated',
+      authData: {
+        supabaseUserId: 'clinic-user',
+        userEmail: 'clinic@example.com',
+        userType: 'clinic',
+      },
+    })
+    mocks.findUserBySupabaseId.mockResolvedValue(staffDocument)
+
+    const response = await clinicDashboardBootstrapGetHandler(request(payload, null))
+
+    expect(response.status).toBe(200)
+    expect(mocks.findUserBySupabaseId).toHaveBeenCalledOnce()
+    expect(payload.create).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['pending', { ...staffDocument, status: 'pending' }],
+    ['rejected', { ...staffDocument, status: 'rejected' }],
+    ['without clinic', { ...staffDocument, clinic: null }],
+  ])('returns 403 for staff that is %s', async (_label, staff) => {
+    const payload = createMockPayload()
+    arrangeCurrentDocuments(payload, staff)
+
+    const response = await clinicDashboardBootstrapGetHandler(request(payload, mockUsers.clinic(22, 8)))
+
+    expect(await readResponse(response)).toEqual({
+      status: 403,
+      body: { error: { code: 'CLINIC_DASHBOARD_ACCESS_DENIED' } },
+    })
+    expect(payload.find).toHaveBeenCalledTimes(1)
+    expectPrivateLiveHeaders(response)
+  })
+
+  it('returns 403 when the assigned clinic no longer exists', async () => {
+    const payload = createMockPayload()
+    arrangeCurrentDocuments(payload, staffDocument, null)
+
+    const response = await clinicDashboardBootstrapGetHandler(request(payload, mockUsers.clinic(22, 8)))
+
+    expect(response.status).toBe(403)
+    expectPrivateLiveHeaders(response)
+  })
+
+  it('maps temporary Supabase and Payload failures to 503', async () => {
+    const supabasePayload = createMockPayload()
+    mocks.validateSupabaseBearerToken.mockResolvedValueOnce({ status: 'unavailable' })
+
+    const supabaseResponse = await clinicDashboardBootstrapGetHandler(request(supabasePayload, null))
+    expect(await readResponse(supabaseResponse)).toEqual({
+      status: 503,
+      body: { error: { code: 'CLINIC_DASHBOARD_TEMPORARILY_UNAVAILABLE' } },
+    })
+    expectPrivateLiveHeaders(supabaseResponse)
+
+    const databasePayload = createMockPayload()
+    databasePayload.find.mockRejectedValue(new Error('database-secret-detail'))
+    const databaseResponse = await clinicDashboardBootstrapGetHandler(request(databasePayload, mockUsers.clinic(22, 8)))
+    expect(await readResponse(databaseResponse)).toEqual({
+      status: 503,
+      body: { error: { code: 'CLINIC_DASHBOARD_TEMPORARILY_UNAVAILABLE' } },
+    })
+    expectPrivateLiveHeaders(databaseResponse)
+  })
+
+  it('maps a conflicting Payload principal resolution to 503', async () => {
+    const payload = createMockPayload()
+    mocks.validateSupabaseBearerToken.mockResolvedValue({
+      status: 'authenticated',
+      authData: {
+        supabaseUserId: 'conflicting-user',
+        userEmail: 'conflict@example.com',
+        userType: 'clinic',
+      },
+    })
+    mocks.findUserBySupabaseId.mockRejectedValue(new Error('conflicting principal'))
+
+    const response = await clinicDashboardBootstrapGetHandler(request(payload, null))
+
+    expect(response.status).toBe(503)
+    expect(payload.create).not.toHaveBeenCalled()
+    expectPrivateLiveHeaders(response)
+  })
+
+  it('derives the tenant from current Payload state and ignores client-supplied actors', async () => {
+    const payload = createMockPayload()
+    arrangeCurrentDocuments(payload)
+    const req = request(payload, mockUsers.clinic(22, 8), {
+      body: { actor: 999, clinic: 999 },
+      query: { actor: 999, clinic: 999 },
+    })
+
+    const response = await clinicDashboardBootstrapGetHandler(req)
+
+    expect(response.status).toBe(200)
+    expect(payload.find).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        collection: 'clinics',
+        where: { id: { equals: 8 } },
+      }),
+    )
+  })
+
+  it('keeps two clinic principals isolated through fresh server-side assignments', async () => {
+    const payload = createMockPayload()
+    const staffById = new Map([
+      [22, staffDocument],
+      [23, { ...staffDocument, id: 23, clinic: 9, email: 'second@example.com' }],
+    ])
+    const clinicById = new Map([
+      [8, clinicDocument],
+      [9, { ...clinicDocument, id: 9, name: 'Hamburg Clinic' }],
+    ])
+    payload.find.mockImplementation(
+      async ({ collection, where }: { collection: string; where: { id: { equals: number } } }) => ({
+        docs: [collection === 'clinicStaff' ? staffById.get(where.id.equals) : clinicById.get(where.id.equals)].filter(
+          Boolean,
+        ),
+      }),
+    )
+
+    const first = await clinicDashboardBootstrapGetHandler(request(payload, mockUsers.clinic(22, 8)))
+    const second = await clinicDashboardBootstrapGetHandler(request(payload, mockUsers.clinic(23, 9)))
+
+    expect((await first.json()).clinic).toEqual({ id: '8', name: 'Berlin Clinic' })
+    expect((await second.json()).clinic).toEqual({ id: '9', name: 'Hamburg Clinic' })
+  })
+})

--- a/tests/unit/endpoints/clinicDashboardBootstrap.test.ts
+++ b/tests/unit/endpoints/clinicDashboardBootstrap.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { clinicDashboardBootstrapGetHandler } from '@/endpoints/clinicDashboardBootstrap'
+import { AUTH_FLOW_ERROR_CODES, AuthFlowError } from '@/auth/errors/authFlowError'
 import { CLINIC_DASHBOARD_CAPABILITIES } from '@/features/clinicDashboard/bootstrap'
 import { createMockPayload, createMockReq, type MockPayload } from '../helpers/testHelpers'
 import { mockUsers } from '../helpers/mockUsers'
@@ -238,7 +239,7 @@ describe('Clinic Dashboard bootstrap endpoint', () => {
     expectPrivateLiveHeaders(databaseResponse)
   })
 
-  it('maps a conflicting Payload principal resolution to 503', async () => {
+  it('maps a conflicting Payload principal resolution to 401', async () => {
     const payload = createMockPayload()
     mocks.validateSupabaseBearerToken.mockResolvedValue({
       status: 'authenticated',
@@ -248,12 +249,47 @@ describe('Clinic Dashboard bootstrap endpoint', () => {
         userType: 'clinic',
       },
     })
-    mocks.findUserBySupabaseId.mockRejectedValue(new Error('conflicting principal'))
+    mocks.findUserBySupabaseId.mockRejectedValue(
+      new AuthFlowError({
+        code: AUTH_FLOW_ERROR_CODES.USER_LOOKUP_FAILED,
+        message: 'Supabase identity resolves to more than one Payload principal',
+      }),
+    )
 
     const response = await clinicDashboardBootstrapGetHandler(request(payload, null))
 
-    expect(response.status).toBe(503)
+    expect(await readResponse(response)).toEqual({
+      status: 401,
+      body: { error: { code: 'CLINIC_DASHBOARD_UNAUTHORIZED' } },
+    })
     expect(payload.create).not.toHaveBeenCalled()
+    expectPrivateLiveHeaders(response)
+  })
+
+  it('maps a temporary principal lookup failure to 503', async () => {
+    const payload = createMockPayload()
+    mocks.validateSupabaseBearerToken.mockResolvedValue({
+      status: 'authenticated',
+      authData: {
+        supabaseUserId: 'clinic-user',
+        userEmail: 'clinic@example.com',
+        userType: 'clinic',
+      },
+    })
+    mocks.findUserBySupabaseId.mockRejectedValue(
+      new AuthFlowError({
+        code: AUTH_FLOW_ERROR_CODES.USER_LOOKUP_FAILED,
+        message: 'Payload lookup temporarily failed',
+        retryable: true,
+      }),
+    )
+
+    const response = await clinicDashboardBootstrapGetHandler(request(payload, null))
+
+    expect(await readResponse(response)).toEqual({
+      status: 503,
+      body: { error: { code: 'CLINIC_DASHBOARD_TEMPORARILY_UNAVAILABLE' } },
+    })
     expectPrivateLiveHeaders(response)
   })
 


### PR DESCRIPTION
## Management summary

### Deutsch

Das Clinic Dashboard kann jetzt sicher feststellen, ob ein angemeldeter Klinikmitarbeiter freigegeben ist, zu welcher Klinik er gehört und welche ersten Profilfunktionen verfügbar sind. Abgelehnte oder vorübergehend nicht prüfbare Zugriffe liefern kontrollierte Zustände, ohne interne Konto- oder Klinikdaten offenzulegen.

### English

The Clinic Dashboard can now safely determine whether a signed-in clinic staff member is approved, which clinic they belong to, and which initial profile functions are available. Denied or temporarily unverifiable access returns controlled states without exposing internal account or clinic data.

## What changed

- Add the focused `GET /api/clinic-dashboard/bootstrap` Payload endpoint under a non-collection namespace.
- Require an explicit Supabase Bearer token, resolve only direct `clinicStaff` principals, and re-read current approval and clinic assignment from Payload.
- Return a purpose-limited DTO with the ordered `clinic-profile:view` and `clinic-profile:edit` projection.
- Separate invalid credentials, denied clinic access, identity conflicts, and temporary Supabase or Payload outages through stable `401`, `403`, and `503` contracts.
- Apply private no-store headers to every response and avoid adding CORS, schema, migration, cache, or revalidation behavior.
- Synchronize the durable website contract and capability handoff with the merged [clinic-dashboard#59](https://github.com/findmydoc-platform/clinic-dashboard/pull/59).

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/features/clinicDashboard/bootstrap.ts`, `src/endpoints/clinicDashboardBootstrap.ts` | New authenticated API trust boundary and tenant projection | Explicit Bearer enforcement, fresh server-derived clinic assignment, safe DTO/error shapes, and fail-closed behavior | Focused endpoint tests |
| P1 | `src/auth/utilities/jwtValidation.ts`, `src/auth/utilities/userLookup.ts` | Distinguishes invalid sessions, identity conflicts, and temporary identity-provider failures without logging raw identity IDs | Error classification and unchanged cookie-session/global-strategy behavior | Focused auth and strategy regression tests |
| P2 | `docs/integrations/clinic-dashboard-api.md`, `docs/roadmap/clinic-dashboard/**` | Cross-repository DTO and capability drift would block the later BFF integration | Exact capabilities, error codes, private headers, and future-scope boundary match the Dashboard PR | `pnpm docs:check`; paired PR merged |

## Validation

- [x] `pnpm format`: passed; pre-commit formatting also passed
- [x] `pnpm check`: passed
- [x] `pnpm build`: passed locally with the required Postgres connection and in GitHub Actions
- [x] Focused tests: bootstrap endpoint, JWT validation, principal lookup, and Supabase strategy suites passed
- [ ] UI/mobile QA: not applicable; no UI changed
- [x] Security/privacy review: three independent falsification reviews plus a fourth false-positive/false-negative meta-review completed; the confirmed identity-conflict classification finding was fixed and revalidated
- [x] Migration/schema check: no schema or migration change; endpoint and documentation only
- [x] Documentation/instructions check: `pnpm docs:check` passed; no instruction source changed

## Risk and rollout

The endpoint is private-live and introduces no migration, CORS origin, Supabase configuration, public cache dependency, or revalidation path. The main risk is authentication or tenant-projection drift; focused tests cover explicit Bearer-only access, non-clinic principals, missing and conflicting identities, approval and clinic removal, two-clinic isolation, response shape, private headers, and upstream outages. Rollback is a code revert. Cache decision: `no-public-impact`.

## Development

Closes #1524
