### PR TITLE
fix(admin): expose clinic lifecycle rules

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -24,7 +24,10 @@ import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f
 import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { default as default_5ecb274b48d69152edaeef5b36c5c4d8 } from '@/app/(payload)/components/PolicyAwareUpload'
 import { ClinicStaffAdminGuidance as ClinicStaffAdminGuidance_40aac613a756cdcd1ea79946bc7d5b3e } from '@/app/(payload)/components/AdminNotice/ClinicStaffAdminGuidance'
+import { ClinicStaffStatusField as ClinicStaffStatusField_d0a2f65900e52a342fe0b74a98d8adc2 } from '@/app/(payload)/components/ClinicStaffLifecycle'
+import { ClinicStaffLifecyclePanel as ClinicStaffLifecyclePanel_d0a2f65900e52a342fe0b74a98d8adc2 } from '@/app/(payload)/components/ClinicStaffLifecycle'
 import { PlatformStaffAdminGuidance as PlatformStaffAdminGuidance_44a83a5fcf2c50f5e0c31ed343de2547 } from '@/app/(payload)/components/AdminNotice/PlatformStaffAdminGuidance'
+import { ClinicApplicationLifecyclePanel as ClinicApplicationLifecyclePanel_2ecefdcb5754cece59d0633a49b851df } from '@/app/(payload)/components/ClinicApplicationLifecycle'
 import { ClinicApprovalRequirementError as ClinicApprovalRequirementError_6b9b57c3f957a81847439b14fa4ed9d4 } from '@/app/(payload)/components/ClinicApprovalRequirements'
 import { ClinicApprovalRequirements as ClinicApprovalRequirements_6b9b57c3f957a81847439b14fa4ed9d4 } from '@/app/(payload)/components/ClinicApprovalRequirements'
 import { default as default_edf1bab331b69df45f809a41e2fc2349 } from '@/components/organisms/MedicalSpecialtiesAdminGuidance'
@@ -84,7 +87,10 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@/app/(payload)/components/PolicyAwareUpload#default": default_5ecb274b48d69152edaeef5b36c5c4d8,
   "@/app/(payload)/components/AdminNotice/ClinicStaffAdminGuidance#ClinicStaffAdminGuidance": ClinicStaffAdminGuidance_40aac613a756cdcd1ea79946bc7d5b3e,
+  "@/app/(payload)/components/ClinicStaffLifecycle#ClinicStaffStatusField": ClinicStaffStatusField_d0a2f65900e52a342fe0b74a98d8adc2,
+  "@/app/(payload)/components/ClinicStaffLifecycle#ClinicStaffLifecyclePanel": ClinicStaffLifecyclePanel_d0a2f65900e52a342fe0b74a98d8adc2,
   "@/app/(payload)/components/AdminNotice/PlatformStaffAdminGuidance#PlatformStaffAdminGuidance": PlatformStaffAdminGuidance_44a83a5fcf2c50f5e0c31ed343de2547,
+  "@/app/(payload)/components/ClinicApplicationLifecycle#ClinicApplicationLifecyclePanel": ClinicApplicationLifecyclePanel_2ecefdcb5754cece59d0633a49b851df,
   "@/app/(payload)/components/ClinicApprovalRequirements#ClinicApprovalRequirementError": ClinicApprovalRequirementError_6b9b57c3f957a81847439b14fa4ed9d4,
   "@/app/(payload)/components/ClinicApprovalRequirements#ClinicApprovalRequirements": ClinicApprovalRequirements_6b9b57c3f957a81847439b14fa4ed9d4,
   "@/components/organisms/MedicalSpecialtiesAdminGuidance#default": default_edf1bab331b69df45f809a41e2fc2349,

--- a/src/app/(payload)/components/ClinicApplicationLifecycle/index.tsx
+++ b/src/app/(payload)/components/ClinicApplicationLifecycle/index.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useDocumentInfo, useFormFields } from '@payloadcms/ui'
+
+import { LifecycleStatusPanel } from '@/app/(payload)/components/LifecycleStatusPanel'
+import {
+  clinicApplicationProvisioningInputFields,
+  getClinicApplicationLifecyclePresentation,
+} from '@/collections/clinicApplications/provisioningLifecycle'
+import type { ClinicApplication } from '@/payload-types'
+
+export function ClinicApplicationLifecyclePanel() {
+  const { initialData } = useDocumentInfo()
+  const formState = useFormFields(([fields]) => ({
+    provisioningInputs: clinicApplicationProvisioningInputFields.map((field) => fields[field]?.value),
+    status: fields.status?.value,
+  }))
+  const persistedData = (initialData ?? {}) as Partial<ClinicApplication>
+  const currentData = {
+    ...persistedData,
+    ...Object.fromEntries(
+      clinicApplicationProvisioningInputFields.map((field, index) => [field, formState.provisioningInputs[index]]),
+    ),
+    status: formState.status,
+  } as Partial<ClinicApplication>
+  const presentation = getClinicApplicationLifecyclePresentation({
+    currentData,
+    persistedData,
+  })
+
+  return <LifecycleStatusPanel {...presentation} title="Provisioning lifecycle" />
+}

--- a/src/app/(payload)/components/ClinicStaffLifecycle/index.tsx
+++ b/src/app/(payload)/components/ClinicStaffLifecycle/index.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { SelectField, useDocumentInfo, useFormFields } from '@payloadcms/ui'
+import type { SelectFieldClientProps } from 'payload'
+
+import { LifecycleStatusPanel } from '@/app/(payload)/components/LifecycleStatusPanel'
+import {
+  clinicStaffStatusOptions,
+  getClinicStaffLifecyclePresentation,
+  getClinicStaffSelectableStatuses,
+  isClinicStaffStatus,
+  type ClinicStaffAuthSyncErrorCode,
+  type ClinicStaffAuthSyncStatus,
+} from '@/collections/clinicStaff/lifecycle'
+
+const authSyncStatuses: readonly ClinicStaffAuthSyncStatus[] = ['pending', 'synced', 'failed', 'deleted']
+const authSyncErrorCodes: readonly ClinicStaffAuthSyncErrorCode[] = [
+  'missing_identity',
+  'account_update_failed',
+  'account_delete_failed',
+]
+
+const readAuthSyncStatus = (value: unknown): ClinicStaffAuthSyncStatus | null =>
+  authSyncStatuses.includes(value as ClinicStaffAuthSyncStatus) ? (value as ClinicStaffAuthSyncStatus) : null
+
+const readAuthSyncErrorCode = (value: unknown): ClinicStaffAuthSyncErrorCode | null =>
+  authSyncErrorCodes.includes(value as ClinicStaffAuthSyncErrorCode) ? (value as ClinicStaffAuthSyncErrorCode) : null
+
+export function ClinicStaffStatusField(props: SelectFieldClientProps) {
+  const { initialData } = useDocumentInfo()
+  const persistedStatus = isClinicStaffStatus(initialData?.status) ? initialData.status : 'pending'
+  const selectableStatuses = getClinicStaffSelectableStatuses(persistedStatus)
+  const field = {
+    ...props.field,
+    admin: {
+      ...props.field.admin,
+      readOnly: props.field.admin?.readOnly || persistedStatus === 'offboarded',
+    },
+    options: clinicStaffStatusOptions.filter((option) => selectableStatuses.includes(option.value)),
+  } as SelectFieldClientProps['field']
+
+  return <SelectField {...props} field={field} />
+}
+
+export function ClinicStaffLifecyclePanel() {
+  const { initialData } = useDocumentInfo()
+  const persistedStatus = isClinicStaffStatus(initialData?.status) ? initialData.status : 'pending'
+  const formState = useFormFields(([fields]) => ({
+    authSyncErrorCode: fields['authSync.errorCode']?.value,
+    authSyncStatus: fields['authSync.status']?.value,
+    selectedStatus: fields.status?.value,
+  }))
+  const selectedStatus = isClinicStaffStatus(formState.selectedStatus) ? formState.selectedStatus : persistedStatus
+  const presentation = getClinicStaffLifecyclePresentation({
+    authSyncErrorCode: readAuthSyncErrorCode(formState.authSyncErrorCode),
+    authSyncStatus: readAuthSyncStatus(formState.authSyncStatus),
+    persistedStatus,
+    selectedStatus,
+  })
+
+  return <LifecycleStatusPanel {...presentation} title="Lifecycle impact" />
+}

