### PR TITLE
feat(access): allow clinic staff to manage inquiry status

### DIFF
--- a/docs/security/permission-matrix.generated.md
+++ b/docs/security/permission-matrix.generated.md
@@ -16,7 +16,7 @@
 | Patients `(patients)` | Platform | Conditional<br/><sub>platform full + patient own profile</sub> | Conditional<br/><sub>platform full + own profile only</sub> | Platform | Platform |
 | Posts `(posts)` | Platform | Published (approved) | Platform | Platform | Platform |
 | Pages `(pages)` | Platform | Published (approved) | Platform | Platform | Platform |
-| Doctors `(doctors)` | Conditional<br/><sub>platform full + clinic allowed (hook assigns clinic ownership)</sub> | Anyone | Conditional<br/><sub>platform full + clinic scoped to own clinic</sub> | Platform | Conditional<br/><sub>platform full + clinic scoped to own clinic</sub> |
+| Doctors `(doctors)` | Conditional<br/><sub>platform full + clinic allowed (hook assigns clinic ownership)</sub> | Conditional<br/><sub>platform all + clinic own inactive + everyone active</sub> | Conditional<br/><sub>platform full + clinic scoped to own clinic</sub> | Platform | Conditional<br/><sub>platform full + clinic scoped to own clinic</sub> |
 | Clinics `(clinics)` | Conditional<br/><sub>platform admin/support only</sub> | Conditional<br/><sub>anyone approved, platform all</sub> | Conditional<br/><sub>platform full + clinic own profile only</sub> | Platform | Platform |
 | DoctorSpecialties `(doctorspecialties)` | Conditional<br/><sub>platform full + clinic allowed (hook enforces doctor clinic ownership)</sub> | Anyone | Conditional<br/><sub>platform full + clinic scoped to own clinic</sub> | Platform | Conditional<br/><sub>platform full + clinic scoped to own clinic</sub> |
 | DoctorTreatments `(doctortreatments)` | Conditional<br/><sub>platform full + clinic allowed (hook enforces doctor clinic ownership)</sub> | Anyone | Conditional<br/><sub>platform full + clinic scoped to own clinic</sub> | Platform | Conditional<br/><sub>platform full + clinic scoped to own clinic</sub> |
@@ -37,7 +37,7 @@
 | Categories `(categories)` | Platform | Anyone | Platform | Platform | Platform |
 | Accreditation `(accreditation)` | Platform | Anyone | Platform | Platform | Platform |
 | ClinicApplications `(clinicApplications)` | Platform | Platform | Platform | Platform | Platform |
-| PatientClinicInquiries `(patientClinicInquiries)` | Platform | Platform | Platform | Platform | Platform |
+| PatientClinicInquiries `(patientClinicInquiries)` | Platform | Conditional<br/><sub>platform full + clinic own clinic</sub> | Conditional<br/><sub>platform full + clinic own clinic status transitions only</sub> | Platform | Platform |
 
 ## Notes
 
@@ -52,7 +52,7 @@
 - **Patients**: Patients can update own profile; no self-create/delete
 - **Posts**: Blog content - platform write, published content readable by all
 - **Pages**: Static pages - platform write, published content readable by all
-- **Doctors**: Platform RWDA, clinic RWA own clinic, patients/anonymous R; averageRating is computed-only
+- **Doctors**: Platform RWDA, clinic RWA own clinic including inactive doctors, patients/anonymous R active doctors; averageRating is computed-only
 - **Clinics**: Platform admin/support create, platform read/update/delete, clinic RW own profile, patients/anonymous R approved; averageRating is computed-only
 - **DoctorSpecialties**: Platform RWDA, clinic RWA own clinic, patients/anonymous R
 - **DoctorTreatments**: Platform RWDA, clinic RWA own clinic, patients/anonymous R
