### PR TITLE
refactor: remove legacy PostgreSQL locks

### DIFF
--- a/src/app/api/clinic-contact-requests/route.ts
+++ b/src/app/api/clinic-contact-requests/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
 import configPromise from '@payload-config'
-import { createHash } from 'crypto'
 import { getPayload } from 'payload'
 import { z } from 'zod'
 
@@ -15,6 +14,7 @@ const CONSENT_TEXT =
 
 const DUPLICATE_INQUIRY_WINDOW_MS = 15 * 60 * 1000
 
+// Best-effort only: separate runtimes may still create concurrent duplicates.
 const inProcessDuplicateLocks = new Map<string, Promise<void>>()
 
 const numericIdSchema = z.preprocess((value) => {
@@ -59,14 +59,6 @@ const inquiryRequestSchema = z
   })
 
 type InquiryRequestData = z.infer<typeof inquiryRequestSchema>
-type PayloadClient = Awaited<ReturnType<typeof getPayload>>
-type AdvisoryLockClient = {
-  query: (query: string, params: [number, number]) => Promise<unknown>
-  release: () => void
-}
-type AdvisoryLockPool = {
-  connect: () => Promise<AdvisoryLockClient>
-}
 
 function getFirstValidationMessage(error: z.ZodError): string {
   return error.issues[0]?.message || 'Invalid request payload.'
@@ -106,20 +98,6 @@ function buildDuplicateFingerprint(data: InquiryRequestData): string {
   })
 }
 
-function toAdvisoryLockKeys(fingerprint: string): [number, number] {
-  const digest = createHash('sha256').update(fingerprint).digest()
-  return [digest.readInt32BE(0), digest.readInt32BE(4)]
-}
-
-function getAdvisoryLockPool(payload: PayloadClient): AdvisoryLockPool | null {
-  const pool = (payload as unknown as { db?: { pool?: unknown } }).db?.pool
-  if (!pool || typeof pool !== 'object' || !('connect' in pool) || typeof pool.connect !== 'function') {
-    return null
-  }
-
-  return pool as AdvisoryLockPool
-}
-
 async function withInProcessDuplicateLock<T>(fingerprint: string, action: () => Promise<T>): Promise<T> {
   while (true) {
     const existingLock = inProcessDuplicateLocks.get(fingerprint)
@@ -140,29 +118,6 @@ async function withInProcessDuplicateLock<T>(fingerprint: string, action: () => 
       inProcessDuplicateLocks.delete(fingerprint)
     }
     releaseLock()
-  }
-}
-
-async function withDuplicateLock<T>(payload: PayloadClient, fingerprint: string, action: () => Promise<T>): Promise<T> {
-  const pool = getAdvisoryLockPool(payload)
-
-  if (!pool) {
-    return withInProcessDuplicateLock(fingerprint, action)
-  }
-
-  const client = await pool.connect()
-  const lockKeys = toAdvisoryLockKeys(fingerprint)
-
-  try {
-    await client.query('select pg_advisory_lock($1, $2)', lockKeys)
-    return await action()
-  } finally {
-    try {
-      await client.query('select pg_advisory_unlock($1, $2)', lockKeys)
-    } catch (error: unknown) {
-      payload.logger.warn({ error: serializeError(error) }, 'Patient clinic inquiry duplicate lock release failed')
-    }
-    client.release()
   }
 }
 
@@ -385,7 +340,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Treatment is not available for this clinic.' }, { status: 400 })
     }
 
