### PR TITLE
fix(auth): restore Preview Guard patient access

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -144,7 +144,8 @@ PostHog can enable a temporary public landing mode through the server-side featu
 Priority behavior:
 - Temporary Landing Mode takes precedence over normal preview access behavior for non-platform sessions.
 - Preview Guard is evaluated through the separate PostHog flag `preview-guard-enabled`.
-- When both flags are active, public legal/contact exemptions stay reachable while admin/auth/login/register exemptions remain subject to Preview Guard unless they are Preview Guard login/recovery routes.
+- When both flags are active, public legal/contact exemptions stay reachable while admin/auth/login/register exemptions remain subject to Preview Guard unless they are exact Preview Guard login, recovery, or invitation routes.
+- Preview patient creation is staff-managed through Payload Admin. Patient login, reset, invitation completion, and `/patient/**` remain available for patient-side Preview QA.
 
 ## Preview Access Policy
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -145,7 +145,7 @@ Priority behavior:
 - Temporary Landing Mode takes precedence over normal preview access behavior for non-platform sessions.
 - Preview Guard is evaluated through the separate PostHog flag `preview-guard-enabled`.
 - When both flags are active, public legal/contact exemptions stay reachable while admin/auth/login/register exemptions remain subject to Preview Guard unless they are exact Preview Guard login, recovery, or invitation routes.
-- Preview patient creation is staff-managed through Payload Admin. Patient login, reset, invitation completion, and `/patient/**` remain available for patient-side Preview QA.
+- While Preview Guard is enabled, patient creation is staff-managed through Payload Admin. Patient login, reset, invitation completion, and `/patient/**` remain available for patient-side QA.
 
 ## Preview Access Policy
 

--- a/docs/security/auth-flow-diagram.md
+++ b/docs/security/auth-flow-diagram.md
@@ -93,12 +93,21 @@ Only `platformStaff` can enter Payload Admin. Clinic staff and patients are expl
 
 ```mermaid
 sequenceDiagram
+    actor Platform as Platform Staff
     actor Patient
+    participant Admin as Payload Admin
     participant Portal as Website Portal
     participant Supabase as Supabase Auth
     participant Payload as Website Payload Boundary
     participant DB as Payload Database
 
+    opt Preview account creation
+        Platform->>Admin: Create patient principal
+        Admin->>Payload: Persist patient through Local API
+        Payload->>Supabase: Send patient invitation
+        Supabase-->>Patient: Website invitation callback
+        Patient->>Portal: Confirm invitation and set password
+    end
     Patient->>Portal: Start patient authentication
     Portal->>Supabase: Authenticate or complete callback
     Portal->>Payload: Make an authenticated website request
@@ -107,7 +116,9 @@ sequenceDiagram
     Payload-->>Portal: Patient-scoped result
 ```
 
-The Dashboard decision does not change the patient portal session or ensure-on-auth behavior.
+Preview patient creation requires an authenticated platform staff member and uses the existing Payload Admin invite
+flow. Patient login, reset, invitation completion, and patient-owned routes remain available without a platform
+session. Production patient self-registration and the patient ensure-on-auth behavior are unchanged.
 
 ## Shared Authorization Facts
 

--- a/docs/security/auth-flow-diagram.md
+++ b/docs/security/auth-flow-diagram.md
@@ -101,7 +101,7 @@ sequenceDiagram
     participant Payload as Website Payload Boundary
     participant DB as Payload Database
 
-    opt Preview account creation
+    opt Patient creation while Preview Guard is enabled
         Platform->>Admin: Create patient principal
         Admin->>Payload: Persist patient through Local API
         Payload->>Supabase: Send patient invitation