@@ -73,4 +73,4 @@
 - **Categories**: Supporting data - platform write, everyone read
 - **Accreditation**: Supporting data - platform write, everyone read
 - **ClinicApplications**: Public submissions use the controlled API route; platform approval creates a pending clinic and initial clinic staff principal with duplicate-write observability
-- **PatientClinicInquiries**: Patient-to-clinic inquiry queue - public submissions use the controlled API route only
+- **PatientClinicInquiries**: Patient-to-clinic inquiry queue - public submissions use the controlled API route; clinic staff read own-clinic inquiries and update controlled statuses only

--- a/src/collections/PatientClinicInquiries.ts
+++ b/src/collections/PatientClinicInquiries.ts
@@ -1,6 +1,11 @@
+import { ValidationError } from 'payload'
 import type { CollectionBeforeChangeHook, CollectionConfig } from 'payload'
 
+import { platformOnlyFieldAccess } from '@/access/fieldAccess'
+import { isClinicStaff } from '@/access/isClinicStaff'
 import { isPlatformStaff } from '@/access/isPlatformStaff'
+import { platformOrOwnClinicResource } from '@/access/scopeFilters'
+import type { PatientClinicInquiry } from '@/payload-types'
 
 export const patientClinicInquiryStatusOptions = [
   { label: 'Submitted', value: 'submitted' },
@@ -9,6 +14,16 @@ export const patientClinicInquiryStatusOptions = [
   { label: 'Closed', value: 'closed' },
   { label: 'Spam', value: 'spam' },
 ] as const
+
+type PatientClinicInquiryStatus = (typeof patientClinicInquiryStatusOptions)[number]['value']
+
+export const patientClinicInquiryStatusTransitions = {
+  submitted: ['in_review', 'contacted', 'closed', 'spam'],
+  in_review: ['contacted', 'closed', 'spam'],
+  contacted: ['closed'],
+  closed: [],
+  spam: [],
+} as const satisfies Record<PatientClinicInquiryStatus, readonly PatientClinicInquiryStatus[]>
 
 export const patientClinicInquiryTreatmentTimelineValues = [
   'as_soon_as_possible',
@@ -75,6 +90,36 @@ const freezeSubmissionEvidence: CollectionBeforeChangeHook = ({ data, operation,
   return data
 }
 
+const validateClinicStaffStatusTransition: CollectionBeforeChangeHook<PatientClinicInquiry> = ({
+  data,
+  operation,
+  originalDoc,
+  req,
+}) => {
+  if (operation !== 'update' || !originalDoc?.status || !isClinicStaff({ req })) return data
+
+  const previousStatus = originalDoc.status
+  const nextStatus = data.status ?? previousStatus
+  if (nextStatus === previousStatus) return data
+
+  if (!patientClinicInquiryStatusTransitions[previousStatus].includes(nextStatus as never)) {
+    throw new ValidationError({
+      collection: 'patientClinicInquiries',
+      errors: [
+        {
+          label: 'Status',
+          message: `Clinic inquiry status transition ${previousStatus} -> ${nextStatus} is not allowed.`,
+          path: 'status',
+        },
+      ],
+      id: originalDoc.id,
+      req,
+    })
+  }
+
+  return data
+}
+
 export const PatientClinicInquiries: CollectionConfig = {
   slug: 'patientClinicInquiries',
   labels: {
@@ -89,12 +134,12 @@ export const PatientClinicInquiries: CollectionConfig = {
   },
   access: {
     create: isPlatformStaff,
-    read: isPlatformStaff,
-    update: isPlatformStaff,
+    read: platformOrOwnClinicResource,
+    update: platformOrOwnClinicResource,
     delete: isPlatformStaff,
   },
   hooks: {
-    beforeChange: [freezeSubmissionEvidence],
+    beforeChange: [freezeSubmissionEvidence, validateClinicStaffStatusTransition],
   },
   fields: [
     {
@@ -103,6 +148,9 @@ export const PatientClinicInquiries: CollectionConfig = {
       relationTo: 'clinics',
       required: true,
       index: true,
+      access: {
+        update: platformOnlyFieldAccess,
+      },
       admin: {
         description: 'Clinic profile the request was sent from',
       },
@@ -114,6 +162,9 @@ export const PatientClinicInquiries: CollectionConfig = {
           name: 'fullName',
           type: 'text',
           required: true,
+          access: {
+            update: platformOnlyFieldAccess,
+          },
           admin: {
             description: 'Name entered by the requester',
             width: '50%',
@@ -124,6 +175,9 @@ export const PatientClinicInquiries: CollectionConfig = {
           type: 'email',
           required: true,
           index: true,
+          access: {
+            update: platformOnlyFieldAccess,
+          },
           admin: {
             description: 'Email address for follow-up',
             width: '50%',
@@ -135,6 +189,9 @@ export const PatientClinicInquiries: CollectionConfig = {
       name: 'phoneNumber',
       type: 'text',
       required: true,
+      access: {
+        update: platformOnlyFieldAccess,
+      },
       admin: {
         description: 'Phone number for follow-up',
       },
@@ -146,6 +203,9 @@ export const PatientClinicInquiries: CollectionConfig = {
           name: 'treatmentTimeline',
           type: 'select',
           options: [...patientClinicInquiryTreatmentTimelineOptions],
+          access: {
+            update: platformOnlyFieldAccess,
+          },
           admin: {
             description: 'How soon the requester is considering treatment',
             width: '50%',
@@ -155,6 +215,9 @@ export const PatientClinicInquiries: CollectionConfig = {
           name: 'preferredContactWindow',
           type: 'select',
           options: [...patientClinicInquiryContactWindowOptions],
+          access: {
+            update: platformOnlyFieldAccess,
+          },
           admin: {
             description: 'When the requester prefers to be contacted',
             width: '50%',
@@ -166,6 +229,9 @@ export const PatientClinicInquiries: CollectionConfig = {
       name: 'doctor',
       type: 'relationship',
       relationTo: 'doctors',
+      access: {
+        update: platformOnlyFieldAccess,
+      },
       admin: {
         description: 'Doctor selected on the clinic profile',
       },
@@ -174,6 +240,9 @@ export const PatientClinicInquiries: CollectionConfig = {
       name: 'treatment',
       type: 'relationship',
       relationTo: 'treatments',
+      access: {
+        update: platformOnlyFieldAccess,
+      },
       admin: {
         description: 'Treatment selected on the clinic profile',
       },
@@ -182,6 +251,9 @@ export const PatientClinicInquiries: CollectionConfig = {
       name: 'message',
       type: 'textarea',
       required: true,
+      access: {
+        update: platformOnlyFieldAccess,
+      },
       admin: {
         description: 'Message entered by the requester',
       },
@@ -189,6 +261,10 @@ export const PatientClinicInquiries: CollectionConfig = {
     {
       name: 'consent',
       type: 'group',
+      access: {
+        read: platformOnlyFieldAccess,
+        update: platformOnlyFieldAccess,
+      },
       admin: {
         description: 'Consent captured at submission time',
         readOnly: true,
@@ -224,6 +300,10 @@ export const PatientClinicInquiries: CollectionConfig = {
       name: 'assignedTo',
       type: 'relationship',
       relationTo: 'platformStaff',
+      access: {
+        read: platformOnlyFieldAccess,
+        update: platformOnlyFieldAccess,
+      },
       admin: {
         description: 'Platform user handling this request',
       },

--- a/src/security/permission-matrix.config.ts
+++ b/src/security/permission-matrix.config.ts
@@ -660,12 +660,22 @@ export const permissionMatrix: PermissionMatrix = {
       displayName: 'PatientClinicInquiries',
       operations: {
         create: { type: 'platform' },
-        read: { type: 'platform' },
-        update: { type: 'platform' },
+        read: { type: 'conditional', details: 'platform full + clinic own clinic' },
+        update: {
+          type: 'conditional',
+          details: 'platform full + clinic own clinic status transitions only',
+        },
         delete: { type: 'platform' },
         admin: { type: 'platform' },
       },
-      notes: 'Patient-to-clinic inquiry queue - public submissions use the controlled API route only',
+      meta: {
+        conditional: {
+          read: { kind: 'clinic-scope', path: 'clinic' },
+          update: { kind: 'clinic-scope', path: 'clinic' },
+        },
+      },
+      notes:
+        'Patient-to-clinic inquiry queue - public submissions use the controlled API route; clinic staff read own-clinic inquiries and update controlled statuses only',
     },
   },
 }

--- a/tests/integration/patientClinicInquiries.lifecycle.test.ts
+++ b/tests/integration/patientClinicInquiries.lifecycle.test.ts
@@ -8,6 +8,7 @@ import { createClinicFixture } from '../fixtures/createClinicFixture'
 import { cleanupTestEntities } from '../fixtures/cleanupTestEntities'
 import { testSlug } from '../fixtures/testSlug'
 import {
+  asClinicScopedPayloadUser,
   cleanupTrackedUsers,
   createClinicTestUser,
   createPlatformTestUser,
@@ -111,8 +112,8 @@ describe('PatientClinicInquiries lifecycle integration', () => {
     expect(inquiry.consent?.accepted).toBe(true)
   })
 
-  it('allows platform handling and blocks clinic users from inquiry records', async () => {
-    const { data } = await buildInquiryData('access')
+  it('keeps creation and deletion platform-only while platform handling remains unrestricted', async () => {
+    const { data, clinicId } = await buildInquiryData('platform-access')
 
     const inquiry = (await payload.create({
       collection: 'patientClinicInquiries',
@@ -139,27 +140,242 @@ describe('PatientClinicInquiries lifecycle integration', () => {
     expect(updated.status).toBe('contacted')
     expect(updated.assignedTo).toBe(platformUser.id)
 
-    const clinicUser = await createClinicUser('blocked')
-
     await expect(
-      payload.find({
+      payload.update({
         collection: 'patientClinicInquiries',
-        user: asPayloadStaffUser(clinicUser),
+        id: inquiry.id,
+        data: { status: 'submitted' },
+        user: asPayloadStaffUser(platformUser),
         overrideAccess: false,
         depth: 0,
-      } as PayloadFindArgs),
-    ).rejects.toThrow(/not allowed|perform this action/i)
+      } as PayloadUpdateArgs),
+    ).resolves.toMatchObject({ status: 'submitted' })
+
+    const clinicUser = await createClinicUser('write-boundaries')
+    const clinicPayloadUser = await asClinicScopedPayloadUser(payload, clinicUser, clinicId)
 
     await expect(
       payload.create({
         collection: 'patientClinicInquiries',
         data,
-        user: asPayloadStaffUser(clinicUser),
+        user: clinicPayloadUser,
         overrideAccess: false,
         depth: 0,
       } as PayloadCreateArgs),
     ).rejects.toThrow(/not allowed|perform this action/i)
+
+    await expect(
+      payload.delete({
+        collection: 'patientClinicInquiries',
+        id: inquiry.id,
+        user: clinicPayloadUser,
+        overrideAccess: false,
+        depth: 0,
+      }),
+    ).rejects.toThrow(/not allowed|perform this action/i)
   })
+
+  it('scopes clinic staff reads to their access-ready clinic and hides internal fields', async () => {
+    const own = await buildInquiryData('own-read')
+    const foreign = await buildInquiryData('foreign-read')
+
+    const ownInquiry = (await payload.create({
+      collection: 'patientClinicInquiries',
+      data: own.data,
+      overrideAccess: true,
+      depth: 0,
+    } as PayloadCreateArgs)) as PatientClinicInquiry
+    const foreignInquiry = (await payload.create({
+      collection: 'patientClinicInquiries',
+      data: foreign.data,
+      overrideAccess: true,
+      depth: 0,
+    } as PayloadCreateArgs)) as PatientClinicInquiry
+
+    createdInquiryIds.push(ownInquiry.id, foreignInquiry.id)
+
+    const clinicUser = await createClinicUser('own-reader')
+    const clinicPayloadUser = await asClinicScopedPayloadUser(payload, clinicUser, own.clinicId)
+
+    const visible = await payload.find({
+      collection: 'patientClinicInquiries',
+      where: {
+        id: {
+          in: [ownInquiry.id, foreignInquiry.id],
+        },
+      },
+      user: clinicPayloadUser,
+      overrideAccess: false,
+      depth: 0,
+    } as PayloadFindArgs)
+
+    expect(visible.docs).toHaveLength(1)
+    expect(visible.docs[0]).toMatchObject({
+      id: ownInquiry.id,
+      clinic: own.clinicId,
+      email: own.data.email,
+      message: own.data.message,
+      status: 'submitted',
+    })
+    expect(visible.docs[0]).not.toHaveProperty('consent')
+    expect(visible.docs[0]).not.toHaveProperty('assignedTo')
+
+    const foreignFilter = await payload.find({
+      collection: 'patientClinicInquiries',
+      where: {
+        clinic: {
+          equals: foreign.clinicId,
+        },
+      },
+      user: clinicPayloadUser,
+      overrideAccess: false,
+      depth: 0,
+    } as PayloadFindArgs)
+
+    expect(foreignFilter.docs).toHaveLength(0)
+
+    const pendingUser = await createClinicUser('pending-reader')
+    await expect(
+      payload.find({
+        collection: 'patientClinicInquiries',
+        user: asPayloadStaffUser(pendingUser),
+        overrideAccess: false,
+        depth: 0,
+      } as PayloadFindArgs),
+    ).rejects.toThrow(/not allowed|perform this action/i)
+
+    await payload.update({
+      collection: 'clinics',
+      id: own.clinicId,
+      data: { status: 'pending' },
+      overrideAccess: true,
+      depth: 0,
+    })
+
+    await expect(
+      payload.find({
+        collection: 'patientClinicInquiries',
+        user: clinicPayloadUser,
+        overrideAccess: false,
+        depth: 0,
+      } as PayloadFindArgs),
+    ).rejects.toThrow(/not allowed|perform this action/i)
+  })
+
+  it('allows clinic staff to update status without changing submitted or internal fields', async () => {
+    const own = await buildInquiryData('field-access-own')
+    const foreign = await buildInquiryData('field-access-foreign')
+
+    const inquiry = (await payload.create({
+      collection: 'patientClinicInquiries',
+      data: own.data,
+      overrideAccess: true,
+      depth: 0,
+    } as PayloadCreateArgs)) as PatientClinicInquiry
+    createdInquiryIds.push(inquiry.id)
+
+    const platformUser = await createPlatformUser('field-assignee')
+    const clinicUser = await createClinicUser('field-editor')
+    const clinicPayloadUser = await asClinicScopedPayloadUser(payload, clinicUser, own.clinicId)
+
+    const updated = (await payload.update({
+      collection: 'patientClinicInquiries',
+      id: inquiry.id,
+      data: {
+        assignedTo: platformUser.id,
+        clinic: foreign.clinicId,
+        email: `${slugPrefix}-tampered@example.com`,
+        message: 'Tampered inquiry message.',
+        status: 'in_review',
+      },
+      user: clinicPayloadUser,
+      overrideAccess: false,
+      depth: 0,
+    } as PayloadUpdateArgs)) as PatientClinicInquiry
+
+    expect(updated.status).toBe('in_review')
+    expect(updated.email).toBe(own.data.email)
+    expect(updated.message).toBe(own.data.message)
+    expect(updated.clinic).toBe(own.clinicId)
+    expect(updated).not.toHaveProperty('assignedTo')
+    expect(updated).not.toHaveProperty('consent')
+
+    const stored = (await payload.findByID({
+      collection: 'patientClinicInquiries',
+      id: inquiry.id,
+      overrideAccess: true,
+      depth: 0,
+    })) as PatientClinicInquiry
+
+    expect(stored).toMatchObject({
+      assignedTo: null,
+      clinic: own.clinicId,
+      email: own.data.email,
+      message: own.data.message,
+      status: 'in_review',
+    })
+  })
+
+  it('enforces every clinic staff status transition through the collection', async () => {
+    const { data, clinicId } = await buildInquiryData('status-matrix')
+    const clinicUser = await createClinicUser('status-editor')
+    const clinicPayloadUser = await asClinicScopedPayloadUser(payload, clinicUser, clinicId)
+    const statuses = ['submitted', 'in_review', 'contacted', 'closed', 'spam'] as const
+    const allowedTransitions = {
+      submitted: ['in_review', 'contacted', 'closed', 'spam'],
+      in_review: ['contacted', 'closed', 'spam'],
+      contacted: ['closed'],
+      closed: [],
+      spam: [],
+    } as const
+
+    for (const previousStatus of statuses) {
+      for (const nextStatus of statuses) {
+        if (previousStatus === nextStatus) continue
+
+        const inquiry = (await payload.create({
+          collection: 'patientClinicInquiries',
+          data: {
+            ...data,
+            email: `${slugPrefix}-${previousStatus}-${nextStatus}@example.com`,
+            fullName: `${previousStatus}-${nextStatus} Patient`,
+            status: previousStatus,
+          },
+          overrideAccess: true,
+          depth: 0,
+        } as PayloadCreateArgs)) as PatientClinicInquiry
+        createdInquiryIds.push(inquiry.id)
+
+        const update = payload.update({
+          collection: 'patientClinicInquiries',
+          id: inquiry.id,
+          data: { status: nextStatus },
+          user: clinicPayloadUser,
+          overrideAccess: false,
+          depth: 0,
+        } as PayloadUpdateArgs)
+
+        if (allowedTransitions[previousStatus].includes(nextStatus as never)) {
+          await expect(update).resolves.toMatchObject({ status: nextStatus })
+        } else {
+          await expect(update).rejects.toMatchObject({
+            data: {
+              errors: [expect.objectContaining({ path: 'status' })],
+            },
+            status: 400,
+          })
+          await expect(
+            payload.findByID({
+              collection: 'patientClinicInquiries',
+              id: inquiry.id,
+              overrideAccess: true,
+              depth: 0,
+            }),
+          ).resolves.toMatchObject({ status: previousStatus })
+        }
+      }
+    }
+  }, 45000)
 
   it('prevents platform users from changing consent evidence', async () => {
     const { data } = await buildInquiryData('evidence')

--- a/tests/unit/access-matrix/patientClinicInquiries.permission.test.ts
+++ b/tests/unit/access-matrix/patientClinicInquiries.permission.test.ts
@@ -1,4 +1,65 @@
+import type { FieldAccess } from 'payload'
+import { describe, expect, it } from 'vitest'
+
 import { PatientClinicInquiries } from '@/collections/PatientClinicInquiries'
+import { createAccessArgs } from '../helpers/testHelpers'
+import { mockUsers } from '../helpers/mockUsers'
 import { makePermissionSuite } from './generatePermissionSuite'
 
+type FieldNode = {
+  access?: {
+    read?: FieldAccess
+    update?: FieldAccess
+  }
+  fields?: FieldNode[]
+  name?: string
+}
+
+const findField = (fields: FieldNode[], name: string): FieldNode | undefined => {
+  for (const field of fields) {
+    if (field.name === name) return field
+    const nested = field.fields ? findField(field.fields, name) : undefined
+    if (nested) return nested
+  }
+  return undefined
+}
+
 makePermissionSuite('patientClinicInquiries', PatientClinicInquiries)
+
+describe('patientClinicInquiries field access', () => {
+  const fields = PatientClinicInquiries.fields as FieldNode[]
+
+  it('keeps submitted inquiry data platform-controlled while clinic staff may update status', async () => {
+    for (const name of [
+      'clinic',
+      'fullName',
+      'email',
+      'phoneNumber',
+      'treatmentTimeline',
+      'preferredContactWindow',
+      'doctor',
+      'treatment',
+      'message',
+      'consent',
+      'assignedTo',
+    ]) {
+      const update = findField(fields, name)?.access?.update
+
+      expect(update).toBeTypeOf('function')
+      expect(await update?.(createAccessArgs(mockUsers.platform()))).toBe(true)
+      expect(await update?.(createAccessArgs(mockUsers.clinic()))).toBe(false)
+    }
+
+    expect(findField(fields, 'status')?.access?.update).toBeUndefined()
+  })
+
+  it('keeps consent evidence and platform assignment private from clinic staff', async () => {
+    for (const name of ['consent', 'assignedTo']) {
+      const read = findField(fields, name)?.access?.read
+
+      expect(read).toBeTypeOf('function')
+      expect(await read?.(createAccessArgs(mockUsers.platform()))).toBe(true)
+      expect(await read?.(createAccessArgs(mockUsers.clinic()))).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
## Management summary

### Deutsch

Freigegebenes Klinikpersonal kann eingehende Patienten-Anfragen der eigenen Klinik nun sicher einsehen und ihren Bearbeitungsstatus pflegen. Anfragen anderer Kliniken sowie interne Plattforminformationen bleiben geschützt, während das Plattformteam weiterhin den vollständigen operativen Zugriff behält.

### English

Approved clinic staff can now securely view incoming patient inquiries for their own clinic and maintain their processing status. Inquiries belonging to other clinics and internal platform information remain protected, while the platform team retains full operational access.

## What changed

- Allows access-ready Clinic Staff to read `patientClinicInquiries` for their assigned clinic only.
- Restricts Clinic Staff updates to explicit forward-only status transitions while keeping submitted inquiry data immutable.
- Keeps creation, deletion, internal consent evidence, and platform assignment restricted to Platform Staff.
- Updates the generated permission matrix and adds tenant-isolation, field-access, and transition coverage.
- Keeps the public inquiry submission route and the `private-live` cache classification unchanged.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `src/collections/PatientClinicInquiries.ts` | Defines the clinic tenant boundary and writable field surface. | Clinic Staff can access only their assigned clinic and modify only permitted status transitions. | Integration lifecycle suite and field-access unit suite |
| P1 | `tests/integration/patientClinicInquiries.lifecycle.test.ts` | Proves tenant isolation and negative authorization paths. | Foreign filters, pending staff, and changed clinic assignments cannot widen access. | 7 focused integration tests pass |
| P2 | `src/security/permission-matrix.config.ts`, `docs/security/permission-matrix.generated.md` | Records the intended authorization contract. | Matrix documentation matches the implemented collection access. | `pnpm matrix:verify` passes |

## Validation

- [x] `pnpm format`: passed
- [x] `pnpm check`: passed
- [x] `pnpm build`: passed; no schema generation or migration required
- [x] Focused tests: 18 field/access tests, 7 integration lifecycle tests, and 12 public inquiry route tests passed; `pnpm matrix:verify` and `pnpm tests:sense-check` passed
- [ ] UI/mobile QA: not applicable; no UI or frontend behavior changed
- [x] Security/privacy review: `security_reviewer` found no actionable finding at severity 5/10 or higher
- [x] Migration/schema check: no fields or schema changed; no migration required
- [x] Documentation/instructions check: generated permission matrix updated and verified; no instruction files changed

## Risk and rollout

The change expands private collection access for Clinic Staff and therefore depends on the existing access-ready clinic assignment. Tenant isolation, protected fields, and status transitions are covered by focused integration tests. No environment, cache, public API, schema, or migration changes are required.

## Development

Closes #1526
