### PR TITLE
fix(deps): patch new audit advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,9 +194,9 @@
       "esbuild@<=0.24.2": ">=0.25.0",
       "hono@<4.12.21": ">=4.12.21",
       "postcss@<8.5.18": "8.5.18",
-      "brace-expansion@<5.0.8": "5.0.8",
+      "brace-expansion@<5.0.9": "5.0.9",
       "sharp@<0.35.0": "0.35.3",
-      "fast-uri@<3.1.4": "3.1.4",
+      "fast-uri@<3.1.5": "3.1.5",
       "payload@3.85.1>tsx": "4.21.0"
     },
     "patchedDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,9 @@ overrides:
   esbuild@<=0.24.2: '>=0.25.0'
   hono@<4.12.21: '>=4.12.21'
   postcss@<8.5.18: 8.5.18
-  brace-expansion@<5.0.8: 5.0.8
+  brace-expansion@<5.0.9: 5.0.9
   sharp@<0.35.0: 0.35.3
-  fast-uri@<3.1.4: 3.1.4
+  fast-uri@<3.1.5: 3.1.5
   payload@3.85.1>tsx: 4.21.0
 
 patchedDependencies:
@@ -3829,8 +3829,8 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -4740,8 +4740,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -11142,14 +11142,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11327,7 +11327,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -12351,7 +12351,7 @@ snapshots:
       fast-string-truncated-width: 3.0.3
     optional: true
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -13496,11 +13496,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5(patch_hash=6ef6d9ac96f4561731ab793f4fcee212cbf18d27f4da32c5587660780b43d11b):
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Management summary

### Deutsch

Die automatisierte Sicherheitsprüfung läuft wieder erfolgreich und blockiert Aktualisierungen nicht mehr wegen neu veröffentlichter Sicherheitslücken in transitiven Abhängigkeiten.

### English

The automated security check passes again and no longer blocks updates because of newly published vulnerabilities in transitive dependencies.

## What changed

- Raised the pnpm overrides for `fast-uri` and `brace-expansion` to their first patched versions for the advisories published on 2026-08-03.
- Updated the lockfile package resolutions and snapshots so every affected `ajv` and `minimatch` path uses the patched versions.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------ | -------------- | ---------------------- | -------- |
| P1 | `package.json`, `pnpm-lock.yaml` override and snapshot entries | These entries determine the transitive versions used by the security gate and deployments. | Verify all affected dependency paths resolve to `fast-uri >=3.1.5` and `brace-expansion >=5.0.9` without unrelated lockfile changes. | `pnpm install --frozen-lockfile`; `pnpm deps:audit` passed. |

## Validation

- [x] `pnpm format`: Passed.
- [x] `pnpm check`: Passed.
- [ ] `pnpm build`: Not run; dependency-only lockfile change with no build-relevant source changes.
- [x] Focused tests: `pnpm deps:audit` passed with 0 high and 0 critical vulnerabilities.
- [ ] UI/mobile QA: Not applicable; no UI changes.
- [x] Security/privacy review: Dependency advisories and patched versions verified against GitHub Advisory Database; no application trust-boundary changes.
- [ ] Migration/schema check: Not applicable; no schema or migration changes.
- [ ] Documentation/instructions check: Not applicable; no documentation or instruction changes.

## Risk and rollout

None known. The change only raises existing transitive dependency overrides to their first patched versions. Rollback is a revert of this commit if a package compatibility issue is observed.

## Development

Closes #1645
