### PR TITLE
fix: keep media storage keys stable

### DIFF
--- a/src/hooks/media/computeStorage.ts
+++ b/src/hooks/media/computeStorage.ts
@@ -55,7 +55,8 @@ export function computeStorage({
   overwriteFilename?: (op: 'create' | 'update', draft: Record<string, unknown>) => boolean
   ownerRequired?: boolean
 }): { filename?: string; storagePath?: string } {
-  const incomingFileSize = extractFileSizeFromRequest(req)
+  const isInternalCloudStorageUpdate = operation === 'update' && req?.context?.skipCloudStorage === true
+  const incomingFileSize = isInternalCloudStorageUpdate ? undefined : extractFileSizeFromRequest(req)
   const hasIncomingUpload = typeof incomingFileSize === 'number'
   const logger = req
     ? createScopedLogger(req.payload.logger as ServerLogger, {
@@ -65,6 +66,17 @@ export function computeStorage({
     : null
 
   type RelationInput = Parameters<typeof extractRelationId>[0]
+
+  if (isInternalCloudStorageUpdate) {
+    const existingStoragePath =
+      typeof originalDoc?.storagePath === 'string'
+        ? originalDoc.storagePath
+        : typeof draft.storagePath === 'string'
+          ? draft.storagePath
+          : null
+
+    return existingStoragePath ? { storagePath: existingStoragePath } : {}
+  }
 
   const ownerRelation =
     extractRelationId((draft as Record<string, unknown>)?.[ownerField] as RelationInput) ??

--- a/src/hooks/media/prepareUploadFilename.ts
+++ b/src/hooks/media/prepareUploadFilename.ts
@@ -162,6 +162,11 @@ async function prepareUploadFile(file: UploadFileLike, fallbackFilename: string 
 export const beforeOperationPrepareUploadFilename: CollectionBeforeOperationHook = async ({ args, operation, req }) => {
   if (operation !== 'create' && operation !== 'update') return args
 
+  req.context = req.context ?? {}
+  if (req.context.skipCloudStorage === true || typeof req.context[PREPARED_UPLOAD_FILENAME_CONTEXT_KEY] === 'string') {
+    return args
+  }
+
   const recordArgs = args as Record<string, unknown> | undefined
   const uploadFiles = getUploadFiles(recordArgs, req)
   const fallbackFilename =
@@ -170,7 +175,6 @@ export const beforeOperationPrepareUploadFilename: CollectionBeforeOperationHook
 
   if (uploadFiles.length === 0) return args
 
-  req.context = req.context ?? {}
   const preparedNames: string[] = []
 
   for (const file of uploadFiles) {

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -86,6 +86,7 @@ export default buildConfig({
     abortOnLimit: true,
     responseOnLimit: MEDIA_UPLOAD_TOO_LARGE_MESSAGE,
     safeFileNames: true,
+    preserveExtension: true,
   },
   endpoints: [
     {

--- a/tests/unit/hooks/computeStorage.test.ts
+++ b/tests/unit/hooks/computeStorage.test.ts
@@ -45,6 +45,43 @@ describe('computeStorage', () => {
     expect(result).toEqual({ storagePath: 'platform/draft-asset.png' })
   })
 
+  it('ignores stale request files during internal cloud-storage updates', () => {
+    const req = createReq({
+      context: {
+        skipCloudStorage: true,
+      },
+      files: {
+        file: [
+          {
+            name: 'second-hash-original.png',
+            size: 321,
+          },
+        ],
+      },
+    } as unknown as Partial<PayloadRequest>)
+
+    const result = computeStorage({
+      operation: 'update',
+      draft: {
+        filename: 'first-hash-original.png',
+        storagePath: 'platform/untrusted-path.png',
+      },
+      originalDoc: {
+        filename: 'first-hash-original.png',
+        storagePath: 'platform/first-hash-original.png',
+      },
+      req,
+      key: { type: 'hash' },
+      storagePrefix: 'platform',
+      ownerField: 'platformOwner',
+      ownerRequired: false,
+    })
+
+    expect(result).toEqual({
+      storagePath: 'platform/first-hash-original.png',
+    })
+  })
+
   it('derives a stable fallback hash when a field key is missing on create', () => {
     const result = computeStorage({
       operation: 'create',

--- a/tests/unit/hooks/prepareUploadFilename.test.ts
+++ b/tests/unit/hooks/prepareUploadFilename.test.ts
@@ -5,14 +5,21 @@ import path from 'path'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { PayloadRequest, SanitizedCollectionConfig } from 'payload'
 
+import { ClinicGalleryMedia } from '@/collections/ClinicGalleryMedia'
+import { ClinicMedia } from '@/collections/ClinicMedia'
+import { DoctorMedia } from '@/collections/DoctorMedia'
+import { PlatformContentMedia } from '@/collections/PlatformContentMedia'
+import { UserProfileMedia } from '@/collections/UserProfileMedia'
 import {
   beforeOperationPrepareUploadFilename,
   prepareUploadFilenameFromFilePathSync,
 } from '@/hooks/media/prepareUploadFilename'
+import { beforeOperationValidateMediaUpload } from '@/hooks/media/validateMediaUpload'
 
 const collection = {
   slug: 'clinicMedia',
 } as SanitizedCollectionConfig
+const sharedMediaCollections = [PlatformContentMedia, ClinicMedia, ClinicGalleryMedia, DoctorMedia, UserProfileMedia]
 
 function createReq(overrides: Partial<PayloadRequest> = {}): PayloadRequest {
   return {
@@ -99,5 +106,87 @@ describe('beforeOperationPrepareUploadFilename', () => {
     } as never)
 
     expect(req.context.mediaPreparedUploadFilename).toBeUndefined()
+  })
+
+  it('keeps the prepared filename stable during the internal cloud-storage update', async () => {
+    const buffer = Buffer.from('doctor portrait')
+    const uploadFile = {
+      name: 'portrait.png',
+      originalname: 'portrait.png',
+      data: buffer,
+      size: buffer.length,
+    }
+    const req = createReq({
+      file: uploadFile,
+      files: {
+        file: [uploadFile],
+      },
+    } as unknown as Partial<PayloadRequest>)
+
+    await beforeOperationPrepareUploadFilename({
+      args: { data: {} },
+      collection,
+      operation: 'create',
+      req,
+    } as never)
+
+    const expected = `${shortHash(buffer)}-portrait.png`
+    expect(uploadFile.name).toBe(expected)
+
+    req.file = undefined
+    req.context.skipCloudStorage = true
+
+    await beforeOperationPrepareUploadFilename({
+      args: { data: {} },
+      collection,
+      operation: 'update',
+      req,
+    } as never)
+
+    expect(uploadFile.name).toBe(expected)
+    expect(uploadFile.originalname).toBe(expected)
+    expect(req.context.mediaPreparedUploadFilename).toBe(expected)
+  })
+
+  it.each(sharedMediaCollections)(
+    'wires filename preparation directly after upload validation for $slug',
+    (mediaCollection) => {
+      const beforeOperationHooks = mediaCollection.hooks?.beforeOperation ?? []
+
+      expect(beforeOperationHooks).toContain(beforeOperationValidateMediaUpload)
+      expect(beforeOperationHooks).toContain(beforeOperationPrepareUploadFilename)
+      expect(beforeOperationHooks.indexOf(beforeOperationPrepareUploadFilename)).toBe(
+        beforeOperationHooks.indexOf(beforeOperationValidateMediaUpload) + 1,
+      )
+    },
+  )
+
+  it('does not hash an upload twice when the hook is invoked repeatedly for one request', async () => {
+    const buffer = Buffer.from('repeatable seed image')
+    const uploadFile = {
+      name: 'seed-image.webp',
+      data: buffer,
+      size: buffer.length,
+    }
+    const req = createReq({
+      context: {
+        seedMediaExpectedNoSuchKeyRecovery: true,
+      },
+      file: uploadFile,
+    } as unknown as Partial<PayloadRequest>)
+
+    const hookArgs = {
+      args: { data: {} },
+      collection,
+      operation: 'update',
+      req,
+    } as never
+
+    await beforeOperationPrepareUploadFilename(hookArgs)
+    await beforeOperationPrepareUploadFilename(hookArgs)
+
+    const expected = `${shortHash(buffer)}-seed-image.webp`
+    expect(uploadFile.name).toBe(expected)
+    expect(req.context.mediaPreparedUploadFilename).toBe(expected)
   })
 })


### PR DESCRIPTION
## Management summary

### Deutsch

Medien-Uploads behalten künftig dauerhaft denselben Speicherpfad, sodass Bilder nach der Verarbeitung zuverlässig erreichbar bleiben und wiederholte Upload- oder Seed-Abläufe keine abweichenden Dateiverweise erzeugen.

### English

Media uploads now retain the same storage path throughout processing, keeping images reliably accessible and preventing repeated upload or seed flows from creating inconsistent file references.

## What changed

- Skip filename and storage-path recomputation during internal cloud-storage metadata updates.
- Make upload filename preparation idempotent within one Payload request.
- Preserve uploaded file extensions globally.
- Cover the shared hook wiring across all five S3-backed media collections.
- Keep the existing seed `NoSuchKey` recovery behavior unchanged.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/hooks/media/computeStorage.ts`, `src/hooks/media/prepareUploadFilename.ts` | These hooks determine the database filename and S3 object key. | Internal storage updates preserve the original path and cannot trigger a second content hash. | Focused unit tests and five media lifecycle integration suites |
| P2 | `src/payload.config.ts` | File-extension preservation changes the global upload parser configuration. | Existing MIME validation and collection upload restrictions remain unchanged. | TypeScript check, production build, security review |

## Validation

- [x] `pnpm format`: passed
- [x] `pnpm check`: passed
- [x] `pnpm build`: passed against the local Docker test database
- [x] Focused tests: 20 media/seed unit tests and 32 lifecycle integration tests passed; the final hook-wiring test passed after review follow-up
- [ ] UI/mobile QA: not applicable; no UI or layout code changed
- [x] Security/privacy review: security and cache-architecture reviews found no issues at or above 5/10
- [x] Migration/schema check: no database migration or schema change
- [x] Documentation/instructions check: no permanent documentation change required

## Risk and rollout

Existing objects whose stored path already differs from the S3 key are intentionally not modified by this pull request. They require the separately approved copy-only repair after this fix is deployed. No source objects are deleted.

## Development

Closes #1618
