### PR TITLE
fix: normalize doctor relationship ids

### DIFF
--- a/src/collections/DoctorMedia/hooks/beforeChangeDoctorMedia.ts
+++ b/src/collections/DoctorMedia/hooks/beforeChangeDoctorMedia.ts
@@ -19,7 +19,7 @@ export const beforeChangeDoctorMedia: CollectionBeforeChangeHook<DoctorMedia> = 
   }
 
   const doctorId = Number(incomingDoctorId)
-  if (!Number.isFinite(doctorId)) {
+  if (!Number.isSafeInteger(doctorId) || doctorId <= 0) {
     throw new Error('Doctor id must be numeric')
   }
 
@@ -39,7 +39,7 @@ export const beforeChangeDoctorMedia: CollectionBeforeChangeHook<DoctorMedia> = 
     userCollections: ['platformStaff', 'clinicStaff'],
   })
 
-  draft.doctor = draft.doctor ?? doctorId
+  draft.doctor = doctorId
 
   const clinicId = await getDoctorClinicId(doctorId, req.payload)
 

--- a/src/collections/DoctorSpecialties.ts
+++ b/src/collections/DoctorSpecialties.ts
@@ -1,13 +1,29 @@
 // src/collections/DoctorSpecialties.ts
-import { CollectionConfig } from 'payload'
+import type { CollectionBeforeChangeHook, CollectionConfig } from 'payload'
 import { anyone } from '@/access/anyone'
 import { isClinicStaff } from '@/access/isClinicStaff'
 import { isPlatformStaff } from '@/access/isPlatformStaff'
 import { platformOrAssignedClinicMutation, platformOrOwnClinicDoctorResource } from '@/access/scopeFilters'
 import { getUserAssignedClinicId } from '@/access/utils/getClinicAssignment'
+import { extractRelationId } from '@/collections/common/mediaPathHelpers'
 import { stableIdBeforeChangeHook, stableIdField } from '@/collections/common/stableIdField'
 import { beforeChangeEnforceDoctorInAssignedClinic } from '@/hooks/clinicOwnership'
 import { revalidateDoctorSpecialtyChange, revalidateDoctorSpecialtyDelete } from '@/hooks/revalidateClinicSurfaces'
+
+const beforeChangeNormalizeMedicalSpecialty: CollectionBeforeChangeHook = ({ data }) => {
+  const draft = { ...(data || {}) } as Record<string, unknown>
+  const specialtyId = extractRelationId(
+    draft.medicalSpecialty as string | number | { id?: string | number; value?: string | number } | null,
+  )
+  if (!specialtyId) return draft
+
+  const numericSpecialtyId = Number(specialtyId)
+  if (Number.isSafeInteger(numericSpecialtyId) && numericSpecialtyId > 0) {
+    draft.medicalSpecialty = numericSpecialtyId
+  }
+
+  return draft
+}
 
 export const DoctorSpecialties: CollectionConfig = {
   slug: 'doctorspecialties',
@@ -28,7 +44,11 @@ export const DoctorSpecialties: CollectionConfig = {
     delete: isPlatformStaff, // Only Platform can delete
   },
   hooks: {
-    beforeChange: [stableIdBeforeChangeHook, beforeChangeEnforceDoctorInAssignedClinic({ doctorField: 'doctor' })],
+    beforeChange: [
+      stableIdBeforeChangeHook,
+      beforeChangeNormalizeMedicalSpecialty,
+      beforeChangeEnforceDoctorInAssignedClinic({ doctorField: 'doctor' }),
+    ],
     afterChange: [revalidateDoctorSpecialtyChange],
     afterDelete: [revalidateDoctorSpecialtyDelete],
   },

--- a/src/hooks/doctorProfileImageOwnership.ts
+++ b/src/hooks/doctorProfileImageOwnership.ts
@@ -85,5 +85,10 @@ export const beforeChangeValidateDoctorProfileImage: CollectionBeforeChangeHook<
     })
   }
 
+  const numericProfileImageId = Number(profileImageId)
+  if (profileImageSubmitted && Number.isSafeInteger(numericProfileImageId) && numericProfileImageId > 0) {
+    draft.profileImage = numericProfileImageId
+  }
+
   return draft
 }