@@ -116,9 +116,10 @@ sequenceDiagram
     Payload-->>Portal: Patient-scoped result
 ```
 
-Preview patient creation requires an authenticated platform staff member and uses the existing Payload Admin invite
-flow. Patient login, reset, invitation completion, and patient-owned routes remain available without a platform
-session. Production patient self-registration and the patient ensure-on-auth behavior are unchanged.
+While Preview Guard is enabled, patient creation requires an authenticated platform staff member and uses the existing
+Payload Admin invite flow. Patient login, reset, invitation completion, and patient-owned routes remain available
+without a platform session. When Preview Guard is disabled, public patient self-registration remains available
+regardless of deployment environment; the patient ensure-on-auth behavior is unchanged.
 
 ## Shared Authorization Facts
 

--- a/docs/security/authentication-system.md
+++ b/docs/security/authentication-system.md
@@ -67,6 +67,12 @@ requests retain the website callback and its existing enumeration-resistant resp
 
 Patient provisioning remains the established ensure-on-auth flow. Staff deletion first removes the Payload principal, so a later Supabase deletion failure cannot leave an authorized principal. The trusted operations path can safely retry cleanup.
 
+Preview patient creation is staff-managed. Platform staff create the patient principal through Payload Admin, which
+sends the patient invitation and binds the Supabase identity. The public Preview registration page redirects to that
+Admin form, and direct Preview submissions to the patient registration API are rejected. Patient login, invitation
+completion, password recovery, and patient-owned routes remain available without a platform session. Production
+patient self-registration is unchanged.
+
 Invite and recovery email templates use `TokenHash`, not browser hash tokens. The callback `GET` validates the fixed
 flow and internal destination but does not consume the token. A same-origin confirmation `POST` performs `verifyOtp`.
 The website authorization-code, TokenHash, and browser-hash callback paths serve its Platform and Patient flows.

--- a/docs/security/authentication-system.md
+++ b/docs/security/authentication-system.md
@@ -67,11 +67,12 @@ requests retain the website callback and its existing enumeration-resistant resp
 
 Patient provisioning remains the established ensure-on-auth flow. Staff deletion first removes the Payload principal, so a later Supabase deletion failure cannot leave an authorized principal. The trusted operations path can safely retry cleanup.
 
-Preview patient creation is staff-managed. Platform staff create the patient principal through Payload Admin, which
-sends the patient invitation and binds the Supabase identity. The public Preview registration page redirects to that
-Admin form, and direct Preview submissions to the patient registration API are rejected. Patient login, invitation
-completion, password recovery, and patient-owned routes remain available without a platform session. Production
-patient self-registration is unchanged.
+Patient creation is staff-managed while Preview Guard is enabled. Platform staff create the patient principal through
+Payload Admin, which sends the patient invitation and binds the Supabase identity. The public registration page
+redirects to that Admin form, and direct submissions to the patient registration API are rejected for guarded requests.
+Patient login, invitation completion, password recovery, and patient-owned routes remain available without a platform
+session. When Preview Guard is disabled, public patient self-registration is unchanged regardless of deployment
+environment.
 
 Invite and recovery email templates use `TokenHash`, not browser hash tokens. The callback `GET` validates the fixed
 flow and internal destination but does not consume the token. A same-origin confirmation `POST` performs `verifyOtp`.

--- a/src/app/(frontend)/auth/invite/complete/InviteCompleteForm.tsx
+++ b/src/app/(frontend)/auth/invite/complete/InviteCompleteForm.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/atoms/button'
 import { Alert } from '@/components/atoms/alert'
 import { createClient } from '@/auth/utilities/supaBaseClient'
 import { hydrateSessionFromHash } from '@/auth/utilities/hydrateSessionFromHash'
+import { resolvePasswordResetLoginTarget, type PasswordResetLoginTarget } from '@/auth/utilities/loginRedirects'
 import { usePublicFormValidation } from '@/components/molecules/PublicFormValidation'
 
 const expiredRecoveryHref = '/auth/password/reset?reason=expired'
@@ -28,10 +29,13 @@ const passwordSchema = z
 
 type PasswordState = z.infer<typeof passwordSchema>
 
-export function InviteCompleteForm({ error }: { error?: string }) {
+export function InviteCompleteForm({ clinicLoginHref, error }: { clinicLoginHref?: string; error?: string }) {
   const supabase = useMemo(() => createClient(), [])
   const router = useRouter()
   const [isSessionReady, setSessionReady] = useState(false)
+  const [loginTarget, setLoginTarget] = useState<PasswordResetLoginTarget>(() =>
+    resolvePasswordResetLoginTarget(undefined, clinicLoginHref),
+  )
   const formValidation = usePublicFormValidation({
     messages: {
       confirmPassword: { valueMissing: 'Confirm your new password.' },
@@ -76,6 +80,7 @@ export function InviteCompleteForm({ error }: { error?: string }) {
         return
       }
 
+      setLoginTarget(resolvePasswordResetLoginTarget(session.user.app_metadata?.user_type, clinicLoginHref))
       setSessionReady(true)
     }
 
@@ -84,7 +89,7 @@ export function InviteCompleteForm({ error }: { error?: string }) {
     return () => {
       active = false
     }
-  }, [error, router, supabase])
+  }, [clinicLoginHref, error, router, supabase])
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -145,7 +150,7 @@ export function InviteCompleteForm({ error }: { error?: string }) {
               <Alert className="space-y-2" variant="success" role="status">
                 <p>Password set successfully.</p>
                 <p>
-                  <Link href="/admin/login" className="text-primary hover:underline">
+                  <Link href={loginTarget.href} className="text-primary hover:underline">
                     Return to sign in
                   </Link>
                   .

--- a/src/app/(frontend)/auth/invite/complete/page.tsx
+++ b/src/app/(frontend)/auth/invite/complete/page.tsx
@@ -1,11 +1,14 @@
 export const dynamic = 'force-dynamic'
 
+import { getClinicDashboardOrigin } from '@/auth/utilities/clinicDashboardOrigin'
 import InviteCompleteForm from './InviteCompleteForm'
 
 export default function InviteCompletePage() {
+  const clinicLoginHref = process.env.CLINIC_DASHBOARD_URL?.trim() ? `${getClinicDashboardOrigin()}/login` : undefined
+
   return (
     <div className="flex flex-col items-center justify-center gap-6 p-6 md:p-10">
-      <InviteCompleteForm />
+      <InviteCompleteForm clinicLoginHref={clinicLoginHref} />
     </div>
   )
 }

--- a/src/app/(frontend)/login/patient/page.tsx
+++ b/src/app/(frontend)/login/patient/page.tsx
@@ -5,9 +5,12 @@ import {
 import { AuthFlashStatus } from '@/app/(frontend)/_components/AuthFlashStatus'
 import * as LoginForm from '@/components/organisms/Auth/LoginForm'
 import { PATIENT_LOGIN_PATH } from '@/features/favorites/redirects'
-import { isPreviewRuntime } from '@/features/runtimePolicy'
+import { PREVIEW_GUARD_ACTIVE_REQUEST_HEADER } from '@/features/previewGuard'
 import { sanitizeInternalRedirectPath } from '@/utilities/routing/sanitizeInternalRedirectPath'
 import Link from 'next/link'
+import { headers } from 'next/headers'
+
+export const dynamic = 'force-dynamic'
 
 const patientLoginMessages: Record<string, { text: string; variant?: 'success' | 'info' | 'warning' }> = {
   'patient-check-email': {
@@ -16,18 +19,26 @@ const patientLoginMessages: Record<string, { text: string; variant?: 'success' |
   },
 }
 
+const previewGuardPatientAccountStatus = {
+  text: 'While Preview Guard is active, patient accounts are created by findmydoc staff.',
+  variant: 'info' as const,
+}
+
 export default async function LoginPage({
   searchParams: searchParamsPromise,
 }: {
   searchParams?: Promise<{ message?: string; next?: string }>
 }) {
   const resolvedSearchParams = await searchParamsPromise
+  const requestHeaders = await headers()
   const messageKey = resolvedSearchParams?.message
-  const statusMessage = messageKey ? patientLoginMessages[messageKey] : undefined
-  const isPreview = isPreviewRuntime()
+  const isPreviewGuardActive = requestHeaders.get(PREVIEW_GUARD_ACTIVE_REQUEST_HEADER) === '1'
+  const statusMessage =
+    (messageKey ? patientLoginMessages[messageKey] : undefined) ??
+    (isPreviewGuardActive ? previewGuardPatientAccountStatus : undefined)
   const postLoginRedirectPath = sanitizeInternalRedirectPath({
     nextPath: resolvedSearchParams?.next,
-    fallbackPath: isPreview ? '/patient/favorites' : '/',
+    fallbackPath: isPreviewGuardActive ? '/patient/favorites' : '/',
     blockedPaths: [PATIENT_LOGIN_PATH],
   })
 
@@ -50,18 +61,14 @@ export default async function LoginPage({
           <LoginForm.SubmitButton>Sign in</LoginForm.SubmitButton>
         </LoginForm.Form>
         <LoginForm.Footer>
-          {isPreview ? (
-            <p className="text-sm text-muted-foreground">
-              In Preview, patient accounts are created by findmydoc staff.
-            </p>
-          ) : (
+          {!isPreviewGuardActive ? (
             <p className="text-sm text-muted-foreground">
               Don&apos;t have an account?{' '}
               <Link href="/register/patient" className="text-primary hover:underline">
                 Register here
               </Link>
             </p>
-          )}
+          ) : null}
           <p className="text-sm text-muted-foreground">
             <Link href="/" className="text-primary hover:underline">
               ← Back to home

--- a/src/app/(frontend)/login/patient/page.tsx
+++ b/src/app/(frontend)/login/patient/page.tsx
@@ -51,7 +51,9 @@ export default async function LoginPage({
         </LoginForm.Form>
         <LoginForm.Footer>
           {isPreview ? (
-            <p className="text-sm text-muted-foreground">Patient accounts are created by findmydoc staff.</p>
+            <p className="text-sm text-muted-foreground">
+              In Preview, patient accounts are created by findmydoc staff.
+            </p>
           ) : (
             <p className="text-sm text-muted-foreground">
               Don&apos;t have an account?{' '}

--- a/src/app/(frontend)/login/patient/page.tsx
+++ b/src/app/(frontend)/login/patient/page.tsx
@@ -5,6 +5,7 @@ import {
 import { AuthFlashStatus } from '@/app/(frontend)/_components/AuthFlashStatus'
 import * as LoginForm from '@/components/organisms/Auth/LoginForm'
 import { PATIENT_LOGIN_PATH } from '@/features/favorites/redirects'
+import { isPreviewRuntime } from '@/features/runtimePolicy'
 import { sanitizeInternalRedirectPath } from '@/utilities/routing/sanitizeInternalRedirectPath'
 import Link from 'next/link'
 
@@ -23,9 +24,10 @@ export default async function LoginPage({
   const resolvedSearchParams = await searchParamsPromise
   const messageKey = resolvedSearchParams?.message
   const statusMessage = messageKey ? patientLoginMessages[messageKey] : undefined
+  const isPreview = isPreviewRuntime()
   const postLoginRedirectPath = sanitizeInternalRedirectPath({
     nextPath: resolvedSearchParams?.next,
-    fallbackPath: '/',
+    fallbackPath: isPreview ? '/patient/favorites' : '/',
     blockedPaths: [PATIENT_LOGIN_PATH],
   })
 
@@ -48,12 +50,16 @@ export default async function LoginPage({
           <LoginForm.SubmitButton>Sign in</LoginForm.SubmitButton>
         </LoginForm.Form>
         <LoginForm.Footer>
-          <p className="text-sm text-muted-foreground">
-            Don&apos;t have an account?{' '}
-            <Link href="/register/patient" className="text-primary hover:underline">
-              Register here
-            </Link>
-          </p>
+          {isPreview ? (
+            <p className="text-sm text-muted-foreground">Patient accounts are created by findmydoc staff.</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Don&apos;t have an account?{' '}
+              <Link href="/register/patient" className="text-primary hover:underline">
+                Register here
+              </Link>
+            </p>
+          )}
           <p className="text-sm text-muted-foreground">
             <Link href="/" className="text-primary hover:underline">
               ← Back to home

--- a/src/app/(frontend)/register/patient/page.tsx
+++ b/src/app/(frontend)/register/patient/page.tsx
@@ -3,8 +3,14 @@ import {
   PublicAuthRouteShell,
 } from '@/app/(frontend)/_components/PublicAuthRouteShell'
 import { PatientRegistrationForm } from '@/components/organisms/Auth/PatientRegistrationForm'
+import { isPreviewRuntime } from '@/features/runtimePolicy'
+import { redirect } from 'next/navigation'
 
 export default async function PatientRegistrationPage() {
+  if (isPreviewRuntime()) {
+    redirect('/admin/collections/patients/create')
+  }
+
   return (
     <PublicAuthRouteShell>
       <PatientRegistrationForm containerClassName={PUBLIC_AUTH_FORM_CONTAINER_CLASSNAME} />

--- a/src/app/(frontend)/register/patient/page.tsx
+++ b/src/app/(frontend)/register/patient/page.tsx
@@ -3,11 +3,14 @@ import {
   PublicAuthRouteShell,
 } from '@/app/(frontend)/_components/PublicAuthRouteShell'
 import { PatientRegistrationForm } from '@/components/organisms/Auth/PatientRegistrationForm'
-import { isPreviewRuntime } from '@/features/runtimePolicy'
+import { PREVIEW_GUARD_ACTIVE_REQUEST_HEADER } from '@/features/previewGuard'
+import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 
 export default async function PatientRegistrationPage() {
-  if (isPreviewRuntime()) {
+  const requestHeaders = await headers()
+
+  if (requestHeaders.get(PREVIEW_GUARD_ACTIVE_REQUEST_HEADER) === '1') {
     redirect('/admin/collections/patients/create')
   }
 

--- a/src/app/api/auth/register/patient/route.ts
+++ b/src/app/api/auth/register/patient/route.ts
@@ -4,6 +4,7 @@ import { normalizeEmail } from '@/auth/utilities/emailNormalization'
 import { createAdminClient, createClient } from '@/auth/utilities/supaBaseServer'
 import configPromise from '@/payload.config'
 import { hashLogValue, toLoggedError } from '@/utilities/logging/shared'
+import { isPreviewRuntime } from '@/features/runtimePolicy'
 import type { User } from '@supabase/supabase-js'
 import { getPayload } from 'payload'
 
@@ -20,6 +21,10 @@ const bodySchema = z.object({
 const isObfuscatedExistingUser = (user: User): boolean => Array.isArray(user.identities) && user.identities.length === 0
 
 export async function POST(request: Request) {
+  if (isPreviewRuntime()) {
+    return NextResponse.json({ error: 'Patient accounts are created by platform staff in preview.' }, { status: 403 })
+  }
+
   const payloadClient = await getPayload({ config: configPromise })
 
   try {

--- a/src/app/api/auth/register/patient/route.ts
+++ b/src/app/api/auth/register/patient/route.ts
@@ -4,7 +4,7 @@ import { normalizeEmail } from '@/auth/utilities/emailNormalization'
 import { createAdminClient, createClient } from '@/auth/utilities/supaBaseServer'
 import configPromise from '@/payload.config'
 import { hashLogValue, toLoggedError } from '@/utilities/logging/shared'
-import { isPreviewRuntime } from '@/features/runtimePolicy'
+import { PREVIEW_GUARD_ACTIVE_REQUEST_HEADER } from '@/features/previewGuard'
 import type { User } from '@supabase/supabase-js'
 import { getPayload } from 'payload'
 
@@ -21,8 +21,11 @@ const bodySchema = z.object({
 const isObfuscatedExistingUser = (user: User): boolean => Array.isArray(user.identities) && user.identities.length === 0
 
 export async function POST(request: Request) {
-  if (isPreviewRuntime()) {
-    return NextResponse.json({ error: 'Patient accounts are created by platform staff in preview.' }, { status: 403 })
+  if (request.headers.get(PREVIEW_GUARD_ACTIVE_REQUEST_HEADER) === '1') {
+    return NextResponse.json(
+      { error: 'Patient accounts are created by platform staff while Preview Guard is active.' },
+      { status: 403 },
+    )
   }
 
   const payloadClient = await getPayload({ config: configPromise })

--- a/src/features/previewGuard/README.md
+++ b/src/features/previewGuard/README.md
@@ -5,7 +5,7 @@
 - Provide a temporary in-app guard for preview deployments when external deployment protection is unavailable.
 - Restrict general frontend pages to platform staff sessions.
 - Keep the patient login, recovery, invitation, and patient-owned route flow available for Preview QA.
-- Keep patient account creation staff-managed through the Payload Admin.
+- Keep patient account creation staff-managed through the Payload Admin while the guard is enabled.
 - Keep the code default off unless the server-side PostHog flag `preview-guard-enabled` evaluates to enabled.
 - Let PostHog decide where the guard is active; missing PostHog evaluation keeps the code default off.
 
@@ -22,7 +22,7 @@
 - Platform users: Supabase users with `app_metadata.user_type === "platform"` may access all guarded routes.
 - Patient users: Supabase users with `app_metadata.user_type === "patient"` may access `/patient` and `/patient/**`.
 - Anonymous patient-route requests are redirected to `/login/patient` with a safe internal `next` path.
-- `/register/patient` is not exempt. In Preview, patient creation is redirected to the staff-only Payload Admin form and the public registration API rejects direct submissions.
+- `/register/patient` is not exempt. While Preview Guard is enabled, patient creation is redirected to the staff-only Payload Admin form and the public registration API rejects direct submissions.
 - Unauthorized users are redirected to `/admin/login?message=preview-login-required&next=...`.
 
 ## Related Auth Flow

--- a/src/features/previewGuard/README.md
+++ b/src/features/previewGuard/README.md
@@ -3,7 +3,9 @@
 ## Purpose
 
 - Provide a temporary in-app guard for preview deployments when external deployment protection is unavailable.
-- Restrict access to frontend pages to platform staff sessions only.
+- Restrict general frontend pages to platform staff sessions.
+- Keep the patient login, recovery, invitation, and patient-owned route flow available for Preview QA.
+- Keep patient account creation staff-managed through the Payload Admin.
 - Keep the code default off unless the server-side PostHog flag `preview-guard-enabled` evaluates to enabled.
 - Let PostHog decide where the guard is active; missing PostHog evaluation keeps the code default off.
 
@@ -16,8 +18,11 @@
 ## Behavior
 
 - When enabled by PostHog, guard applies to frontend page routes matched by `src/proxy.ts`.
-- Exempt routes: `/admin/login`.
-- Allowed users: Supabase users with `app_metadata.user_type === "platform"`.
+- Exempt routes: `/admin/login`, `/login/patient`, `/logout`, and the exact callback, confirmation, invite, and password-reset routes.
+- Platform users: Supabase users with `app_metadata.user_type === "platform"` may access all guarded routes.
+- Patient users: Supabase users with `app_metadata.user_type === "patient"` may access `/patient` and `/patient/**`.
+- Anonymous patient-route requests are redirected to `/login/patient` with a safe internal `next` path.
+- `/register/patient` is not exempt. In Preview, patient creation is redirected to the staff-only Payload Admin form and the public registration API rejects direct submissions.
 - Unauthorized users are redirected to `/admin/login?message=preview-login-required&next=...`.
 
 ## Related Auth Flow

--- a/src/features/previewGuard/index.ts
+++ b/src/features/previewGuard/index.ts
@@ -4,9 +4,11 @@ import { isPreviewRuntime, resolveServerRuntimeEnvironment } from '@/features/ru
 import { sanitizeInternalRedirectPath } from '@/utilities/routing/sanitizeInternalRedirectPath'
 
 export const PREVIEW_GUARD_LOCK_REQUEST_HEADER = 'x-preview-guard-lock'
+export const PREVIEW_GUARD_ACTIVE_REQUEST_HEADER = 'x-preview-guard-active'
 export const PREVIEW_GUARD_LOGIN_REQUIRED_MESSAGE_KEY = 'preview-login-required'
 export const PREVIEW_GUARD_LOGIN_PATH = '/admin/login'
 export const PREVIEW_GUARD_FALLBACK_REDIRECT = '/admin'
+export const PREVIEW_GUARD_PATIENT_REGISTRATION_API_PATH = '/api/auth/register/patient'
 
 const PREVIEW_GUARD_EXEMPT_PATHS = new Set([
   PREVIEW_GUARD_LOGIN_PATH,
@@ -46,6 +48,9 @@ export const isPreviewGuardPatientPath = (pathname: string): boolean => {
   const normalizedPath = normalizePathname(pathname)
   return normalizedPath === '/patient' || normalizedPath.startsWith('/patient/')
 }
+
+export const isPreviewGuardPatientRegistrationApiPath = (pathname: string): boolean =>
+  normalizePathname(pathname) === PREVIEW_GUARD_PATIENT_REGISTRATION_API_PATH
 
 export const isAllowedPreviewUser = (user: UserTypeCarrier): boolean => {
   const userType = user?.app_metadata?.user_type

--- a/src/features/previewGuard/index.ts
+++ b/src/features/previewGuard/index.ts
@@ -1,4 +1,5 @@
 import type { User } from '@supabase/supabase-js'
+import { buildPatientLoginHref } from '@/features/favorites/redirects'
 import { isPreviewRuntime, resolveServerRuntimeEnvironment } from '@/features/runtimePolicy'
 import { sanitizeInternalRedirectPath } from '@/utilities/routing/sanitizeInternalRedirectPath'
 
@@ -7,7 +8,16 @@ export const PREVIEW_GUARD_LOGIN_REQUIRED_MESSAGE_KEY = 'preview-login-required'
 export const PREVIEW_GUARD_LOGIN_PATH = '/admin/login'
 export const PREVIEW_GUARD_FALLBACK_REDIRECT = '/admin'
 
-const PREVIEW_GUARD_EXEMPT_PATHS = new Set([PREVIEW_GUARD_LOGIN_PATH, '/logout'])
+const PREVIEW_GUARD_EXEMPT_PATHS = new Set([
+  PREVIEW_GUARD_LOGIN_PATH,
+  '/auth/callback',
+  '/auth/confirm',
+  '/auth/invite/complete',
+  '/auth/password/reset',
+  '/auth/password/reset/complete',
+  '/login/patient',
+  '/logout',
+])
 
 type DeploymentEnvInput = Pick<NodeJS.ProcessEnv, 'DEPLOYMENT_ENV' | 'NODE_ENV' | 'VERCEL_ENV'>
 type UserTypeCarrier = Pick<User, 'app_metadata'> | null
@@ -32,9 +42,19 @@ export const isNonProductionDeployment = (env: DeploymentEnvInput = process.env)
 export const isPreviewGuardExemptPath = (pathname: string): boolean =>
   PREVIEW_GUARD_EXEMPT_PATHS.has(normalizePathname(pathname))
 
+export const isPreviewGuardPatientPath = (pathname: string): boolean => {
+  const normalizedPath = normalizePathname(pathname)
+  return normalizedPath === '/patient' || normalizedPath.startsWith('/patient/')
+}
+
 export const isAllowedPreviewUser = (user: UserTypeCarrier): boolean => {
   const userType = user?.app_metadata?.user_type
   return typeof userType === 'string' && userType.trim().toLowerCase() === 'platform'
+}
+
+export const isAllowedPreviewPatient = (user: UserTypeCarrier): boolean => {
+  const userType = user?.app_metadata?.user_type
+  return typeof userType === 'string' && userType.trim().toLowerCase() === 'patient'
 }
 
 export const buildPreviewGuardLoginRedirect = (url: URL): string => {
@@ -45,6 +65,11 @@ export const buildPreviewGuardLoginRedirect = (url: URL): string => {
   })
 
   return `${PREVIEW_GUARD_LOGIN_PATH}?${params.toString()}`
+}
+
+export const buildPreviewGuardPatientLoginRedirect = (url: URL): string => {
+  const nextPath = `${url.pathname}${url.search || ''}` || '/patient/favorites'
+  return buildPatientLoginHref(nextPath)
 }
 
 export const sanitizePreviewGuardNextPath = (nextPath: string | null | undefined): string => {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,8 +3,11 @@ import { type NextRequest, NextResponse } from 'next/server'
 
 import {
   buildPreviewGuardLoginRedirect,
+  buildPreviewGuardPatientLoginRedirect,
+  isAllowedPreviewPatient,
   isAllowedPreviewUser,
   isPreviewGuardExemptPath,
+  isPreviewGuardPatientPath,
   PREVIEW_GUARD_LOCK_REQUEST_HEADER,
 } from '@/features/previewGuard'
 import {
@@ -146,10 +149,23 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
 
   const user = await getPreviewUser(request)
   const isPlatformUser = isAllowedPreviewUser(user)
+  const isPatientUser = isAllowedPreviewPatient(user)
+  const isPatientPath = isPreviewGuardPatientPath(pathname)
 
   if (temporaryLandingModeEnabled && !isPlatformUser) {
     if (isTemporaryLandingRootPath(pathname) || isTemporaryLandingPublicExemptPath(pathname)) {
       return withSearchRobotsHeader(nextWithTemporaryLandingHeaders(request))
+    }
+
+    if (previewGuardEnabled && isPatientPath) {
+      if (isPatientUser) {
+        return withSearchRobotsHeader(nextWithGuardLockHeader(request))
+      }
+
+      const redirectTarget = user
+        ? buildPreviewGuardLoginRedirect(request.nextUrl)
+        : buildPreviewGuardPatientLoginRedirect(request.nextUrl)
+      return withSearchRobotsHeader(NextResponse.redirect(new URL(redirectTarget, request.url)))
     }
 
     if (previewGuardEnabled && isTemporaryLandingModeExemptPath(pathname)) {
@@ -174,6 +190,17 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
 
   if (isPlatformUser) {
     return withSearchRobotsHeader(NextResponse.next())
+  }
+
+  if (isPatientPath) {
+    if (isPatientUser) {
+      return withSearchRobotsHeader(NextResponse.next())
+    }
+
+    const redirectTarget = user
+      ? buildPreviewGuardLoginRedirect(request.nextUrl)
+      : buildPreviewGuardPatientLoginRedirect(request.nextUrl)
+    return withSearchRobotsHeader(NextResponse.redirect(new URL(redirectTarget, request.url)))
   }
 
   if (isPreviewGuardExemptPath(pathname)) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,6 +8,8 @@ import {
   isAllowedPreviewUser,
   isPreviewGuardExemptPath,
   isPreviewGuardPatientPath,
+  isPreviewGuardPatientRegistrationApiPath,
+  PREVIEW_GUARD_ACTIVE_REQUEST_HEADER,
   PREVIEW_GUARD_LOCK_REQUEST_HEADER,
 } from '@/features/previewGuard'
 import {
@@ -70,7 +72,7 @@ const isFirstAdminBootstrapPath = (pathname: string): boolean => {
 }
 
 const shouldBypassProxy = (pathname: string): boolean => {
-  if (pathname.startsWith('/api')) return true
+  if (pathname.startsWith('/api') && !isPreviewGuardPatientRegistrationApiPath(pathname)) return true
   if (pathname.startsWith('/_next')) return true
   if (isPublicAssetPath(pathname)) return true
   return false
@@ -101,9 +103,14 @@ const getPreviewUser = async (request: NextRequest) => {
   return user
 }
 
-const nextWithRequestHeaders = (request: NextRequest, headersToSet: Record<string, string>): NextResponse => {
+const nextWithRequestHeaders = (request: NextRequest, headersToSet: Record<string, string | null>): NextResponse => {
   const requestHeaders = new Headers(request.headers)
   Object.entries(headersToSet).forEach(([key, value]) => {
+    if (value === null) {
+      requestHeaders.delete(key)
+      return
+    }
+
     requestHeaders.set(key, value)
   })
 
@@ -115,13 +122,32 @@ const withSearchRobotsHeader = (response: NextResponse): NextResponse => {
   return response
 }
 
+const nextWithGuardActiveHeader = (request: NextRequest): NextResponse =>
+  nextWithRequestHeaders(request, {
+    [PREVIEW_GUARD_ACTIVE_REQUEST_HEADER]: '1',
+    [PREVIEW_GUARD_LOCK_REQUEST_HEADER]: null,
+    [TEMPORARY_LANDING_MODE_REQUEST_HEADER]: null,
+  })
+
 const nextWithGuardLockHeader = (request: NextRequest): NextResponse =>
-  nextWithRequestHeaders(request, { [PREVIEW_GUARD_LOCK_REQUEST_HEADER]: '1' })
+  nextWithRequestHeaders(request, {
+    [PREVIEW_GUARD_ACTIVE_REQUEST_HEADER]: '1',
+    [PREVIEW_GUARD_LOCK_REQUEST_HEADER]: '1',
+    [TEMPORARY_LANDING_MODE_REQUEST_HEADER]: null,
+  })
 
 const nextWithTemporaryLandingHeaders = (request: NextRequest): NextResponse =>
   nextWithRequestHeaders(request, {
+    [PREVIEW_GUARD_ACTIVE_REQUEST_HEADER]: null,
     [PREVIEW_GUARD_LOCK_REQUEST_HEADER]: '1',
     [TEMPORARY_LANDING_MODE_REQUEST_HEADER]: '1',
+  })
+
+const nextWithoutGuardHeaders = (request: NextRequest): NextResponse =>
+  nextWithRequestHeaders(request, {
+    [PREVIEW_GUARD_ACTIVE_REQUEST_HEADER]: null,
+    [PREVIEW_GUARD_LOCK_REQUEST_HEADER]: null,
+    [TEMPORARY_LANDING_MODE_REQUEST_HEADER]: null,
   })
 
 export async function proxy(request: NextRequest): Promise<NextResponse> {
@@ -144,7 +170,11 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   const previewGuardEnabled = flags.isEnabled('preview-guard-enabled')
 
   if (!previewGuardEnabled && !temporaryLandingModeEnabled) {
-    return NextResponse.next()
+    return nextWithoutGuardHeaders(request)
+  }
+
+  if (isPreviewGuardPatientRegistrationApiPath(pathname)) {
+    return previewGuardEnabled ? nextWithGuardActiveHeader(request) : nextWithoutGuardHeaders(request)
   }
 
   const user = await getPreviewUser(request)
@@ -185,16 +215,16 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   }
 
   if (!previewGuardEnabled) {
-    return withSearchRobotsHeader(NextResponse.next())
+    return withSearchRobotsHeader(nextWithoutGuardHeaders(request))
   }
 
   if (isPlatformUser) {
-    return withSearchRobotsHeader(NextResponse.next())
+    return withSearchRobotsHeader(nextWithGuardActiveHeader(request))
   }
 
   if (isPatientPath) {
     if (isPatientUser) {
-      return withSearchRobotsHeader(NextResponse.next())
+      return withSearchRobotsHeader(nextWithGuardActiveHeader(request))
     }
 
     const redirectTarget = user
@@ -212,5 +242,5 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
 }
 
 export const config = {
-  matcher: ['/((?!api|_next/static|_next/image|_next/data).*)'],
+  matcher: ['/api/auth/register/patient', '/((?!api|_next/static|_next/image|_next/data).*)'],
 }

--- a/tests/unit/api/patientRegistration.route.test.ts
+++ b/tests/unit/api/patientRegistration.route.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { POST } from '@/app/api/auth/register/patient/route'
+import { PREVIEW_GUARD_ACTIVE_REQUEST_HEADER } from '@/features/previewGuard'
 
 const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() }
 
@@ -35,11 +36,14 @@ vi.mock('@/auth/utilities/supaBaseServer', () => ({
   createClient: createClientMock,
 }))
 
-function makeRequest(body: unknown) {
+function makeRequest(body: unknown, { previewGuardActive = false }: { previewGuardActive?: boolean } = {}) {
   return new Request('http://localhost/api/auth/register/patient', {
     method: 'POST',
     body: JSON.stringify(body),
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      ...(previewGuardActive ? { [PREVIEW_GUARD_ACTIVE_REQUEST_HEADER]: '1' } : {}),
+    },
   })
 }
 
@@ -51,15 +55,7 @@ const validBody = {
 }
 
 describe('POST /api/auth/register/patient', () => {
-  const originalEnv = process.env
-
   beforeEach(() => {
-    process.env = {
-      ...originalEnv,
-      DEPLOYMENT_ENV: undefined,
-      VERCEL_ENV: undefined,
-      NODE_ENV: 'test',
-    }
     vi.clearAllMocks()
     signupClient.auth.signUp.mockResolvedValue({
       data: {
@@ -75,18 +71,12 @@ describe('POST /api/auth/register/patient', () => {
     adminClient.auth.admin.updateUserById.mockResolvedValue({ data: {}, error: null })
   })
 
-  afterEach(() => {
-    process.env = originalEnv
-  })
-
-  test('rejects direct patient self-registration in preview', async () => {
-    process.env.VERCEL_ENV = 'preview'
-
-    const response = await POST(makeRequest(validBody))
+  test('rejects direct patient self-registration while Preview Guard is active', async () => {
+    const response = await POST(makeRequest(validBody, { previewGuardActive: true }))
 
     expect(response.status).toBe(403)
     await expect(response.json()).resolves.toEqual({
-      error: 'Patient accounts are created by platform staff in preview.',
+      error: 'Patient accounts are created by platform staff while Preview Guard is active.',
     })
     expect(createClientMock).not.toHaveBeenCalled()
     expect(createAdminClientMock).not.toHaveBeenCalled()

--- a/tests/unit/api/patientRegistration.route.test.ts
+++ b/tests/unit/api/patientRegistration.route.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { POST } from '@/app/api/auth/register/patient/route'
 
 const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() }
@@ -51,7 +51,15 @@ const validBody = {
 }
 
 describe('POST /api/auth/register/patient', () => {
+  const originalEnv = process.env
+
   beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      DEPLOYMENT_ENV: undefined,
+      VERCEL_ENV: undefined,
+      NODE_ENV: 'test',
+    }
     vi.clearAllMocks()
     signupClient.auth.signUp.mockResolvedValue({
       data: {
@@ -65,6 +73,23 @@ describe('POST /api/auth/register/patient', () => {
       error: null,
     })
     adminClient.auth.admin.updateUserById.mockResolvedValue({ data: {}, error: null })
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  test('rejects direct patient self-registration in preview', async () => {
+    process.env.VERCEL_ENV = 'preview'
+
+    const response = await POST(makeRequest(validBody))
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Patient accounts are created by platform staff in preview.',
+    })
+    expect(createClientMock).not.toHaveBeenCalled()
+    expect(createAdminClientMock).not.toHaveBeenCalled()
   })
 
   test('creates a patient signup and sets app metadata server-side', async () => {

--- a/tests/unit/app/frontend/auth/invite/complete/InviteCompleteForm.test.tsx
+++ b/tests/unit/app/frontend/auth/invite/complete/InviteCompleteForm.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { InviteCompleteForm } from '@/app/(frontend)/auth/invite/complete/InviteCompleteForm'
@@ -93,5 +93,30 @@ describe('InviteCompleteForm', () => {
       expect(passwordInput).toBeEnabled()
     })
     expect(routerMock.replace).not.toHaveBeenCalled()
+  })
+
+  it('links invited patients to the patient login after setting their password', async () => {
+    supabaseAuthMock.getSession.mockResolvedValueOnce({
+      data: {
+        session: {
+          user: {
+            app_metadata: { user_type: 'patient' },
+          },
+        },
+      },
+    })
+
+    render(<InviteCompleteForm />)
+
+    const passwordInput = await screen.findByLabelText('New password')
+    const confirmationInput = screen.getByLabelText('Confirm password')
+    await waitFor(() => expect(passwordInput).toBeEnabled())
+
+    fireEvent.change(passwordInput, { target: { value: 'PatientPass123' } })
+    fireEvent.change(confirmationInput, { target: { value: 'PatientPass123' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Set password' }))
+
+    const signInLink = await screen.findByRole('link', { name: 'Return to sign in' })
+    expect(signInLink).toHaveAttribute('href', '/login/patient')
   })
 })

--- a/tests/unit/app/frontend/patient/login/page.test.tsx
+++ b/tests/unit/app/frontend/patient/login/page.test.tsx
@@ -96,6 +96,6 @@ describe('Patient LoginPage', () => {
 
     expect(loginRoot?.props.redirectPath).toBe('/patient/favorites')
     expect(containsHref(result, '/register/patient')).toBe(false)
-    expect(containsText(result, 'Patient accounts are created by findmydoc staff.')).toBe(true)
+    expect(containsText(result, 'In Preview, patient accounts are created by findmydoc staff.')).toBe(true)
   })
 })

--- a/tests/unit/app/frontend/patient/login/page.test.tsx
+++ b/tests/unit/app/frontend/patient/login/page.test.tsx
@@ -1,8 +1,23 @@
 import React from 'react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 ;(globalThis as unknown as { React: typeof React }).React = React
 
 describe('Patient LoginPage', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      DEPLOYMENT_ENV: undefined,
+      VERCEL_ENV: undefined,
+      NODE_ENV: 'development',
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
   type LoginRootElement = React.ReactElement<{ redirectPath: string; children: React.ReactNode }>
 
   const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
@@ -19,6 +34,22 @@ describe('Patient LoginPage', () => {
     }
 
     return null
+  }
+
+  const containsHref = (node: React.ReactNode, href: string): boolean => {
+    if (!React.isValidElement(node)) return false
+    if (isObjectRecord(node.props) && node.props.href === href) return true
+
+    const children = isObjectRecord(node.props) ? node.props.children : undefined
+    return React.Children.toArray(children as React.ReactNode).some((child) => containsHref(child, href))
+  }
+
+  const containsText = (node: React.ReactNode, text: string): boolean => {
+    if (typeof node === 'string') return node.includes(text)
+    if (!React.isValidElement(node)) return false
+
+    const children = isObjectRecord(node.props) ? node.props.children : undefined
+    return React.Children.toArray(children as React.ReactNode).some((child) => containsText(child, text))
   }
 
   const getLoginPage = async () => {
@@ -50,5 +81,21 @@ describe('Patient LoginPage', () => {
     const loginRoot = findLoginRootElement(result)
 
     expect(loginRoot?.props.redirectPath).toBe('/')
+  })
+
+  it('falls back to patient favorites and hides self-registration in preview', async () => {
+    process.env.VERCEL_ENV = 'preview'
+    const LoginPage = await getLoginPage()
+
+    const result = await LoginPage({
+      searchParams: Promise.resolve({
+        next: '//evil.example.com',
+      }),
+    })
+    const loginRoot = findLoginRootElement(result)
+
+    expect(loginRoot?.props.redirectPath).toBe('/patient/favorites')
+    expect(containsHref(result, '/register/patient')).toBe(false)
+    expect(containsText(result, 'Patient accounts are created by findmydoc staff.')).toBe(true)
   })
 })

--- a/tests/unit/app/frontend/patient/login/page.test.tsx
+++ b/tests/unit/app/frontend/patient/login/page.test.tsx
@@ -1,6 +1,14 @@
 import React from 'react'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 ;(globalThis as unknown as { React: typeof React }).React = React
+
+import { PREVIEW_GUARD_ACTIVE_REQUEST_HEADER } from '@/features/previewGuard'
+
+const headersMock = vi.hoisted(() => vi.fn(async () => new Headers()))
+
+vi.mock('next/headers', () => ({
+  headers: headersMock,
+}))
 
 describe('Patient LoginPage', () => {
   const originalEnv = process.env
@@ -12,6 +20,7 @@ describe('Patient LoginPage', () => {
       VERCEL_ENV: undefined,
       NODE_ENV: 'development',
     }
+    headersMock.mockResolvedValue(new Headers())
   })
 
   afterEach(() => {
@@ -52,6 +61,14 @@ describe('Patient LoginPage', () => {
     return React.Children.toArray(children as React.ReactNode).some((child) => containsText(child, text))
   }
 
+  const containsMessage = (node: React.ReactNode, message: string): boolean => {
+    if (!React.isValidElement(node)) return false
+    if (isObjectRecord(node.props) && node.props.message === message) return true
+
+    const children = isObjectRecord(node.props) ? node.props.children : undefined
+    return React.Children.toArray(children as React.ReactNode).some((child) => containsMessage(child, message))
+  }
+
   const getLoginPage = async () => {
     const pageModule = await import('@/app/(frontend)/login/patient/page')
     return pageModule.default
@@ -83,8 +100,13 @@ describe('Patient LoginPage', () => {
     expect(loginRoot?.props.redirectPath).toBe('/')
   })
 
-  it('falls back to patient favorites and hides self-registration in preview', async () => {
-    process.env.VERCEL_ENV = 'preview'
+  it('uses guard-active fallback and messaging independently of the deployment environment', async () => {
+    process.env.VERCEL_ENV = 'production'
+    headersMock.mockResolvedValue(
+      new Headers({
+        [PREVIEW_GUARD_ACTIVE_REQUEST_HEADER]: '1',
+      }),
+    )
     const LoginPage = await getLoginPage()
 
     const result = await LoginPage({
@@ -96,6 +118,24 @@ describe('Patient LoginPage', () => {
 
     expect(loginRoot?.props.redirectPath).toBe('/patient/favorites')
     expect(containsHref(result, '/register/patient')).toBe(false)
-    expect(containsText(result, 'In Preview, patient accounts are created by findmydoc staff.')).toBe(true)
+    expect(
+      containsMessage(result, 'While Preview Guard is active, patient accounts are created by findmydoc staff.'),
+    ).toBe(true)
+    expect(containsText(result, 'While Preview Guard is active')).toBe(false)
+  })
+
+  it('keeps public registration visible when Preview Guard is inactive in Preview', async () => {
+    process.env.VERCEL_ENV = 'preview'
+    const LoginPage = await getLoginPage()
+
+    const result = await LoginPage({
+      searchParams: Promise.resolve({
+        next: '//evil.example.com',
+      }),
+    })
+    const loginRoot = findLoginRootElement(result)
+
+    expect(loginRoot?.props.redirectPath).toBe('/')
+    expect(containsHref(result, '/register/patient')).toBe(true)
   })
 })

--- a/tests/unit/app/frontend/patient/register/page.test.tsx
+++ b/tests/unit/app/frontend/patient/register/page.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+;(globalThis as unknown as { React: typeof React }).React = React
+
+const redirectMock = vi.hoisted(() =>
+  vi.fn((destination: string) => {
+    throw Object.assign(new Error('NEXT_REDIRECT'), { destination })
+  }),
+)
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}))
+
+describe('PatientRegistrationPage', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      DEPLOYMENT_ENV: undefined,
+      VERCEL_ENV: undefined,
+      NODE_ENV: 'development',
+    }
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  const getRegistrationPage = async () => {
+    const pageModule = await import('@/app/(frontend)/register/patient/page')
+    return pageModule.default
+  }
+
+  it('redirects preview patient creation to the staff-only Payload form', async () => {
+    process.env.VERCEL_ENV = 'preview'
+    const PatientRegistrationPage = await getRegistrationPage()
+
+    await expect(PatientRegistrationPage()).rejects.toThrow('NEXT_REDIRECT')
+    expect(redirectMock).toHaveBeenCalledWith('/admin/collections/patients/create')
+  })
+
+  it('keeps production patient self-registration unchanged', async () => {
+    process.env.VERCEL_ENV = 'production'
+    const PatientRegistrationPage = await getRegistrationPage()
+
+    const result = await PatientRegistrationPage()
+
+    expect(React.isValidElement(result)).toBe(true)
+    expect(redirectMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/app/frontend/patient/register/page.test.tsx
+++ b/tests/unit/app/frontend/patient/register/page.test.tsx
@@ -1,32 +1,28 @@
 import React from 'react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 ;(globalThis as unknown as { React: typeof React }).React = React
+
+import { PREVIEW_GUARD_ACTIVE_REQUEST_HEADER } from '@/features/previewGuard'
 
 const redirectMock = vi.hoisted(() =>
   vi.fn((destination: string) => {
     throw Object.assign(new Error('NEXT_REDIRECT'), { destination })
   }),
 )
+const headersMock = vi.hoisted(() => vi.fn(async () => new Headers()))
 
 vi.mock('next/navigation', () => ({
   redirect: redirectMock,
 }))
 
+vi.mock('next/headers', () => ({
+  headers: headersMock,
+}))
+
 describe('PatientRegistrationPage', () => {
-  const originalEnv = process.env
-
   beforeEach(() => {
-    process.env = {
-      ...originalEnv,
-      DEPLOYMENT_ENV: undefined,
-      VERCEL_ENV: undefined,
-      NODE_ENV: 'development',
-    }
     vi.clearAllMocks()
-  })
-
-  afterEach(() => {
-    process.env = originalEnv
+    headersMock.mockResolvedValue(new Headers())
   })
 
   const getRegistrationPage = async () => {
@@ -34,16 +30,19 @@ describe('PatientRegistrationPage', () => {
     return pageModule.default
   }
 
-  it('redirects preview patient creation to the staff-only Payload form', async () => {
-    process.env.VERCEL_ENV = 'preview'
+  it('redirects patient creation to the staff-only Payload form when Preview Guard is active', async () => {
+    headersMock.mockResolvedValue(
+      new Headers({
+        [PREVIEW_GUARD_ACTIVE_REQUEST_HEADER]: '1',
+      }),
+    )
     const PatientRegistrationPage = await getRegistrationPage()
 
     await expect(PatientRegistrationPage()).rejects.toThrow('NEXT_REDIRECT')
     expect(redirectMock).toHaveBeenCalledWith('/admin/collections/patients/create')
   })
 
-  it('keeps production patient self-registration unchanged', async () => {
-    process.env.VERCEL_ENV = 'production'
+  it('keeps public patient self-registration when Preview Guard is inactive', async () => {
     const PatientRegistrationPage = await getRegistrationPage()
 
     const result = await PatientRegistrationPage()

--- a/tests/unit/app/frontend/previewLock.middleware.test.ts
+++ b/tests/unit/app/frontend/previewLock.middleware.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 
-import { PREVIEW_GUARD_LOCK_REQUEST_HEADER } from '@/features/previewGuard'
+import {
+  PREVIEW_GUARD_ACTIVE_REQUEST_HEADER,
+  PREVIEW_GUARD_LOCK_REQUEST_HEADER,
+  PREVIEW_GUARD_PATIENT_REGISTRATION_API_PATH,
+} from '@/features/previewGuard'
 import { SEARCH_ROBOTS_HEADER, SEARCH_ROBOTS_HEADER_VALUE } from '@/features/searchIndexing'
 import { TEMPORARY_LANDING_MODE_REQUEST_HEADER } from '@/features/temporaryLandingMode'
 
@@ -243,6 +247,7 @@ describe('preview lock proxy', () => {
 
       expect(response.status).toBe(200)
       expect(response.headers.get('location')).toBeNull()
+      expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_ACTIVE_REQUEST_HEADER}`)).toBe('1')
       expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBe('1')
       expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
     }
@@ -258,6 +263,20 @@ describe('preview lock proxy', () => {
     expect(response.status).toBe(307)
     expect(location).toContain('/admin/login')
     expect(location).toContain('next=%2Fregister%2Fpatient')
+  })
+
+  it('forwards the active guard state to staff opening patient registration', async () => {
+    mockGuardFlags({ 'preview-guard-enabled': true })
+    mocks.getUser.mockResolvedValue({
+      data: { user: { id: 'platform-1', app_metadata: { user_type: 'platform' } } },
+      error: null,
+    })
+
+    const response = await proxy(new NextRequest('https://findmydoc.eu/register/patient'))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('location')).toBeNull()
+    expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_ACTIVE_REQUEST_HEADER}`)).toBe('1')
   })
 
   it('redirects anonymous patient routes to the patient login with a safe next path', async () => {
@@ -286,6 +305,7 @@ describe('preview lock proxy', () => {
 
     expect(patientResponse.status).toBe(200)
     expect(patientResponse.headers.get('location')).toBeNull()
+    expect(patientResponse.headers.get(`x-middleware-request-${PREVIEW_GUARD_ACTIVE_REQUEST_HEADER}`)).toBe('1')
     expect(patientResponse.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
 
     expect(adminResponse.status).toBe(307)
@@ -562,6 +582,39 @@ describe('preview lock proxy', () => {
     expect(mocks.logCrawlerRequest).not.toHaveBeenCalled()
   })
 
+  it('forwards the active Preview Guard state to the patient registration API', async () => {
+    mockGuardFlags({ 'preview-guard-enabled': true })
+    const request = new NextRequest(`https://preview.findmydoc.eu${PREVIEW_GUARD_PATIENT_REGISTRATION_API_PATH}`, {
+      method: 'POST',
+    })
+
+    const response = await proxy(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_ACTIVE_REQUEST_HEADER}`)).toBe('1')
+    expect(mocks.evaluatePostHogFlags).toHaveBeenCalledTimes(1)
+    expect(mocks.createServerClient).not.toHaveBeenCalled()
+  })
+
+  it('removes spoofed guard headers when Preview Guard is inactive', async () => {
+    const request = new NextRequest(`https://preview.findmydoc.eu${PREVIEW_GUARD_PATIENT_REGISTRATION_API_PATH}`, {
+      method: 'POST',
+      headers: {
+        [PREVIEW_GUARD_ACTIVE_REQUEST_HEADER]: '1',
+        [PREVIEW_GUARD_LOCK_REQUEST_HEADER]: '1',
+        [TEMPORARY_LANDING_MODE_REQUEST_HEADER]: '1',
+      },
+    })
+
+    const response = await proxy(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_ACTIVE_REQUEST_HEADER}`)).toBeNull()
+    expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBeNull()
+    expect(response.headers.get(`x-middleware-request-${TEMPORARY_LANDING_MODE_REQUEST_HEADER}`)).toBeNull()
+    expect(mocks.createServerClient).not.toHaveBeenCalled()
+  })
+
   it('bypasses known public assets before evaluating PostHog flags', async () => {
     process.env.DEPLOYMENT_ENV = 'preview'
     mockGuardFlags({ 'preview-guard-enabled': true })
@@ -602,6 +655,7 @@ describe('preview lock proxy', () => {
   })
 
   it('matcher excludes API and Next internals without excluding all dotted content paths', () => {
+    expect(config.matcher).toContain(PREVIEW_GUARD_PATIENT_REGISTRATION_API_PATH)
     expect(config.matcher).toContain('/((?!api|_next/static|_next/image|_next/data).*)')
     expect(config.matcher.join(' ')).not.toContain('.*\\..*')
   })

--- a/tests/unit/app/frontend/previewLock.middleware.test.ts
+++ b/tests/unit/app/frontend/previewLock.middleware.test.ts
@@ -224,6 +224,88 @@ describe('preview lock proxy', () => {
     expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
   })
 
+  it('keeps the exact patient auth lifecycle reachable without a staff session', async () => {
+    process.env.DEPLOYMENT_ENV = 'preview'
+    mockGuardFlags({ 'preview-guard-enabled': true })
+
+    const allowedPaths = [
+      '/login/patient',
+      '/auth/password/reset',
+      '/auth/callback',
+      '/auth/confirm?type=recovery',
+      '/auth/password/reset/complete',
+      '/auth/invite/complete',
+      '/logout',
+    ]
+
+    for (const path of allowedPaths) {
+      const response = await proxy(new NextRequest(`https://preview.findmydoc.eu${path}`))
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('location')).toBeNull()
+      expect(response.headers.get(`x-middleware-request-${PREVIEW_GUARD_LOCK_REQUEST_HEADER}`)).toBe('1')
+      expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
+    }
+  })
+
+  it('keeps patient self-registration behind the staff preview guard', async () => {
+    process.env.DEPLOYMENT_ENV = 'preview'
+    mockGuardFlags({ 'preview-guard-enabled': true })
+
+    const response = await proxy(new NextRequest('https://preview.findmydoc.eu/register/patient'))
+    const location = response.headers.get('location')
+
+    expect(response.status).toBe(307)
+    expect(location).toContain('/admin/login')
+    expect(location).toContain('next=%2Fregister%2Fpatient')
+  })
+
+  it('redirects anonymous patient routes to the patient login with a safe next path', async () => {
+    process.env.DEPLOYMENT_ENV = 'preview'
+    mockGuardFlags({ 'preview-guard-enabled': true })
+
+    const response = await proxy(new NextRequest('https://preview.findmydoc.eu/patient/favorites?from=account-menu'))
+    const location = response.headers.get('location')
+
+    expect(response.status).toBe(307)
+    expect(location).toContain('/login/patient')
+    expect(location).toContain('next=%2Fpatient%2Ffavorites%3Ffrom%3Daccount-menu')
+    expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
+  })
+
+  it('allows patient sessions only on patient routes', async () => {
+    process.env.DEPLOYMENT_ENV = 'preview'
+    mockGuardFlags({ 'preview-guard-enabled': true })
+    mocks.getUser.mockResolvedValue({
+      data: { user: { id: 'patient-1', app_metadata: { user_type: 'patient' } } },
+      error: null,
+    })
+
+    const patientResponse = await proxy(new NextRequest('https://preview.findmydoc.eu/patient/favorites'))
+    const adminResponse = await proxy(new NextRequest('https://preview.findmydoc.eu/admin'))
+
+    expect(patientResponse.status).toBe(200)
+    expect(patientResponse.headers.get('location')).toBeNull()
+    expect(patientResponse.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
+
+    expect(adminResponse.status).toBe(307)
+    expect(adminResponse.headers.get('location')).toContain('/admin/login')
+  })
+
+  it('does not grant clinic sessions access to patient routes', async () => {
+    process.env.DEPLOYMENT_ENV = 'preview'
+    mockGuardFlags({ 'preview-guard-enabled': true })
+    mocks.getUser.mockResolvedValue({
+      data: { user: { id: 'clinic-1', app_metadata: { user_type: 'clinic' } } },
+      error: null,
+    })
+
+    const response = await proxy(new NextRequest('https://preview.findmydoc.eu/patient/favorites'))
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toContain('/admin/login')
+  })
+
   it('returns 404 for first-admin bootstrap paths before preview guard redirects', async () => {
     process.env.DEPLOYMENT_ENV = 'preview'
     mockGuardFlags({ 'preview-guard-enabled': true })
@@ -445,6 +527,28 @@ describe('preview lock proxy', () => {
     expect(location).toContain('message=preview-login-required')
     expect(response.headers.get(`x-middleware-request-${TEMPORARY_LANDING_MODE_REQUEST_HEADER}`)).toBeNull()
     expect(response.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
+  })
+
+  it('keeps patient login and patient routes usable when both guards are active', async () => {
+    process.env.DEPLOYMENT_ENV = 'preview'
+    mockGuardFlags({ 'preview-guard-enabled': true, 'temporary-landing-mode': true })
+
+    const loginResponse = await proxy(new NextRequest('https://preview.findmydoc.eu/login/patient'))
+    const anonymousPatientResponse = await proxy(new NextRequest('https://preview.findmydoc.eu/patient/favorites'))
+
+    mocks.getUser.mockResolvedValue({
+      data: { user: { id: 'patient-2', app_metadata: { user_type: 'patient' } } },
+      error: null,
+    })
+    const authenticatedPatientResponse = await proxy(new NextRequest('https://preview.findmydoc.eu/patient/favorites'))
+
+    expect(loginResponse.status).toBe(200)
+    expect(loginResponse.headers.get('location')).toBeNull()
+    expect(anonymousPatientResponse.status).toBe(307)
+    expect(anonymousPatientResponse.headers.get('location')).toContain('/login/patient')
+    expect(authenticatedPatientResponse.status).toBe(200)
+    expect(authenticatedPatientResponse.headers.get('location')).toBeNull()
+    expect(authenticatedPatientResponse.headers.get(SEARCH_ROBOTS_HEADER)).toBe(SEARCH_ROBOTS_HEADER_VALUE)
   })
 
   it('bypasses API routes before evaluating PostHog flags', async () => {

--- a/tests/unit/features/previewGuard/index.test.ts
+++ b/tests/unit/features/previewGuard/index.test.ts
@@ -10,6 +10,7 @@ import {
   isPreviewDeployment,
   isPreviewGuardExemptPath,
   isPreviewGuardPatientPath,
+  isPreviewGuardPatientRegistrationApiPath,
   PREVIEW_GUARD_FALLBACK_REDIRECT,
   PREVIEW_GUARD_LOGIN_PATH,
   PREVIEW_GUARD_LOGIN_REQUIRED_MESSAGE_KEY,
@@ -123,6 +124,13 @@ describe('previewGuard feature', () => {
     expect(isPreviewGuardPatientPath('/patient/favorites')).toBe(true)
     expect(isPreviewGuardPatientPath('/patients')).toBe(false)
     expect(isPreviewGuardPatientPath('/patient-support')).toBe(false)
+  })
+
+  it('recognizes only the patient registration API path', () => {
+    expect(isPreviewGuardPatientRegistrationApiPath('/api/auth/register/patient')).toBe(true)
+    expect(isPreviewGuardPatientRegistrationApiPath('/api/auth/register/patient/')).toBe(true)
+    expect(isPreviewGuardPatientRegistrationApiPath('/api/auth/register/patients')).toBe(false)
+    expect(isPreviewGuardPatientRegistrationApiPath('/register/patient')).toBe(false)
   })
 
   it('builds preview guard login redirect with message and next path', () => {

--- a/tests/unit/features/previewGuard/index.test.ts
+++ b/tests/unit/features/previewGuard/index.test.ts
@@ -3,10 +3,13 @@ import { type User } from '@supabase/supabase-js'
 
 import {
   buildPreviewGuardLoginRedirect,
+  buildPreviewGuardPatientLoginRedirect,
+  isAllowedPreviewPatient,
   isAllowedPreviewUser,
   isNonProductionDeployment,
   isPreviewDeployment,
   isPreviewGuardExemptPath,
+  isPreviewGuardPatientPath,
   PREVIEW_GUARD_FALLBACK_REDIRECT,
   PREVIEW_GUARD_LOGIN_PATH,
   PREVIEW_GUARD_LOGIN_REQUIRED_MESSAGE_KEY,
@@ -62,23 +65,47 @@ describe('previewGuard feature', () => {
   })
 
   it('recognizes preview guard exempt paths', () => {
-    expect(isPreviewGuardExemptPath('/admin/login')).toBe(true)
+    const exemptPaths = [
+      '/admin/login',
+      '/auth/callback',
+      '/auth/confirm',
+      '/auth/invite/complete',
+      '/auth/password/reset',
+      '/auth/password/reset/complete',
+      '/login/patient',
+      '/logout',
+    ]
+
+    for (const path of exemptPaths) {
+      expect(isPreviewGuardExemptPath(path)).toBe(true)
+      expect(isPreviewGuardExemptPath(`${path}/`)).toBe(true)
+    }
+
     expect(isPreviewGuardExemptPath('/admin/first-admin/')).toBe(false)
-    expect(isPreviewGuardExemptPath('/logout')).toBe(true)
+    expect(isPreviewGuardExemptPath('/auth/password/reset-help')).toBe(false)
+    expect(isPreviewGuardExemptPath('/register/patient')).toBe(false)
     expect(isPreviewGuardExemptPath('/posts')).toBe(false)
   })
 
-  it('allows only platform users', () => {
+  it('keeps platform and patient access roles separate', () => {
     const platformUser = {
       app_metadata: { user_type: 'platform' },
+    } as Pick<User, 'app_metadata'>
+    const patientUser = {
+      app_metadata: { user_type: 'patient' },
     } as Pick<User, 'app_metadata'>
     const clinicUser = {
       app_metadata: { user_type: 'clinic' },
     } as Pick<User, 'app_metadata'>
 
     expect(isAllowedPreviewUser(platformUser)).toBe(true)
+    expect(isAllowedPreviewPatient(platformUser)).toBe(false)
+    expect(isAllowedPreviewUser(patientUser)).toBe(false)
+    expect(isAllowedPreviewPatient(patientUser)).toBe(true)
     expect(isAllowedPreviewUser(clinicUser)).toBe(false)
+    expect(isAllowedPreviewPatient(clinicUser)).toBe(false)
     expect(isAllowedPreviewUser(null)).toBe(false)
+    expect(isAllowedPreviewPatient(null)).toBe(false)
   })
 
   it('returns false for malformed user_type values without throwing', () => {
@@ -87,6 +114,15 @@ describe('previewGuard feature', () => {
     } as unknown as Pick<User, 'app_metadata'>
 
     expect(isAllowedPreviewUser(malformedUser)).toBe(false)
+    expect(isAllowedPreviewPatient(malformedUser)).toBe(false)
+  })
+
+  it('recognizes only the patient route family', () => {
+    expect(isPreviewGuardPatientPath('/patient')).toBe(true)
+    expect(isPreviewGuardPatientPath('/patient/')).toBe(true)
+    expect(isPreviewGuardPatientPath('/patient/favorites')).toBe(true)
+    expect(isPreviewGuardPatientPath('/patients')).toBe(false)
+    expect(isPreviewGuardPatientPath('/patient-support')).toBe(false)
   })
 
   it('builds preview guard login redirect with message and next path', () => {
@@ -96,6 +132,16 @@ describe('previewGuard feature', () => {
     expect(url.pathname).toBe(PREVIEW_GUARD_LOGIN_PATH)
     expect(url.searchParams.get('message')).toBe(PREVIEW_GUARD_LOGIN_REQUIRED_MESSAGE_KEY)
     expect(url.searchParams.get('next')).toBe('/posts/a?foo=bar')
+  })
+
+  it('builds a patient login redirect with the protected route as next path', () => {
+    const redirectPath = buildPreviewGuardPatientLoginRedirect(
+      new URL('https://example.com/patient/favorites?from=header'),
+    )
+    const url = new URL(redirectPath, 'https://example.com')
+
+    expect(url.pathname).toBe('/login/patient')
+    expect(url.searchParams.get('next')).toBe('/patient/favorites?from=header')
   })
 
   it('keeps valid relative redirect paths', () => {


### PR DESCRIPTION
## Management summary

### Deutsch

Patienten können sich bei aktivem Preview Guard selbst einloggen, Einladungen abschließen und ihr Passwort zurücksetzen, ohne dass parallel ein Staff-Login nötig ist. Neue Patientenkonten werden in diesem Zustand bewusst nur durch eingeloggte findmydoc-Mitarbeiter angelegt. Ist der Guard aus, bleibt die öffentliche Patientenregistrierung unabhängig von der Deployment-Umgebung unverändert verfügbar.

### English

While Preview Guard is active, patients can sign in, complete invitations, and reset their password without requiring a parallel staff session. New patient accounts are intentionally created only by signed-in findmydoc staff in that state. When the guard is disabled, public patient registration remains available regardless of the deployment environment.

## What changed

- Expanded the Preview Guard's exact auth exemptions for patient login, invitation completion, callbacks, confirmation, password recovery, and logout.
- Added a role-scoped Preview boundary: platform staff retain full access, while patient sessions can access only `/patient` and `/patient/**`.
- Propagated the actual `preview-guard-enabled` decision from the proxy to guarded patient pages and the registration API; patient policy no longer depends on `VERCEL_ENV`.
- Redirected patient registration to the staff-only Payload Admin form and rejected direct registration API submissions only while Preview Guard is active.
- Moved the guarded account-creation notice above the login form as the primary status message.
- Routed successful invitation completion back to the correct role-specific login.
- Documented the guard-dependent account-creation policy and added focused regression coverage.
- Cache impact classification: `no-public-impact`; private auth routes remain live and public self-registration/cache behavior is unchanged while the guard is disabled.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/proxy.ts`, `src/features/previewGuard/index.ts` | The role-to-route boundary and propagated guard state control protected access. | Platform users keep full access; patients reach only patient routes; clinic and unknown sessions gain no additional access; internal guard headers cannot be spoofed; exact auth routes stay reachable. | Focused middleware and helper tests |
| P1 | `src/app/(frontend)/register/patient/page.tsx`, `src/app/api/auth/register/patient/route.ts` | Account creation must require staff only when the guard is active. | Guard-active requests redirect to Payload Admin and direct API submissions fail closed; guard-inactive requests retain the existing public flow in every deployment environment. | Focused page/API tests |
| P2 | `src/app/(frontend)/auth/invite/complete/**` | Invitation completion previously returned every role to staff login. | Patient invitations now return to patient login while platform and clinic destinations retain their role-specific behavior. | Focused invitation-completion tests |
| P2 | `src/app/(frontend)/login/patient/page.tsx` | Guard-dependent copy and fallback affect the patient entry point. | The staff-created status appears above the form and the registration CTA is hidden only while the guard is active. | Unit test and Playwright viewport QA |

## Validation

- [x] `pnpm format`: passed with the repository Node 24 toolchain.
- [x] `pnpm check`: passed.
- [x] `pnpm build`: passed against the local PostgreSQL development database.
- [x] Focused tests: original auth/Preview suite passed across 12 files and 111 tests; the guard-state follow-up passed across 5 files and 63 tests. `pnpm tests:sense-check` also passed across 381 test files.
- [x] UI/mobile QA: guard-active patient login checked in Chromium at 320×568, 375×667, 375×500, 640×800, 768×900, and 1024×900; no horizontal overflow, console errors, clipped form content, or obstructed actions found.
- [x] Security/privacy review: specialist review completed. The existing ensure-on-auth behavior and anonymous registration redirect explanation were explicitly accepted as out of scope for this fix.
- [x] Accessibility review: specialist review completed; the selected status-placement finding is fixed. The anonymous registration redirect explanation was explicitly accepted as out of scope.
- [x] Mobile, cache, and SEO reviews: completed; no additional fix-before-handoff finding was selected. Cache classification remains `no-public-impact`.
- [x] Migration/schema check: no schema, migration, data backfill, or Supabase configuration change.
- [x] Documentation/instructions check: Preview Guard auth policy updated in feature and authentication documentation; no instruction files changed.

## Risk and rollout

The primary risk is an incorrect role, route, or propagated guard-state classification. Focused tests cover anonymous, platform, patient, clinic, guard-active, guard-inactive, Preview-runtime, Production-runtime, spoofed-header, and combined Temporary Landing Mode behavior. No environment variable, database schema, migration, cache invalidation, or public self-registration change while the guard is disabled is required. Rollback is limited to the commits in this pull request.

## Development

Closes #1609
