### PR TITLE
fix: harden public discovery XML parsing

### DIFF
--- a/scripts/public-discovery-health.mjs
+++ b/scripts/public-discovery-health.mjs
@@ -16,6 +16,7 @@ export const PUBLIC_DISCOVERY_HEALTH_PATHS = [
 ]
 
 const SITEMAP_PATHS = new Set(['/pages-sitemap.xml', '/posts-sitemap.xml'])
+const SITEMAP_NAMESPACE = 'http://www.sitemaps.org/schemas/sitemap/0.9'
 
 export function parseArgs(argv = process.argv.slice(2)) {
   const options = {
@@ -60,7 +61,7 @@ export function buildAbsoluteUrl(baseUrl, path) {
 export function extractSitemapLocations(xml) {
   const document = new JSDOM(xml, { contentType: 'text/xml' }).window.document
 
-  return Array.from(document.getElementsByTagNameNS('*', 'loc'))
+  return Array.from(document.getElementsByTagNameNS(SITEMAP_NAMESPACE, 'loc'))
     .map((element) => element.textContent?.trim())
     .filter((location) => typeof location === 'string' && location.length > 0)
 }

--- a/scripts/public-discovery-health.mjs
+++ b/scripts/public-discovery-health.mjs
@@ -120,7 +120,20 @@ export async function runPublicDiscoveryHealthCheck({
 
     if (!SITEMAP_PATHS.has(path)) continue
 
-    for (const location of extractSitemapLocations(text)) {
+    let locations
+    try {
+      locations = extractSitemapLocations(text)
+    } catch {
+      failures.push({
+        kind: 'sitemap-xml',
+        path,
+        status: 'invalid-xml',
+        url,
+      })
+      continue
+    }
+
+    for (const location of locations) {
       const sitemapUrl = new URL(location, baseUrl)
       const base = new URL(baseUrl)
       if (sitemapUrl.origin !== base.origin) {

--- a/scripts/public-discovery-health.mjs
+++ b/scripts/public-discovery-health.mjs
@@ -2,6 +2,8 @@
 
 import { pathToFileURL } from 'node:url'
 
+import { JSDOM } from 'jsdom'
+
 export const DEFAULT_PUBLIC_DISCOVERY_BASE_URL = 'http://localhost:3000'
 
 export const PUBLIC_DISCOVERY_HEALTH_PATHS = [
@@ -56,8 +58,10 @@ export function buildAbsoluteUrl(baseUrl, path) {
 }
 
 export function extractSitemapLocations(xml) {
-  return [...xml.matchAll(/<loc>\s*([^<]+?)\s*<\/loc>/giu)]
-    .map((match) => match[1]?.trim())
+  const document = new JSDOM(xml, { contentType: 'text/xml' }).window.document
+
+  return Array.from(document.getElementsByTagNameNS('*', 'loc'))
+    .map((element) => element.textContent?.trim())
     .filter((location) => typeof location === 'string' && location.length > 0)
 }
 

--- a/tests/tooling/scripts/public-discovery-health.test.ts
+++ b/tests/tooling/scripts/public-discovery-health.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../scripts/public-discovery-health.mjs'
 
 const createResponse = (body: string, status = 200): Response => new Response(body, { status })
+const EMPTY_SITEMAP_XML = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>'
 
 describe('public discovery health script', () => {
   it('parses base URL arguments', () => {
@@ -14,15 +15,23 @@ describe('public discovery health script', () => {
     expect(parseArgs(['--base-url=https://preview.findmydoc.eu']).baseUrl).toBe('https://preview.findmydoc.eu')
   })
 
-  it('extracts sitemap locations from XML', () => {
+  it('extracts sitemap locations from namespaced XML', () => {
     expect(
-      extractSitemapLocations(`
-        <urlset>
+      extractSitemapLocations(`<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
           <url><loc>https://findmydoc.eu/</loc></url>
           <url><loc> https://findmydoc.eu/posts/example </loc></url>
         </urlset>
       `),
     ).toEqual(['https://findmydoc.eu/', 'https://findmydoc.eu/posts/example'])
+  })
+
+  it('accepts a valid empty sitemap', () => {
+    expect(extractSitemapLocations('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>')).toEqual([])
+  })
+
+  it('rejects malformed sitemap XML', () => {
+    expect(() => extractSitemapLocations('<urlset><url><loc>https://findmydoc.eu/</url></urlset>')).toThrow()
   })
 
   it('passes when discovery endpoints and sitemap URLs are reachable', async () => {
@@ -59,6 +68,9 @@ describe('public discovery health script', () => {
       if (init?.method === 'GET' && url.endsWith('/pages-sitemap.xml')) {
         return createResponse('<urlset><url><loc>https://findmydoc.eu/missing</loc></url></urlset>')
       }
+      if (init?.method === 'GET' && url.endsWith('/posts-sitemap.xml')) {
+        return createResponse(EMPTY_SITEMAP_XML)
+      }
       if (init?.method === 'GET' && url.endsWith('/sitemap.xml')) {
         return createResponse('<sitemapindex></sitemapindex>')
       }
@@ -86,6 +98,9 @@ describe('public discovery health script', () => {
       if (init?.method === 'GET' && url.endsWith('/pages-sitemap.xml')) {
         return createResponse('<urlset><url><loc>https://findmydoc.eu/head-not-allowed</loc></url></urlset>')
       }
+      if (init?.method === 'GET' && url.endsWith('/posts-sitemap.xml')) {
+        return createResponse(EMPTY_SITEMAP_XML)
+      }
       if (init?.method === 'GET' && url.endsWith('/sitemap.xml')) {
         return createResponse('<sitemapindex></sitemapindex>')
       }
@@ -110,6 +125,9 @@ describe('public discovery health script', () => {
       const url = String(input)
       if (init?.method === 'GET' && url.endsWith('/pages-sitemap.xml')) {
         return createResponse('<urlset><url><loc>https://other.example.com/private</loc></url></urlset>')
+      }
+      if (init?.method === 'GET' && url.endsWith('/posts-sitemap.xml')) {
+        return createResponse(EMPTY_SITEMAP_XML)
       }
       return createResponse('', 200)
     })

--- a/tests/tooling/scripts/public-discovery-health.test.ts
+++ b/tests/tooling/scripts/public-discovery-health.test.ts
@@ -34,6 +34,36 @@ describe('public discovery health script', () => {
     expect(() => extractSitemapLocations('<urlset><url><loc>https://findmydoc.eu/</url></urlset>')).toThrow()
   })
 
+  it('reports malformed sitemap XML and continues checking discovery endpoints', async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      if (init?.method === 'GET' && url.endsWith('/pages-sitemap.xml')) {
+        return createResponse('<urlset><url><loc>https://findmydoc.eu/</url></urlset>')
+      }
+      if (init?.method === 'GET' && url.endsWith('/posts-sitemap.xml')) {
+        return createResponse(EMPTY_SITEMAP_XML)
+      }
+      return createResponse('', 200)
+    })
+
+    const result = await runPublicDiscoveryHealthCheck({
+      baseUrl: 'https://findmydoc.eu',
+      fetchImpl,
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.failures).toContainEqual({
+      kind: 'sitemap-xml',
+      path: '/pages-sitemap.xml',
+      status: 'invalid-xml',
+      url: 'https://findmydoc.eu/pages-sitemap.xml',
+    })
+    expect(fetchImpl).toHaveBeenCalledWith('https://findmydoc.eu/posts-sitemap.xml', {
+      method: 'GET',
+      redirect: 'follow',
+    })
+  })
+
   it('passes when discovery endpoints and sitemap URLs are reachable', async () => {
     const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = String(input)

--- a/tests/tooling/scripts/public-discovery-health.test.ts
+++ b/tests/tooling/scripts/public-discovery-health.test.ts
@@ -7,7 +7,8 @@ import {
 } from '../../../scripts/public-discovery-health.mjs'
 
 const createResponse = (body: string, status = 200): Response => new Response(body, { status })
-const EMPTY_SITEMAP_XML = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>'
+const SITEMAP_NAMESPACE = 'http://www.sitemaps.org/schemas/sitemap/0.9'
+const EMPTY_SITEMAP_XML = `<urlset xmlns="${SITEMAP_NAMESPACE}"></urlset>`
 
 describe('public discovery health script', () => {
   it('parses base URL arguments', () => {
@@ -18,9 +19,12 @@ describe('public discovery health script', () => {
   it('extracts sitemap locations from namespaced XML', () => {
     expect(
       extractSitemapLocations(`<?xml version="1.0" encoding="UTF-8"?>
-        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
           <url><loc>https://findmydoc.eu/</loc></url>
-          <url><loc> https://findmydoc.eu/posts/example </loc></url>
+          <url>
+            <loc> https://findmydoc.eu/posts/example </loc>
+            <image:image><image:loc>https://cdn.example.com/example.jpg</image:loc></image:image>
+          </url>
         </urlset>
       `),
     ).toEqual(['https://findmydoc.eu/', 'https://findmydoc.eu/posts/example'])
@@ -68,13 +72,17 @@ describe('public discovery health script', () => {
     const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = String(input)
       if (init?.method === 'GET' && url.endsWith('/pages-sitemap.xml')) {
-        return createResponse('<urlset><url><loc>https://findmydoc.eu/</loc></url></urlset>')
+        return createResponse(
+          `<urlset xmlns="${SITEMAP_NAMESPACE}"><url><loc>https://findmydoc.eu/</loc></url></urlset>`,
+        )
       }
       if (init?.method === 'GET' && url.endsWith('/sitemap.xml')) {
-        return createResponse('<sitemapindex></sitemapindex>')
+        return createResponse(`<sitemapindex xmlns="${SITEMAP_NAMESPACE}"></sitemapindex>`)
       }
       if (init?.method === 'GET' && url.endsWith('/posts-sitemap.xml')) {
-        return createResponse('<urlset><url><loc>https://findmydoc.eu/posts/example</loc></url></urlset>')
+        return createResponse(
+          `<urlset xmlns="${SITEMAP_NAMESPACE}"><url><loc>https://findmydoc.eu/posts/example</loc></url></urlset>`,
+        )
       }
       return createResponse('', 200)
     })
@@ -96,13 +104,15 @@ describe('public discovery health script', () => {
     const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = String(input)
       if (init?.method === 'GET' && url.endsWith('/pages-sitemap.xml')) {
-        return createResponse('<urlset><url><loc>https://findmydoc.eu/missing</loc></url></urlset>')
+        return createResponse(
+          `<urlset xmlns="${SITEMAP_NAMESPACE}"><url><loc>https://findmydoc.eu/missing</loc></url></urlset>`,
+        )
       }
       if (init?.method === 'GET' && url.endsWith('/posts-sitemap.xml')) {
         return createResponse(EMPTY_SITEMAP_XML)
       }
       if (init?.method === 'GET' && url.endsWith('/sitemap.xml')) {
-        return createResponse('<sitemapindex></sitemapindex>')
+        return createResponse(`<sitemapindex xmlns="${SITEMAP_NAMESPACE}"></sitemapindex>`)
       }
       if (url.endsWith('/missing')) return createResponse('', 404)
       return createResponse('', 200)
@@ -126,13 +136,15 @@ describe('public discovery health script', () => {
     const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = String(input)
       if (init?.method === 'GET' && url.endsWith('/pages-sitemap.xml')) {
-        return createResponse('<urlset><url><loc>https://findmydoc.eu/head-not-allowed</loc></url></urlset>')
+        return createResponse(
+          `<urlset xmlns="${SITEMAP_NAMESPACE}"><url><loc>https://findmydoc.eu/head-not-allowed</loc></url></urlset>`,
+        )
       }
       if (init?.method === 'GET' && url.endsWith('/posts-sitemap.xml')) {
         return createResponse(EMPTY_SITEMAP_XML)
       }
       if (init?.method === 'GET' && url.endsWith('/sitemap.xml')) {
-        return createResponse('<sitemapindex></sitemapindex>')
+        return createResponse(`<sitemapindex xmlns="${SITEMAP_NAMESPACE}"></sitemapindex>`)
       }
       if (url.endsWith('/head-not-allowed') && init?.method === 'HEAD') return createResponse('', 405)
       return createResponse('', 200)
@@ -154,7 +166,9 @@ describe('public discovery health script', () => {
     const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = String(input)
       if (init?.method === 'GET' && url.endsWith('/pages-sitemap.xml')) {
-        return createResponse('<urlset><url><loc>https://other.example.com/private</loc></url></urlset>')
+        return createResponse(
+          `<urlset xmlns="${SITEMAP_NAMESPACE}"><url><loc>https://other.example.com/private</loc></url></urlset>`,
+        )
       }
       if (init?.method === 'GET' && url.endsWith('/posts-sitemap.xml')) {
         return createResponse(EMPTY_SITEMAP_XML)


### PR DESCRIPTION
## Management summary

### Deutsch

Die interne Sitemap-Prüfung erkennt fehlerhafte XML-Daten jetzt zuverlässig. Dadurch kann eine beschädigte Discovery-Konfiguration nicht mehr unbemerkt als leere, scheinbar gültige Sitemap behandelt werden.

### English

The internal sitemap validation now detects malformed XML reliably. This prevents a broken discovery configuration from being treated as an empty, seemingly valid sitemap.

## What changed

- Replaced regular-expression sitemap location extraction with structured, namespace-aware XML parsing through the existing `jsdom` dependency.
- Preserved valid empty sitemap behavior while making malformed XML fail deterministically.
- Added focused tooling coverage for namespaced, empty, and malformed sitemap documents while retaining status, fallback, and same-origin checks.

## Points to review

| Priority | Files / paths                                                       | Why focus here                                          | Reviewer should verify                                                                      | Evidence                      |
| -------- | ------------------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ----------------------------- |
| P2       | `scripts/public-discovery-health.mjs`                               | XML parsing now controls which advertised URLs are read. | Valid namespaced and empty sitemaps remain accepted while malformed XML fails deterministically. | Focused Vitest coverage       |
| P3       | `tests/tooling/scripts/public-discovery-health.test.ts`             | Existing mocked sitemap responses needed valid XML.     | Fixtures cover the new parser contract without weakening status, fallback, or origin checks. | 8 focused tests passing       |

## Validation

- [x] `pnpm format`: Passed.
- [x] `pnpm check`: Passed.
- [ ] `pnpm build`: Not applicable; this changes repository tooling and tests only.
- [x] Focused tests: `pnpm exec vitest run tests/tooling/scripts/public-discovery-health.test.ts` (8 passed).
- [ ] UI/mobile QA: Not applicable; no UI changes.
- [ ] Security/privacy review: Not run; URL fetching and the same-origin guard are unchanged.
- [ ] Migration/schema check: Not applicable; no schema or data changes.
- [x] Documentation/instructions check: Issue #1045 was updated; repository documentation is intentionally unchanged.

## Risk and rollout

Low. Malformed sitemap XML now produces a failing command instead of an empty location set. Valid empty and namespaced sitemaps remain supported. No configuration, environment, migration, or rollout work is required.

## Development

Closes #1045
