### PR TITLE
fix(frontend): stabilize post detail rendering

### DIFF
--- a/docs/frontend/content-data-access.md
+++ b/docs/frontend/content-data-access.md
@@ -16,8 +16,8 @@ Use these helpers whenever multiple routes or blocks need the same Payload query
 
 - `findLatestPosts(payload, limit)` for homepage and partner landing cards
 - `findPublishedPostsPage(payload, options)` for paginated post archives
-- `findPostBySlug(payload, slug, draft)` for the post detail route
-- `findPostSlugs(payload)` for `generateStaticParams`
+- `getCachedPublishedPostBySlug(options)` for published post detail reads
+- `findPostBySlug(payload, slug, draft, contentLocale)` for live draft and preview post detail reads
 - `findPostSitemapDocs(payload)` for sitemap generation
 - `countPublishedPosts(payload, where?)` for archive counts
 
@@ -32,3 +32,5 @@ Use these helpers whenever multiple routes or blocks need the same Payload query
 - Keep presentation mapping in `normalizePost` or route adapters.
 - Prefer the shared helpers when the query shape is reused.
 - Keep one-off, feature-specific queries local if they are not reused.
+- Keep published post detail reads in the public Data Cache with `collection:posts` and `slug:posts:<slug>` tags. The cache key includes its version, slug, locale, and fallback locale.
+- Keep draft and preview post detail reads live. The dynamic `/posts/[slug]` route memoizes one request-scoped resolver across page and metadata rendering without placing request-bound draft state in the public Data Cache.

--- a/src/app/(frontend)/admin/logout/page.tsx
+++ b/src/app/(frontend)/admin/logout/page.tsx
@@ -6,6 +6,8 @@ import { createClient } from '@/auth/utilities/supaBaseClient'
 import { resetPostHogBrowserIdentity } from '@/posthog/client-api'
 import { Heading } from '@/components/atoms/Heading'
 
+const EXIT_PREVIEW_PATH = `/next/exit-preview?redirect=${encodeURIComponent('/admin/login')}`
+
 export default function LogoutPage() {
   const router = useRouter()
 
@@ -15,16 +17,20 @@ export default function LogoutPage() {
         const supabase = createClient()
 
         await supabase.auth.signOut()
-        resetPostHogBrowserIdentity()
-
-        // Small delay to show the "logging out" message
-        setTimeout(() => {
-          router.push('/admin/login')
-        }, 1000)
       } catch (error) {
         console.error('Logout error:', error)
-        router.push('/admin/login')
       }
+
+      try {
+        resetPostHogBrowserIdentity()
+      } catch (error) {
+        console.error('Logout identity reset error:', error)
+      }
+
+      // Small delay to show the "logging out" message.
+      setTimeout(() => {
+        router.replace(EXIT_PREVIEW_PATH)
+      }, 1000)
     }
 
     handleLogout()

--- a/src/app/(frontend)/logout/page.tsx
+++ b/src/app/(frontend)/logout/page.tsx
@@ -7,6 +7,8 @@ import { Heading } from '@/components/atoms/Heading'
 import { createClient } from '@/auth/utilities/supaBaseClient'
 import { resetPostHogBrowserIdentity } from '@/posthog/client-api'
 
+const EXIT_PREVIEW_PATH = `/next/exit-preview?redirect=${encodeURIComponent('/login/patient')}`
+
 export default function PublicLogoutPage() {
   const router = useRouter()
 
@@ -16,15 +18,19 @@ export default function PublicLogoutPage() {
         const supabase = createClient()
 
         await supabase.auth.signOut()
-        resetPostHogBrowserIdentity()
-
-        setTimeout(() => {
-          router.push('/login/patient')
-        }, 1000)
       } catch (error) {
         console.error('Logout error:', error)
-        router.push('/login/patient')
       }
+
+      try {
+        resetPostHogBrowserIdentity()
+      } catch (error) {
+        console.error('Logout identity reset error:', error)
+      }
+
+      setTimeout(() => {
+        router.replace(EXIT_PREVIEW_PATH)
+      }, 1000)
     }
 
     handleLogout()

--- a/src/app/(frontend)/next/exit-preview/route.ts
+++ b/src/app/(frontend)/next/exit-preview/route.ts
@@ -1,7 +1,24 @@
 import { draftMode } from 'next/headers'
+import { redirect } from 'next/navigation'
+import type { NextRequest } from 'next/server'
 
