### PR TITLE
fix(collections): validate clinic gallery ownership

### DIFF
--- a/src/collections/Clinics.ts
+++ b/src/collections/Clinics.ts
@@ -15,6 +15,22 @@ import { beforeChangeImmutableField } from '@/hooks/immutability'
 
 const APPROVED_CLINIC_REQUIRED_MESSAGE =
   'Approved clinics require a complete address, internal primary contact, and at least one supported language.'
+const GALLERY_ENTRIES_SAME_CLINIC_MESSAGE = 'Gallery entries must belong to this clinic.'
+
+const getRelationshipId = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isSafeInteger(value)) return value
+
+  if (typeof value === 'string') {
+    const numericId = Number(value)
+    return Number.isSafeInteger(numericId) ? numericId : null
+  }
+
+  if (value && typeof value === 'object' && 'id' in value) {
+    return getRelationshipId((value as { id?: unknown }).id)
+  }
+
+  return null
+}
 
 const isNonEmptyString = (value: unknown): boolean => typeof value === 'string' && value.trim().length > 0
 
@@ -84,6 +100,55 @@ const validateApprovedClinicCompleteness: CollectionBeforeValidateHook<Clinic> =
   return data
 }
 
+const validateGalleryEntriesBeforeValidate: CollectionBeforeValidateHook<Clinic> = async ({
+  data,
+  originalDoc,
+  req,
+}) => {
+  if (!data || !Object.prototype.hasOwnProperty.call(data, 'galleryEntries')) return data
+
+  const incomingEntries = data.galleryEntries
+  if (incomingEntries === null || incomingEntries === undefined || incomingEntries.length === 0) return data
+
+  const clinicId = getRelationshipId(originalDoc?.id)
+  const entryIds = Array.from(new Set(incomingEntries.map(getRelationshipId)))
+
+  if (!clinicId || entryIds.some((id) => id === null)) {
+    throw new Error(GALLERY_ENTRIES_SAME_CLINIC_MESSAGE)
+  }
+
+  const normalizedEntryIds = entryIds as number[]
+  const entries = await req.payload.find({
+    collection: 'clinicGalleryEntries',
+    depth: 0,
+    limit: normalizedEntryIds.length,
+    pagination: false,
+    overrideAccess: true,
+    req,
+    select: {
+      id: true,
+      clinic: true,
+    },
+    where: {
+      id: {
+        in: normalizedEntryIds,
+      },
+    },
+  })
+
+  const validEntryIds = new Set(
+    entries.docs
+      .filter((entry) => getRelationshipId(entry.clinic) === clinicId)
+      .map((entry) => getRelationshipId(entry.id)),
+  )
+
+  if (normalizedEntryIds.some((id) => !validEntryIds.has(id))) {
+    throw new Error(GALLERY_ENTRIES_SAME_CLINIC_MESSAGE)
+  }
+
+  return data
+}
+
 export const Clinics: CollectionConfig<'clinics'> = {
   slug: 'clinics',
   // This config controls what's populated by default when a clinic is referenced
@@ -112,7 +177,7 @@ export const Clinics: CollectionConfig<'clinics'> = {
     delete: isPlatformStaff, // Only Platform can delete clinics
   },
   hooks: {
-    beforeValidate: [validateApprovedClinicCompleteness],
+    beforeValidate: [validateApprovedClinicCompleteness, validateGalleryEntriesBeforeValidate],
     beforeChange: [
       stableIdBeforeChangeHook,
       beforeChangeImmutableField({ field: 'onboardingKey', message: 'onboardingKey cannot be changed once set' }),

--- a/tests/integration/clinicGalleryEntries.lifecycle.test.ts
+++ b/tests/integration/clinicGalleryEntries.lifecycle.test.ts
@@ -7,7 +7,7 @@ import { createClinicFixture } from '../fixtures/createClinicFixture'
 import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
 import { testSlug } from '../fixtures/testSlug'
 import { runBaselineContract } from './contracts/baselineContract'
-import type { ClinicGalleryEntry, ClinicGalleryMedia, ClinicStaff, PlatformStaff } from '@/payload-types'
+import type { Clinic, ClinicGalleryEntry, ClinicGalleryMedia, ClinicStaff, PlatformStaff } from '@/payload-types'
 
 vi.mock('@payloadcms/storage-s3', () => ({
   s3Storage: () => (incomingConfig: unknown) => incomingConfig,
@@ -356,6 +356,43 @@ describe('ClinicGalleryEntries integration - lifecycle', () => {
         depth: 0,
       } as PayloadCreateArgs),
     ).rejects.toThrow(/same clinic/i)
+  })
+
+  it('rejects gallery entries from a different clinic on clinic profiles', async () => {
+    const { clinic: clinicA } = await createClinicFixture(payload, cityId, {
+      slugPrefix: `${slugPrefix}-profile-gallery-a`,
+    })
+    const { clinic: clinicB } = await createClinicFixture(payload, cityId, {
+      slugPrefix: `${slugPrefix}-profile-gallery-b`,
+    })
+
+    const { clinicUser: clinicUserA, clinicStaff: staffA } = await createClinicUser('profile-gallery-a')
+    await approveClinicStaff(staffA.id, clinicA.id as number)
+
+    const { clinicUser: clinicUserB, clinicStaff: staffB } = await createClinicUser('profile-gallery-b')
+    await approveClinicStaff(staffB.id, clinicB.id as number)
+
+    const beforeB = await createGalleryMedia(clinicB.id as number, clinicUserB, 'profile-before-b', 'published')
+    const afterB = await createGalleryMedia(clinicB.id as number, clinicUserB, 'profile-after-b', 'published')
+    const entryB = await createEntry({
+      clinicId: clinicB.id as number,
+      user: clinicUserB,
+      beforeMediaId: beforeB.id,
+      afterMediaId: afterB.id,
+      status: 'published',
+      titleSuffix: 'profile-gallery-entry-b',
+    })
+
+    await expect(
+      payload.update({
+        collection: 'clinics',
+        id: clinicA.id,
+        data: { galleryEntries: [entryB.id] } as Partial<Clinic>,
+        user: asClinicUser(clinicUserA),
+        overrideAccess: false,
+        depth: 0,
+      } as PayloadUpdateArgs),
+    ).rejects.toThrow(/belong to this clinic/i)
   })
 
   it('scopes reads to published for public, clinic for staff, and all for platform', async () => {


### PR DESCRIPTION
## Management summary

### Deutsch

Klinikprofile können nur noch Galerieeinträge derselben Klinik verwenden. Dadurch lassen sich Bilder und Behandlungsfälle einer anderen Klinik nicht mehr versehentlich oder unberechtigt in ein fremdes Profil übernehmen.

### English

Clinic profiles can now use only gallery entries owned by the same clinic. This prevents images and treatment cases from another clinic from being accidentally or improperly attached to a different profile.

## What changed

- Validate changed `galleryEntries` relationships before a clinic profile is saved.
- Resolve every referenced gallery entry with server-side access and reject missing or cross-clinic relationships.
- Preserve the existing public cache owner: successful clinic updates continue through the existing clinic revalidation hooks, while rejected updates do not invalidate public data.
- Add an integration test proving clinic staff cannot attach another clinic's published gallery entry.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/collections/Clinics.ts` | Relationship validation enforces a clinic trust boundary before persistence. | Confirm all supplied relationship shapes are normalized, every entry is checked, and missing or foreign records fail closed. | Integration lifecycle test passed; `pnpm check` and `pnpm build` passed. |
| P2 | `tests/integration/clinicGalleryEntries.lifecycle.test.ts` | The regression test exercises the real Payload access and relationship lifecycle. | Confirm it models separate clinics and a clinic-staff update without bypassing access. | 7 integration tests passed. |

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed.
- [x] `pnpm build`: passed; the existing local log about missing `NEXT_PUBLIC_SUPABASE_URL` appeared during static generation without failing the build.
- [x] Focused tests: `tests/integration/clinicGalleryEntries.lifecycle.test.ts` passed (7 tests).
- [ ] UI/mobile QA: not applicable; no UI change.
- [ ] Security/privacy review: not run yet; security reviewer recommended for the clinic ownership boundary.
- [x] Migration/schema check: no schema migration required; relationship validation only.
- [ ] Documentation/instructions check: not applicable; no documentation or instruction source changed.

## Risk and rollout

Existing invalid cross-clinic relationships are not rewritten by this PR, but any subsequent save that supplies `galleryEntries` will reject them until corrected. No migration or environment change is required.

## Development

Closes #1513