--- a/src/app/(payload)/components/LifecycleStatusPanel/index.scss
+++ b/src/app/(payload)/components/LifecycleStatusPanel/index.scss
@@ -1,0 +1,161 @@
+@layer payload-default {
+  .lifecycle-status-panel {
+    display: grid;
+    min-width: 0;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    padding: 1rem;
+    border: 1px solid var(--theme-elevation-250, #d4d4d4);
+    border-left-width: 5px;
+    border-radius: var(--style-radius-s, 4px);
+    background: var(--theme-elevation-50, #fafafa);
+    color: var(--theme-elevation-800, #333);
+  }
+
+  .lifecycle-status-panel--info {
+    border-color: var(--color-blue-250, #bfdbfe);
+    border-left-color: var(--color-blue-500, #2563eb);
+    background: var(--color-blue-100, #eff6ff);
+    color: var(--color-blue-700, #1d4ed8);
+  }
+
+  .lifecycle-status-panel--success {
+    border-color: var(--theme-success-250, #bbf7d0);
+    border-left-color: var(--theme-success-500, #16a34a);
+    background: var(--theme-success-100, #f0fdf4);
+    color: var(--theme-success-700, #15803d);
+  }
+
+  .lifecycle-status-panel--warning {
+    border-color: var(--theme-warning-250, #fde68a);
+    border-left-color: var(--theme-warning-500, #d97706);
+    background: var(--theme-warning-100, #fffbeb);
+    color: var(--theme-warning-700, #92400e);
+  }
+
+  .lifecycle-status-panel--error {
+    border-color: var(--theme-error-250, #fecaca);
+    border-left-color: var(--theme-error-500, #dc2626);
+    background: var(--theme-error-100, #fef2f2);
+    color: var(--theme-error-700, #b91c1c);
+  }
+
+  .lifecycle-status-panel__heading {
+    display: flex;
+    min-width: 0;
+    align-items: flex-start;
+    gap: 0.625rem;
+
+    > svg {
+      flex: 0 0 auto;
+      margin-top: 0.125rem;
+    }
+
+    > div {
+      min-width: 0;
+    }
+
+    h3,
+    p {
+      margin: 0;
+      overflow-wrap: anywhere;
+    }
+
+    h3 {
+      font-size: 1rem;
+      font-weight: 600;
+      line-height: 1.5rem;
+    }
+  }
+
+  .lifecycle-status-panel__state {
+    margin-top: 0.25rem !important;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    line-height: 1.125rem;
+    text-transform: uppercase;
+  }
+
+  .lifecycle-status-panel__summary {
+    margin-top: 0.125rem !important;
+    font-size: 0.875rem;
+    line-height: 1.375rem;
+  }
+
+  .lifecycle-status-panel__details {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+    margin: 0;
+
+    > div {
+      min-width: 0;
+    }
+
+    dt,
+    dd {
+      margin: 0;
+      overflow-wrap: anywhere;
+    }
+
+    dt {
+      font-size: 0.75rem;
+      font-weight: 600;
+      line-height: 1.125rem;
+      opacity: 0.78;
+    }
+
+    dd {
+      margin-top: 0.125rem;
+      font-size: 0.875rem;
+      line-height: 1.375rem;
+    }
+  }
+
+  .lifecycle-status-panel__guidance {
+    padding-top: 0.75rem;
+    border-top: 1px solid currentColor;
+    margin: 0;
+    font-size: 0.875rem;
+    line-height: 1.375rem;
+    opacity: 0.9;
+    overflow-wrap: anywhere;
+  }
+
+  @media (min-width: 640px) {
+    .lifecycle-status-panel__details {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  html[data-theme='dark'] {
+    .lifecycle-status-panel--info {
+      border-color: var(--color-blue-750, #1e40af);
+      border-left-color: var(--color-blue-500, #3b82f6);
+      background: var(--color-blue-900, #172554);
+      color: var(--color-blue-300, #bfdbfe);
+    }
+
+    .lifecycle-status-panel--success {
+      border-color: var(--theme-success-250, #166534);
+      border-left-color: var(--theme-success-500, #22c55e);
+      background: var(--theme-success-100, #052e16);
+      color: var(--theme-success-700, #bbf7d0);
+    }
+
+    .lifecycle-status-panel--warning {
+      border-color: var(--theme-warning-250, #92400e);
+      border-left-color: var(--theme-warning-500, #f59e0b);
+      background: var(--theme-warning-100, #451a03);
+      color: var(--theme-warning-700, #fde68a);
+    }
+
+    .lifecycle-status-panel--error {
+      border-color: var(--theme-error-250, #991b1b);
+      border-left-color: var(--theme-error-500, #ef4444);
+      background: var(--theme-error-100, #450a0a);
+      color: var(--theme-error-700, #fecaca);
+    }
+  }
+}

--- a/src/app/(payload)/components/LifecycleStatusPanel/index.tsx
+++ b/src/app/(payload)/components/LifecycleStatusPanel/index.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { CircleCheck, CircleDashed, CircleX, TriangleAlert } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useId } from 'react'
+
+import './index.scss'
+
+export type LifecycleStatusPanelDetail = Readonly<{
+  label: string
+  value: ReactNode
+}>
+
+type LifecycleStatusPanelProps = Readonly<{
+  details?: readonly LifecycleStatusPanelDetail[]
+  guidance: ReactNode
+  stateLabel: string
+  summary: ReactNode
+  title: string
+  tone: 'error' | 'info' | 'success' | 'warning'
+}>
+
+const StateIcon = ({ tone }: Pick<LifecycleStatusPanelProps, 'tone'>) => {
+  if (tone === 'success') return <CircleCheck aria-hidden="true" size={20} />
+  if (tone === 'warning') return <TriangleAlert aria-hidden="true" size={20} />
+  if (tone === 'error') return <CircleX aria-hidden="true" size={20} />
+  return <CircleDashed aria-hidden="true" size={20} />
+}
+
+export function LifecycleStatusPanel({
+  details = [],
+  guidance,
+  stateLabel,
+  summary,
+  title,
+  tone,
+}: LifecycleStatusPanelProps) {
+  const titleId = useId()
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className={`lifecycle-status-panel lifecycle-status-panel--${tone}`}
+      data-lifecycle-state={stateLabel}
+    >
+      <div className="lifecycle-status-panel__heading">
+        <StateIcon tone={tone} />
+        <div>
+          <h3 id={titleId}>{title}</h3>
+          <p className="lifecycle-status-panel__state">{stateLabel}</p>
+          <p aria-live="polite" className="lifecycle-status-panel__summary">
+            {summary}
+          </p>
+        </div>
+      </div>
+
+      {details.length > 0 ? (
+        <dl className="lifecycle-status-panel__details">
+          {details.map((detail) => (
+            <div key={detail.label}>
+              <dt>{detail.label}</dt>
+              <dd>{detail.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+
+      <p className="lifecycle-status-panel__guidance">{guidance}</p>
+    </section>
+  )
+}

--- a/src/collections/ClinicApplications.ts
+++ b/src/collections/ClinicApplications.ts
@@ -4,17 +4,12 @@ import { computedOnlyFieldAccess } from '@/access/fieldAccess'
 import { CLINIC_ONBOARDING_ERROR_CODES } from '@/features/clinicOnboarding/provisionClinicOnboarding'
 import { provisionApprovedClinicApplication } from '@/hooks/clinicApplicationProvisioning'
 import { clinicContactRoleOptions } from './common/selectionOptions'
+import { clinicApplicationProvisioningErrorLabels } from './clinicApplications/provisioningLifecycle'
 
 // Platform-controlled application intake for clinics.
 // Public submissions are accepted only through /api/auth/register/clinic.
 // Only platform staff can create/read/update/delete records directly.
 // Approval workflow: platform sets status to approved; provisioning creates the pending clinic and initial staff access.
-
-const provisioningErrorLabels: Record<(typeof CLINIC_ONBOARDING_ERROR_CODES)[number], string> = {
-  record_failed: 'Record failed',
-  auth_failed: 'Authentication failed',
-  binding_failed: 'Identity binding failed',
-}
 
 export const ClinicApplications: CollectionConfig = {
   slug: 'clinicApplications',
@@ -144,6 +139,15 @@ export const ClinicApplications: CollectionConfig = {
       admin: { description: 'Application review status' },
     },
     {
+      name: 'lifecycleGuidance',
+      type: 'ui',
+      admin: {
+        components: {
+          Field: '@/app/(payload)/components/ClinicApplicationLifecycle#ClinicApplicationLifecyclePanel',
+        },
+      },
+    },
+    {
       name: 'reviewNotes',
       type: 'textarea',
       admin: { description: 'Notes about this application' },
@@ -176,7 +180,10 @@ export const ClinicApplications: CollectionConfig = {
     {
       name: 'provisioningErrorCode',
       type: 'select',
-      options: CLINIC_ONBOARDING_ERROR_CODES.map((value) => ({ label: provisioningErrorLabels[value], value })),
+      options: CLINIC_ONBOARDING_ERROR_CODES.map((value) => ({
+        label: clinicApplicationProvisioningErrorLabels[value],
+        value,
+      })),
       access: {
         create: computedOnlyFieldAccess,
         update: computedOnlyFieldAccess,

--- a/src/collections/ClinicStaff.ts
+++ b/src/collections/ClinicStaff.ts
@@ -6,6 +6,7 @@ import { getUserAssignedClinicId } from '@/access/utils/getClinicAssignment'
 import { platformOnlyFieldAccess, staffProfileFieldReadAccess } from '@/access/fieldAccess'
 import { synchronizeClinicStaffAuthState, validateClinicStaffStatusTransition } from '@/hooks/clinicStaffLifecycle'
 import { beforeChangeImmutableField } from '@/hooks/immutability'
+import { clinicStaffStatusOptions } from './clinicStaff/lifecycle'
 
 // Direct authentication principal for clinic dashboard and API access, never Payload Admin.
 export const ClinicStaff: CollectionConfig = {
@@ -181,13 +182,7 @@ export const ClinicStaff: CollectionConfig = {
     {
       name: 'status',
       type: 'select',
-      options: [
-        { label: 'Pending', value: 'pending' },
-        { label: 'Approved', value: 'approved' },
-        { label: 'Rejected', value: 'rejected' },
-        { label: 'Disabled', value: 'disabled' },
-        { label: 'Offboarded', value: 'offboarded' },
-      ],
+      options: clinicStaffStatusOptions,
       defaultValue: 'pending',
       required: true,
       access: {
@@ -196,11 +191,24 @@ export const ClinicStaff: CollectionConfig = {
         update: platformOnlyFieldAccess,
       },
       admin: {
+        components: {
+          Field: '@/app/(payload)/components/ClinicStaffLifecycle#ClinicStaffStatusField',
+        },
         description: 'Staff approval status',
         condition: (data, siblingData, { user }) => {
           // Hide status field from non-platform users in admin UI
           return Boolean(user && user.collection === 'platformStaff')
         },
+      },
+    },
+    {
+      name: 'lifecycleGuidance',
+      type: 'ui',
+      admin: {
+        components: {
+          Field: '@/app/(payload)/components/ClinicStaffLifecycle#ClinicStaffLifecyclePanel',
+        },
+        condition: (data, siblingData, { user }) => Boolean(user && user.collection === 'platformStaff'),
       },
     },
     {

--- a/src/collections/clinicApplications/provisioningLifecycle.ts
+++ b/src/collections/clinicApplications/provisioningLifecycle.ts
@@ -1,0 +1,186 @@
+import type { ClinicApplication } from '@/payload-types'
+
+export type ClinicApplicationProvisioningInputField =
+  'clinicName' | 'clinicWebsite' | 'contactEmail' | 'contactFirstName' | 'contactLastName' | 'contactRole'
+
+export const clinicApplicationProvisioningInputFields = [
+  'clinicName',
+  'clinicWebsite',
+  'contactFirstName',
+  'contactLastName',
+  'contactEmail',
+  'contactRole',
+] as const satisfies readonly ClinicApplicationProvisioningInputField[]
+
+export const clinicApplicationProvisioningErrorLabels = {
+  record_failed: 'Record failed',
+  auth_failed: 'Authentication failed',
+  binding_failed: 'Identity binding failed',
+} as const
+
+export const hasClinicApplicationProvisioningInputChanged = (
+  doc: Partial<ClinicApplication>,
+  previousDoc: Partial<ClinicApplication>,
+): boolean => clinicApplicationProvisioningInputFields.some((field) => doc[field] !== previousDoc[field])
+
+type RelationshipValue =
+  | null
+  | number
+  | string
+  | {
+      email?: string | null
+      id?: number | string
+      name?: string | null
+    }
+
+type ClinicApplicationLifecyclePresentationInput = Readonly<{
+  currentData: Partial<ClinicApplication>
+  persistedData: Partial<ClinicApplication>
+}>
+
+export type ClinicApplicationLifecyclePresentation = Readonly<{
+  details: ReadonlyArray<Readonly<{ label: string; value: string }>>
+  guidance: string
+  stateLabel: 'Awaiting review' | 'Completed' | 'Failed' | 'Provisioning pending' | 'Rejected'
+  summary: string
+  tone: 'error' | 'info' | 'success' | 'warning'
+}>
+
+const formatRelationship = (value: RelationshipValue | undefined): string => {
+  if (value === null || value === undefined) return 'Not available'
+  if (typeof value === 'number' || typeof value === 'string') return String(value)
+
+  return value.name || value.email || (value.id === undefined ? 'Not available' : String(value.id))
+}
+
+const formatProcessedAt = (value: string | null | undefined): string => {
+  if (!value) return 'Not available'
+
+  const date = new Date(value)
+  if (Number.isNaN(date.valueOf())) return value
+
+  return new Intl.DateTimeFormat('en-GB', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date)
+}
+
+export const getClinicApplicationLifecyclePresentation = ({
+  currentData,
+  persistedData,
+}: ClinicApplicationLifecyclePresentationInput): ClinicApplicationLifecyclePresentation => {
+  const status = currentData.status ?? persistedData.status ?? 'submitted'
+  const provisioningStatus = persistedData.provisioningStatus ?? 'not_started'
+  const provisioningErrorCode = persistedData.provisioningErrorCode
+  const inputChanged = hasClinicApplicationProvisioningInputChanged(currentData, persistedData)
+  const commonDetails = [
+    {
+      label: 'Review status',
+      value: status === 'approved' ? 'Approved' : status === 'rejected' ? 'Rejected' : 'Submitted',
+    },
+    {
+      label: 'Provisioning result',
+      value:
+        provisioningStatus === 'completed' ? 'Completed' : provisioningStatus === 'failed' ? 'Failed' : 'Not started',
+    },
+  ]
+
+  if (provisioningStatus === 'completed') {
+    return {
+      details: [
+        ...commonDetails,
+        ...(provisioningErrorCode
+          ? [
+              {
+                label: 'Error category',
+                value: clinicApplicationProvisioningErrorLabels[provisioningErrorCode],
+              },
+            ]
+          : []),
+        ...(persistedData.linkedRecords?.clinic
+          ? [
+              {
+                label: 'Created clinic',
+                value: formatRelationship(persistedData.linkedRecords.clinic as RelationshipValue),
+              },
+            ]
+          : []),
+        ...(persistedData.linkedRecords?.clinicStaff
+          ? [
+              {
+                label: 'Created clinic staff',
+                value: formatRelationship(persistedData.linkedRecords.clinicStaff as RelationshipValue),
+              },
+            ]
+          : []),
+        ...(persistedData.linkedRecords?.processedAt
+          ? [
+              {
+                label: 'Processed',
+                value: formatProcessedAt(persistedData.linkedRecords.processedAt),
+              },
+            ]
+          : []),
+      ],
+      guidance: 'The linked clinic and clinic staff records are available for the remaining review steps.',
+      stateLabel: 'Completed',
+      summary: 'Automatic clinic and clinic staff creation completed.',
+      tone: 'success',
+    }
+  }
+
+  if (provisioningStatus === 'failed') {
+    return {
+      details: [
+        ...commonDetails,
+        ...(provisioningErrorCode
+          ? [
+              {
+                label: 'Error category',
+                value: clinicApplicationProvisioningErrorLabels[provisioningErrorCode],
+              },
+            ]
+          : []),
+      ],
+      guidance: inputChanged
+        ? 'Saving starts another provisioning attempt.'
+        : 'Change at least the clinic name, website, contact first name, contact last name, email, or role, then save.',
+      stateLabel: 'Failed',
+      summary: inputChanged
+        ? 'A provisioning input changed and the application is ready to retry.'
+        : 'The last automatic provisioning attempt failed.',
+      tone: 'error',
+    }
+  }
+
+  if (status === 'rejected') {
+    return {
+      details: commonDetails,
+      guidance: 'Saving keeps the application rejected and does not start provisioning.',
+      stateLabel: 'Rejected',
+      summary: 'This application is rejected.',
+      tone: 'warning',
+    }
+  }
+
+  if (status === 'approved') {
+    return {
+      details: commonDetails,
+      guidance:
+        persistedData.status === 'approved'
+          ? 'Provisioning is waiting for the existing automatic process to complete.'
+          : 'Saving Approved starts automatic clinic and clinic staff creation.',
+      stateLabel: 'Provisioning pending',
+      summary: 'This application is approved and awaiting automatic provisioning.',
+      tone: 'warning',
+    }
+  }
+
+  return {
+    details: commonDetails,
+    guidance: 'Review the application and select Approved or Rejected.',
+    stateLabel: 'Awaiting review',
+    summary: 'This application is waiting for a review decision.',
+    tone: 'info',
+  }
+}

--- a/src/collections/clinicStaff/lifecycle.ts
+++ b/src/collections/clinicStaff/lifecycle.ts
@@ -1,0 +1,164 @@
+import type { ClinicStaff } from '@/payload-types'
+
+export type ClinicStaffStatus = NonNullable<ClinicStaff['status']>
+export type ClinicStaffAuthSyncStatus = NonNullable<NonNullable<ClinicStaff['authSync']>['status']>
+export type ClinicStaffAuthSyncErrorCode = NonNullable<NonNullable<ClinicStaff['authSync']>['errorCode']>
+
+export const clinicStaffStatusOptions = [
+  { label: 'Pending', value: 'pending' },
+  { label: 'Approved', value: 'approved' },
+  { label: 'Rejected', value: 'rejected' },
+  { label: 'Disabled', value: 'disabled' },
+  { label: 'Offboarded', value: 'offboarded' },
+] satisfies Array<{ label: string; value: ClinicStaffStatus }>
+
+export const clinicStaffStatusTransitions = {
+  pending: ['approved', 'rejected', 'offboarded'],
+  approved: ['disabled', 'offboarded'],
+  disabled: ['approved', 'offboarded'],
+  rejected: ['offboarded'],
+  offboarded: [],
+} as const satisfies Record<ClinicStaffStatus, readonly ClinicStaffStatus[]>
+
+export const clinicStaffAuthSyncStatusLabels = {
+  pending: 'Pending',
+  synced: 'Synced',
+  failed: 'Failed',
+  deleted: 'Deleted',
+} as const satisfies Record<ClinicStaffAuthSyncStatus, string>
+
+export const clinicStaffAuthSyncErrorLabels = {
+  missing_identity: 'Missing Supabase identity',
+  account_update_failed: 'Account update failed',
+  account_delete_failed: 'Account deletion failed',
+} as const satisfies Record<ClinicStaffAuthSyncErrorCode, string>
+
+export const isClinicStaffStatus = (value: unknown): value is ClinicStaffStatus =>
+  clinicStaffStatusOptions.some((option) => option.value === value)
+
+export const getClinicStaffStatusLabel = (status: ClinicStaffStatus): string =>
+  clinicStaffStatusOptions.find((option) => option.value === status)?.label ?? status
+
+export const getClinicStaffSelectableStatuses = (persistedStatus: ClinicStaffStatus): readonly ClinicStaffStatus[] => [
+  persistedStatus,
+  ...clinicStaffStatusTransitions[persistedStatus],
+]
+
+export const isClinicStaffStatusTransitionAllowed = (
+  persistedStatus: ClinicStaffStatus,
+  selectedStatus: ClinicStaffStatus,
+): boolean =>
+  selectedStatus === persistedStatus || clinicStaffStatusTransitions[persistedStatus].includes(selectedStatus as never)
+
+type ClinicStaffLifecyclePresentationInput = Readonly<{
+  authSyncErrorCode?: ClinicStaffAuthSyncErrorCode | null
+  authSyncStatus?: ClinicStaffAuthSyncStatus | null
+  persistedStatus: ClinicStaffStatus
+  selectedStatus: ClinicStaffStatus
+}>
+
+export type ClinicStaffLifecyclePresentation = Readonly<{
+  details: ReadonlyArray<Readonly<{ label: string; value: string }>>
+  guidance: string
+  stateLabel: string
+  summary: string
+  tone: 'error' | 'info' | 'success' | 'warning'
+}>
+
+const getTransitionSummary = (
+  persistedStatus: ClinicStaffStatus,
+  selectedStatus: ClinicStaffStatus,
+): Pick<ClinicStaffLifecyclePresentation, 'guidance' | 'stateLabel' | 'summary' | 'tone'> => {
+  if (selectedStatus === 'approved') {
+    return {
+      guidance:
+        'Clinic Dashboard access still requires a successful authentication sync and an assigned approved clinic.',
+      stateLabel: persistedStatus === 'disabled' ? 'Reactivation selected' : 'Activation selected',
+      summary:
+        persistedStatus === 'disabled'
+          ? 'Saving reactivates the Supabase identity.'
+          : 'Saving activates the Supabase identity.',
+      tone: 'warning',
+    }
+  }
+
+  if (selectedStatus === 'offboarded') {
+    return {
+      guidance: 'Offboarding is terminal. The clinic staff lifecycle cannot be reopened after saving.',
+      stateLabel: 'Offboarding selected',
+      summary: 'Saving permanently deletes the Supabase identity.',
+      tone: 'warning',
+    }
+  }
+
+  return {
+    guidance: 'The status change remains saved even if the subsequent Supabase synchronization fails.',
+    stateLabel: 'Access removal selected',
+    summary: 'Saving disables the Supabase identity.',
+    tone: 'warning',
+  }
+}
+
+export const getClinicStaffLifecyclePresentation = ({
+  authSyncErrorCode,
+  authSyncStatus,
+  persistedStatus,
+  selectedStatus,
+}: ClinicStaffLifecyclePresentationInput): ClinicStaffLifecyclePresentation => {
+  const details = [
+    { label: 'Saved status', value: getClinicStaffStatusLabel(persistedStatus) },
+    { label: 'After save', value: getClinicStaffStatusLabel(selectedStatus) },
+    {
+      label: 'Authentication sync',
+      value: authSyncStatus ? clinicStaffAuthSyncStatusLabels[authSyncStatus] : 'Not reported',
+    },
+    ...(authSyncErrorCode
+      ? [{ label: 'Last sync issue', value: clinicStaffAuthSyncErrorLabels[authSyncErrorCode] }]
+      : []),
+  ]
+
+  if (selectedStatus !== persistedStatus) {
+    return {
+      details,
+      ...getTransitionSummary(persistedStatus, selectedStatus),
+    }
+  }
+
+  if (authSyncStatus === 'failed') {
+    return {
+      details,
+      guidance: 'Saving this record again retries the same Supabase operation.',
+      stateLabel: 'Sync failed',
+      summary: 'The last Supabase synchronization failed.',
+      tone: 'error',
+    }
+  }
+
+  if (persistedStatus === 'offboarded') {
+    return {
+      details,
+      guidance: 'No further lifecycle transition is available.',
+      stateLabel: 'Terminal',
+      summary: 'The Supabase identity is deleted and this lifecycle is terminal.',
+      tone: 'success',
+    }
+  }
+
+  if (persistedStatus === 'pending') {
+    return {
+      details,
+      guidance: 'Choose an allowed status to see its Supabase effect before saving.',
+      stateLabel: 'Awaiting decision',
+      summary: 'No lifecycle change is selected.',
+      tone: 'info',
+    }
+  }
+
+  return {
+    details,
+    guidance: 'Saving an unrelated change does not repeat a successful synchronization.',
+    stateLabel: 'Synchronized',
+    summary: 'Supabase access matches the saved clinic staff status.',
+    tone: 'success',
+  }
+}

--- a/src/hooks/clinicApplicationProvisioning.ts
+++ b/src/hooks/clinicApplicationProvisioning.ts
@@ -5,19 +5,8 @@ import {
   type ClinicOnboardingErrorCode,
 } from '@/features/clinicOnboarding/provisionClinicOnboarding'
 import { getCurrentIsoTimestampString } from '@/utilities/timestamps'
+import { hasClinicApplicationProvisioningInputChanged } from '@/collections/clinicApplications/provisioningLifecycle'
 import type { CollectionAfterChangeHook } from 'payload'
-
-const provisioningInputFields = [
-  'clinicName',
-  'clinicWebsite',
-  'contactFirstName',
-  'contactLastName',
-  'contactEmail',
-  'contactRole',
-] as const satisfies ReadonlyArray<keyof ClinicApplication>
-
-const hasProvisioningInputChanged = (doc: ClinicApplication, previousDoc: ClinicApplication): boolean =>
-  provisioningInputFields.some((field) => doc[field] !== previousDoc[field])
 
 const updateProvisioningState = async (
   req: Parameters<CollectionAfterChangeHook<ClinicApplication>>[0]['req'],
@@ -48,7 +37,7 @@ export const provisionApprovedClinicApplication: CollectionAfterChangeHook<Clini
 
   const transitionedToApproved = previousDoc?.status !== 'approved'
   const shouldRetryFailedProvisioning =
-    provisioningStatus === 'failed' && previousDoc && hasProvisioningInputChanged(doc, previousDoc)
+    provisioningStatus === 'failed' && previousDoc && hasClinicApplicationProvisioningInputChanged(doc, previousDoc)
 
   if (!transitionedToApproved && !shouldRetryFailedProvisioning) return doc
 

--- a/src/hooks/clinicStaffLifecycle.ts
+++ b/src/hooks/clinicStaffLifecycle.ts
@@ -1,22 +1,17 @@
 import type { ClinicStaff } from '@/payload-types'
 import { deleteClinicSupabaseAccount, setClinicSupabaseAccountAccess } from '@/auth/utilities/supabaseProvision'
+import {
+  isClinicStaffStatusTransitionAllowed,
+  type ClinicStaffAuthSyncErrorCode,
+} from '@/collections/clinicStaff/lifecycle'
 import type { CollectionAfterChangeHook, CollectionBeforeChangeHook } from 'payload'
-
-type ClinicStaffStatus = NonNullable<ClinicStaff['status']>
-type AuthSyncErrorCode = NonNullable<NonNullable<ClinicStaff['authSync']>['errorCode']>
-
-const allowedTransitions: Record<ClinicStaffStatus, readonly ClinicStaffStatus[]> = {
-  pending: ['approved', 'rejected', 'offboarded'],
-  approved: ['disabled', 'offboarded'],
-  disabled: ['approved', 'offboarded'],
-  rejected: ['offboarded'],
-  offboarded: [],
-}
+import { ValidationError } from 'payload'
 
 export const validateClinicStaffStatusTransition: CollectionBeforeChangeHook<ClinicStaff> = async ({
   data,
   operation,
   originalDoc,
+  req,
 }) => {
   if (operation !== 'update' || !originalDoc?.status) return data
 
@@ -24,8 +19,19 @@ export const validateClinicStaffStatusTransition: CollectionBeforeChangeHook<Cli
   const nextStatus = data.status ?? previousStatus
   if (nextStatus === previousStatus) return data
 
-  if (!allowedTransitions[previousStatus].includes(nextStatus)) {
-    throw new Error(`Clinic staff status transition ${previousStatus} -> ${nextStatus} is not allowed`)
+  if (!isClinicStaffStatusTransitionAllowed(previousStatus, nextStatus)) {
+    throw new ValidationError({
+      collection: 'clinicStaff',
+      errors: [
+        {
+          label: 'Status',
+          message: `Clinic staff status transition ${previousStatus} -> ${nextStatus} is not allowed.`,
+          path: 'status',
+        },
+      ],
+      id: originalDoc.id,
+      req,
+    })
   }
 
   return data
@@ -35,7 +41,7 @@ const updateAuthSync = async (
   req: Parameters<CollectionAfterChangeHook<ClinicStaff>>[0]['req'],
   id: number | string,
   status: 'deleted' | 'failed' | 'synced',
-  errorCode: AuthSyncErrorCode | null,
+  errorCode: ClinicStaffAuthSyncErrorCode | null,
 ) => {
   await req.payload.update({
     collection: 'clinicStaff',
@@ -59,7 +65,8 @@ export const synchronizeClinicStaffAuthState: CollectionAfterChangeHook<ClinicSt
   const statusChanged = previousDoc?.status !== doc.status
   if (!statusChanged && doc.authSync?.status === expectedSyncStatus) return doc
 
-  let failureCode: AuthSyncErrorCode = doc.status === 'offboarded' ? 'account_delete_failed' : 'account_update_failed'
+  let failureCode: ClinicStaffAuthSyncErrorCode =
+    doc.status === 'offboarded' ? 'account_delete_failed' : 'account_update_failed'
 
   try {
     if (!doc.supabaseUserId) {

--- a/tests/e2e/admin/platform.admin-regression.spec.ts
+++ b/tests/e2e/admin/platform.admin-regression.spec.ts
@@ -20,6 +20,41 @@ test('platform staff sees and completes clinic approval requirements @regression
   await expectNoBrowserIssues(issues)
 })
 
+test('platform staff sees valid clinic staff transitions and structured API validation @regression', async ({
+  page,
+}) => {
+  const issues = createBrowserIssueCollector(page)
+  const result = await executeAdminJourney(getAdminJourneyDefinition('admin.clinic-staff.lifecycle-guidance'), {
+    mode: 'regression',
+    page,
+    persona: 'admin',
+    request: page.request,
+  })
+
+  await expect(result.state.clinicStaffId).toBeTruthy()
+  await expect(page.getByText('Saving disables the Supabase identity.')).toBeVisible()
+  await expectNoBrowserIssues(issues)
+})
+
+test('platform staff sees clinic application provisioning guidance without starting provisioning @regression', async ({
+  page,
+}) => {
+  const issues = createBrowserIssueCollector(page)
+  const result = await executeAdminJourney(
+    getAdminJourneyDefinition('admin.clinic-applications.provisioning-guidance'),
+    {
+      mode: 'regression',
+      page,
+      persona: 'admin',
+      request: page.request,
+    },
+  )
+
+  await expect(result.state.applicationId).toBeTruthy()
+  await expect(page.getByText('Provisioning pending', { exact: true })).toBeVisible()
+  await expectNoBrowserIssues(issues)
+})
+
 test('platform staff sees the patient requirement while creating a review @regression', async ({ page }) => {
   const issues = createBrowserIssueCollector(page, {
     ignoredConsoleErrors: [/status of 400.*\/api\/reviews(?:\?|$)/, /server responded with a status of 400/i],

--- a/tests/e2e/helpers/adminJourneys/journeys/clinicLifecycle.ts
+++ b/tests/e2e/helpers/adminJourneys/journeys/clinicLifecycle.ts
@@ -1,0 +1,305 @@
+import { expect } from '@playwright/test'
+import { getPayload, type Payload } from 'payload'
+import config from '@payload-config'
+
+import { ensureApprovedClinicStaffAccess, ensureMedicalSpecialtyFixture } from '../../adminFixtures'
+import { getRecordId, type CollectionListResponse, type CreatedDocResponse, type RecordId } from '../../adminApi'
+import { getAdminFieldRoot, openAdminDocumentPage, selectComboboxOption } from '../../adminUI'
+import { defineJourneySteps } from '../fragments'
+import type { AdminJourneyDefinition, AdminJourneyStep } from '../types'
+
+type ClinicStaffLifecycleJourneyState = {
+  clinicStaffId?: RecordId
+  ownsClinicStaffFixture: boolean
+}
+
+type ClinicApplicationLifecycleJourneyState = {
+  applicationId?: RecordId
+}
+
+let clinicStaffFixturePayload: Payload | null = null
+
+const getClinicStaffFixturePayload = async (): Promise<Payload> => {
+  clinicStaffFixturePayload ??= await getPayload({ config, key: 'clinic-staff-lifecycle-journey' })
+  return clinicStaffFixturePayload
+}
+
+const collectValidationPaths = (value: unknown): string[] => {
+  if (Array.isArray(value)) return value.flatMap(collectValidationPaths)
+  if (!value || typeof value !== 'object') return []
+
+  const record = value as Record<string, unknown>
+  return [
+    ...(typeof record.path === 'string' ? [record.path] : []),
+    ...Object.values(record).flatMap(collectValidationPaths),
+  ]
+}
+
+const ensureApprovedClinicStaffStep = {
+  collections: ['clinicStaff'],
+  kind: 'api-fixture',
+  label: 'Ensure the fixed clinic staff account is approved',
+  producesState: ['clinicStaffId'],
+  run: async ({ request, state }) => {
+    const fixedClinicEmail = process.env.E2E_CLINIC_EMAIL?.trim()
+
+    if (fixedClinicEmail) {
+      const fixture = await ensureApprovedClinicStaffAccess(request, {
+        email: fixedClinicEmail,
+      })
+      state.clinicStaffId = fixture.clinicStaffId
+      return
+    }
+
+    const fixtureResponse = await request.get(
+      '/api/clinicStaff?depth=0&limit=1&where[status][equals]=approved&where[authSync.status][equals]=synced',
+    )
+    expect(fixtureResponse.ok()).toBeTruthy()
+    const fixtureBody = (await fixtureResponse.json()) as CollectionListResponse
+    state.clinicStaffId = getRecordId(fixtureBody.docs?.[0]?.id)
+    if (state.clinicStaffId) return
+
+    const payload = await getClinicStaffFixturePayload()
+    const temporaryStaff = await payload.create({
+      collection: 'clinicStaff',
+      context: { skipClinicStaffAuthSync: true },
+      data: {
+        authSync: { errorCode: null, status: 'synced' },
+        email: `clinic-lifecycle-${Date.now()}@example.com`,
+        firstName: 'Lifecycle',
+        lastName: 'Fixture',
+        status: 'approved',
+        supabaseUserId: `clinic-lifecycle-${Date.now()}`,
+      },
+      depth: 0,
+      overrideAccess: true,
+    })
+    state.clinicStaffId = temporaryStaff.id
+    state.ownsClinicStaffFixture = true
+  },
+  stepId: 'ensure-approved-clinic-staff',
+} satisfies AdminJourneyStep<ClinicStaffLifecycleJourneyState>
+
+const deleteTemporaryClinicStaffStep = {
+  collections: ['clinicStaff'],
+  kind: 'api-fixture',
+  label: 'Delete the temporary clinic staff fixture',
+  requiresState: ['clinicStaffId'],
+  run: async ({ state }) => {
+    if (!state.ownsClinicStaffFixture || state.clinicStaffId === undefined) return
+
+    const payload = await getClinicStaffFixturePayload()
+
+    try {
+      await payload.delete({
+        collection: 'clinicStaff',
+        id: state.clinicStaffId,
+        overrideAccess: true,
+      })
+    } finally {
+      await payload.destroy()
+      clinicStaffFixturePayload = null
+    }
+  },
+  stepId: 'delete-temporary-clinic-staff',
+} satisfies AdminJourneyStep<ClinicStaffLifecycleJourneyState>
+
+const assertInvalidClinicStaffTransitionStep = {
+  collections: ['clinicStaff'],
+  kind: 'assertion',
+  label: 'Verify the API rejects an invalid clinic staff transition',
+  requiresState: ['clinicStaffId'],
+  run: async ({ request, state }) => {
+    const response = await request.patch(`/api/clinicStaff/${state.clinicStaffId}`, {
+      data: { status: 'rejected' },
+    })
+    const responseBody = (await response.json()) as unknown
+
+    expect(response.status()).toBe(400)
+    expect(collectValidationPaths(responseBody)).toContain('status')
+
+    const unchanged = await request.get(`/api/clinicStaff/${state.clinicStaffId}?depth=0`)
+    expect(unchanged.ok()).toBeTruthy()
+    await expect(unchanged.json()).resolves.toMatchObject({ status: 'approved' })
+  },
+  stepId: 'assert-invalid-transition-api',
+} satisfies AdminJourneyStep<ClinicStaffLifecycleJourneyState>
+
+const openClinicStaffLifecycleStep = {
+  checkpoint: {
+    label: 'Approved clinic staff lifecycle options',
+    screenshotSlug: 'clinic-staff-approved-lifecycle',
+  },
+  collections: ['clinicStaff'],
+  kind: 'navigation',
+  label: 'Open the approved clinic staff document',
+  requiresState: ['clinicStaffId'],
+  run: async ({ page, state }) => {
+    if (state.clinicStaffId === undefined) throw new Error('Clinic staff fixture is missing.')
+
+    await openAdminDocumentPage(page, 'clinicStaff', state.clinicStaffId)
+    await expect(page.getByRole('region', { name: 'Lifecycle impact' })).toBeVisible()
+    await expect(page.getByText('Supabase access matches the saved clinic staff status.')).toBeVisible()
+  },
+  stepId: 'open-clinic-staff-lifecycle',
+} satisfies AdminJourneyStep<ClinicStaffLifecycleJourneyState>
+
+const inspectClinicStaffOptionsStep = {
+  checkpoint: {
+    label: 'Clinic staff disabled transition preview',
+    screenshotSlug: 'clinic-staff-disabled-preview',
+  },
+  collections: ['clinicStaff'],
+  kind: 'form-fill',
+  label: 'Inspect allowed options and preview Disabled without saving',
+  run: async ({ page }) => {
+    const statusField = getAdminFieldRoot(page, 'status')
+    const combobox = statusField.getByRole('combobox')
+    await combobox.focus()
+    await expect(combobox).toBeFocused()
+    await page.keyboard.press('ArrowDown')
+
+    await expect(page.getByRole('option', { name: 'Disabled' })).toBeVisible()
+    await expect(page.getByRole('option', { name: 'Offboarded' })).toBeVisible()
+    await expect(page.getByRole('option', { name: 'Pending' })).toHaveCount(0)
+    await expect(page.getByRole('option', { name: 'Rejected' })).toHaveCount(0)
+    await page.keyboard.press('Escape')
+
+    await selectComboboxOption(page, 'Status', 'Disabled', { scope: statusField })
+    const lifecyclePanel = page.getByRole('region', { name: 'Lifecycle impact' })
+    await expect(page.getByText('Saving disables the Supabase identity.')).toBeVisible()
+    await expect(page.getByText('Access removal selected')).toBeVisible()
+    await expect(page.getByText('Something went wrong.')).toHaveCount(0)
+    await lifecyclePanel.scrollIntoViewIfNeeded()
+    expect(
+      await lifecyclePanel.evaluate((element) => {
+        const bounds = element.getBoundingClientRect()
+        return element.scrollWidth <= element.clientWidth && bounds.left >= 0 && bounds.right <= window.innerWidth + 1
+      }),
+    ).toBe(true)
+  },
+  stepId: 'inspect-clinic-staff-options',
+} satisfies AdminJourneyStep<ClinicStaffLifecycleJourneyState>
+
+const createSubmittedClinicApplicationStep = {
+  collections: ['clinicApplications', 'medical-specialties'],
+  kind: 'api-fixture',
+  label: 'Create a temporary submitted clinic application',
+  producesState: ['applicationId'],
+  run: async ({ request, state }) => {
+    const specialty = await ensureMedicalSpecialtyFixture(request, { reuseExisting: true })
+    const suffix = Date.now()
+    const response = await request.post('/api/clinicApplications', {
+      data: {
+        clinicName: `E2E Lifecycle Clinic ${suffix}`,
+        clinicWebsite: `https://lifecycle-${suffix}.example`,
+        contactFirstName: 'Journey',
+        contactLastName: 'Reviewer',
+        contactEmail: `lifecycle-${suffix}@example.com`,
+        contactRole: 'Clinic Management',
+        medicalSpecialties: [specialty.specialtyId],
+        status: 'submitted',
+      },
+    })
+    expect(response.ok()).toBeTruthy()
+
+    const body = (await response.json()) as CreatedDocResponse
+    state.applicationId = getRecordId(body.doc?.id)
+    expect(state.applicationId).toBeTruthy()
+  },
+  stepId: 'create-submitted-clinic-application',
+} satisfies AdminJourneyStep<ClinicApplicationLifecycleJourneyState>
+
+const openSubmittedClinicApplicationStep = {
+  checkpoint: {
+    label: 'Clinic application awaiting review',
+    screenshotSlug: 'clinic-application-awaiting-review',
+  },
+  collections: ['clinicApplications'],
+  kind: 'navigation',
+  label: 'Open the submitted clinic application',
+  requiresState: ['applicationId'],
+  run: async ({ page, state }) => {
+    if (state.applicationId === undefined) throw new Error('Clinic application fixture is missing.')
+
+    await openAdminDocumentPage(page, 'clinicApplications', state.applicationId)
+    await expect(page.getByRole('region', { name: 'Provisioning lifecycle' })).toBeVisible()
+    await expect(page.getByText('Awaiting review', { exact: true })).toBeVisible()
+  },
+  stepId: 'open-submitted-clinic-application',
+} satisfies AdminJourneyStep<ClinicApplicationLifecycleJourneyState>
+
+const previewClinicApplicationApprovalStep = {
+  checkpoint: {
+    label: 'Clinic application Approved provisioning preview',
+    screenshotSlug: 'clinic-application-approved-preview',
+  },
+  collections: ['clinicApplications'],
+  kind: 'form-fill',
+  label: 'Preview Approved without starting provisioning',
+  run: async ({ page }) => {
+    await selectComboboxOption(page, 'Status', 'Approved')
+    const lifecyclePanel = page.getByRole('region', { name: 'Provisioning lifecycle' })
+    await expect(page.getByText('Provisioning pending', { exact: true })).toBeVisible()
+    await expect(page.getByText('Saving Approved starts automatic clinic and clinic staff creation.')).toBeVisible()
+    await expect(page.getByText('Something went wrong.')).toHaveCount(0)
+    expect(
+      await lifecyclePanel.evaluate((element) => {
+        const bounds = element.getBoundingClientRect()
+        return element.scrollWidth <= element.clientWidth && bounds.left >= 0 && bounds.right <= window.innerWidth + 1
+      }),
+    ).toBe(true)
+  },
+  stepId: 'preview-clinic-application-approval',
+} satisfies AdminJourneyStep<ClinicApplicationLifecycleJourneyState>
+
+const deleteClinicApplicationStep = {
+  collections: ['clinicApplications'],
+  kind: 'api-fixture',
+  label: 'Delete the temporary clinic application',
+  requiresState: ['applicationId'],
+  run: async ({ request, state }) => {
+    const response = await request.delete(`/api/clinicApplications/${state.applicationId}`)
+    expect(response.ok()).toBeTruthy()
+  },
+  stepId: 'delete-clinic-application',
+} satisfies AdminJourneyStep<ClinicApplicationLifecycleJourneyState>
+
+export const clinicStaffLifecycleJourney: AdminJourneyDefinition<ClinicStaffLifecycleJourneyState> = {
+  createState: () => ({ clinicStaffId: undefined, ownsClinicStaffFixture: false }),
+  description: 'Inspect valid clinic staff transitions, lifecycle impact, and structured API validation.',
+  journeyId: 'admin.clinic-staff.lifecycle-guidance',
+  metadata: {
+    collections: ['clinicStaff'],
+    consumers: ['regression', 'capture'],
+    entrypoints: ['document-page'],
+    riskTags: ['clinic-staff', 'lifecycle', 'supabase-sync'],
+  },
+  persona: 'admin',
+  steps: defineJourneySteps<ClinicStaffLifecycleJourneyState>([
+    ensureApprovedClinicStaffStep,
+    assertInvalidClinicStaffTransitionStep,
+    openClinicStaffLifecycleStep,
+    inspectClinicStaffOptionsStep,
+    deleteTemporaryClinicStaffStep,
+  ]),
+}
+
+export const clinicApplicationLifecycleJourney: AdminJourneyDefinition<ClinicApplicationLifecycleJourneyState> = {
+  createState: () => ({ applicationId: undefined }),
+  description: 'Inspect clinic application review and automatic provisioning lifecycle guidance.',
+  journeyId: 'admin.clinic-applications.provisioning-guidance',
+  metadata: {
+    collections: ['clinicApplications', 'medical-specialties'],
+    consumers: ['regression', 'capture'],
+    entrypoints: ['document-page'],
+    riskTags: ['clinic-application', 'provisioning', 'lifecycle'],
+  },
+  persona: 'admin',
+  steps: defineJourneySteps<ClinicApplicationLifecycleJourneyState>([
+    createSubmittedClinicApplicationStep,
+    openSubmittedClinicApplicationStep,
+    previewClinicApplicationApprovalStep,
+    deleteClinicApplicationStep,
+  ]),
+}

--- a/tests/e2e/helpers/adminJourneys/registry.ts
+++ b/tests/e2e/helpers/adminJourneys/registry.ts
@@ -1,5 +1,6 @@
 import type { AdminJourneyDefinition } from './types'
 import { clinicApprovalJourney, clinicCreateDraftJourney, clinicTreatmentJoinJourney } from './journeys/clinics'
+import { clinicApplicationLifecycleJourney, clinicStaffLifecycleJourney } from './journeys/clinicLifecycle'
 import { reviewPatientValidationJourney } from './journeys/reviews'
 import { relationshipEligibilityJourney } from './journeys/relationshipEligibility'
 import {
@@ -20,6 +21,8 @@ import {
 } from './journeys/treatments'
 
 export const adminJourneyRegistry = {
+  'admin.clinic-applications.provisioning-guidance': clinicApplicationLifecycleJourney,
+  'admin.clinic-staff.lifecycle-guidance': clinicStaffLifecycleJourney,
   'admin.clinics.approve-pending': clinicApprovalJourney,
   'admin.clinics.create-draft': clinicCreateDraftJourney,
   'admin.clinictreatments.create-link': clinicTreatmentLinkJourney,

--- a/tests/integration/clinicStaff.lifecycle.test.ts
+++ b/tests/integration/clinicStaff.lifecycle.test.ts
@@ -6,6 +6,9 @@ import { createClinicFixture } from '../fixtures/createClinicFixture'
 import { ensureBaseline } from '../fixtures/ensureBaseline'
 import { testSlug } from '../fixtures/testSlug'
 import { deleteClinicSupabaseAccount, setClinicSupabaseAccountAccess } from '@/auth/utilities/supabaseProvision'
+import { clinicStaffStatusTransitions, type ClinicStaffStatus } from '@/collections/clinicStaff/lifecycle'
+
+const clinicStaffStatuses: readonly ClinicStaffStatus[] = ['pending', 'approved', 'rejected', 'disabled', 'offboarded']
 
 describe('ClinicStaff lifecycle integration', () => {
   let payload: Payload
@@ -118,14 +121,104 @@ describe('ClinicStaff lifecycle integration', () => {
     })
     staffIds.push(staff.id)
 
+    const invalidTransition = payload.update({
+      collection: 'clinicStaff',
+      id: staff.id,
+      data: { status: 'disabled' },
+      overrideAccess: true,
+    })
+
+    await expect(invalidTransition).rejects.toMatchObject({
+      data: {
+        errors: [expect.objectContaining({ path: 'status' })],
+      },
+      status: 400,
+    })
+
+    const unchanged = await payload.findByID({
+      collection: 'clinicStaff',
+      id: staff.id,
+      overrideAccess: true,
+      depth: 0,
+    })
+    expect(unchanged.status).toBe('pending')
+  })
+
+  it('enforces every allowed and forbidden status transition through the collection', async () => {
+    for (const previousStatus of clinicStaffStatuses) {
+      for (const nextStatus of clinicStaffStatuses) {
+        if (nextStatus === previousStatus) continue
+
+        const transitionStaff = await payload.create({
+          collection: 'clinicStaff',
+          data: {
+            email: `${slugPrefix}-${previousStatus}-${nextStatus}@example.com`,
+            firstName: 'Matrix',
+            lastName: 'Staff',
+            status: previousStatus,
+            supabaseUserId: `sb-${slugPrefix}-${previousStatus}-${nextStatus}`,
+          },
+          overrideAccess: true,
+          depth: 0,
+        })
+        staffIds.push(transitionStaff.id)
+
+        const update = payload.update({
+          collection: 'clinicStaff',
+          id: transitionStaff.id,
+          data: { status: nextStatus },
+          overrideAccess: true,
+          depth: 0,
+        })
+        const isAllowed = clinicStaffStatusTransitions[previousStatus].includes(nextStatus as never)
+
+        if (isAllowed) {
+          await expect(update).resolves.toMatchObject({ status: nextStatus })
+        } else {
+          await expect(update).rejects.toMatchObject({
+            data: {
+              errors: [expect.objectContaining({ path: 'status' })],
+            },
+            status: 400,
+          })
+          await expect(
+            payload.findByID({
+              collection: 'clinicStaff',
+              id: transitionStaff.id,
+              overrideAccess: true,
+              depth: 0,
+            }),
+          ).resolves.toMatchObject({ status: previousStatus })
+        }
+      }
+    }
+  }, 45000)
+
+  it('allows an unchanged status update without repeating a successful sync', async () => {
+    const staff = await payload.create({
+      collection: 'clinicStaff',
+      data: {
+        email: `${slugPrefix}-unchanged@example.com`,
+        firstName: 'Unchanged',
+        lastName: 'Staff',
+        status: 'approved',
+        supabaseUserId: `sb-${slugPrefix}-unchanged`,
+      },
+      overrideAccess: true,
+      depth: 0,
+    })
+    staffIds.push(staff.id)
+    vi.clearAllMocks()
+
     await expect(
       payload.update({
         collection: 'clinicStaff',
         id: staff.id,
-        data: { status: 'disabled' },
+        data: { lastName: 'Updated', status: 'approved' },
         overrideAccess: true,
       }),
-    ).rejects.toThrow(/pending -> disabled/)
+    ).resolves.toMatchObject({ lastName: 'Updated', status: 'approved' })
+    expect(setClinicSupabaseAccountAccess).not.toHaveBeenCalled()
   })
 
   it('stores and retries a resumable Supabase synchronization failure', async () => {

--- a/tests/unit/collections/clinicLifecycleAdminContract.test.ts
+++ b/tests/unit/collections/clinicLifecycleAdminContract.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { ValidationError } from 'payload'
+
+import { ClinicApplications } from '@/collections/ClinicApplications'
+import { ClinicStaff } from '@/collections/ClinicStaff'
+import { clinicStaffStatusOptions } from '@/collections/clinicStaff/lifecycle'
+import { validateClinicStaffStatusTransition } from '@/hooks/clinicStaffLifecycle'
+
+type FieldNode = {
+  admin?: { components?: { Field?: unknown }; readOnly?: boolean }
+  name?: string
+  options?: unknown
+  type?: string
+}
+
+const getField = (fields: FieldNode[], name: string): FieldNode | undefined =>
+  fields.find((field) => field.name === name)
+
+describe('Clinic lifecycle Admin contract', () => {
+  it('installs the shared status options, filtered status field, and collection panels', () => {
+    const staffFields = ClinicStaff.fields as FieldNode[]
+    const applicationFields = ClinicApplications.fields as FieldNode[]
+
+    expect(getField(staffFields, 'status')?.options).toBe(clinicStaffStatusOptions)
+    expect(getField(staffFields, 'status')?.admin?.components?.Field).toBe(
+      '@/app/(payload)/components/ClinicStaffLifecycle#ClinicStaffStatusField',
+    )
+    expect(getField(staffFields, 'lifecycleGuidance')?.admin?.components?.Field).toBe(
+      '@/app/(payload)/components/ClinicStaffLifecycle#ClinicStaffLifecyclePanel',
+    )
+    expect(getField(applicationFields, 'lifecycleGuidance')?.admin?.components?.Field).toBe(
+      '@/app/(payload)/components/ClinicApplicationLifecycle#ClinicApplicationLifecyclePanel',
+    )
+  })
+
+  it('returns a structured status field error for a forbidden API transition', async () => {
+    const result = validateClinicStaffStatusTransition({
+      data: { status: 'rejected' },
+      operation: 'update',
+      originalDoc: { id: 12, status: 'approved' },
+      req: {},
+    } as never)
+
+    await expect(result).rejects.toBeInstanceOf(ValidationError)
+    await expect(result).rejects.toMatchObject({
+      data: {
+        errors: [
+          expect.objectContaining({
+            path: 'status',
+          }),
+        ],
+      },
+      status: 400,
+    })
+  })
+})

--- a/tests/unit/collections/clinicLifecycleRules.test.ts
+++ b/tests/unit/collections/clinicLifecycleRules.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  clinicStaffStatusTransitions,
+  getClinicStaffLifecyclePresentation,
+  getClinicStaffSelectableStatuses,
+  isClinicStaffStatusTransitionAllowed,
+  type ClinicStaffStatus,
+} from '@/collections/clinicStaff/lifecycle'
+import {
+  clinicApplicationProvisioningInputFields,
+  getClinicApplicationLifecyclePresentation,
+  hasClinicApplicationProvisioningInputChanged,
+} from '@/collections/clinicApplications/provisioningLifecycle'
+import type { ClinicApplication } from '@/payload-types'
+
+const clinicStaffStatuses: readonly ClinicStaffStatus[] = ['pending', 'approved', 'rejected', 'disabled', 'offboarded']
+
+describe('Clinic lifecycle rules', () => {
+  it('defines the complete ClinicStaff transition matrix', () => {
+    const expected = {
+      pending: ['approved', 'rejected', 'offboarded'],
+      approved: ['disabled', 'offboarded'],
+      disabled: ['approved', 'offboarded'],
+      rejected: ['offboarded'],
+      offboarded: [],
+    }
+
+    expect(clinicStaffStatusTransitions).toEqual(expected)
+
+    for (const persistedStatus of clinicStaffStatuses) {
+      for (const selectedStatus of clinicStaffStatuses) {
+        expect(isClinicStaffStatusTransitionAllowed(persistedStatus, selectedStatus)).toBe(
+          selectedStatus === persistedStatus ||
+            (expected[persistedStatus] as readonly string[]).includes(selectedStatus),
+        )
+      }
+    }
+  })
+
+  it('keeps selectable statuses anchored to the saved value and treats offboarded as terminal', () => {
+    expect(getClinicStaffSelectableStatuses('approved')).toEqual(['approved', 'disabled', 'offboarded'])
+    expect(getClinicStaffSelectableStatuses('offboarded')).toEqual(['offboarded'])
+  })
+
+  it('describes activation, reactivation, disabling, offboarding, and sync retry effects', () => {
+    expect(
+      getClinicStaffLifecyclePresentation({
+        persistedStatus: 'pending',
+        selectedStatus: 'approved',
+      }).summary,
+    ).toBe('Saving activates the Supabase identity.')
+    expect(
+      getClinicStaffLifecyclePresentation({
+        persistedStatus: 'disabled',
+        selectedStatus: 'approved',
+      }).summary,
+    ).toBe('Saving reactivates the Supabase identity.')
+    expect(
+      getClinicStaffLifecyclePresentation({
+        persistedStatus: 'approved',
+        selectedStatus: 'disabled',
+      }).summary,
+    ).toBe('Saving disables the Supabase identity.')
+    expect(
+      getClinicStaffLifecyclePresentation({
+        persistedStatus: 'approved',
+        selectedStatus: 'offboarded',
+      }).summary,
+    ).toBe('Saving permanently deletes the Supabase identity.')
+    expect(
+      getClinicStaffLifecyclePresentation({
+        authSyncErrorCode: 'account_update_failed',
+        authSyncStatus: 'failed',
+        persistedStatus: 'approved',
+        selectedStatus: 'approved',
+      }),
+    ).toMatchObject({
+      guidance: 'Saving this record again retries the same Supabase operation.',
+      stateLabel: 'Sync failed',
+      tone: 'error',
+    })
+  })
+
+  it('uses the exact provisioning fields shared with retry detection', () => {
+    expect(clinicApplicationProvisioningInputFields).toEqual([
+      'clinicName',
+      'clinicWebsite',
+      'contactFirstName',
+      'contactLastName',
+      'contactEmail',
+      'contactRole',
+    ])
+
+    const previousDoc: Partial<ClinicApplication> = {
+      clinicName: 'Clinic',
+      clinicWebsite: 'https://clinic.example',
+      contactFirstName: 'Ada',
+      contactLastName: 'Lovelace',
+      contactEmail: 'clinic@example.com',
+      contactRole: 'Clinic Management',
+    }
+
+    expect(hasClinicApplicationProvisioningInputChanged({ ...previousDoc, reviewNotes: 'Changed' }, previousDoc)).toBe(
+      false,
+    )
+
+    for (const field of clinicApplicationProvisioningInputFields) {
+      expect(
+        hasClinicApplicationProvisioningInputChanged(
+          {
+            ...previousDoc,
+            [field]: `${String(previousDoc[field])}-changed`,
+          },
+          previousDoc,
+        ),
+      ).toBe(true)
+    }
+  })
+
+  it.each([
+    [{ provisioningStatus: 'completed', status: 'rejected' }, 'Completed'],
+    [{ provisioningStatus: 'failed', status: 'rejected' }, 'Failed'],
+    [{ provisioningStatus: 'not_started', status: 'rejected' }, 'Rejected'],
+    [{ provisioningStatus: 'not_started', status: 'approved' }, 'Provisioning pending'],
+    [{ provisioningStatus: 'not_started', status: 'submitted' }, 'Awaiting review'],
+  ] as const)('applies provisioning state precedence for %o', (persistedData, stateLabel) => {
+    expect(
+      getClinicApplicationLifecyclePresentation({
+        currentData: persistedData,
+        persistedData,
+      }).stateLabel,
+    ).toBe(stateLabel)
+  })
+
+  it('distinguishes a failed retry with and without changed provisioning input', () => {
+    const persistedData: Partial<ClinicApplication> = {
+      clinicName: 'Clinic',
+      provisioningErrorCode: 'auth_failed',
+      provisioningStatus: 'failed',
+      status: 'approved',
+    }
+
+    expect(
+      getClinicApplicationLifecyclePresentation({
+        currentData: persistedData,
+        persistedData,
+      }).guidance,
+    ).toContain('Change at least')
+    expect(
+      getClinicApplicationLifecyclePresentation({
+        currentData: { ...persistedData, clinicName: 'Updated Clinic' },
+        persistedData,
+      }).guidance,
+    ).toBe('Saving starts another provisioning attempt.')
+  })
+
+  it('explains that the first Approved save starts automatic provisioning', () => {
+    const persistedData: Partial<ClinicApplication> = {
+      provisioningStatus: 'not_started',
+      status: 'submitted',
+    }
+
+    expect(
+      getClinicApplicationLifecyclePresentation({
+        currentData: { ...persistedData, status: 'approved' },
+        persistedData,
+      }).guidance,
+    ).toBe('Saving Approved starts automatic clinic and clinic staff creation.')
+  })
+
+  it('shows completed linked records and a formatted processing date', () => {
+    const presentation = getClinicApplicationLifecyclePresentation({
+      currentData: { status: 'approved' },
+      persistedData: {
+        linkedRecords: {
+          clinic: { id: 12, name: 'Lifecycle Clinic' } as never,
+          clinicStaff: { email: 'staff@example.com', id: 13 } as never,
+          processedAt: '2026-07-22T09:30:00.000Z',
+        },
+        provisioningStatus: 'completed',
+        status: 'approved',
+      },
+    })
+
+    expect(presentation.details).toEqual(
+      expect.arrayContaining([
+        { label: 'Created clinic', value: 'Lifecycle Clinic' },
+        { label: 'Created clinic staff', value: 'staff@example.com' },
+        expect.objectContaining({ label: 'Processed' }),
+      ]),
+    )
+  })
+})

--- a/tests/unit/components/clinicStaffLifecycle.test.tsx
+++ b/tests/unit/components/clinicStaffLifecycle.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import type { SelectFieldClientProps } from 'payload'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const adminState = vi.hoisted(() => ({
+  fields: {} as Record<string, { value?: unknown }>,
+  initialData: {} as Record<string, unknown>,
+}))
+
+vi.mock('@payloadcms/ui', () => ({
+  SelectField: ({
+    field,
+  }: {
+    field: { admin?: { readOnly?: boolean }; options: Array<{ label: string; value: string }> }
+  }) => (
+    <select aria-label="Status" disabled={field.admin?.readOnly}>
+      {field.options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+  useDocumentInfo: () => ({ initialData: adminState.initialData }),
+  useFormFields: (selector: (context: [Record<string, { value?: unknown }>, unknown]) => unknown) =>
+    selector([adminState.fields, undefined]),
+}))
+
+import { ClinicStaffLifecyclePanel, ClinicStaffStatusField } from '@/app/(payload)/components/ClinicStaffLifecycle'
+
+const statusFieldProps = {
+  field: {
+    admin: {},
+    hasMany: false,
+    name: 'status',
+    options: [],
+  },
+  path: 'status',
+} as unknown as SelectFieldClientProps
+
+describe('ClinicStaff lifecycle Admin components', () => {
+  beforeEach(() => {
+    adminState.fields = {}
+    adminState.initialData = {}
+  })
+
+  it('uses the saved status for options even after an unsaved selection', () => {
+    adminState.initialData = { status: 'approved' }
+    adminState.fields = {
+      status: { value: 'disabled' },
+      'authSync.status': { value: 'synced' },
+    }
+
+    render(
+      <>
+        <ClinicStaffStatusField {...statusFieldProps} />
+        <ClinicStaffLifecyclePanel />
+      </>,
+    )
+
+    const options = screen.getByLabelText('Status').querySelectorAll('option')
+    expect(Array.from(options).map((option) => option.textContent)).toEqual(['Approved', 'Disabled', 'Offboarded'])
+    expect(screen.queryByRole('option', { name: 'Rejected' })).not.toBeInTheDocument()
+    expect(screen.getByText('Saving disables the Supabase identity.')).toBeVisible()
+    expect(screen.getByText('Access removal selected')).toBeVisible()
+  })
+
+  it('renders offboarded as terminal and read-only', () => {
+    adminState.initialData = { status: 'offboarded' }
+    adminState.fields = {
+      status: { value: 'offboarded' },
+      'authSync.status': { value: 'deleted' },
+    }
+
+    render(
+      <>
+        <ClinicStaffStatusField {...statusFieldProps} />
+        <ClinicStaffLifecyclePanel />
+      </>,
+    )
+
+    const select = screen.getByLabelText('Status')
+    expect(select).toBeDisabled()
+    expect(select.querySelectorAll('option')).toHaveLength(1)
+    expect(screen.getByText('No further lifecycle transition is available.')).toBeVisible()
+  })
+
+  it('shows the readable sync failure and retry path', () => {
+    adminState.initialData = { status: 'approved' }
+    adminState.fields = {
+      status: { value: 'approved' },
+      'authSync.errorCode': { value: 'account_update_failed' },
+      'authSync.status': { value: 'failed' },
+    }
+
+    render(<ClinicStaffLifecyclePanel />)
+
+    expect(screen.getByText('The last Supabase synchronization failed.')).toBeVisible()
+    expect(screen.getByText('Account update failed')).toBeVisible()
+    expect(screen.getByText('Saving this record again retries the same Supabase operation.')).toBeVisible()
+  })
+})

--- a/tests/unit/components/lifecycleStatusPanel.test.tsx
+++ b/tests/unit/components/lifecycleStatusPanel.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { LifecycleStatusPanel } from '@/app/(payload)/components/LifecycleStatusPanel'
+
+describe('LifecycleStatusPanel', () => {
+  it('renders a domain-neutral, labelled status region with announced summary and details', () => {
+    render(
+      <LifecycleStatusPanel
+        details={[
+          { label: 'Current state', value: 'Pending' },
+          { label: 'After save', value: 'Approved' },
+        ]}
+        guidance="Save to continue."
+        stateLabel="Action selected"
+        summary="Saving starts the configured process."
+        title="Process lifecycle"
+        tone="warning"
+      />,
+    )
+
+    const panel = screen.getByRole('region', { name: 'Process lifecycle' })
+    expect(panel).toHaveAttribute('data-lifecycle-state', 'Action selected')
+    expect(screen.getByText('Saving starts the configured process.')).toHaveAttribute('aria-live', 'polite')
+    expect(screen.getByText('Current state').tagName).toBe('DT')
+    expect(screen.getByText('Pending').tagName).toBe('DD')
+    expect(screen.getByText('Save to continue.')).toBeInTheDocument()
+  })
+
+  it.each(['error', 'info', 'success', 'warning'] as const)('exposes the %s state through text and styling', (tone) => {
+    render(
+      <LifecycleStatusPanel
+        guidance="Next action"
+        stateLabel={`${tone} state`}
+        summary="State summary"
+        title={`${tone} lifecycle`}
+        tone={tone}
+      />,
+    )
+
+    const panel = screen.getByRole('region', { name: `${tone} lifecycle` })
+    expect(panel).toHaveClass(`lifecycle-status-panel--${tone}`)
+    expect(screen.getByText(`${tone} state`)).toBeVisible()
+  })
+})

--- a/tests/unit/hooks/clinicStaffLifecycle.test.ts
+++ b/tests/unit/hooks/clinicStaffLifecycle.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ValidationError } from 'payload'
 import { synchronizeClinicStaffAuthState, validateClinicStaffStatusTransition } from '@/hooks/clinicStaffLifecycle'
 import type { ClinicStaff } from '@/payload-types'
 
@@ -48,9 +49,12 @@ describe('ClinicStaff lifecycle hooks', () => {
   it.each([
     ['pending', 'approved'],
     ['pending', 'rejected'],
+    ['pending', 'offboarded'],
     ['approved', 'disabled'],
     ['disabled', 'approved'],
     ['approved', 'offboarded'],
+    ['disabled', 'offboarded'],
+    ['rejected', 'offboarded'],
   ] as const)('allows %s -> %s', async (previousStatus, nextStatus) => {
     await expect(
       validateClinicStaffStatusTransition({
@@ -67,13 +71,25 @@ describe('ClinicStaff lifecycle hooks', () => {
     ['rejected', 'approved'],
     ['offboarded', 'approved'],
   ] as const)('rejects %s -> %s', async (previousStatus, nextStatus) => {
-    await expect(
-      validateClinicStaffStatusTransition({
-        data: { status: nextStatus },
-        operation: 'update',
-        originalDoc: staff({ status: previousStatus }),
-      } as never),
-    ).rejects.toThrow(`${previousStatus} -> ${nextStatus}`)
+    const result = validateClinicStaffStatusTransition({
+      data: { status: nextStatus },
+      operation: 'update',
+      originalDoc: staff({ status: previousStatus }),
+      req: {},
+    } as never)
+
+    await expect(result).rejects.toBeInstanceOf(ValidationError)
+    await expect(result).rejects.toMatchObject({
+      data: {
+        errors: [
+          expect.objectContaining({
+            message: expect.stringContaining(`${previousStatus} -> ${nextStatus}`),
+            path: 'status',
+          }),
+        ],
+      },
+      status: 400,
+    })
   })
 
   it.each([


### PR DESCRIPTION
## Management summary

### Deutsch

Das Payload Admin zeigt bei Klinikmitarbeitenden jetzt nur gültige nächste Statusschritte und erklärt deren Auswirkung auf den Zugang. Bei Klinikregistrierungen macht ein Prozesshinweis sichtbar, ob eine Prüfung aussteht, die automatische Anlage beginnt, fehlgeschlagen ist oder abgeschlossen wurde. Ungültige Statuswechsel erscheinen als verständliche Feldfehler statt als allgemeiner Systemfehler.

### English

The Payload Admin now shows only valid next status steps for clinic staff and explains their access impact. For clinic applications, process guidance makes it clear whether review is pending, automatic setup is about to start, has failed, or has completed. Invalid status changes now appear as understandable field errors instead of a generic system error.

## What changed

- Added a domain-neutral, accessible `LifecycleStatusPanel` for lifecycle state, guidance, and responsive detail values.
- Centralized the ClinicStaff transition matrix and Supabase impact copy collection-near, then reused it in the Admin status field, panel, hook, and tests.
- Restricted the ClinicStaff Admin status options to the saved status plus valid next transitions; offboarded records are terminal and read-only.
- Converted invalid direct ClinicStaff transitions to structured Payload `ValidationError` responses with HTTP 400 and path `status`.
- Centralized ClinicApplication provisioning inputs and lifecycle evaluation so the panel and retry hook use the same field contract without changing provisioning behavior.
- Added reusable Admin journeys for ClinicStaff lifecycle guidance and ClinicApplication provisioning guidance.
- Regenerated the Payload Admin import map. Persisted fields, enums, public APIs, cache policy, and Clinic Dashboard DTOs remain unchanged.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/hooks/clinicStaffLifecycle.ts`, `src/collections/clinicStaff/lifecycle.ts` | The shared transition contract guards lifecycle state and triggers Supabase effects. | Confirm every allowed transition and the structured `status` error preserve the intended auth-sync behavior. | Unit and integration transition-matrix tests; Admin API regression journey. |
| P2 | `src/app/(payload)/components/ClinicStaffLifecycle/` | The filtered status options must remain anchored to persisted state while an unsaved choice previews impact. | Confirm options do not recalculate from an unsaved selection and offboarded stays read-only. | Component tests and six-viewport Admin captures. |
| P2 | `src/collections/clinicApplications/provisioningLifecycle.ts`, `src/hooks/clinicApplicationProvisioning.ts` | UI retry guidance and provisioning retries must use exactly the same input fields. | Confirm state precedence and changed-input detection match the existing provisioning hook. | Rule tests and ClinicApplication Admin regression journey. |

## UI/UX

The lifecycle panels and status interactions were checked at 320, 375, 640, 768, 1024, and 1280 pixels. Evidence covers the ClinicStaff Disabled preview and ClinicApplication Approved preview; screenshots are attached below.

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed.
- [x] `pnpm build`: passed.
- [x] Focused tests: 8 Vitest suites / 64 tests passed; both new Admin regression journeys passed (3 Playwright tests including setup); `pnpm admin:journey:coverage` passed with 19 journeys.
- [x] UI/mobile QA: production-build captures passed at 320, 375, 640, 768, 1024, and 1280 pixels; keyboard-opened status options, focus, wrapping, horizontal overflow, and both panel states checked; no page or console errors in capture metadata. The full platform regression command was also retried, but the pre-existing Clinic Approval journey stopped the serial run on a local `TypeError: Failed to fetch` before the new journeys; the new journeys pass when selected directly.
  <!-- gh-ui-screenshots:start -->
  ### Clinic Staff Disabled Preview 320px
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":1.775,"capturedAt":"2026-07-23T07:31:39.712Z","contentType":"image/png","focus":"clinic-staff-disabled-preview-320px","focusLabel":"Clinic Staff Disabled Preview 320px","formFactor":"mobile","gitSha":"589498b2","height":568,"releaseEligible":false,"releaseRole":"qa","size":29100,"sizeKb":29,"uploadName":"clinic-staff-disabled-preview-320px__mobile__320x568__20260723T073139Z__589498b2__320x568__29kb.png","viewport":"320x568","warnings":["not_release_marked"],"width":320,"url":"https://github.com/user-attachments/assets/892718f2-4efe-4aa2-abfd-2e8011ecbc1e"} -->
  ![Clinic Staff Disabled Preview 320px](https://github.com/user-attachments/assets/892718f2-4efe-4aa2-abfd-2e8011ecbc1e)
  
  
  > Screenshot warning: not_release_marked
  
  ### Clinic Application Approved Preview 1280px
  
  <!-- gh-ui-screenshots:metadata {"aspectRatio":0.625,"capturedAt":"2026-07-23T07:32:27.799Z","contentType":"image/png","focus":"clinic-application-approved-preview-1280px","focusLabel":"Clinic Application Approved Preview 1280px","formFactor":"desktop","gitSha":"589498b2","height":800,"releaseEligible":false,"releaseRole":"qa","size":85911,"sizeKb":84,"uploadName":"clinic-application-approved-preview-1280px__desktop__1280x800__20260723T073227Z__589498b2__1280x800__84kb.png","viewport":"1280x800","warnings":["not_release_marked"],"width":1280,"url":"https://github.com/user-attachments/assets/bcf4c69d-8904-4868-ad5b-e851264a2192"} -->
  ![Clinic Application Approved Preview 1280px](https://github.com/user-attachments/assets/bcf4c69d-8904-4868-ad5b-e851264a2192)
  
  
  > Screenshot warning: not_release_marked
  <!-- gh-ui-screenshots:end -->
- [ ] Security/privacy review: not run; awaiting the required explicit reviewer confirmation.
- [x] Migration/schema check: `pnpm generate` passed, Payload types stayed unchanged, and schema alignment reported no pending migration.
- [ ] Documentation/instructions check: not applicable; no documentation or instruction files changed.

## Risk and rollout

No database migration, environment change, public cache change, new endpoint, or successful-response contract change. The only error-contract change is that invalid ClinicStaff status transitions now return HTTP 400 with a field path instead of a generic error. Rollback is the single PR commit.

## Development

Closes #1590