-export async function GET(): Promise<Response> {
+import { sanitizeInternalRedirectPath } from '@/utilities/routing/sanitizeInternalRedirectPath'
+
+export async function GET(request: NextRequest): Promise<Response> {
   const draft = await draftMode()
   draft.disable()
+
+  const requestedRedirect = request.nextUrl.searchParams.get('redirect')
+
+  if (requestedRedirect) {
+    const safeRedirect = sanitizeInternalRedirectPath({
+      nextPath: requestedRedirect,
+      fallbackPath: '/',
+      blockedPaths: ['/next/exit-preview'],
+    })
+
+    redirect(safeRedirect)
+  }
+
   return new Response('Draft mode is disabled')
 }

--- a/src/app/(frontend)/next/preview/route.ts
+++ b/src/app/(frontend)/next/preview/route.ts
@@ -9,7 +9,7 @@ import { sanitizeInternalRedirectPath } from '@/utilities/routing/sanitizeIntern
 
 /**
  * Route handler to enable Next.js draft (preview) mode for a specific document.
- * Validates a shared secret and authenticates the requesting user through Payload.
+ * Validates a shared secret and requires an authenticated Payload platform staff user.
  * Next.js 15 requires the first arg to be a NextRequest for correct typing.
  */
 export async function GET(request: NextRequest): Promise<Response> {
@@ -39,26 +39,25 @@ export async function GET(request: NextRequest): Promise<Response> {
     return new Response('This endpoint can only be used for relative previews', { status: 500 })
   }
 
+  const draft = await draftMode()
   let user
 
   try {
-    user = await payload.auth({
+    const authResult = await payload.auth({
       req: request as unknown as PayloadRequest,
       headers: request.headers,
     })
+    user = authResult.user
   } catch (error) {
     payload.logger.error(error, 'Error verifying token for live preview')
-    return new Response('You are not allowed to preview this page', { status: 403 })
-  }
-
-  const draft = await draftMode()
-
-  if (!user) {
     draft.disable()
     return new Response('You are not allowed to preview this page', { status: 403 })
   }
 
-  // You can add additional checks here to see if the user is allowed to preview this page
+  if (user?.collection !== 'platformStaff') {
+    draft.disable()
+    return new Response('You are not allowed to preview this page', { status: 403 })
+  }
 
   draft.enable()
 

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -172,28 +172,39 @@ const resolvePost = cache(async (slug: string, locale?: ContentLocale, fallbackL
     ...(locale ? { locale } : {}),
     ...(fallbackLocale !== undefined ? { fallbackLocale } : {}),
   }
-  const draft = await resolveDraftAccess()
+  const draftPayload = await resolveDraftPayload()
 
-  if (!draft) {
+  if (!draftPayload) {
     const post = await getCachedPublishedPostBySlug({ contentLocale, slug })
 
-    return { draft, post }
+    return { draft: false, post }
   }
 
-  const payload = await getPayload({ config: configPromise })
-  const post = await findPostBySlug(payload, slug, true, contentLocale)
+  const post = await findPostBySlug(draftPayload, slug, true, contentLocale)
 
-  return { draft, post }
+  return { draft: true, post }
 })
 
-const resolveDraftAccess = async (): Promise<boolean> => {
+const resolveDraftPayload = async () => {
   const { isEnabled } = await draftMode()
 
   if (!isEnabled) {
-    return false
+    return null
   }
 
   const requestHeaders = await headers()
 
-  return !isTemporaryLandingModeRequest(requestHeaders)
+  if (isTemporaryLandingModeRequest(requestHeaders)) {
+    return null
+  }
+
+  const payload = await getPayload({ config: configPromise })
+
+  try {
+    const { user } = await payload.auth({ headers: requestHeaders })
+
+    return user?.collection === 'platformStaff' ? payload : null
+  } catch {
+    return null
+  }
 }

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -15,26 +15,22 @@ import { LivePreviewListener } from '@/components/organisms/LivePreviewListener'
 import { Container } from '@/components/molecules/Container'
 import { DisclaimerNotice } from '@/components/molecules/DisclaimerNotice'
 import { calculateReadTime } from '@/utilities/blog/calculateReadTime'
-import { findPostBySlug, findPostSlugs } from '@/utilities/content/serverData'
+import { findPostBySlug, getCachedPublishedPostBySlug } from '@/utilities/content/serverData'
 import { DISCLAIMER_COPY } from '@/utilities/legal/disclaimers'
 import { resolveMediaImage } from '@/utilities/media/resolveMediaImage'
 import { PostShareActionBar } from './PostShareActionBar'
-import { resolveContentLocaleContext, type ContentLocaleContext } from '@/utilities/contentLocalization'
+import {
+  resolveContentLocaleContext,
+  type ContentFallbackLocale,
+  type ContentLocale,
+  type ContentLocaleContext,
+} from '@/utilities/contentLocalization'
 import { buildPostPath, buildPostsIndexPath } from '@/utilities/content/postPaths'
 import { createBlogBreadcrumb, HOME_BREADCRUMB } from '@/utilities/breadcrumbs'
 import { JsonLdScript, buildArticlePageJsonLd } from '@/utilities/structuredData'
 import { isTemporaryLandingModeRequest } from '@/features/temporaryLandingMode'
 
-export async function generateStaticParams() {
-  const payload = await getPayload({ config: configPromise })
-  const posts = await findPostSlugs(payload)
-
-  const params = posts.map(({ slug }) => {
-    return { slug }
-  })
-
-  return params
-}
+export const dynamic = 'force-dynamic'
 
 type Args = {
   params: Promise<{
@@ -46,13 +42,12 @@ type Args = {
 }
 
 export default async function Post({ params: paramsPromise, searchParams: searchParamsPromise }: Args) {
-  const draft = await resolveDraftAccess()
   const { slug = '' } = await paramsPromise
   const searchParams = await searchParamsPromise
   const contentLocale = resolveContentLocaleContext(searchParams.locale)
   const canonicalPostPath = buildPostPath(slug)
   const localizedPostPath = buildPostPath(slug, contentLocale)
-  const post = await queryPostBySlug({ contentLocale, draft, slug })
+  const { draft, post } = await resolvePost(slug, contentLocale.locale, contentLocale.fallbackLocale)
 
   if (!post) return <PayloadRedirects url={canonicalPostPath} />
 
@@ -167,24 +162,38 @@ export async function generateMetadata({
   const { slug = '' } = await paramsPromise
   const searchParams = await searchParamsPromise
   const contentLocale = resolveContentLocaleContext(searchParams.locale)
-  const draft = await resolveDraftAccess()
-  const post = await queryPostBySlug({ contentLocale, draft, slug })
+  const { post } = await resolvePost(slug, contentLocale.locale, contentLocale.fallbackLocale)
 
   return generateMeta({ doc: post, path: buildPostPath(slug, contentLocale), sourceCollection: 'posts' })
 }
 
-const queryPostBySlug = cache(
-  async ({ slug, contentLocale, draft }: { contentLocale?: ContentLocaleContext; draft: boolean; slug: string }) => {
-    const normalizedContentLocale = contentLocale ?? {}
+const resolvePost = cache(async (slug: string, locale?: ContentLocale, fallbackLocale?: ContentFallbackLocale) => {
+  const contentLocale: ContentLocaleContext = {
+    ...(locale ? { locale } : {}),
+    ...(fallbackLocale !== undefined ? { fallbackLocale } : {}),
+  }
+  const draft = await resolveDraftAccess()
 
-    const payload = await getPayload({ config: configPromise })
+  if (!draft) {
+    const post = await getCachedPublishedPostBySlug({ contentLocale, slug })
 
-    return findPostBySlug(payload, slug, draft, normalizedContentLocale)
-  },
-)
+    return { draft, post }
+  }
+
+  const payload = await getPayload({ config: configPromise })
+  const post = await findPostBySlug(payload, slug, true, contentLocale)
+
+  return { draft, post }
+})
 
 const resolveDraftAccess = async (): Promise<boolean> => {
-  const [{ isEnabled }, requestHeaders] = await Promise.all([draftMode(), headers()])
+  const { isEnabled } = await draftMode()
 
-  return isEnabled && !isTemporaryLandingModeRequest(requestHeaders)
+  if (!isEnabled) {
+    return false
+  }
+
+  const requestHeaders = await headers()
+
+  return !isTemporaryLandingModeRequest(requestHeaders)
 }

--- a/src/utilities/content/serverData/posts.ts
+++ b/src/utilities/content/serverData/posts.ts
@@ -4,7 +4,7 @@ import configPromise from '@payload-config'
 import { unstable_cache } from 'next/cache'
 import { getPayload } from 'payload'
 import type { Post, PostsSelect } from '@/payload-types'
-import { buildCollectionTag, buildSitemapTag, buildSurfaceTag } from '@/utilities/cachePolicy'
+import { buildCollectionTag, buildSitemapTag, buildSlugTag, buildSurfaceTag } from '@/utilities/cachePolicy'
 
 import {
   buildLocalizedQueryOptions,
@@ -53,7 +53,6 @@ export type PostDetailDoc = Omit<
   relatedPosts?: Array<number | PostSummaryDoc> | null
 }
 
-export type PostSlugDoc = Pick<Post, 'id' | 'slug'>
 export type PostSitemapDoc = Pick<Post, 'id' | 'slug' | 'updatedAt'>
 
 export type FindPublishedPostsArgs = {
@@ -71,6 +70,11 @@ export type CachedPublishedPostsPageArgs = {
   contentLocale?: LocalizedDocQuery
   limit?: number
   page?: number
+}
+
+export type CachedPublishedPostBySlugArgs = {
+  contentLocale?: LocalizedDocQuery
+  slug: string
 }
 
 const POST_LIST_SELECT = {
@@ -126,16 +130,13 @@ const POST_DETAIL_SELECT = {
   },
 } satisfies PostsSelect<true>
 
-const POST_SLUG_SELECT = {
-  slug: true,
-} satisfies PostsSelect<true>
-
 const POST_SITEMAP_SELECT = {
   slug: true,
   updatedAt: true,
 } satisfies PostsSelect<true>
 
 const POSTS_LIST_DATA_CACHE_KEY_VERSION = '2026-07-08'
+const POST_DETAIL_DATA_CACHE_KEY_VERSION = '2026-07-31'
 
 export const buildPostListDataCacheTags = (): string[] => [
   buildCollectionTag('posts'),
@@ -157,6 +158,19 @@ export const buildPostListDataCacheKey = ({
     limit,
     page,
   })
+
+export const buildPostDetailDataCacheKey = ({ contentLocale, slug }: CachedPublishedPostBySlugArgs): string =>
+  JSON.stringify({
+    version: POST_DETAIL_DATA_CACHE_KEY_VERSION,
+    slug,
+    locale: contentLocale?.locale ?? null,
+    fallbackLocale: contentLocale?.fallbackLocale ?? null,
+  })
+
+export const buildPostDetailDataCacheTags = (slug: string): string[] => [
+  buildCollectionTag('posts'),
+  buildSlugTag('posts', slug),
+]
 
 type RelatedPostValue = number | { id?: number | null } | null | undefined
 
@@ -381,15 +395,21 @@ export async function findPostBySlug(
   return hydrateRelatedPostCards(payload, post, draft, contentLocale)
 }
 
-export async function findPostSlugs(payload: Payload): Promise<PostSlugDoc[]> {
-  const result = await queryPosts<PostSlugDoc>(payload, {
-    depth: 0,
-    limit: 1000,
-    pagination: false,
-    select: POST_SLUG_SELECT,
-  })
+const getCachedPublishedPostBySlugByArgs = (args: CachedPublishedPostBySlugArgs) =>
+  unstable_cache(
+    async () => {
+      const payload = await getPayload({ config: configPromise })
 
-  return result.docs
+      return findPostBySlug(payload, args.slug, false, args.contentLocale)
+    },
+    ['post-detail', buildPostDetailDataCacheKey(args)],
+    {
+      tags: buildPostDetailDataCacheTags(args.slug),
+    },
+  )
+
+export async function getCachedPublishedPostBySlug(args: CachedPublishedPostBySlugArgs): Promise<PostDetailDoc | null> {
+  return getCachedPublishedPostBySlugByArgs(args)()
 }
 
 export async function findPostSitemapDocs(payload: Payload): Promise<PostSitemapDoc[]> {
@@ -413,4 +433,4 @@ export async function countPublishedPosts(payload: Payload, where?: Where): Prom
   return result.totalDocs
 }
 
-export { POST_DETAIL_SELECT, POST_LATEST_SELECT, POST_LIST_SELECT, POST_SITEMAP_SELECT, POST_SLUG_SELECT }
+export { POST_DETAIL_SELECT, POST_LATEST_SELECT, POST_LIST_SELECT, POST_SITEMAP_SELECT }

--- a/src/utilities/content/serverData/posts.ts
+++ b/src/utilities/content/serverData/posts.ts
@@ -4,7 +4,13 @@ import configPromise from '@payload-config'
 import { unstable_cache } from 'next/cache'
 import { getPayload } from 'payload'
 import type { Post, PostsSelect } from '@/payload-types'
-import { buildCollectionTag, buildSitemapTag, buildSlugTag, buildSurfaceTag } from '@/utilities/cachePolicy'
+import {
+  buildCollectionTag,
+  buildPostPath,
+  buildSitemapTag,
+  buildSlugTag,
+  buildSurfaceTag,
+} from '@/utilities/cachePolicy'
 
 import {
   buildLocalizedQueryOptions,
@@ -171,6 +177,15 @@ export const buildPostDetailDataCacheTags = (slug: string): string[] => [
   buildCollectionTag('posts'),
   buildSlugTag('posts', slug),
 ]
+
+const isValidPublicPostSlug = (slug: string): boolean => {
+  try {
+    buildPostPath(slug)
+    return true
+  } catch {
+    return false
+  }
+}
 
 type RelatedPostValue = number | { id?: number | null } | null | undefined
 
@@ -395,21 +410,22 @@ export async function findPostBySlug(
   return hydrateRelatedPostCards(payload, post, draft, contentLocale)
 }
 
-const getCachedPublishedPostBySlugByArgs = (args: CachedPublishedPostBySlugArgs) =>
-  unstable_cache(
+export async function getCachedPublishedPostBySlug(args: CachedPublishedPostBySlugArgs): Promise<PostDetailDoc | null> {
+  if (!isValidPublicPostSlug(args.slug)) {
+    return null
+  }
+
+  const tags = buildPostDetailDataCacheTags(args.slug)
+
+  return unstable_cache(
     async () => {
       const payload = await getPayload({ config: configPromise })
 
       return findPostBySlug(payload, args.slug, false, args.contentLocale)
     },
     ['post-detail', buildPostDetailDataCacheKey(args)],
-    {
-      tags: buildPostDetailDataCacheTags(args.slug),
-    },
-  )
-
-export async function getCachedPublishedPostBySlug(args: CachedPublishedPostBySlugArgs): Promise<PostDetailDoc | null> {
-  return getCachedPublishedPostBySlugByArgs(args)()
+    { tags },
+  )()
 }
 
 export async function findPostSitemapDocs(payload: Payload): Promise<PostSitemapDoc[]> {

--- a/tests/unit/app/frontend/logout.pages.test.tsx
+++ b/tests/unit/app/frontend/logout.pages.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom'
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import AdminLogoutPage from '@/app/(frontend)/admin/logout/page'
+import PublicLogoutPage from '@/app/(frontend)/logout/page'
+
+const mocks = vi.hoisted(() => ({
+  replaceMock: vi.fn(),
+  resetIdentityMock: vi.fn(),
+  signOutMock: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mocks.replaceMock,
+  }),
+}))
+
+vi.mock('@/auth/utilities/supaBaseClient', () => ({
+  createClient: () => ({
+    auth: {
+      signOut: mocks.signOutMock,
+    },
+  }),
+}))
+
+vi.mock('@/posthog/client-api', () => ({
+  resetPostHogBrowserIdentity: mocks.resetIdentityMock,
+}))
+
+const finishLogout = async () => {
+  await act(async () => {
+    await Promise.resolve()
+    await vi.runAllTimersAsync()
+  })
+}
+
+describe('frontend logout pages', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    mocks.signOutMock.mockResolvedValue({ error: null })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it.each([
+    ['admin', AdminLogoutPage, '/next/exit-preview?redirect=%2Fadmin%2Flogin'],
+    ['patient', PublicLogoutPage, '/next/exit-preview?redirect=%2Flogin%2Fpatient'],
+  ] as const)('clears draft mode through the exit-preview route after %s logout', async (_label, Page, path) => {
+    render(<Page />)
+
+    await finishLogout()
+
+    expect(mocks.signOutMock).toHaveBeenCalledOnce()
+    expect(mocks.resetIdentityMock).toHaveBeenCalledOnce()
+    expect(mocks.replaceMock).toHaveBeenCalledWith(path)
+  })
+
+  it('still clears draft mode when Supabase logout fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    mocks.signOutMock.mockRejectedValue(new Error('logout failed'))
+
+    render(<AdminLogoutPage />)
+    await finishLogout()
+
+    expect(mocks.resetIdentityMock).toHaveBeenCalledOnce()
+    expect(mocks.replaceMock).toHaveBeenCalledWith('/next/exit-preview?redirect=%2Fadmin%2Flogin')
+
+    consoleError.mockRestore()
+  })
+})

--- a/tests/unit/app/frontend/next/exit-preview.route.test.ts
+++ b/tests/unit/app/frontend/next/exit-preview.route.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  disableDraftMock: vi.fn(),
+  redirectMock: vi.fn(),
+}))
+
+vi.mock('next/headers', () => ({
+  draftMode: vi.fn().mockResolvedValue({
+    disable: mocks.disableDraftMock,
+  }),
+}))
+
+vi.mock('next/navigation', () => ({
+  redirect: mocks.redirectMock,
+}))
+
+import { GET } from '@/app/(frontend)/next/exit-preview/route'
+
+describe('GET /next/exit-preview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('clears draft mode without requiring a redirect', async () => {
+    const response = await GET(new NextRequest('http://localhost/next/exit-preview'))
+
+    expect(mocks.disableDraftMock).toHaveBeenCalledOnce()
+    expect(mocks.redirectMock).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    await expect(response.text()).resolves.toBe('Draft mode is disabled')
+  })
+
+  it('clears draft mode before redirecting to a sanitized internal path', async () => {
+    await GET(new NextRequest('http://localhost/next/exit-preview?redirect=%2Fadmin%2Flogin%3Freason%3Dlogout'))
+
+    expect(mocks.disableDraftMock).toHaveBeenCalledOnce()
+    expect(mocks.redirectMock).toHaveBeenCalledWith('/admin/login?reason=logout')
+    expect(mocks.disableDraftMock.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.redirectMock.mock.invocationCallOrder[0]!,
+    )
+  })
+
+  it.each([
+    ['external URL', 'https://evil.example'],
+    ['protocol-relative URL', '//evil.example'],
+    ['exit-preview loop', '/next/exit-preview?redirect=/admin/login'],
+  ])('falls back to the homepage for an invalid %s redirect', async (_label, redirectTarget) => {
+    const request = new NextRequest(`http://localhost/next/exit-preview?redirect=${encodeURIComponent(redirectTarget)}`)
+
+    await GET(request)
+
+    expect(mocks.disableDraftMock).toHaveBeenCalledOnce()
+    expect(mocks.redirectMock).toHaveBeenCalledWith('/')
+  })
+})

--- a/tests/unit/app/frontend/next/preview/route.test.ts
+++ b/tests/unit/app/frontend/next/preview/route.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 
-const { authMock, redirectMock } = vi.hoisted(() => ({
+const { authMock, draftDisableMock, draftEnableMock, draftModeMock, redirectMock } = vi.hoisted(() => ({
   authMock: vi.fn(),
+  draftDisableMock: vi.fn(),
+  draftEnableMock: vi.fn(),
+  draftModeMock: vi.fn(),
   redirectMock: vi.fn(),
 }))
 
@@ -22,10 +25,7 @@ vi.mock('next/navigation', () => ({
 }))
 
 vi.mock('next/headers', () => ({
-  draftMode: vi.fn().mockResolvedValue({
-    disable: vi.fn(),
-    enable: vi.fn(),
-  }),
+  draftMode: draftModeMock,
 }))
 
 import { GET } from '@/app/(frontend)/next/preview/route'
@@ -33,6 +33,11 @@ import { GET } from '@/app/(frontend)/next/preview/route'
 describe('GET /next/preview', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    authMock.mockReset()
+    draftModeMock.mockResolvedValue({
+      disable: draftDisableMock,
+      enable: draftEnableMock,
+    })
     process.env.PREVIEW_SECRET = 'test-secret'
   })
 
@@ -89,7 +94,7 @@ describe('GET /next/preview', () => {
   })
 
   it('redirects with the sanitized relative path after auth succeeds', async () => {
-    authMock.mockResolvedValue({ id: 'user-1' })
+    authMock.mockResolvedValue({ user: { id: 'user-1', collection: 'platformStaff' } })
 
     const request = new NextRequest(
       'http://localhost/next/preview?path=%2Fposts%2Fhello-world%3Fpreview%3D1%23draft&collection=posts&slug=hello-world&previewSecret=test-secret',
@@ -98,6 +103,40 @@ describe('GET /next/preview', () => {
     await GET(request)
 
     expect(authMock).toHaveBeenCalledOnce()
+    expect(draftEnableMock).toHaveBeenCalledOnce()
+    expect(draftDisableMock).not.toHaveBeenCalled()
     expect(redirectMock).toHaveBeenCalledWith('/posts/hello-world?preview=1#draft')
+  })
+
+  it.each([
+    ['unauthenticated', null],
+    ['clinic staff', { id: 'clinic-user', collection: 'clinicStaff' }],
+    ['patient', { id: 'patient-user', collection: 'patients' }],
+  ] as const)('rejects %s users and clears any existing draft cookie', async (_label, user) => {
+    authMock.mockResolvedValue({ user })
+    const request = new NextRequest(
+      'http://localhost/next/preview?path=%2Fposts%2Fhello-world&collection=posts&slug=hello-world&previewSecret=test-secret',
+    )
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(403)
+    expect(draftDisableMock).toHaveBeenCalledOnce()
+    expect(draftEnableMock).not.toHaveBeenCalled()
+    expect(redirectMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects stale authentication without enabling draft mode', async () => {
+    authMock.mockRejectedValue(new Error('stale session'))
+    const request = new NextRequest(
+      'http://localhost/next/preview?path=%2Fposts%2Fhello-world&collection=posts&slug=hello-world&previewSecret=test-secret',
+    )
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(403)
+    expect(draftDisableMock).toHaveBeenCalledOnce()
+    expect(draftEnableMock).not.toHaveBeenCalled()
+    expect(redirectMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/app/frontend/post.page.test.tsx
+++ b/tests/unit/app/frontend/post.page.test.tsx
@@ -1,24 +1,52 @@
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mocks = vi.hoisted(() => ({
-  buildArticlePageJsonLdMock: vi.fn(() => [{ '@type': 'Article' }]),
-  calculateReadTimeMock: vi.fn(() => '5 min read'),
-  draftModeMock: vi.fn(),
-  headersMock: vi.fn(),
-  findPostBySlugMock: vi.fn(),
-  findPostSlugsMock: vi.fn(),
-  generateMetaMock: vi.fn((args: unknown) => args),
-  getPayloadMock: vi.fn(),
-  payloadRedirectsComponent: vi.fn(() => null),
-  postHeroComponent: vi.fn(() => null),
-  postShareActionBarComponent: vi.fn(() => null),
-  relatedPostsComponent: vi.fn(() => null),
-  richTextComponent: vi.fn(() => null),
-  disclaimerNoticeComponent: vi.fn(() => null),
-  jsonLdScriptComponent: vi.fn(() => null),
-  resolveMediaImageMock: vi.fn<() => unknown>(() => undefined),
-}))
+const mocks = vi.hoisted(() => {
+  const reactCacheResolverMock = vi.fn()
+
+  return {
+    buildArticlePageJsonLdMock: vi.fn(() => [{ '@type': 'Article' }]),
+    calculateReadTimeMock: vi.fn(() => '5 min read'),
+    draftModeMock: vi.fn(),
+    headersMock: vi.fn(),
+    findPostBySlugMock: vi.fn(),
+    generateMetaMock: vi.fn((args: unknown) => args),
+    getCachedPublishedPostBySlugMock: vi.fn(),
+    getPayloadMock: vi.fn(),
+    payloadRedirectsComponent: vi.fn(() => null),
+    postHeroComponent: vi.fn(() => null),
+    postShareActionBarComponent: vi.fn(() => null),
+    reactCacheMock: vi.fn((callback: (...args: unknown[]) => unknown) => {
+      const entries = new Map<string, unknown>()
+      reactCacheResolverMock.mockImplementation((...args: unknown[]) => {
+        const key = JSON.stringify(args)
+
+        if (!entries.has(key)) {
+          entries.set(key, callback(...args))
+        }
+
+        return entries.get(key)
+      })
+
+      return reactCacheResolverMock
+    }),
+    reactCacheResolverMock,
+    relatedPostsComponent: vi.fn(() => null),
+    richTextComponent: vi.fn(() => null),
+    disclaimerNoticeComponent: vi.fn(() => null),
+    jsonLdScriptComponent: vi.fn(() => null),
+    resolveMediaImageMock: vi.fn<() => unknown>(() => undefined),
+  }
+})
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>()
+
+  return {
+    ...actual,
+    cache: mocks.reactCacheMock,
+  }
+})
 
 vi.mock('next/headers', () => ({
   draftMode: mocks.draftModeMock,
@@ -75,7 +103,7 @@ vi.mock('@/utilities/generateMeta', () => ({
 
 vi.mock('@/utilities/content/serverData', () => ({
   findPostBySlug: mocks.findPostBySlugMock,
-  findPostSlugs: mocks.findPostSlugsMock,
+  getCachedPublishedPostBySlug: mocks.getCachedPublishedPostBySlugMock,
 }))
 
 vi.mock('@/utilities/structuredData', () => ({
@@ -118,14 +146,13 @@ describe('frontend post detail route', () => {
     mocks.draftModeMock.mockResolvedValue({ isEnabled: false })
     mocks.headersMock.mockResolvedValue(new Headers())
     mocks.getPayloadMock.mockResolvedValue({})
-    mocks.findPostSlugsMock.mockResolvedValue([{ slug: 'hello-world' }])
     mocks.resolveMediaImageMock.mockReturnValue({
       src: '/api/platformContentMedia/file/post-hero.webp',
       alt: 'Hallo Welt',
       sizes: '100vw',
       quality: 75,
     })
-    mocks.findPostBySlugMock.mockResolvedValue({
+    mocks.getCachedPublishedPostBySlugMock.mockResolvedValue({
       slug: 'hello-world',
       title: 'Hallo Welt',
       excerpt: 'Deutscher Auszug.',
@@ -157,10 +184,17 @@ describe('frontend post detail route', () => {
       searchParams: Promise.resolve({ locale: 'de' }),
     })
 
-    expect(mocks.findPostBySlugMock).toHaveBeenCalledWith({}, 'hello-world', false, {
-      locale: 'de',
-      fallbackLocale: 'en',
+    expect(pageModule.dynamic).toBe('force-dynamic')
+    expect(mocks.getCachedPublishedPostBySlugMock).toHaveBeenCalledWith({
+      slug: 'hello-world',
+      contentLocale: {
+        locale: 'de',
+        fallbackLocale: 'en',
+      },
     })
+    expect(mocks.findPostBySlugMock).not.toHaveBeenCalled()
+    expect(mocks.getPayloadMock).not.toHaveBeenCalled()
+    expect(mocks.headersMock).not.toHaveBeenCalled()
     expect(mocks.resolveMediaImageMock).toHaveBeenCalledWith(
       {
         url: '/api/platformContentMedia/file/post-hero.webp',
@@ -264,6 +298,49 @@ describe('frontend post detail route', () => {
         path: '/posts/hello-world?locale=de',
       }),
     )
+    expect(mocks.getCachedPublishedPostBySlugMock).toHaveBeenCalledWith({
+      slug: 'hello-world',
+      contentLocale: {
+        locale: 'de',
+        fallbackLocale: 'en',
+      },
+    })
+  })
+
+  it('routes unknown public slugs through the redirect and not-found boundary', async () => {
+    mocks.getCachedPublishedPostBySlugMock.mockResolvedValueOnce(null)
+
+    const pageModule = await import('@/app/(frontend)/posts/[slug]/page')
+    const result = await pageModule.default({
+      params: Promise.resolve({ slug: 'missing-post' }),
+      searchParams: Promise.resolve({}),
+    })
+
+    const redirectElement = findElementByType(result, mocks.payloadRedirectsComponent) as React.ReactElement<{
+      disableNotFound?: boolean
+      url: string
+    }> | null
+
+    expect(redirectElement?.props).toEqual({ url: '/posts/missing-post' })
+    expect(findElementByType(result, mocks.postHeroComponent)).toBeNull()
+  })
+
+  it('shares one primitive-keyed React cache resolver between metadata and page rendering', async () => {
+    const pageModule = await import('@/app/(frontend)/posts/[slug]/page')
+
+    await pageModule.generateMetadata({
+      params: Promise.resolve({ slug: 'hello-world' }),
+      searchParams: Promise.resolve({ locale: 'de' }),
+    })
+    await pageModule.default({
+      params: Promise.resolve({ slug: 'hello-world' }),
+      searchParams: Promise.resolve({ locale: 'de' }),
+    })
+
+    expect(mocks.reactCacheResolverMock).toHaveBeenNthCalledWith(1, 'hello-world', 'de', 'en')
+    expect(mocks.reactCacheResolverMock).toHaveBeenNthCalledWith(2, 'hello-world', 'de', 'en')
+    expect(mocks.draftModeMock).toHaveBeenCalledTimes(1)
+    expect(mocks.getCachedPublishedPostBySlugMock).toHaveBeenCalledTimes(1)
   })
 
   it('disables draft access for anonymous temporary landing requests', async () => {
@@ -276,12 +353,21 @@ describe('frontend post detail route', () => {
       searchParams: Promise.resolve({}),
     })
 
-    expect(mocks.findPostBySlugMock).toHaveBeenCalledWith({}, 'hello-world', false, {})
+    expect(mocks.getCachedPublishedPostBySlugMock).toHaveBeenCalledWith({
+      slug: 'hello-world',
+      contentLocale: {},
+    })
+    expect(mocks.findPostBySlugMock).not.toHaveBeenCalled()
     expect(findElementByType(result, mocks.jsonLdScriptComponent)?.props.data).toEqual([{ '@type': 'Article' }])
   })
 
   it('keeps authorized draft access when temporary landing headers are absent', async () => {
     mocks.draftModeMock.mockResolvedValue({ isEnabled: true })
+    mocks.findPostBySlugMock.mockResolvedValue({
+      slug: 'hello-world',
+      title: 'Hallo Welt',
+      content: { root: { children: [] } },
+    })
 
     const pageModule = await import('@/app/(frontend)/posts/[slug]/page')
     const result = await pageModule.default({
@@ -290,6 +376,7 @@ describe('frontend post detail route', () => {
     })
 
     expect(mocks.findPostBySlugMock).toHaveBeenCalledWith({}, 'hello-world', true, {})
+    expect(mocks.getCachedPublishedPostBySlugMock).not.toHaveBeenCalled()
     expect(findElementByType(result, mocks.jsonLdScriptComponent)?.props.data).toBeNull()
   })
 })

--- a/tests/unit/app/frontend/post.page.test.tsx
+++ b/tests/unit/app/frontend/post.page.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => {
     generateMetaMock: vi.fn((args: unknown) => args),
     getCachedPublishedPostBySlugMock: vi.fn(),
     getPayloadMock: vi.fn(),
+    payloadAuthMock: vi.fn(),
     payloadRedirectsComponent: vi.fn(() => null),
     postHeroComponent: vi.fn(() => null),
     postShareActionBarComponent: vi.fn(() => null),
@@ -145,7 +146,8 @@ describe('frontend post detail route', () => {
 
     mocks.draftModeMock.mockResolvedValue({ isEnabled: false })
     mocks.headersMock.mockResolvedValue(new Headers())
-    mocks.getPayloadMock.mockResolvedValue({})
+    mocks.payloadAuthMock.mockResolvedValue({ user: null })
+    mocks.getPayloadMock.mockResolvedValue({ auth: mocks.payloadAuthMock })
     mocks.resolveMediaImageMock.mockReturnValue({
       src: '/api/platformContentMedia/file/post-hero.webp',
       alt: 'Hallo Welt',
@@ -358,11 +360,61 @@ describe('frontend post detail route', () => {
       contentLocale: {},
     })
     expect(mocks.findPostBySlugMock).not.toHaveBeenCalled()
+    expect(mocks.payloadAuthMock).not.toHaveBeenCalled()
     expect(findElementByType(result, mocks.jsonLdScriptComponent)?.props.data).toEqual([{ '@type': 'Article' }])
   })
 
-  it('keeps authorized draft access when temporary landing headers are absent', async () => {
+  it('falls back to published data when a stale draft cookie has no current user', async () => {
     mocks.draftModeMock.mockResolvedValue({ isEnabled: true })
+
+    const pageModule = await import('@/app/(frontend)/posts/[slug]/page')
+    const result = await pageModule.default({
+      params: Promise.resolve({ slug: 'hello-world' }),
+      searchParams: Promise.resolve({}),
+    })
+
+    expect(mocks.payloadAuthMock).toHaveBeenCalledWith({ headers: expect.any(Headers) })
+    expect(mocks.getCachedPublishedPostBySlugMock).toHaveBeenCalledWith({
+      slug: 'hello-world',
+      contentLocale: {},
+    })
+    expect(mocks.findPostBySlugMock).not.toHaveBeenCalled()
+    expect(findElementByType(result, mocks.jsonLdScriptComponent)?.props.data).toEqual([{ '@type': 'Article' }])
+  })
+
+  it.each(['clinicStaff', 'patients'] as const)('does not authorize %s users for draft reads', async (collection) => {
+    mocks.draftModeMock.mockResolvedValue({ isEnabled: true })
+    mocks.payloadAuthMock.mockResolvedValue({ user: { collection, id: 'non-platform-user' } })
+
+    const pageModule = await import('@/app/(frontend)/posts/[slug]/page')
+    await pageModule.default({
+      params: Promise.resolve({ slug: 'hello-world' }),
+      searchParams: Promise.resolve({}),
+    })
+
+    expect(mocks.getCachedPublishedPostBySlugMock).toHaveBeenCalledOnce()
+    expect(mocks.findPostBySlugMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to published data when current authentication fails', async () => {
+    mocks.draftModeMock.mockResolvedValue({ isEnabled: true })
+    mocks.payloadAuthMock.mockRejectedValue(new Error('stale session'))
+
+    const pageModule = await import('@/app/(frontend)/posts/[slug]/page')
+
+    await expect(
+      pageModule.default({
+        params: Promise.resolve({ slug: 'hello-world' }),
+        searchParams: Promise.resolve({}),
+      }),
+    ).resolves.toBeDefined()
+    expect(mocks.getCachedPublishedPostBySlugMock).toHaveBeenCalledOnce()
+    expect(mocks.findPostBySlugMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps authorized platform staff draft access when temporary landing headers are absent', async () => {
+    mocks.draftModeMock.mockResolvedValue({ isEnabled: true })
+    mocks.payloadAuthMock.mockResolvedValue({ user: { collection: 'platformStaff', id: 'platform-user' } })
     mocks.findPostBySlugMock.mockResolvedValue({
       slug: 'hello-world',
       title: 'Hallo Welt',
@@ -375,7 +427,12 @@ describe('frontend post detail route', () => {
       searchParams: Promise.resolve({}),
     })
 
-    expect(mocks.findPostBySlugMock).toHaveBeenCalledWith({}, 'hello-world', true, {})
+    expect(mocks.findPostBySlugMock).toHaveBeenCalledWith(
+      expect.objectContaining({ auth: mocks.payloadAuthMock }),
+      'hello-world',
+      true,
+      {},
+    )
     expect(mocks.getCachedPublishedPostBySlugMock).not.toHaveBeenCalled()
     expect(findElementByType(result, mocks.jsonLdScriptComponent)?.props.data).toBeNull()
   })

--- a/tests/unit/utilities/contentServerData.test.ts
+++ b/tests/unit/utilities/contentServerData.test.ts
@@ -9,13 +9,11 @@ import {
   findPageSlugs,
   findPostBySlug,
   findPostSitemapDocs,
-  findPostSlugs,
   findPublishedPostsPage,
   POST_DETAIL_SELECT,
   POST_LATEST_SELECT,
   POST_LIST_SELECT,
   POST_SITEMAP_SELECT,
-  POST_SLUG_SELECT,
   PAGE_DETAIL_SELECT,
   PAGE_SITEMAP_SELECT,
   PAGE_SLUG_SELECT,
@@ -248,18 +246,15 @@ describe('content server data helpers', () => {
     )
   })
 
-  it('exposes dedicated post sitemap and slug queries', async () => {
+  it('exposes the dedicated post sitemap query and published count', async () => {
     const { payload, findMock, countMock } = createPayloadMock()
     findMock.mockResolvedValueOnce({ docs: [{ id: 5, slug: 'sitemap-post', updatedAt: '2026-01-01T00:00:00.000Z' }] })
-    findMock.mockResolvedValueOnce({ docs: [{ id: 6, slug: 'archive-post' }] })
     countMock.mockResolvedValue({ totalDocs: 17 })
 
     const sitemapDocs = await findPostSitemapDocs(payload)
-    const slugs = await findPostSlugs(payload)
     const totalDocs = await countPublishedPosts(payload)
 
     expect(sitemapDocs).toEqual([{ id: 5, slug: 'sitemap-post', updatedAt: '2026-01-01T00:00:00.000Z' }])
-    expect(slugs).toEqual([{ id: 6, slug: 'archive-post' }])
     expect(totalDocs).toBe(17)
     expect(findMock).toHaveBeenNthCalledWith(
       1,
@@ -270,17 +265,6 @@ describe('content server data helpers', () => {
         pagination: false,
         overrideAccess: false,
         select: POST_SITEMAP_SELECT,
-      }),
-    )
-    expect(findMock).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        collection: 'posts',
-        depth: 0,
-        limit: 1000,
-        pagination: false,
-        overrideAccess: false,
-        select: POST_SLUG_SELECT,
       }),
     )
     expect(countMock).toHaveBeenCalledWith({

--- a/tests/unit/utilities/postsServerDataCache.test.ts
+++ b/tests/unit/utilities/postsServerDataCache.test.ts
@@ -22,15 +22,64 @@ vi.mock('next/cache', () => ({
 }))
 
 import {
+  buildPostDetailDataCacheKey,
+  buildPostDetailDataCacheTags,
   buildPostListDataCacheKey,
   buildPostListDataCacheTags,
   getCachedLatestPosts,
+  getCachedPublishedPostBySlug,
   getCachedPublishedPostsPage,
 } from '@/utilities/content/serverData/posts'
 
 describe('posts server data cache contract', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  it('caches published post detail reads by slug and locale with canonical invalidation tags', async () => {
+    const payload = {
+      find: vi.fn().mockResolvedValue({ docs: [{ id: 7, slug: 'hello-world', title: 'Hallo Welt' }] }),
+    }
+    cacheMocks.getPayload.mockResolvedValue(payload)
+    const args = {
+      slug: 'hello-world',
+      contentLocale: { locale: 'de' as const, fallbackLocale: false as const },
+    }
+
+    await expect(getCachedPublishedPostBySlug(args)).resolves.toEqual({
+      id: 7,
+      slug: 'hello-world',
+      title: 'Hallo Welt',
+    })
+
+    expect(buildPostDetailDataCacheKey(args)).toBe(
+      JSON.stringify({
+        version: '2026-07-31',
+        slug: 'hello-world',
+        locale: 'de',
+        fallbackLocale: false,
+      }),
+    )
+    expect(buildPostDetailDataCacheTags('hello-world')).toEqual(['collection:posts', 'slug:posts:hello-world'])
+    expect(cacheMocks.unstableCache).toHaveBeenCalledWith(
+      expect.any(Function),
+      ['post-detail', buildPostDetailDataCacheKey(args)],
+      {
+        tags: ['collection:posts', 'slug:posts:hello-world'],
+      },
+    )
+    expect(payload.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'posts',
+        draft: false,
+        fallbackLocale: false,
+        locale: 'de',
+        overrideAccess: false,
+        where: {
+          and: [{ _status: { equals: 'published' } }, { slug: { equals: 'hello-world' } }],
+        },
+      }),
+    )
   })
 
   it('uses canonical aggregated-public tags for latest post teaser reads', async () => {

--- a/tests/unit/utilities/postsServerDataCache.test.ts
+++ b/tests/unit/utilities/postsServerDataCache.test.ts
@@ -82,6 +82,16 @@ describe('posts server data cache contract', () => {
     )
   })
 
+  it.each(['foo:bar', 'foo bar', 'foo/bar', ''])(
+    'treats invalid public route slug %j as a missing post',
+    async (slug) => {
+      await expect(getCachedPublishedPostBySlug({ slug })).resolves.toBeNull()
+
+      expect(cacheMocks.unstableCache).not.toHaveBeenCalled()
+      expect(cacheMocks.getPayload).not.toHaveBeenCalled()
+    },
+  )
+
   it('uses canonical aggregated-public tags for latest post teaser reads', async () => {
     const payload = {
       find: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Management summary

### Deutsch

Öffentliche Blogartikel laden künftig zuverlässig, auch wenn sie erst nach einem Website-Build veröffentlicht wurden. Entwürfe bleiben geschützt: Ein vorhandenes Preview-Cookie reicht nicht mehr aus, sondern jeder Draft-Aufruf benötigt weiterhin eine aktive Platform-Staff-Sitzung.

### English

Public blog articles now load reliably even when they are published after a website build. Drafts remain protected: a persisted preview cookie is no longer sufficient, and every draft request still requires an active platform staff session.

## What changed

- Made the post detail route explicitly request-rendered while keeping published post data in the existing public Data Cache.
- Added a published post detail cache contract keyed by slug and content locale with canonical collection and slug tags; draft and preview reads remain live.
- Shared one primitive-keyed request resolver between page and metadata rendering, and read temporary-landing headers only when Draft Mode is active.
- Required current Payload `platformStaff` authentication for every draft read and for the preview entrypoint; stale, anonymous, clinic staff, patient, and failed-auth requests fall back to published data.
- Cleared Draft Mode through a sanitized internal exit route during admin and patient logout, including sign-out failure paths.
- Removed the obsolete build-time post slug enumeration path and updated the content data access documentation and focused tests.
- Cache decision: `public-cached`, reusing the existing `critical-public` policy, Posts collection hook owner, tag families, and bounded detail paths.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `src/app/(frontend)/posts/[slug]/page.tsx`, `src/app/(frontend)/next/**` | The route separates public cached reads from authenticated draft access. | Draft content cannot enter the public cache, every draft read requires current platform staff authentication, and temporary-landing requests suppress stale draft cookies. | Focused route and security tests plus a security re-review cover stale cookies, role denial, auth failure, preview entry, and logout. |
| P2 | `src/utilities/content/serverData/posts.ts` | The new detail cache must stay symmetric with existing Posts invalidation. | Cache keys contain slug and locale dimensions, and read tags match the existing collection-hook planner output. | Cache contract tests plus the unchanged Posts hook tests passed. |

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed.
- [x] `pnpm build`: passed; `/posts/[slug]` is reported as `ƒ Dynamic`.
- [x] Original route/cache/hook focused tests: 4 files, 28 tests passed.
- [x] Security-fix focused tests: 4 files, 27 tests passed.
- [x] Standard PR preview: passed; read-only checks returned `200` for all six published preview slugs, `404` for an unknown slug, and the exit-preview route cleared the Draft Mode cookie before redirecting internally.
- [ ] UI/mobile QA: not applicable; rendering and visible UI are unchanged.
- [x] Security/privacy review: the reviewer found one `7/10` stale-session draft authorization issue; the fix was re-reviewed and the original finding is resolved with no remaining finding at `5/10` or higher.
- [x] Cache Architecture review: no finding at `5/10` or higher.
- [x] SEO review: no finding at `5/10` or higher.
- [x] Migration/schema check: no schema or migration changes.
- [x] Documentation/instructions check: content data access documentation updated; no instruction files changed.

## Risk and rollout

The route is rendered per request, while published Payload reads remain explicitly cached and keep their existing invalidation owner. Draft reads add a current platform staff authentication check and remain private and live. The automatic PR preview confirmed published, unknown-slug, and exit-preview behavior. Publishing a new post after the build and authenticated draft rendering were not exercised against shared preview data; focused behavior tests cover those paths. Validation ran locally on Node 26.5 while the repository targets Node 24; CI uses the repository Node version. No manual preview or production deployment was performed. Rollback is a normal revert of this PR.

## Development

Closes #1637
