### PR TITLE
fix: trust persisted doctor ID for profile images

### DIFF
--- a/src/hooks/doctorProfileImageOwnership.ts
+++ b/src/hooks/doctorProfileImageOwnership.ts
@@ -1,7 +1,7 @@
 import type { CollectionBeforeChangeHook, PayloadRequest } from 'payload'
 import { ValidationError } from 'payload'
 
-import { extractRelationId, resolveDocumentId } from '@/collections/common/mediaPathHelpers'
+import { extractRelationId } from '@/collections/common/mediaPathHelpers'
 import { DOCTOR_PROFILE_IMAGE_MESSAGES } from '@/collections/doctors/profileImageEligibility'
 import type { Doctor, DoctorMedia } from '@/payload-types'
 
@@ -38,12 +38,7 @@ export const beforeChangeValidateDoctorProfileImage: CollectionBeforeChangeHook<
   const profileImageId = extractRelationId(profileImageSubmitted ? draft.profileImage : originalDoc?.profileImage)
   if (!profileImageId) return draft
 
-  const doctorId = resolveDocumentId({
-    operation,
-    data: draft as Record<string, unknown>,
-    originalDoc: originalDoc as unknown as Record<string, unknown> | undefined,
-    req: req as unknown as Record<string, unknown>,
-  })
+  const doctorId = operation === 'update' ? extractRelationId(originalDoc?.id) : null
   if (!doctorId) {
     throwProfileImageValidation({ message: DOCTOR_PROFILE_IMAGE_MESSAGES.doctorMissing, req })
   }

--- a/tests/integration/doctors.lifecycle.test.ts
+++ b/tests/integration/doctors.lifecycle.test.ts
@@ -155,6 +155,49 @@ describe('Doctors lifecycle integration', () => {
       status: 400,
     })
 
+    const sameClinicDoctor = (await payload.create({
+      collection: 'doctors',
+      data: {
+        firstName: `${slugPrefix}-profile-same-clinic`,
+        gender: 'female',
+        lastName: 'Doctor',
+        clinic: clinicA.id,
+        qualifications: ['MD'],
+        languages: ['english'],
+      } as unknown as Doctor,
+      user: platformUser,
+      overrideAccess: false,
+      depth: 0,
+    })) as Doctor
+    const sameClinicMedia = await createMedia(sameClinicDoctor, 'profile-same-clinic')
+    const clinicUser = await createClinicUser(`${slugPrefix}-profile-clinic`, clinicA.id)
+
+    const spoofedDoctorId = payload.update({
+      collection: 'doctors',
+      id: doctorA.id,
+      data: {
+        id: sameClinicDoctor.id,
+        profileImage: sameClinicMedia.id,
+      } as unknown as Partial<Doctor>,
+      user: clinicUser,
+      overrideAccess: false,
+      depth: 0,
+    })
+    await expect(spoofedDoctorId).rejects.toMatchObject({
+      data: {
+        errors: [expect.objectContaining({ path: 'profileImage' })],
+      },
+      status: 400,
+    })
+    await expect(
+      payload.findByID({
+        collection: 'doctors',
+        id: doctorA.id,
+        overrideAccess: true,
+        depth: 0,
+      }),
+    ).resolves.toMatchObject({ profileImage: mediaA.id })
+
     const clinicChange = payload.update({
       collection: 'doctors',
       id: doctorA.id,

--- a/tests/unit/hooks/doctorProfileImageOwnership.test.ts
+++ b/tests/unit/hooks/doctorProfileImageOwnership.test.ts
@@ -95,6 +95,20 @@ describe('beforeChangeValidateDoctorProfileImage', () => {
     )
   })
 
+  it('does not trust an incoming document ID when validating ownership on update', async () => {
+    const req = createReq()
+    vi.mocked(req.payload.findByID).mockResolvedValue({ id: 20, doctor: 11, clinic: 4 } as never)
+
+    await expectProfileImageError(
+      runHook({
+        data: { id: 11, profileImage: 20 },
+        originalDoc: { id: 10, clinic: 4 },
+        req,
+      }),
+      'Selected profile image does not belong to this doctor.',
+    )
+  })
+
   it('rejects media owned by another clinic', async () => {
     const req = createReq()
     vi.mocked(req.payload.findByID).mockResolvedValue({ id: 20, doctor: 10, clinic: 5 } as never)


### PR DESCRIPTION
## Management summary

### Deutsch

Die Zuordnung von Arzt-Profilbildern wird jetzt immer gegen den tatsächlich bearbeiteten Arzt geprüft. Manipulierte Angaben in einer Aktualisierung können die Eigentumsprüfung damit nicht mehr auf einen anderen Arzt derselben Klinik umlenken.

### English

Doctor profile image assignments are now always checked against the doctor being edited. Manipulated update data can no longer redirect the ownership check to another doctor in the same clinic.

## What changed

- Uses the persisted `originalDoc.id` as the only trusted doctor identity during profile-image validation on updates.
- Keeps profile-image assignment blocked during doctor creation until a persisted doctor identity exists.
- Adds a hook-level regression test proving that a request-body `id` cannot redirect ownership validation.
- Adds a Local API integration scenario for a clinic-scoped user, confirming the crafted update returns HTTP 400 at `profileImage` and leaves the target doctor unchanged.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/hooks/doctorProfileImageOwnership.ts` | This hook is the server-side ownership boundary between doctors and their profile media. | Confirm updates trust only `originalDoc.id` and creates still require a persisted doctor. | Focused unit and integration tests; specialist security review. |
| P1 | `tests/unit/hooks/doctorProfileImageOwnership.test.ts`, `tests/integration/doctors.lifecycle.test.ts` | The regression must cover both the isolated hook bypass and the external clinic-scoped update contract. | Confirm the spoofed ID targets another doctor in the same clinic and the original assignment remains unchanged. | 2 suites / 19 tests passed. |

## Validation

- [x] `pnpm format`: passed after all changes.
- [x] `pnpm check`: passed.
- [x] `pnpm build`: passed; the local build logged the known missing Supabase URL diagnostic but completed successfully.
- [x] Focused tests: `doctorProfileImageOwnership` unit tests and `doctors.lifecycle` integration tests passed, 2 suites / 19 tests.
- [ ] UI/mobile QA: not applicable; no UI behavior or rendering changed.
- [x] Security/privacy review: no findings rated 5/10 or higher; the reviewer confirmed the previous trust-boundary path is closed and found no merge blocker.
- [x] Cache architecture review: no findings rated 5/10 or higher; existing Doctor `afterChange` revalidation ownership, planner events, tags, and cache classification remain unchanged.
- [x] Migration/schema check: not required; no persisted schema or Payload field configuration changed.
- [ ] Documentation/instructions check: not applicable; no documentation or instruction files changed.

## Risk and rollout

No migration, environment, public API, cache, revalidation, or successful-response change. Payload relationship validation already rejected the crafted Local API request; this change hardens the underlying hook so its ownership decision no longer depends on client-controlled identity data. Rollback is the single commit in this pull request.

## Development

Closes #1595
