### PR TITLE
fix(search): emit Safari-compatible JSON-LD

### DIFF
--- a/src/utilities/structuredData/JsonLdScript.tsx
+++ b/src/utilities/structuredData/JsonLdScript.tsx
@@ -12,5 +12,17 @@ export function JsonLdScript({ data }: JsonLdScriptProps) {
 
   if (!jsonLd || (Array.isArray(jsonLd) && jsonLd.length === 0)) return null
 
+  if (Array.isArray(jsonLd)) {
+    return (
+      <>
+        {jsonLd.map((node, index) => (
+          <script key={index} type="application/ld+json">
+            {serializeJsonLd(node)}
+          </script>
+        ))}
+      </>
+    )
+  }
+
   return <script type="application/ld+json">{serializeJsonLd(jsonLd)}</script>
 }

--- a/tests/unit/utilities/jsonLdScript.test.tsx
+++ b/tests/unit/utilities/jsonLdScript.test.tsx
@@ -16,31 +16,43 @@ describe('JsonLdScript', () => {
     })
   })
 
-  it('renders a list of JSON-LD nodes and removes empty fields', () => {
+  it('renders each JSON-LD node in its own script and removes empty fields', () => {
     const { container } = render(
       <JsonLdScript
         data={[
           {
             '@context': 'https://schema.org',
+            '@id': 'https://findmydoc.eu/#organization',
             '@type': 'Organization',
             name: 'findmydoc',
             description: '',
             image: undefined,
           },
-          { '@context': 'https://schema.org', '@type': 'WebSite', name: 'findmydoc' },
+          {
+            '@context': 'https://schema.org',
+            '@id': 'https://findmydoc.eu/#website',
+            '@type': 'WebSite',
+            name: 'findmydoc',
+          },
         ]}
       />,
     )
 
-    const script = container.querySelector('script[type="application/ld+json"]')
-    expect(JSON.parse(script?.textContent ?? '')).toEqual([
+    const scripts = Array.from(container.querySelectorAll('script[type="application/ld+json"]'))
+    const nodes = scripts.map((script) => JSON.parse(script.textContent ?? ''))
+
+    expect(scripts).toHaveLength(2)
+    expect(nodes.every((node) => !Array.isArray(node))).toBe(true)
+    expect(nodes).toEqual([
       {
         '@context': 'https://schema.org',
+        '@id': 'https://findmydoc.eu/#organization',
         '@type': 'Organization',
         name: 'findmydoc',
       },
       {
         '@context': 'https://schema.org',
+        '@id': 'https://findmydoc.eu/#website',
         '@type': 'WebSite',
         name: 'findmydoc',
       },


### PR DESCRIPTION
## Management summary

### Deutsch

Safari-Besucher lösen beim Laden der strukturierten Seitendaten keinen Browserfehler mehr aus. Die Informationen für Suchmaschinen bleiben inhaltlich unverändert und werden lediglich browserkompatibel ausgegeben.

### English

Safari visitors no longer trigger a browser error when structured page data loads. The information provided to search engines remains unchanged and is only emitted in a browser-compatible form.

## What changed

- Rendered arrays of structured-data nodes as one `application/ld+json` script per node instead of one top-level JSON array.
- Preserved the existing builders, public component props, node contexts and identifiers, empty-input handling, and script-text escaping.
- Added serializer coverage proving that multiple nodes produce multiple top-level objects with no top-level arrays.
- Cache decision: `no-public-impact`; no reads, tags, invalidation paths, or freshness behavior changed.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P2 | `src/utilities/structuredData/JsonLdScript.tsx` | The shared serializer affects structured data on all public routes. | Multiple nodes retain their contexts and IDs while each script contains one valid top-level object. | Unit coverage, the deployed PR preview, a real-Safari before/after parser reproduction, and the SEO review passed. |

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed.
- [x] `pnpm build`: passed, including `next-sitemap`.
- [x] Focused tests: 2 files, 9 tests passed.
- [x] Standard PR preview: passed; a published post emitted two JSON-LD scripts, each containing one top-level object with `@context`, while the article `@id` was retained.
- [ ] UI/mobile QA: not applicable; JSON-LD is non-visual metadata.
- [ ] Security/privacy review: not applicable; no data sources, permissions, or trust boundaries changed.
- [x] SEO review: no finding at `5/10` or higher.
- [x] Migration/schema check: no schema or migration changes.
- [x] Documentation/instructions check: no documentation or instruction changes required.

## Risk and rollout

The output remains valid JSON-LD and preserves all existing structured-data content. In real Safari, the previous top-level array reproduced the exact `r["@context"].toLowerCase` TypeError, while the new separate object scripts produced no parser error. The automatic PR preview confirmed the deployed post output. The preview homepage remained in Temporary Landing Mode and emitted no JSON-LD, so the full homepage and external structured-data validator checks remain open. Validation ran on Node 26.5 while the repository targets Node 24. No manual preview or production deployment was performed. Rollback is a normal revert of this PR.

## Development

Closes #1638
