### PR TITLE
fix(access): block incomplete patient deletion

### DIFF
--- a/src/collections/Patients/hooks/patientSupabaseDelete.ts
+++ b/src/collections/Patients/hooks/patientSupabaseDelete.ts
@@ -3,18 +3,24 @@ import { deleteSupabaseAccount } from '@/auth/utilities/supabaseProvision'
 
 export const patientSupabaseDeleteHook: CollectionBeforeDeleteHook = async ({ req, id }) => {
   const { payload } = req
+
   try {
     const doc = await payload.findByID({ collection: 'patients', id, req, overrideAccess: true })
     if (!doc) return
+
     if (!doc.supabaseUserId) {
       payload.logger.warn(`No supabaseUserId found for Patient ${id} during deletion`)
       return
     }
+
     payload.logger.info({ supabaseUserId: doc.supabaseUserId }, `Deleting Supabase user for Patient: ${id}`)
     const ok = await deleteSupabaseAccount(doc.supabaseUserId)
-    if (!ok)
-      payload.logger.error({ supabaseUserId: doc.supabaseUserId }, `Failed to delete Supabase user for Patient: ${id}`)
+
+    if (!ok) {
+      throw new Error(`Failed to delete the external account for Patient ${id}`)
+    }
   } catch (error: unknown) {
     payload.logger.error(error, `Error during Supabase user deletion for Patient: ${id}`)
+    throw new Error(`Failed to delete the external account for Patient ${id}`)
   }
 }

--- a/tests/unit/hooks/patientSupabaseHooks.test.ts
+++ b/tests/unit/hooks/patientSupabaseHooks.test.ts
@@ -181,4 +181,44 @@ describe('patientSupabaseDeleteHook', () => {
     expect(deleteSupabaseAccount).toHaveBeenCalledWith('sb-unit-1')
     expect(payload.logger.info).toHaveBeenCalled()
   })
+
+  it('blocks patient deletion when supabase deletion returns false', async () => {
+    const { req, payload } = getMocks()
+    vi.mocked(payload.findByID).mockResolvedValue({
+      id: 1,
+      email: 'p@test.com',
+      firstName: 'P',
+      lastName: 'T',
+      supabaseUserId: 'sb-unit-1',
+      createdAt: '2023-01-01',
+      updatedAt: '2023-01-02',
+    } as Patient)
+    vi.mocked(deleteSupabaseAccount).mockResolvedValueOnce(false)
+
+    await expect(
+      patientSupabaseDeleteHook({ req, id: '1', collection: mockCollection, context: emptyContext }),
+    ).rejects.toThrow('Failed to delete the external account for Patient 1')
+
+    expect(payload.logger.error).toHaveBeenCalled()
+  })
+
+  it('blocks patient deletion when supabase deletion throws', async () => {
+    const { req, payload } = getMocks()
+    vi.mocked(payload.findByID).mockResolvedValue({
+      id: 1,
+      email: 'p@test.com',
+      firstName: 'P',
+      lastName: 'T',
+      supabaseUserId: 'sb-unit-1',
+      createdAt: '2023-01-01',
+      updatedAt: '2023-01-02',
+    } as Patient)
+    vi.mocked(deleteSupabaseAccount).mockRejectedValueOnce(new Error('identity provider unavailable'))
+
+    await expect(
+      patientSupabaseDeleteHook({ req, id: '1', collection: mockCollection, context: emptyContext }),
+    ).rejects.toThrow('Failed to delete the external account for Patient 1')
+
+    expect(payload.logger.error).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Management summary

### Deutsch

Die Löschung eines Patientenkontos wird jetzt abgebrochen, wenn das zugehörige externe Login-Konto nicht gelöscht werden konnte. Dadurch bleiben Konto- und Patientendaten in einem nachvollziehbaren Zustand und eine unvollständige Löschung wird nicht fälschlich als erfolgreich behandelt.

### English

Deleting a patient account now stops when the associated external login account could not be removed. This keeps account and patient data in a traceable state and prevents an incomplete deletion from being treated as successful.

## What changed

- Treat a false or failed Supabase account deletion as a blocking error in the patient `beforeDelete` hook.
- Keep the local patient record when the external account removal fails.
- Cover both explicit failure results and thrown provider errors with focused unit tests.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/collections/Patients/hooks/patientSupabaseDelete.ts` | The hook coordinates deletion across Payload and Supabase and therefore protects account-data consistency. | Confirm every external deletion failure blocks the local delete without exposing provider details to callers. | 10 focused unit tests passed; `pnpm check` passed. |

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed.
- [ ] `pnpm build`: not required; no build entry point, schema, route, or Payload config changed.
- [x] Focused tests: `tests/unit/hooks/patientSupabaseHooks.test.ts` passed (10 tests).
- [ ] UI/mobile QA: not applicable; no UI change.
- [ ] Security/privacy review: not run yet; security reviewer recommended because the change affects account deletion and patient-data consistency.
- [ ] Migration/schema check: not applicable; no schema or data migration.
- [ ] Documentation/instructions check: not applicable; no documentation or instruction source changed.

## Risk and rollout

The behavioral change is intentionally fail-closed: an unavailable or rejecting external identity provider now prevents patient deletion. Operators may see a failed delete that must be retried after the provider recovers; no migration or environment change is required.

## Development

Closes #1512
