### PR TITLE
fix(auth): reconcile missing clinic staff identities

### DIFF
--- a/src/auth/utilities/supabaseProvision.ts
+++ b/src/auth/utilities/supabaseProvision.ts
@@ -39,6 +39,12 @@ export interface ClinicInviteProvisionArgs {
   userMetadata?: SupabaseProvisionMetadata
 }
 
+export interface ExistingClinicAccountReconciliationArgs {
+  email: string
+  onboardingKey?: string | null
+  userMetadata?: SupabaseProvisionMetadata
+}
+
 export interface ClinicAccountAccessArgs {
   enabled: boolean
   supabaseUserId: string
@@ -215,11 +221,10 @@ const toSupabaseErrorMessage = (error: unknown): string =>
       ? error.message
       : String(error)
 
-const findClinicSupabaseUser = async (
+const findSupabaseUsersByEmail = async (
   supabase: Awaited<ReturnType<typeof getProvisionAdminClient>>['supabase'],
   email: string,
-  onboardingKey: string,
-): Promise<User | null> => {
+): Promise<User[]> => {
   const matches: User[] = []
   let page: number | null = 1
 
@@ -229,13 +234,21 @@ const findClinicSupabaseUser = async (
       throw new Error(`Supabase user reconciliation failed: ${error.message}`)
     }
 
-    matches.push(
-      ...data.users.filter(
-        (user) => normalizeEmail(user.email) === email && user.user_metadata?.onboarding_key === onboardingKey,
-      ),
-    )
+    matches.push(...data.users.filter((user) => normalizeEmail(user.email) === email))
     page = data.nextPage
   }
+
+  return matches
+}
+
+const findClinicSupabaseUser = async (
+  supabase: Awaited<ReturnType<typeof getProvisionAdminClient>>['supabase'],
+  email: string,
+  onboardingKey: string,
+): Promise<User | null> => {
+  const matches = (await findSupabaseUsersByEmail(supabase, email)).filter(
+    (user) => user.user_metadata?.onboarding_key === onboardingKey,
+  )
 
   if (matches.length > 1) {
     throw new Error('Supabase user reconciliation found multiple clinic identities')
@@ -253,7 +266,7 @@ const repairClinicSupabaseUser = async ({
 }: {
   firstName?: string
   lastName?: string
-  onboardingKey: string
+  onboardingKey?: string
   supabase: Awaited<ReturnType<typeof getProvisionAdminClient>>['supabase']
   user: User
 }): Promise<void> => {
@@ -263,7 +276,7 @@ const repairClinicSupabaseUser = async ({
       ...user.user_metadata,
       first_name: firstName ?? user.user_metadata?.first_name,
       last_name: lastName ?? user.user_metadata?.last_name,
-      onboarding_key: onboardingKey,
+      ...(onboardingKey ? { onboarding_key: onboardingKey } : {}),
     },
   })
 
@@ -347,6 +360,72 @@ export async function inviteClinicSupabaseAccount(
       userType: 'clinic',
     },
     invitedUser ? 'Invited Supabase clinic user' : 'Reconciled Supabase clinic user',
+  )
+
+  return user.id
+}
+
+/**
+ * Reconciles one existing clinic-tagged Supabase account without creating or inviting a user.
+ */
+export async function reconcileExistingClinicSupabaseAccount(
+  { email, onboardingKey, userMetadata }: ExistingClinicAccountReconciliationArgs,
+  logger?: ServerLogger,
+): Promise<string> {
+  const normalizedEmail = normalizeEmail(email)
+  const normalizedOnboardingKey = onboardingKey?.trim() || undefined
+  if (!isValidEmail(normalizedEmail)) {
+    throw new Error('Supabase clinic reconciliation failed: Invalid email format')
+  }
+
+  const { activeLogger, supabase } = await getProvisionAdminClient(logger, {
+    emailHash: hashLogValue(normalizedEmail),
+    operation: 'reconcile_clinic_user',
+    userType: 'clinic',
+  })
+  const matches = await findSupabaseUsersByEmail(supabase, normalizedEmail)
+
+  if (matches.length !== 1) {
+    throw new Error(`Supabase clinic reconciliation expected one identity, found ${matches.length}`)
+  }
+
+  const user = matches[0]
+  if (!user) {
+    throw new Error('Supabase clinic reconciliation found no identity')
+  }
+  const existingUserType = typeof user.app_metadata?.user_type === 'string' ? user.app_metadata.user_type : undefined
+  const existingOnboardingKey =
+    typeof user.user_metadata?.onboarding_key === 'string' ? user.user_metadata.onboarding_key.trim() : undefined
+
+  if (existingUserType && existingUserType !== 'clinic') {
+    throw new Error('Supabase clinic reconciliation found a non-clinic identity')
+  }
+  if (normalizedOnboardingKey && existingOnboardingKey && existingOnboardingKey !== normalizedOnboardingKey) {
+    throw new Error('Supabase clinic reconciliation found a different onboarding identity')
+  }
+  if (
+    existingUserType !== 'clinic' &&
+    (!normalizedOnboardingKey || existingOnboardingKey !== normalizedOnboardingKey)
+  ) {
+    throw new Error('Supabase clinic reconciliation could not verify the clinic identity')
+  }
+
+  await repairClinicSupabaseUser({
+    firstName: userMetadata?.firstName,
+    lastName: userMetadata?.lastName,
+    onboardingKey: normalizedOnboardingKey ?? existingOnboardingKey,
+    supabase,
+    user,
+  })
+
+  activeLogger.info(
+    {
+      emailHash: hashLogValue(normalizedEmail),
+      event: 'auth.supabase.admin.clinic_identity_reconciled',
+      supabaseUserId: user.id,
+      userType: 'clinic',
+    },
+    'Reconciled existing Supabase clinic user',
   )
 
   return user.id

--- a/src/hooks/clinicStaffLifecycle.ts
+++ b/src/hooks/clinicStaffLifecycle.ts
@@ -1,5 +1,9 @@
 import type { ClinicStaff } from '@/payload-types'
-import { deleteClinicSupabaseAccount, setClinicSupabaseAccountAccess } from '@/auth/utilities/supabaseProvision'
+import {
+  deleteClinicSupabaseAccount,
+  reconcileExistingClinicSupabaseAccount,
+  setClinicSupabaseAccountAccess,
+} from '@/auth/utilities/supabaseProvision'
 import {
   isClinicStaffStatusTransitionAllowed,
   type ClinicStaffAuthSyncErrorCode,
@@ -69,24 +73,43 @@ export const synchronizeClinicStaffAuthState: CollectionAfterChangeHook<ClinicSt
     doc.status === 'offboarded' ? 'account_delete_failed' : 'account_update_failed'
 
   try {
-    if (!doc.supabaseUserId) {
+    let supabaseUserId = doc.supabaseUserId?.trim()
+
+    if (!supabaseUserId) {
       if (doc.status === 'offboarded') {
         await updateAuthSync(req, doc.id, 'deleted', null)
         return doc
       }
 
       failureCode = 'missing_identity'
-      throw new Error('Clinic staff has no Supabase identity')
+      supabaseUserId = await reconcileExistingClinicSupabaseAccount(
+        {
+          email: doc.email ?? '',
+          onboardingKey: doc.onboardingKey,
+          userMetadata: {
+            firstName: doc.firstName ?? undefined,
+            lastName: doc.lastName ?? undefined,
+          },
+        },
+        req.payload.logger,
+      )
+      await req.payload.update({
+        collection: 'clinicStaff',
+        id: doc.id,
+        context: { ...req.context, skipClinicStaffAuthSync: true },
+        data: { supabaseUserId },
+        depth: 0,
+        overrideAccess: true,
+        req,
+      })
     }
 
     if (doc.status === 'offboarded') {
-      await deleteClinicSupabaseAccount(doc.supabaseUserId, req.payload.logger)
+      await deleteClinicSupabaseAccount(supabaseUserId, req.payload.logger)
       await updateAuthSync(req, doc.id, 'deleted', null)
     } else {
-      await setClinicSupabaseAccountAccess(
-        { enabled: doc.status === 'approved', supabaseUserId: doc.supabaseUserId },
-        req.payload.logger,
-      )
+      failureCode = 'account_update_failed'
+      await setClinicSupabaseAccountAccess({ enabled: doc.status === 'approved', supabaseUserId }, req.payload.logger)
       await updateAuthSync(req, doc.id, 'synced', null)
     }
   } catch (error) {

--- a/tests/unit/auth/utilities/supabaseProvision.test.ts
+++ b/tests/unit/auth/utilities/supabaseProvision.test.ts
@@ -309,6 +309,69 @@ describe('clinic Supabase provisioning', () => {
     ).rejects.toThrow('Supabase clinic invite failed: already registered')
   })
 
+  it('reconciles one existing clinic-tagged identity without sending another invite', async () => {
+    const { reconcileExistingClinicSupabaseAccount } = await actualModulePromise
+    adminClient.auth.admin.listUsers.mockResolvedValueOnce({
+      data: {
+        users: [
+          {
+            id: 'reconciled-id',
+            email: 'CLINIC@example.com',
+            app_metadata: { user_type: 'clinic' },
+            user_metadata: {},
+          },
+        ],
+        nextPage: null,
+      },
+      error: null,
+    })
+
+    await expect(
+      reconcileExistingClinicSupabaseAccount({
+        email: 'clinic@example.com',
+        onboardingKey: 'clinic-application:42',
+        userMetadata: { firstName: 'Ada', lastName: 'Lovelace' },
+      }),
+    ).resolves.toBe('reconciled-id')
+
+    expect(adminClient.auth.admin.inviteUserByEmail).not.toHaveBeenCalled()
+    expect(adminClient.auth.admin.updateUserById).toHaveBeenCalledWith('reconciled-id', {
+      app_metadata: { user_type: 'clinic' },
+      user_metadata: {
+        first_name: 'Ada',
+        last_name: 'Lovelace',
+        onboarding_key: 'clinic-application:42',
+      },
+    })
+  })
+
+  it('refuses to reconcile an existing identity tagged for another principal type', async () => {
+    const { reconcileExistingClinicSupabaseAccount } = await actualModulePromise
+    adminClient.auth.admin.listUsers.mockResolvedValueOnce({
+      data: {
+        users: [
+          {
+            id: 'patient-id',
+            email: 'clinic@example.com',
+            app_metadata: { user_type: 'patient' },
+            user_metadata: { onboarding_key: 'clinic-application:42' },
+          },
+        ],
+        nextPage: null,
+      },
+      error: null,
+    })
+
+    await expect(
+      reconcileExistingClinicSupabaseAccount({
+        email: 'clinic@example.com',
+        onboardingKey: 'clinic-application:42',
+      }),
+    ).rejects.toThrow('Supabase clinic reconciliation found a non-clinic identity')
+
+    expect(adminClient.auth.admin.updateUserById).not.toHaveBeenCalled()
+  })
+
   it('synchronizes clinic access with explicit ban and unban durations', async () => {
     const { setClinicSupabaseAccountAccess } = await actualModulePromise
 

--- a/tests/unit/hooks/clinicStaffLifecycle.test.ts
+++ b/tests/unit/hooks/clinicStaffLifecycle.test.ts
@@ -5,6 +5,7 @@ import type { ClinicStaff } from '@/payload-types'
 
 const authMocks = vi.hoisted(() => ({
   deleteClinicSupabaseAccount: vi.fn(),
+  reconcileExistingClinicSupabaseAccount: vi.fn(),
   setClinicSupabaseAccountAccess: vi.fn(),
 }))
 
@@ -43,6 +44,7 @@ describe('ClinicStaff lifecycle hooks', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     authMocks.deleteClinicSupabaseAccount.mockResolvedValue(undefined)
+    authMocks.reconcileExistingClinicSupabaseAccount.mockResolvedValue('reconciled-supabase-4')
     authMocks.setClinicSupabaseAccountAccess.mockResolvedValue(undefined)
   })
 
@@ -129,8 +131,50 @@ describe('ClinicStaff lifecycle hooks', () => {
     )
   })
 
-  it('stores a resumable failure when a non-pending principal has no identity', async () => {
+  it('reconciles and binds an existing identity when a non-pending principal has no identity', async () => {
     const request = req()
+
+    await synchronizeClinicStaffAuthState({
+      doc: staff({
+        status: 'approved',
+        supabaseUserId: null,
+        onboardingKey: 'clinic-application:42',
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+      }),
+      previousDoc: staff({ status: 'pending' }),
+      req: request,
+    } as never)
+
+    expect(authMocks.reconcileExistingClinicSupabaseAccount).toHaveBeenCalledWith(
+      {
+        email: 'clinic@example.com',
+        onboardingKey: 'clinic-application:42',
+        userMetadata: { firstName: 'Ada', lastName: 'Lovelace' },
+      },
+      request.payload.logger,
+    )
+    expect(request.payload.update).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        data: { supabaseUserId: 'reconciled-supabase-4' },
+      }),
+    )
+    expect(authMocks.setClinicSupabaseAccountAccess).toHaveBeenCalledWith(
+      { enabled: true, supabaseUserId: 'reconciled-supabase-4' },
+      request.payload.logger,
+    )
+    expect(request.payload.update).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        data: { authSync: { errorCode: null, status: 'synced' } },
+      }),
+    )
+  })
+
+  it('stores a resumable missing-identity failure when reconciliation cannot verify an account', async () => {
+    const request = req()
+    authMocks.reconcileExistingClinicSupabaseAccount.mockRejectedValueOnce(new Error('No verified clinic identity'))
 
     await synchronizeClinicStaffAuthState({
       doc: staff({ status: 'approved', supabaseUserId: null }),
@@ -143,6 +187,7 @@ describe('ClinicStaff lifecycle hooks', () => {
         data: { authSync: { errorCode: 'missing_identity', status: 'failed' } },
       }),
     )
+    expect(authMocks.setClinicSupabaseAccountAccess).not.toHaveBeenCalled()
   })
 
   it('retries a failed unchanged lifecycle state and skips an already synchronized one', async () => {


### PR DESCRIPTION
## Management summary

### Deutsch

Bereits vorhandene Klinikkonten können nach der Freigabe wieder automatisch mit ihrem Zugang verknüpft werden, statt dauerhaft im Zustand „nicht bereit“ zu bleiben. Der Abgleich bleibt bewusst eng begrenzt und lehnt unklare oder fremde Konten ab.

### English

Existing clinic accounts can now be linked to their access record automatically after approval instead of remaining permanently “not ready.” The reconciliation stays deliberately narrow and rejects ambiguous or unrelated accounts.

## What changed

- Added a fail-closed reconciliation path for one existing Supabase account with the same normalized email.
- Requires either existing clinic metadata or a matching onboarding identity and rejects identities assigned to another principal type.
- Binds the recovered Supabase ID through Payload so the existing identity invariant remains enforced.
- Continues the normal clinic access synchronization after binding and stores a successful `authSync` result.
- Added focused tests for successful reconciliation, foreign principal rejection, binding, access synchronization, and resumable failure handling.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `src/auth/utilities/supabaseProvision.ts` | Reconciles an authentication identity from email and metadata. | The verification rules fail closed for ambiguous or non-clinic accounts and preserve existing metadata. | Focused Supabase provisioning unit tests |
| P1 | `src/hooks/clinicStaffLifecycle.ts` | Persists the recovered identity and changes account readiness. | The Payload identity invariant remains active, recursive sync is prevented, and failures remain retryable. | Focused lifecycle hook unit tests |

## Validation

- [x] `pnpm format`: completed successfully.
- [x] `pnpm check`: completed successfully.
- [x] `pnpm build`: completed successfully against the local Postgres service.
- [x] Focused tests: 32 tests passed across the clinic staff lifecycle and Supabase provisioning suites.
- [ ] UI/mobile QA: not applicable; no UI code changed.
- [ ] Security/privacy review: specialist review not run; the new reconciliation path is covered by fail-closed unit tests.
- [x] Migration/schema check: no schema or migration change required.
- [x] Documentation/instructions check: no documentation or instruction change required.

## Risk and rollout

The behavior runs only when a non-pending clinic staff record has no Supabase identity and is saved again. It does not create or invite a new user. Ambiguous matches, another principal type, or conflicting onboarding metadata remain failed and retryable. Cache decision: `no-public-impact`; the flow is private auth state and adds no public cache or revalidation behavior. Production remains unchanged until the normal release process includes this change.

## Development

Closes #1606