--- a/tests/integration/doctorMedia.lifecycle.test.ts
+++ b/tests/integration/doctorMedia.lifecycle.test.ts
@@ -63,7 +63,7 @@ describe('DoctorMedia integration - lifecycle', () => {
       collection: 'doctorMedia',
       data: {
         alt: 'Doctor headshot',
-        doctor: doctor.id,
+        doctor: String(doctor.id) as unknown as number,
       } as Partial<DoctorMedia>,
       file: createTinyPngFile(`${slugPrefix}-doctor.png`),
       user: asStaffPayloadUser(staffUser),
@@ -75,6 +75,7 @@ describe('DoctorMedia integration - lifecycle', () => {
 
     expect(created.createdBy).toEqual({ relationTo: 'clinicStaff', value: staffUser.id })
     expect(created.clinic).toBe(clinic.id)
+    expect(created.doctor).toBe(doctor.id)
     expect(created.storagePath).toMatch(new RegExp(`^doctors/${doctor.id}-[a-f0-9]{10}-.+\\.png$`))
   })
 

--- a/tests/integration/doctorSpecialties.lifecycle.test.ts
+++ b/tests/integration/doctorSpecialties.lifecycle.test.ts
@@ -396,8 +396,8 @@ describe('DoctorSpecialties lifecycle integration', () => {
     const ownDoctorSpecialty = (await payload.create({
       collection: 'doctorspecialties',
       data: {
-        doctor: ownDoctor.id,
-        medicalSpecialty: medicalSpecialtyId,
+        doctor: String(ownDoctor.id) as unknown as number,
+        medicalSpecialty: String(medicalSpecialtyId) as unknown as number,
         specializationLevel: 'advanced',
       } as unknown as Doctorspecialty,
       user: clinicUser,
@@ -406,6 +406,8 @@ describe('DoctorSpecialties lifecycle integration', () => {
     })) as Doctorspecialty
 
     createdDoctorSpecialtyIds.push(ownDoctorSpecialty.id)
+    expect(ownDoctorSpecialty.doctor).toBe(ownDoctor.id)
+    expect(ownDoctorSpecialty.medicalSpecialty).toBe(medicalSpecialtyId)
 
     const updatedOwnDoctorSpecialty = (await payload.update({
       collection: 'doctorspecialties',

--- a/tests/integration/doctors.lifecycle.test.ts
+++ b/tests/integration/doctors.lifecycle.test.ts
@@ -128,7 +128,7 @@ describe('Doctors lifecycle integration', () => {
     const assigned = (await payload.update({
       collection: 'doctors',
       id: doctorA.id,
-      data: { profileImage: mediaA.id },
+      data: { profileImage: String(mediaA.id) as unknown as number },
       user: platformUser,
       overrideAccess: false,
       depth: 0,


### PR DESCRIPTION
## Management summary

### Deutsch

Arztprofile aus dem Klinik-Dashboard können Profilbilder und vorhandene medizinische Fachgebiete wieder zuverlässig speichern. Bereits bestehende Profile und ihre öffentlichen Darstellungen bleiben unverändert.

### English

Doctor profiles from the clinic dashboard can once again save profile photos and existing medical specialties reliably. Existing profiles and their public presentation remain unchanged.

## What changed

- Normalizes numeric string relationship IDs at the three affected Website boundaries: `DoctorMedia.doctor`, `DoctorSpecialties.medicalSpecialty`, and `Doctors.profileImage`.
- Keeps the existing clinic ownership and doctor/media validation hooks authoritative; no access rule is bypassed or broadened.
- Extends the existing lifecycle integration tests with Dashboard-shaped numeric string inputs and verifies that Payload stores numeric relationships.

## Points to review

| Priority | Files / paths                                                                                                           | Why focus here                                                            | Reviewer should verify                                                            | Evidence                                            |
| -------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------- |
| P1       | `src/collections/DoctorMedia/hooks/beforeChangeDoctorMedia.ts`, `src/hooks/doctorProfileImageOwnership.ts`              | These hooks protect doctor/media ownership while normalizing input types. | Normalization occurs without trusting client clinic data or weakening ownership.  | Focused integration tests and security review.      |
| P2       | `src/collections/DoctorSpecialties.ts`, `tests/integration/doctorSpecialties.lifecycle.test.ts`                         | Specialty selection uses an existing reviewed catalogue relationship.     | Numeric string IDs become numeric relationships before the existing clinic hook. | Focused lifecycle test with a numeric string input. |

## Validation

- [x] `pnpm format`: completed successfully.
- [x] `pnpm check`: completed successfully.
- [x] `pnpm build`: completed successfully against the local Docker test database.
- [x] Focused tests: 29 Doctor, DoctorMedia, and DoctorSpecialties integration tests passed.
- [ ] UI/mobile QA: not applicable; this PR changes server-side relationship normalization only.
- [x] Security/privacy review: read-only security review found no credible finding at or above 5/10.
- [x] Migration/schema check: no schema change or migration is required.
- [x] Documentation/instructions check: no durable documentation or instruction change is required.

## Risk and rollout

Cache impact is `public-cached`. Existing Doctor and DoctorSpecialty invalidation ownership, Clinic Detail dependencies, and read/write symmetry remain unchanged; no new cache tag or stop condition is introduced. No environment, schema, or data migration is required. Rollback is the normal commit revert.

## Development

Closes #1616