-    return await withDuplicateLock(payload, buildDuplicateFingerprint(parsed.data), async () => {
+    return await withInProcessDuplicateLock(buildDuplicateFingerprint(parsed.data), async () => {
       const duplicateInquiry = await findDuplicateInquiry(payload, parsed.data)
       if (duplicateInquiry) {
         payload.logger.info(

--- a/src/endpoints/seed/utils/finalFlush.ts
+++ b/src/endpoints/seed/utils/finalFlush.ts
@@ -38,19 +38,6 @@ type ScopeEntry = {
   readonly sitemaps?: readonly CacheSitemapId[]
 }
 
-type PostgresLockClient = {
-  query: (text: string, params?: readonly unknown[]) => Promise<{ rows?: Array<{ acquired?: unknown }> }>
-  release: () => void
-}
-
-type PayloadWithOptionalPostgresPool = Payload & {
-  db?: {
-    pool?: {
-      connect?: () => Promise<PostgresLockClient>
-    }
-  }
-}
-
 type FinalFlushClaim = {
   release: () => Promise<void>
 }
@@ -62,6 +49,7 @@ const PUBLIC_GLOBALS = [
   'cookieConsent',
 ] as const satisfies readonly CachePolicyGlobal[]
 
+// Best-effort only: separate runtimes may execute the same idempotent flush.
 const activeFinalFlushRunIds = new Set<string>()
 
 const isFinalFlushComplete = (finalFlush: SeedRunFinalFlushRecord | undefined): boolean => {
@@ -258,85 +246,28 @@ const markFinalFlush = async (
   })
 }
 
-const acquireDatabaseFinalFlushLock = async (
-  payload: Payload,
-  runId: string,
-): Promise<(() => Promise<void>) | null | undefined> => {
-  const pool = (payload as PayloadWithOptionalPostgresPool).db?.pool
-  if (typeof pool?.connect !== 'function') return undefined
-
-  const client = await pool.connect()
-
-  try {
-    const result = await client.query('select pg_try_advisory_lock(hashtext($1), hashtext($2)) as acquired', [
-      'seed-final-flush',
-      runId,
-    ])
-    const acquired = result.rows?.[0]?.acquired === true
-
-    if (!acquired) {
-      client.release()
-      return null
-    }
-
-    return async () => {
-      try {
-        await client.query('select pg_advisory_unlock(hashtext($1), hashtext($2))', ['seed-final-flush', runId])
-      } finally {
-        client.release()
-      }
-    }
-  } catch (error) {
-    client.release()
-    throw error
-  }
-}
-
 const claimFinalFlush = async (payload: Payload, runId: string): Promise<FinalFlushClaim | null> => {
   if (activeFinalFlushRunIds.has(runId)) {
     return null
   }
 
   activeFinalFlushRunIds.add(runId)
-  let releaseDatabaseLock: (() => Promise<void>) | undefined
 
   try {
-    const databaseLock = await acquireDatabaseFinalFlushLock(payload, runId)
-    if (databaseLock === null) {
+    const record = await loadSeedRunRecord(payload, runId)
+    if (!record || isFinalFlushComplete(record.finalFlush)) {
       activeFinalFlushRunIds.delete(runId)
       return null
     }
-    releaseDatabaseLock = databaseLock
+
+    return {
+      release: async () => {
+        activeFinalFlushRunIds.delete(runId)
+      },
+    }
   } catch (error) {
     activeFinalFlushRunIds.delete(runId)
-    payload.logger.warn({
-      event: 'cache.revalidation.failed',
-      operation: 'seed-final-flush',
-      source: { kind: 'seed-runner', id: runId },
-      message: error instanceof Error ? error.message : String(error),
-    })
-    return null
-  }
-
-  const record = await loadSeedRunRecord(payload, runId)
-  if (!record || isFinalFlushComplete(record.finalFlush)) {
-    if (releaseDatabaseLock) {
-      await releaseDatabaseLock()
-    }
-    activeFinalFlushRunIds.delete(runId)
-    return null
-  }
-
-  return {
-    release: async () => {
-      try {
-        if (releaseDatabaseLock) {
-          await releaseDatabaseLock()
-        }
-      } finally {
-        activeFinalFlushRunIds.delete(runId)
-      }
-    },
+    throw error
   }
 }
 

--- a/tests/unit/app/api/clinic-contact-requests/route.test.ts
+++ b/tests/unit/app/api/clinic-contact-requests/route.test.ts
@@ -5,6 +5,9 @@ const findMock = vi.fn()
 const findByIDMock = vi.fn()
 const createMock = vi.fn()
 const loggerMock = { error: vi.fn(), info: vi.fn() }
+const databaseAdapterAccessMock = vi.fn(() => {
+  throw new Error('Payload database adapter must not be accessed')
+})
 
 vi.mock('payload', async (importOriginal) => {
   const actual = await importOriginal<typeof import('payload')>()
@@ -17,6 +20,9 @@ vi.mock('payload', async (importOriginal) => {
       findByID: findByIDMock,
       create: createMock,
       logger: loggerMock,
+      get db() {
+        return databaseAdapterAccessMock()
+      },
     }),
   }
 })
@@ -344,7 +350,7 @@ describe('POST /api/clinic-contact-requests', () => {
     expect(createMock).toHaveBeenCalledTimes(1)
   })
 
-  it('serializes concurrent identical requests before creating a duplicate', async () => {
+  it('serializes concurrent identical requests within the current runtime without database access', async () => {
     let createdInquiry: Record<string, unknown> | null = null
 
     findMock.mockImplementation(async (args: { collection: string }) => {
@@ -387,5 +393,6 @@ describe('POST /api/clinic-contact-requests', () => {
     expect(createMock).toHaveBeenCalledTimes(1)
     expect([firstJson, secondJson]).toContainEqual({ success: true, id: 42, status: 'submitted' })
     expect([firstJson, secondJson]).toContainEqual({ success: true, id: 42, status: 'submitted', deduped: true })
+    expect(databaseAdapterAccessMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/endpoints/seed/seedEndpoint-success.test.ts
+++ b/tests/unit/endpoints/seed/seedEndpoint-success.test.ts
@@ -225,7 +225,7 @@ describe('seed endpoints success paths', () => {
     },
   )
 
-  it('retries a failed terminal seed final flush on a later poll', async () => {
+  it('retries a failed terminal seed final flush with at-least-once invalidation', async () => {
     const { payload } = makePayloadReq({})
     const runId = 'seed-run-retry-failed-final-flush'
     const queue = `seed:${runId}`
@@ -289,9 +289,8 @@ describe('seed endpoints success paths', () => {
       failureCount: 1,
       reason: 'executor-error',
     })
-
-    vi.mocked(revalidateTag).mockClear()
-    vi.mocked(revalidatePath).mockClear()
+    expect(revalidateTag).toHaveBeenCalledWith('surface:posts-list', { expire: 0 })
+    expect(revalidatePath).toHaveBeenCalledWith('/posts')
 
     const secondRes = makeRes()
     await seedAdvanceHandler(
@@ -308,6 +307,8 @@ describe('seed endpoints success paths', () => {
     })
     expect(revalidateTag).toHaveBeenCalledWith('collection:posts', { expire: 0 })
     expect(revalidatePath).toHaveBeenCalledWith('/posts')
+    expect(vi.mocked(revalidateTag).mock.calls.filter(([tag]) => tag === 'surface:posts-list')).toHaveLength(2)
+    expect(vi.mocked(revalidatePath).mock.calls.filter(([path]) => path === '/posts')).toHaveLength(2)
   })
 
   it('does not flush a cancelled public seed job that never wrote public work', async () => {
@@ -552,9 +553,9 @@ describe('seed endpoints success paths', () => {
     expect(revalidatePath).not.toHaveBeenCalled()
   })
 
-  it('does not flush while another runtime holds the database final-flush lock', async () => {
+  it('runs the final flush without accessing the Payload database adapter', async () => {
     const { payload } = makePayloadReq({})
-    const runId = 'seed-run-cross-runtime-final-flush-lock'
+    const runId = 'seed-run-without-database-adapter'
     const queue = `seed:${runId}`
     const record = createSeedRunRecord({
       runId,
@@ -598,15 +599,10 @@ describe('seed endpoints success paths', () => {
     ]
     await saveSeedRunRecord(payload as unknown as Payload, record)
 
-    const release = vi.fn()
-    const query = vi.fn(async (text: string) => ({
-      rows: text.includes('pg_try_advisory_lock') ? [{ acquired: false }] : [],
-    }))
-    ;(payload as typeof payload & { db: { pool: { connect: ReturnType<typeof vi.fn> } } }).db = {
-      pool: {
-        connect: vi.fn(async () => ({ query, release })),
-      },
-    }
+    const databaseAdapterAccess = vi.fn(() => {
+      throw new Error('Payload database adapter must not be accessed')
+    })
+    Object.defineProperty(payload, 'db', { configurable: true, get: databaseAdapterAccess })
 
     const res = makeRes()
     await seedAdvanceHandler(
@@ -617,100 +613,13 @@ describe('seed endpoints success paths', () => {
     )
 
     expect(res._status).toBe(200)
-    expect((res._body as { finalFlush?: unknown }).finalFlush).toBeUndefined()
-    expect(revalidateTag).not.toHaveBeenCalled()
-    expect(revalidatePath).not.toHaveBeenCalled()
-    expect(query).toHaveBeenCalledWith('select pg_try_advisory_lock(hashtext($1), hashtext($2)) as acquired', [
-      'seed-final-flush',
-      runId,
-    ])
-    expect(release).toHaveBeenCalledTimes(1)
-  })
-
-  it('binds the pool while holding and releasing the database final-flush lock', async () => {
-    const { payload } = makePayloadReq({})
-    const runId = 'seed-run-database-final-flush-lock'
-    const queue = `seed:${runId}`
-    const record = createSeedRunRecord({
-      runId,
-      type: 'demo',
-      reset: false,
-      queue,
-      totalJobs: 1,
-    }) as SeedRunRecord
-    record.status = 'completed'
-    record.completedAt = '2026-07-08T10:00:00.000Z'
-    record.completedJobs = 1
-    record.succeededJobs = 1
-    record.jobs = [
-      {
-        id: 'job-posts',
-        order: 1,
-        status: 'succeeded',
-        input: {
-          runId,
-          type: 'demo',
-          reset: false,
-          queue,
-          stepName: 'posts',
-          kind: 'collection',
-          collection: 'posts',
-          fileName: 'posts',
-        },
-        queue,
-        title: 'Posts',
-        stepName: 'posts',
-        kind: 'collection',
-        collection: 'posts',
-        fileName: 'posts',
-        createdAt: '2026-07-08T09:00:00.000Z',
-        completedAt: '2026-07-08T10:00:00.000Z',
-        created: 1,
-        updated: 0,
-        warnings: [],
-        failures: [],
-      },
-    ]
-    await saveSeedRunRecord(payload as unknown as Payload, record)
-
-    const release = vi.fn()
-    const query = vi.fn(async (text: string) => ({
-      rows: text.includes('pg_try_advisory_lock') ? [{ acquired: true }] : [],
-    }))
-    const poolMarker = Symbol('seed-final-flush-pool')
-    const connect = vi.fn(async function (this: { marker?: symbol }) {
-      if (this.marker !== poolMarker) {
-        throw new Error('Database pool context was not preserved')
-      }
-
-      return { query, release }
-    })
-    const pool = { marker: poolMarker, connect }
-    ;(payload as typeof payload & { db: { pool: { connect: ReturnType<typeof vi.fn> } } }).db = {
-      pool,
-    }
-
-    await finalizeSeedRunPublicCaches(payload as unknown as Payload, {
-      ...record,
-      progress: { completed: 1, total: 1, percent: 100 },
-      jobIds: ['job-posts'],
-      hasActiveJob: false,
-    })
-
+    expect((res._body as { finalFlush?: { status: string } }).finalFlush?.status).toBe('executed')
     expect(revalidateTag).toHaveBeenCalled()
-    expect(connect).toHaveBeenCalledTimes(1)
-    expect(query).toHaveBeenCalledWith('select pg_try_advisory_lock(hashtext($1), hashtext($2)) as acquired', [
-      'seed-final-flush',
-      runId,
-    ])
-    expect(query).toHaveBeenCalledWith('select pg_advisory_unlock(hashtext($1), hashtext($2))', [
-      'seed-final-flush',
-      runId,
-    ])
-    expect(release).toHaveBeenCalledTimes(1)
+    expect(revalidatePath).toHaveBeenCalled()
+    expect(databaseAdapterAccess).not.toHaveBeenCalled()
   })
 
-  it('guards final flush execution so concurrent terminal pollers do not both flush', async () => {
+  it('keeps a best-effort in-process guard for concurrent terminal pollers', async () => {
     const { payload } = makePayloadReq({})
     const runId = 'seed-run-concurrent-final-flush'
     const queue = `seed:${runId}`


### PR DESCRIPTION
## Management summary

### Deutsch

Kontaktanfragen an Kliniken und die abschließende Aktualisierung nach Datenbefüllungen bleiben zuverlässig, ohne von einem systemspezifischen Sondermechanismus abhängig zu sein. Bestehende Schutz- und Wiederholungsmechanismen bleiben erhalten, wodurch Betrieb und Wartung einfacher werden.

### English

Clinic contact requests and the final refresh after data seeding remain reliable without depending on a system-specific mechanism. Existing safeguards and retry behavior stay in place, making operations and maintenance simpler.

## What changed

- Removed direct `payload.db.pool` access and PostgreSQL advisory lock queries from the clinic contact route. Recent duplicate detection through Payload and the best-effort in-process guard remain unchanged.
- Removed direct database pool access and PostgreSQL advisory lock queries from the seed final cache flush. Payload run state, the best-effort in-process guard, planner/executor behavior, logging, and retries remain unchanged.
- Added regression coverage that fails on database adapter access and makes the accepted at-least-once retry behavior explicit.
- Cache impact decision: `public-cached`. Existing cache policy entries, read tags, planner events, invalidation ownership, tags, and paths remain unchanged.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/app/api/clinic-contact-requests/route.ts`, `tests/unit/app/api/clinic-contact-requests/route.test.ts` | This public API stores patient contact details and retains only best-effort same-runtime duplicate coordination. | Verify the route never reaches the Payload database adapter while sequential Payload duplicate detection and same-runtime coordination still work. | Focused unit suite: 26/26 tests passed. |
| P1 | `src/endpoints/seed/utils/finalFlush.ts`, `tests/unit/endpoints/seed/seedEndpoint-success.test.ts` | Cross-runtime final flushes now deliberately use at-least-once semantics. | Verify repeated invalidation remains safe, failed flushes remain retryable, and successful or failed outcomes remain recorded. | Focused unit suite, `pnpm check`, and `pnpm build` passed. |

## Validation

- [x] `pnpm format`: completed successfully.
- [x] `pnpm check`: completed successfully; existing repository-wide sense-check warnings only.
- [x] `pnpm build`: completed successfully. The local development environment logged its existing missing `NEXT_PUBLIC_SUPABASE_URL` message during auth extraction, but the build and postbuild completed.
- [x] Focused tests: `pnpm tests:unit tests/unit/app/api/clinic-contact-requests/route.test.ts tests/unit/endpoints/seed/seedEndpoint-success.test.ts` — 2 files, 26 tests passed.
- [ ] UI/mobile QA: not applicable; no UI or frontend rendering changed.
- [ ] Security/privacy review: specialized reviewer not run; auth, access control, request fields, stored data, and logging payloads are unchanged.
- [ ] Migration/schema check: not applicable; no schema, collection, migration, or data change.
- [x] Documentation/instructions check: cache ADR and runtime guide reviewed; no update is needed because cache policy and invalidation semantics remain unchanged.

## Risk and rollout

Rare simultaneous execution in separate runtimes may repeat a clinic inquiry creation or an idempotent seed cache flush. This at-least-once behavior is explicitly accepted for this scope. Sequential Payload duplicate detection, same-runtime best-effort guards, final-flush status recording, and retry behavior remain in place. No environment, schema, migration, or rollout change is required. Rollback is a normal revert.

## Development

Closes #1567
