### PR TITLE
fix(deps): deduplicate dependency lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7241,10 +7241,6 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
@@ -8175,7 +8171,7 @@ snapshots:
       open: 8.4.2
       picomatch: 4.0.5
       systeminformation: 5.31.14
-      undici: 7.28.0
+      undici: 7.29.0
       which: 4.0.0
       yocto-spinner: 1.2.1
 
@@ -11118,11 +11114,11 @@ snapshots:
 
   acorn-loose@8.5.2:
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   acorn-walk@8.3.5:
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   acorn@8.16.0: {}
 
@@ -13005,7 +13001,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -14634,7 +14630,7 @@ snapshots:
       tailwind-merge: 3.6.0
       ts-morph: 26.0.0
       tsconfig-paths: 4.2.0
-      undici: 7.28.0
+      undici: 7.29.0
       validate-npm-package-name: 7.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
@@ -15181,8 +15177,6 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@7.24.6: {}
-
-  undici@7.28.0: {}
 
   undici@7.29.0: {}
 


### PR DESCRIPTION
## Management summary

### Deutsch

Die nächtliche Qualitätsprüfung läuft wieder ohne den bekannten Lockfile-Fehler. Dadurch bleibt die Abhängigkeitsprüfung auf dem Hauptzweig verlässlich und echte Probleme werden nicht durch veraltete Auflösungen verdeckt.

### English

The nightly quality check no longer fails on the known lockfile issue. This keeps dependency validation on the main branch reliable and prevents stale resolutions from obscuring real problems.

## What changed

- Deduplicated the committed `pnpm-lock.yaml`.
- Consolidated the existing `undici` and `acorn` resolutions to the versions selected by pnpm's current dependency graph.
- No application source, runtime configuration, or dependency declarations changed.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `pnpm-lock.yaml` | The scheduled Deep Quality Lane failed on lockfile drift. | Verify that only deduplication changes are present and the committed graph is stable. | Local `pnpm deps:dedupe:check` passes; run `30243995615` failed before this fix. |

## Validation

- [x] `pnpm format`: passed; no formatting changes.
- [x] `pnpm check`: passed.
- [ ] `pnpm build`: not run; lockfile-only change with no build-relevant source changes.
- [x] Focused tests: `pnpm deps:dedupe:check` and `pnpm deps:audit` passed; audit reported 0 high and 0 critical vulnerabilities.
- [ ] UI/mobile QA: not applicable; no UI changes.
- [x] Security/privacy review: dependency audit passed; existing moderate Dependabot alert #163 remains outside this lockfile-only fix.
- [ ] Migration/schema check: not applicable; no schema or migration changes.
- [ ] Documentation/instructions check: not applicable; no documentation or instruction changes.

## Risk and rollout

No application behavior or runtime dependency declaration changes. The change only records the already selected transitive resolutions in the lockfile. Revert the commit to roll back.

## Development

Closes #1613
