### PR TITLE
fix(collections): enforce review command invariants

### DIFF
--- a/docs/seeding.md
+++ b/docs/seeding.md
@@ -34,6 +34,10 @@ Demo units (current):
 - Reviews
 - Review responses and appeals, including native-version history fixtures
 
+Review workflow snapshots run in dependency order: reviews, initial and final review responses, initial appeals,
+review moderation updates, and final appeals. The moderation update uses the normal Review lifecycle so the native
+Review version and platform actor audit exist before an upheld appeal snapshot is written.
+
 Demo reset collection list (ordered for safe clearing):
 1. reviewAppeals (depends on reviews and clinics)
 2. reviewResponses (depends on reviews and clinics)

--- a/src/collections/reviewWorkflow.ts
+++ b/src/collections/reviewWorkflow.ts
@@ -158,8 +158,27 @@ const hasPublicModerationAfterAppealSubmission = (context: ReviewContext, appeal
   return (
     Number.isFinite(submittedTimestamp) &&
     Number.isFinite(moderatedTimestamp) &&
-    moderatedTimestamp >= submittedTimestamp
+    moderatedTimestamp > submittedTimestamp
   )
+}
+
+const requirePublicModerationAfterAppealSubmission = (
+  context: ReviewContext,
+  appealCreatedAt: unknown,
+  req: PayloadRequest,
+): void => {
+  if (hasPublicModerationAfterAppealSubmission(context, appealCreatedAt)) return
+
+  throw new ValidationError({
+    collection: 'reviewAppeals',
+    errors: [
+      {
+        message: 'An upheld appeal requires a separate public moderation action recorded after submission.',
+        path: 'status',
+      },
+    ],
+    req,
+  })
 }
 
 const now = (): string => new Date().toISOString()
@@ -461,6 +480,17 @@ export const prepareReviewAppealChange: CollectionBeforeChangeHook = async ({ da
   }
 
   if (isTrustedSeed(req)) {
+    const requestedStatus =
+      typeof draft.status === 'string'
+        ? draft.status
+        : typeof original.status === 'string'
+          ? original.status
+          : 'submitted'
+
+    if (requestedStatus === 'upheld') {
+      requirePublicModerationAfterAppealSubmission(context, original.createdAt ?? incoming.createdAt, req)
+    }
+
     return prepareTrustedAppealSeed(draft, original, req)
   }
 
@@ -512,21 +542,8 @@ export const prepareReviewAppealChange: CollectionBeforeChangeHook = async ({ da
     })
   }
 
-  if (
-    requestedStatus === 'upheld' &&
-    currentStatus !== 'upheld' &&
-    !hasPublicModerationAfterAppealSubmission(context, original.createdAt)
-  ) {
-    throw new ValidationError({
-      collection: 'reviewAppeals',
-      errors: [
-        {
-          message: 'An upheld appeal requires a separate public moderation action recorded after submission.',
-          path: 'status',
-        },
-      ],
-      req,
-    })
+  if (requestedStatus === 'upheld' && currentStatus !== 'upheld') {
+    requirePublicModerationAfterAppealSubmission(context, original.createdAt, req)
   }
 
   const timestamp = now()

--- a/src/collections/reviews/commandTransaction.ts
+++ b/src/collections/reviews/commandTransaction.ts
@@ -1,0 +1,94 @@
+import type { PayloadRequest } from 'payload'
+
+const MAX_TRANSACTION_ATTEMPTS = 3
+
+const TRANSACTION_OPTIONS = {
+  accessMode: 'read write',
+  isolationLevel: 'serializable',
+} as const
+
+export class ReviewCommandTransactionUnavailableError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ReviewCommandTransactionUnavailableError'
+  }
+}
+
+const errorRecord = (error: unknown): Record<string, unknown> | null =>
+  error !== null && (typeof error === 'object' || typeof error === 'function')
+    ? (error as Record<string, unknown>)
+    : null
+
+export const isSerializationFailure = (error: unknown): boolean => {
+  const visited = new Set<unknown>()
+  let current: unknown = error
+
+  while (current !== null && typeof current !== 'undefined' && !visited.has(current)) {
+    visited.add(current)
+    const record = errorRecord(current)
+    if (!record) return false
+
+    if (record.code === '40001' || record.sqlState === '40001' || record.sqlstate === '40001') {
+      return true
+    }
+
+    current = record.cause
+  }
+
+  return false
+}
+
+const clearOwnedTransaction = (req: PayloadRequest, transactionID: number | string): void => {
+  if (req.transactionID === transactionID) {
+    delete req.transactionID
+  }
+}
+
+export const runReviewCommandTransaction = async <Result>(
+  req: PayloadRequest,
+  command: () => Promise<Result>,
+): Promise<Result> => {
+  if (typeof req.transactionID !== 'undefined') {
+    throw new ReviewCommandTransactionUnavailableError('Review commands cannot run inside a pre-existing transaction.')
+  }
+
+  for (let attempt = 1; attempt <= MAX_TRANSACTION_ATTEMPTS; attempt += 1) {
+    let transactionID: null | number | string = null
+
+    try {
+      transactionID = await req.payload.db.beginTransaction(TRANSACTION_OPTIONS)
+      if (transactionID === null) {
+        throw new ReviewCommandTransactionUnavailableError(
+          'The database adapter did not start a review command transaction.',
+        )
+      }
+
+      req.transactionID = transactionID
+      const result = await command()
+      await req.payload.db.commitTransaction(transactionID)
+      return result
+    } catch (error: unknown) {
+      if (transactionID !== null) {
+        try {
+          await req.payload.db.rollbackTransaction(transactionID)
+        } catch (rollbackError: unknown) {
+          throw new AggregateError([error, rollbackError], 'Review command transaction and rollback both failed.', {
+            cause: error,
+          })
+        }
+      }
+
+      if (isSerializationFailure(error) && attempt < MAX_TRANSACTION_ATTEMPTS) {
+        continue
+      }
+
+      throw error
+    } finally {
+      if (transactionID !== null) {
+        clearOwnedTransaction(req, transactionID)
+      }
+    }
+  }
+
+  throw new ReviewCommandTransactionUnavailableError('Review command transaction attempts were exhausted.')
+}

--- a/src/collections/reviews/endpoints.ts
+++ b/src/collections/reviews/endpoints.ts
@@ -12,6 +12,7 @@ import {
   REVIEW_REDACTION_NOTICE,
   type ReviewPublicMeasure,
 } from '@/collections/reviews/publicProjection'
+import { dispatchReviewChangeRevalidation } from '@/hooks/revalidateClinicSurfaces'
 import { toLoggedError } from '@/utilities/logging/shared'
 
 const PRIVATE_HEADERS = {
@@ -99,6 +100,26 @@ const commandResult = (review: Review) => ({
   withdrawnAt: typeof review.withdrawnAt === 'string' ? review.withdrawnAt : null,
 })
 
+type ReviewCommandOutcome =
+  | { readonly response: Response }
+  | {
+      readonly doc: Review
+      readonly previousDoc: Review
+      readonly response: Response
+    }
+
+const finalizeReviewCommandOutcome = async (req: PayloadRequest, outcome: ReviewCommandOutcome): Promise<Response> => {
+  if ('doc' in outcome) {
+    await dispatchReviewChangeRevalidation({
+      doc: outcome.doc,
+      previousDoc: outcome.previousDoc,
+      req,
+    })
+  }
+
+  return outcome.response
+}
+
 const moderationData = (
   input: z.infer<typeof moderationInputSchema>,
   req: PayloadRequest,
@@ -144,24 +165,31 @@ export const reviewModerationPostHandler: PayloadHandler = async (req) => {
   if (!parsed.success) return errorResponse('INVALID_INPUT', 400)
 
   try {
-    return await runReviewCommandTransaction(req, async () => {
+    const outcome = await runReviewCommandTransaction<ReviewCommandOutcome>(req, async () => {
       const review = await findReview(req, id)
-      if (!review) return errorResponse('NOT_FOUND', 404)
+      if (!review) return { response: errorResponse('NOT_FOUND', 404) }
       if (getReviewWithdrawalState(review) === 'withdrawn') {
-        return errorResponse('REVIEW_WITHDRAWN', 409)
+        return { response: errorResponse('REVIEW_WITHDRAWN', 409) }
       }
 
       const updated = (await req.payload.update({
         collection: 'reviews',
         id,
+        context: { disableRevalidate: true },
         data: moderationData(parsed.data, req, new Date().toISOString()),
         depth: 0,
         overrideAccess: true,
         req,
       })) as Review
 
-      return privateJsonResponse({ data: commandResult(updated) }, 200)
+      return {
+        doc: updated,
+        previousDoc: review,
+        response: privateJsonResponse({ data: commandResult(updated) }, 200),
+      }
     })
+
+    return await finalizeReviewCommandOutcome(req, outcome)
   } catch (error: unknown) {
     return unexpectedErrorResponse(req, error, 'moderation')
   }
@@ -182,20 +210,21 @@ export const reviewWithdrawPostHandler: PayloadHandler = async (req) => {
   const patientWithdrawal = isPatientRequest(req)
 
   try {
-    return await runReviewCommandTransaction(req, async () => {
+    const outcome = await runReviewCommandTransaction<ReviewCommandOutcome>(req, async () => {
       const review = await findReview(req, id)
-      if (!review) return errorResponse('NOT_FOUND', 404)
+      if (!review) return { response: errorResponse('NOT_FOUND', 404) }
       if (isPatientRequest(req) && !sameId(review.patient, user.id)) {
-        return errorResponse('NOT_FOUND', 404)
+        return { response: errorResponse('NOT_FOUND', 404) }
       }
 
       if (getReviewWithdrawalState(review) === 'withdrawn') {
-        return privateJsonResponse({ data: commandResult(review) }, 200)
+        return { response: privateJsonResponse({ data: commandResult(review) }, 200) }
       }
 
       const updated = (await req.payload.update({
         collection: 'reviews',
         id,
+        context: { disableRevalidate: true },
         data: {
           withdrawalState: 'withdrawn',
           withdrawalSource: patientWithdrawal ? 'patient' : 'platform',
@@ -211,8 +240,14 @@ export const reviewWithdrawPostHandler: PayloadHandler = async (req) => {
         req,
       })) as Review
 
-      return privateJsonResponse({ data: commandResult(updated) }, 200)
+      return {
+        doc: updated,
+        previousDoc: review,
+        response: privateJsonResponse({ data: commandResult(updated) }, 200),
+      }
     })
+
+    return await finalizeReviewCommandOutcome(req, outcome)
   } catch (error: unknown) {
     return unexpectedErrorResponse(req, error, 'withdraw')
   }
@@ -230,16 +265,17 @@ export const reviewWithdrawalCorrectionPostHandler: PayloadHandler = async (req)
   if (!parsed.success) return errorResponse('INVALID_INPUT', 400)
 
   try {
-    return await runReviewCommandTransaction(req, async () => {
+    const outcome = await runReviewCommandTransaction<ReviewCommandOutcome>(req, async () => {
       const review = await findReview(req, id)
-      if (!review) return errorResponse('NOT_FOUND', 404)
+      if (!review) return { response: errorResponse('NOT_FOUND', 404) }
       if (getReviewWithdrawalState(review) !== 'withdrawn') {
-        return errorResponse('INVALID_INPUT', 409)
+        return { response: errorResponse('INVALID_INPUT', 409) }
       }
 
       const updated = (await req.payload.update({
         collection: 'reviews',
         id,
+        context: { disableRevalidate: true },
         data: {
           withdrawalState: 'active',
           withdrawalSource: 'platform',
@@ -252,8 +288,14 @@ export const reviewWithdrawalCorrectionPostHandler: PayloadHandler = async (req)
         req,
       })) as Review
 
-      return privateJsonResponse({ data: commandResult(updated) }, 200)
+      return {
+        doc: updated,
+        previousDoc: review,
+        response: privateJsonResponse({ data: commandResult(updated) }, 200),
+      }
     })
+
+    return await finalizeReviewCommandOutcome(req, outcome)
   } catch (error: unknown) {
     return unexpectedErrorResponse(req, error, 'withdrawal_correction')
   }

--- a/src/collections/reviews/endpoints.ts
+++ b/src/collections/reviews/endpoints.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 
 import type { Review } from '@/payload-types'
 import { getUserAssignedClinicId } from '@/access/utils/getClinicAssignment'
+import { runReviewCommandTransaction } from '@/collections/reviews/commandTransaction'
 import {
   getReviewPublicMeasure,
   getReviewWithdrawalState,
@@ -77,17 +78,14 @@ const readRequestBody = async (req: PayloadRequest): Promise<unknown> =>
   typeof req.json === 'function' ? req.json().catch(() => undefined) : undefined
 
 const findReview = async (req: PayloadRequest, id: string | number): Promise<Review | null> => {
-  try {
-    return (await req.payload.findByID({
-      collection: 'reviews',
-      id,
-      depth: 0,
-      overrideAccess: true,
-      req,
-    })) as Review
-  } catch {
-    return null
-  }
+  return (await req.payload.findByID({
+    collection: 'reviews',
+    id,
+    depth: 0,
+    disableErrors: true,
+    overrideAccess: true,
+    req,
+  })) as Review | null
 }
 
 const commandResult = (review: Review) => ({
@@ -145,21 +143,25 @@ export const reviewModerationPostHandler: PayloadHandler = async (req) => {
   const parsed = moderationInputSchema.safeParse(await readRequestBody(req))
   if (!parsed.success) return errorResponse('INVALID_INPUT', 400)
 
-  const review = await findReview(req, id)
-  if (!review) return errorResponse('NOT_FOUND', 404)
-  if (getReviewWithdrawalState(review) === 'withdrawn') return errorResponse('REVIEW_WITHDRAWN', 409)
-
   try {
-    const updated = (await req.payload.update({
-      collection: 'reviews',
-      id,
-      data: moderationData(parsed.data, req, new Date().toISOString()),
-      depth: 0,
-      overrideAccess: true,
-      req,
-    })) as Review
+    return await runReviewCommandTransaction(req, async () => {
+      const review = await findReview(req, id)
+      if (!review) return errorResponse('NOT_FOUND', 404)
+      if (getReviewWithdrawalState(review) === 'withdrawn') {
+        return errorResponse('REVIEW_WITHDRAWN', 409)
+      }
 
-    return privateJsonResponse({ data: commandResult(updated) }, 200)
+      const updated = (await req.payload.update({
+        collection: 'reviews',
+        id,
+        data: moderationData(parsed.data, req, new Date().toISOString()),
+        depth: 0,
+        overrideAccess: true,
+        req,
+      })) as Review
+
+      return privateJsonResponse({ data: commandResult(updated) }, 200)
+    })
   } catch (error: unknown) {
     return unexpectedErrorResponse(req, error, 'moderation')
   }
@@ -168,6 +170,7 @@ export const reviewModerationPostHandler: PayloadHandler = async (req) => {
 export const reviewWithdrawPostHandler: PayloadHandler = async (req) => {
   if (!req.user) return errorResponse('UNAUTHORIZED', 401)
   if (!isPatientRequest(req) && !isPlatformStaffRequest(req)) return errorResponse('FORBIDDEN', 403)
+  const user = req.user
 
   const id = routeReviewId(req)
   if (id === null) return errorResponse('NOT_FOUND', 404)
@@ -176,37 +179,40 @@ export const reviewWithdrawPostHandler: PayloadHandler = async (req) => {
   if (!parsed.success) return errorResponse('INVALID_INPUT', 400)
   if (isPlatformStaffRequest(req) && !parsed.data.reason) return errorResponse('INVALID_INPUT', 400)
 
-  const review = await findReview(req, id)
-  if (!review) return errorResponse('NOT_FOUND', 404)
-  if (isPatientRequest(req) && !sameId(review.patient, req.user.id)) return errorResponse('NOT_FOUND', 404)
-
-  if (getReviewWithdrawalState(review) === 'withdrawn') {
-    return privateJsonResponse({ data: commandResult(review) }, 200)
-  }
-
   const patientWithdrawal = isPatientRequest(req)
-  const timestamp = new Date().toISOString()
 
   try {
-    const updated = (await req.payload.update({
-      collection: 'reviews',
-      id,
-      data: {
-        withdrawalState: 'withdrawn',
-        withdrawalSource: patientWithdrawal ? 'patient' : 'platform',
-        withdrawalReason: patientWithdrawal ? 'Withdrawn by the review author.' : parsed.data.reason,
-        withdrawnAt: timestamp,
-        withdrawnBy: {
-          relationTo: patientWithdrawal ? 'patients' : 'platformStaff',
-          value: req.user.id,
-        },
-      },
-      depth: 0,
-      overrideAccess: true,
-      req,
-    })) as Review
+    return await runReviewCommandTransaction(req, async () => {
+      const review = await findReview(req, id)
+      if (!review) return errorResponse('NOT_FOUND', 404)
+      if (isPatientRequest(req) && !sameId(review.patient, user.id)) {
+        return errorResponse('NOT_FOUND', 404)
+      }
 
-    return privateJsonResponse({ data: commandResult(updated) }, 200)
+      if (getReviewWithdrawalState(review) === 'withdrawn') {
+        return privateJsonResponse({ data: commandResult(review) }, 200)
+      }
+
+      const updated = (await req.payload.update({
+        collection: 'reviews',
+        id,
+        data: {
+          withdrawalState: 'withdrawn',
+          withdrawalSource: patientWithdrawal ? 'patient' : 'platform',
+          withdrawalReason: patientWithdrawal ? 'Withdrawn by the review author.' : parsed.data.reason,
+          withdrawnAt: new Date().toISOString(),
+          withdrawnBy: {
+            relationTo: patientWithdrawal ? 'patients' : 'platformStaff',
+            value: user.id,
+          },
+        },
+        depth: 0,
+        overrideAccess: true,
+        req,
+      })) as Review
+
+      return privateJsonResponse({ data: commandResult(updated) }, 200)
+    })
   } catch (error: unknown) {
     return unexpectedErrorResponse(req, error, 'withdraw')
   }
@@ -215,6 +221,7 @@ export const reviewWithdrawPostHandler: PayloadHandler = async (req) => {
 export const reviewWithdrawalCorrectionPostHandler: PayloadHandler = async (req) => {
   if (!req.user) return errorResponse('UNAUTHORIZED', 401)
   if (!isPlatformStaffRequest(req)) return errorResponse('FORBIDDEN', 403)
+  const user = req.user
 
   const id = routeReviewId(req)
   if (id === null) return errorResponse('NOT_FOUND', 404)
@@ -222,27 +229,31 @@ export const reviewWithdrawalCorrectionPostHandler: PayloadHandler = async (req)
   const parsed = correctionInputSchema.safeParse(await readRequestBody(req))
   if (!parsed.success) return errorResponse('INVALID_INPUT', 400)
 
-  const review = await findReview(req, id)
-  if (!review) return errorResponse('NOT_FOUND', 404)
-  if (getReviewWithdrawalState(review) !== 'withdrawn') return errorResponse('INVALID_INPUT', 409)
-
   try {
-    const updated = (await req.payload.update({
-      collection: 'reviews',
-      id,
-      data: {
-        withdrawalState: 'active',
-        withdrawalSource: 'platform',
-        withdrawalReason: parsed.data.reason,
-        withdrawnAt: new Date().toISOString(),
-        withdrawnBy: { relationTo: 'platformStaff', value: req.user.id },
-      },
-      depth: 0,
-      overrideAccess: true,
-      req,
-    })) as Review
+    return await runReviewCommandTransaction(req, async () => {
+      const review = await findReview(req, id)
+      if (!review) return errorResponse('NOT_FOUND', 404)
+      if (getReviewWithdrawalState(review) !== 'withdrawn') {
+        return errorResponse('INVALID_INPUT', 409)
+      }
 
-    return privateJsonResponse({ data: commandResult(updated) }, 200)
+      const updated = (await req.payload.update({
+        collection: 'reviews',
+        id,
+        data: {
+          withdrawalState: 'active',
+          withdrawalSource: 'platform',
+          withdrawalReason: parsed.data.reason,
+          withdrawnAt: new Date().toISOString(),
+          withdrawnBy: { relationTo: 'platformStaff', value: user.id },
+        },
+        depth: 0,
+        overrideAccess: true,
+        req,
+      })) as Review
+
+      return privateJsonResponse({ data: commandResult(updated) }, 200)
+    })
   } catch (error: unknown) {
     return unexpectedErrorResponse(req, error, 'withdrawal_correction')
   }
@@ -336,16 +347,17 @@ export const reviewPublicationHistoryGetHandler: PayloadHandler = async (req) =>
 
   const id = routeReviewId(req)
   if (id === null) return errorResponse('NOT_FOUND', 404)
-  const review = await findReview(req, id)
-  if (!review) return errorResponse('NOT_FOUND', 404)
-
-  if (isClinicStaffRequest(req)) {
-    if (review.status !== 'approved' || review.deletedAt) return errorResponse('NOT_FOUND', 404)
-    const clinicId = await getUserAssignedClinicId(req.user, req.payload)
-    if (clinicId === null || !sameId(review.clinic, clinicId)) return errorResponse('NOT_FOUND', 404)
-  }
 
   try {
+    const review = await findReview(req, id)
+    if (!review) return errorResponse('NOT_FOUND', 404)
+
+    if (isClinicStaffRequest(req)) {
+      if (review.status !== 'approved' || review.deletedAt) return errorResponse('NOT_FOUND', 404)
+      const clinicId = await getUserAssignedClinicId(req.user, req.payload)
+      if (clinicId === null || !sameId(review.clinic, clinicId)) return errorResponse('NOT_FOUND', 404)
+    }
+
     const versions = await req.payload.findVersions({
       collection: 'reviews',
       where: { parent: { equals: id } },

--- a/src/collections/reviews/endpoints.ts
+++ b/src/collections/reviews/endpoints.ts
@@ -110,11 +110,18 @@ type ReviewCommandOutcome =
 
 const finalizeReviewCommandOutcome = async (req: PayloadRequest, outcome: ReviewCommandOutcome): Promise<Response> => {
   if ('doc' in outcome) {
-    await dispatchReviewChangeRevalidation({
-      doc: outcome.doc,
-      previousDoc: outcome.previousDoc,
-      req,
-    })
+    try {
+      await dispatchReviewChangeRevalidation({
+        doc: outcome.doc,
+        previousDoc: outcome.previousDoc,
+        req,
+      })
+    } catch (error: unknown) {
+      req.payload.logger.error(
+        { err: toLoggedError(error), event: 'review_publication.post_commit_revalidation_failed' },
+        'Review publication post-commit revalidation failed',
+      )
+    }
   }
 
   return outcome.response

--- a/src/endpoints/seed/data/demo/reviewAppealsInitial.json
+++ b/src/endpoints/seed/data/demo/reviewAppealsInitial.json
@@ -18,7 +18,8 @@
     "reviewStableId": "seed-review-06",
     "reason": "privacy_concern",
     "details": "The clinic reports that the review includes details that could identify another patient.",
-    "status": "submitted"
+    "status": "submitted",
+    "createdAt": "2026-01-24T09:00:00.000Z"
   },
   {
     "stableId": "seed-review-appeal-04",

--- a/src/endpoints/seed/data/demo/reviewModerations.json
+++ b/src/endpoints/seed/data/demo/reviewModerations.json
@@ -1,0 +1,11 @@
+[
+  {
+    "stableId": "seed-review-06",
+    "publicMeasure": "removed",
+    "publicComment": null,
+    "publicNotice": null,
+    "moderationReason": "The review contains privacy-sensitive details that could identify another patient.",
+    "moderatedAt": "2026-01-24T09:30:00.000Z",
+    "moderatedByStableId": "seed-platform-admin"
+  }
+]

--- a/src/endpoints/seed/utils/load-json.ts
+++ b/src/endpoints/seed/utils/load-json.ts
@@ -31,6 +31,7 @@ const demoPatients: unknown = loadSeedJson('../data/demo/patients.json')
 const demoPlatformContentMedia: unknown = loadSeedJson('../data/demo/platformContentMedia.json')
 const demoPosts: unknown = loadSeedJson('../data/demo/posts.json')
 const demoReviews: unknown = loadSeedJson('../data/demo/reviews.json')
+const demoReviewModerations: unknown = loadSeedJson('../data/demo/reviewModerations.json')
 const demoReviewResponsesInitial: unknown = loadSeedJson('../data/demo/reviewResponsesInitial.json')
 const demoReviewResponses: unknown = loadSeedJson('../data/demo/reviewResponses.json')
 const demoReviewAppealsInitial: unknown = loadSeedJson('../data/demo/reviewAppealsInitial.json')
@@ -66,6 +67,7 @@ const seedFileMap: SeedFileMap = {
     platformContentMedia: demoPlatformContentMedia,
     posts: demoPosts,
     reviews: demoReviews,
+    reviewModerations: demoReviewModerations,
     reviewResponsesInitial: demoReviewResponsesInitial,
     reviewResponses: demoReviewResponses,
     reviewAppealsInitial: demoReviewAppealsInitial,

--- a/src/endpoints/seed/utils/plan.ts
+++ b/src/endpoints/seed/utils/plan.ts
@@ -454,6 +454,21 @@ export const demoPlan: SeedPlanStep[] = [
   },
   {
     kind: 'collection',
+    name: 'review-moderations',
+    collection: 'reviews',
+    fileName: 'reviewModerations',
+    reqUserStableId: 'seed-platform-admin',
+    mapping: [
+      {
+        sourceField: 'moderatedByStableId',
+        targetField: 'moderatedBy',
+        collection: 'platformStaff',
+        required: true,
+      },
+    ],
+  },
+  {
+    kind: 'collection',
     name: 'review-appeals-final-state',
     collection: 'reviewAppeals',
     fileName: 'reviewAppeals',

--- a/src/hooks/revalidateClinicSurfaces.ts
+++ b/src/hooks/revalidateClinicSurfaces.ts
@@ -20,6 +20,19 @@ type RevalidatableDoc = {
   readonly publishedResponse?: unknown
 }
 
+type ReviewRevalidatableDoc = RevalidatableDoc & {
+  readonly comment?: unknown
+  readonly deletedAt?: unknown
+  readonly publicAuthorName?: unknown
+  readonly publicComment?: unknown
+  readonly publicMeasure?: unknown
+  readonly publicNotice?: unknown
+  readonly reviewDate?: unknown
+  readonly starRating?: unknown
+  readonly treatment?: unknown
+  readonly withdrawalState?: unknown
+}
+
 type ClinicIdentity = {
   readonly id: RelationId
   readonly slug: string
@@ -246,16 +259,7 @@ export const revalidateClinicDelete: CollectionAfterDeleteHook = ({ doc, req }) 
   return doc
 }
 
-const revalidateRelatedClinicSurface = async ({
-  collection,
-  currentClinics,
-  doc,
-  operation,
-  previousClinics = [],
-  req,
-  status,
-  previousStatus,
-}: {
+type RelatedClinicSurfaceRevalidationArgs = {
   readonly collection: ClinicSurfaceRevalidationCollection
   readonly currentClinics: readonly ClinicIdentity[]
   readonly doc: RevalidatableDoc
@@ -264,9 +268,18 @@ const revalidateRelatedClinicSurface = async ({
   readonly req: PayloadRequest
   readonly status?: ClinicSurfacePublicStatus
   readonly previousStatus?: ClinicSurfacePublicStatus
-}): Promise<RevalidatableDoc> => {
-  if (isRevalidationDisabled(req)) return doc
+}
 
+const dispatchRelatedClinicSurfaceRevalidation = ({
+  collection,
+  currentClinics,
+  doc,
+  operation,
+  previousClinics = [],
+  req,
+  status,
+  previousStatus,
+}: RelatedClinicSurfaceRevalidationArgs): void => {
   const id = normalizeId(doc.id, `${collection} id`)
   const current = uniqueIdentities(currentClinics)
   const previous = uniqueIdentities(previousClinics)
@@ -289,8 +302,16 @@ const revalidateRelatedClinicSurface = async ({
     },
     req.payload.logger,
   )
+}
 
-  return doc
+const revalidateRelatedClinicSurface = async (
+  args: RelatedClinicSurfaceRevalidationArgs,
+): Promise<RevalidatableDoc> => {
+  if (isRevalidationDisabled(args.req)) return args.doc
+
+  dispatchRelatedClinicSurfaceRevalidation(args)
+
+  return args.doc
 }
 
 export const revalidateClinicTreatmentChange: CollectionAfterChangeHook = async ({ doc, previousDoc, req }) => {
@@ -377,24 +398,41 @@ export const revalidateDoctorSpecialtyDelete: CollectionAfterDeleteHook = async 
   })
 }
 
-export const revalidateReviewChange: CollectionAfterChangeHook = async ({ doc, previousDoc, req }) => {
-  if (isRevalidationDisabled(req)) return doc
+export const dispatchReviewChangeRevalidation = async ({
+  doc,
+  previousDoc,
+  req,
+}: {
+  readonly doc: ReviewRevalidatableDoc
+  readonly previousDoc?: ReviewRevalidatableDoc
+  readonly req: PayloadRequest
+}): Promise<void> => {
+  const current = doc
+  const previous = previousDoc
 
-  const current = doc as RevalidatableDoc
-  const previous = previousDoc as RevalidatableDoc | undefined
+  if (hasSameReviewPublicCacheProjection(current, previous)) return
 
-  if (hasSameReviewPublicCacheProjection(current, previous)) return doc
+  const currentClinics = [await resolveClinicIdentity(req, current.clinic)].filter(isClinicIdentity)
+  const previousClinics = [await resolveClinicIdentity(req, previous?.clinic)].filter(isClinicIdentity)
 
-  return revalidateRelatedClinicSurface({
+  dispatchRelatedClinicSurfaceRevalidation({
     collection: 'reviews',
-    currentClinics: [await resolveClinicIdentity(req, current.clinic)].filter(isClinicIdentity),
-    previousClinics: [await resolveClinicIdentity(req, previous?.clinic)].filter(isClinicIdentity),
+    currentClinics,
+    previousClinics,
     doc: current,
     operation: 'related-update',
     req,
     status: normalizeOptionalStatus(current.status),
     previousStatus: normalizeOptionalStatus(previous?.status),
   })
+}
+
+export const revalidateReviewChange: CollectionAfterChangeHook = async ({ doc, previousDoc, req }) => {
+  if (isRevalidationDisabled(req)) return doc
+
+  await dispatchReviewChangeRevalidation({ doc, previousDoc, req })
+
+  return doc
 }
 
 export const revalidateReviewDelete: CollectionAfterDeleteHook = async ({ doc, req }) => {

--- a/tests/data-integrity/endpoints/seed/reviewAppealModerationSnapshots.test.ts
+++ b/tests/data-integrity/endpoints/seed/reviewAppealModerationSnapshots.test.ts
@@ -1,0 +1,74 @@
+import platformStaff from '@/endpoints/seed/data/demo/platformStaff.json'
+import reviewAppeals from '@/endpoints/seed/data/demo/reviewAppeals.json'
+import reviewAppealsInitial from '@/endpoints/seed/data/demo/reviewAppealsInitial.json'
+import reviewModerations from '@/endpoints/seed/data/demo/reviewModerations.json'
+import reviews from '@/endpoints/seed/data/demo/reviews.json'
+import { loadSeedFile } from '@/endpoints/seed/utils/load-json'
+import { demoPlan } from '@/endpoints/seed/utils/plan'
+import { describe, expect, it } from 'vitest'
+
+describe('review appeal moderation seed snapshots', () => {
+  it('registers the partial review moderation fixture with its platform actor', async () => {
+    const records = await loadSeedFile('demo', 'reviewModerations')
+    const moderation = reviewModerations[0]
+
+    expect(records).toEqual(reviewModerations)
+    expect(reviewModerations).toHaveLength(1)
+    expect(moderation).toMatchObject({
+      stableId: 'seed-review-06',
+      publicMeasure: 'removed',
+      publicComment: null,
+      publicNotice: null,
+      moderatedAt: '2026-01-24T09:30:00.000Z',
+      moderatedByStableId: 'seed-platform-admin',
+    })
+    expect(moderation?.moderationReason).toMatch(/privacy|identify another patient/i)
+    expect(reviews.some((review) => review.stableId === moderation?.stableId)).toBe(true)
+    expect(platformStaff.some((staff) => staff.stableId === moderation?.moderatedByStableId)).toBe(true)
+  })
+
+  it('orders the audited review moderation between the initial and final appeal snapshots', () => {
+    const initialIndex = demoPlan.findIndex((step) => step.name === 'review-appeals-initial-history')
+    const moderationIndex = demoPlan.findIndex((step) => step.name === 'review-moderations')
+    const finalIndex = demoPlan.findIndex((step) => step.name === 'review-appeals-final-state')
+    const moderationStep = demoPlan[moderationIndex]
+
+    expect(initialIndex).toBeGreaterThanOrEqual(0)
+    expect(moderationIndex).toBeGreaterThan(initialIndex)
+    expect(finalIndex).toBeGreaterThan(moderationIndex)
+    expect(moderationStep).toMatchObject({
+      kind: 'collection',
+      collection: 'reviews',
+      fileName: 'reviewModerations',
+      reqUserStableId: 'seed-platform-admin',
+      mapping: [
+        {
+          sourceField: 'moderatedByStableId',
+          targetField: 'moderatedBy',
+          collection: 'platformStaff',
+          required: true,
+        },
+      ],
+    })
+    expect(moderationStep).not.toHaveProperty('context')
+  })
+
+  it('keeps appeal submission, review moderation, and appeal decision timestamps ordered', () => {
+    const initialAppeal = reviewAppealsInitial.find((appeal) => appeal.stableId === 'seed-review-appeal-03')
+    const finalAppeal = reviewAppeals.find((appeal) => appeal.stableId === 'seed-review-appeal-03')
+    const moderation = reviewModerations.find((review) => review.stableId === 'seed-review-06')
+
+    expect(initialAppeal).toMatchObject({
+      reviewStableId: 'seed-review-06',
+      status: 'submitted',
+      createdAt: '2026-01-24T09:00:00.000Z',
+    })
+    expect(finalAppeal).toMatchObject({
+      reviewStableId: 'seed-review-06',
+      status: 'upheld',
+      decidedAt: '2026-01-24T10:00:00.000Z',
+    })
+    expect(Date.parse(initialAppeal?.createdAt ?? '')).toBeLessThan(Date.parse(moderation?.moderatedAt ?? ''))
+    expect(Date.parse(moderation?.moderatedAt ?? '')).toBeLessThan(Date.parse(finalAppeal?.decidedAt ?? ''))
+  })
+})

--- a/tests/integration/reviewAppeals.lifecycle.test.ts
+++ b/tests/integration/reviewAppeals.lifecycle.test.ts
@@ -430,4 +430,149 @@ describe('reviewAppeals lifecycle', () => {
     expect(reviewVersionsAfterDecision.docs).toHaveLength(reviewVersionsBeforeDecision.docs.length)
     expect(responseVersionsAfterDecision.docs).toHaveLength(responseVersionsBeforeDecision.docs.length)
   }, 60000)
+
+  it('requires an audited review moderation before a trusted upheld snapshot', async () => {
+    const appealCreatedAt = '2026-01-24T09:00:00.000Z'
+    const moderatedAt = '2026-01-24T09:30:00.000Z'
+    const decidedAt = '2026-01-24T10:00:00.000Z'
+    const { review } = await createApprovedReview('trusted-upheld')
+    const moderator = await createPlatformTestUser(payload, {
+      emailPrefix: `${slugPrefix}-trusted-upheld-platform`,
+      createdStaffIds: staffIds,
+    })
+    const platformUser = asPayloadStaffUser(moderator)
+    const appeal = await payload.create({
+      collection: 'reviewAppeals',
+      data: {
+        review: review.id,
+        reason: 'privacy_concern',
+        details: 'The clinic reports privacy-sensitive details that could identify another patient.',
+        status: 'submitted',
+        createdAt: appealCreatedAt,
+      } as unknown as ReviewAppeal,
+      user: platformUser,
+      overrideAccess: true,
+      context: { trustedReviewWorkflowSeed: true },
+      depth: 0,
+    })
+    appealIds.push(appeal.id)
+    expect(appeal.createdAt).toBe(appealCreatedAt)
+
+    const finalSnapshot = {
+      status: 'upheld',
+      decisionReason: 'The privacy concern was confirmed after the separate public moderation action.',
+      decidedAt,
+    } as unknown as ReviewAppeal
+
+    await expect(
+      payload.update({
+        collection: 'reviewAppeals',
+        id: appeal.id,
+        data: finalSnapshot,
+        user: platformUser,
+        overrideAccess: true,
+        context: { trustedReviewWorkflowSeed: true },
+        depth: 0,
+      }),
+    ).rejects.toMatchObject({
+      data: {
+        errors: [
+          expect.objectContaining({
+            message: expect.stringContaining('separate public moderation action'),
+            path: 'status',
+          }),
+        ],
+      },
+    })
+
+    await payload.update({
+      collection: 'reviews',
+      id: review.id,
+      data: {
+        publicMeasure: 'removed',
+        publicComment: null,
+        publicNotice: null,
+        moderationReason: 'The review contains privacy-sensitive details that could identify another patient.',
+        moderatedAt: appealCreatedAt,
+        moderatedBy: moderator.id,
+      } as unknown as Review,
+      user: platformUser,
+      overrideAccess: true,
+      depth: 0,
+    })
+
+    await expect(
+      payload.update({
+        collection: 'reviewAppeals',
+        id: appeal.id,
+        data: finalSnapshot,
+        user: platformUser,
+        overrideAccess: true,
+        context: { trustedReviewWorkflowSeed: true },
+        depth: 0,
+      }),
+    ).rejects.toMatchObject({
+      data: {
+        errors: [
+          expect.objectContaining({
+            message: expect.stringContaining('recorded after submission'),
+            path: 'status',
+          }),
+        ],
+      },
+    })
+
+    await payload.update({
+      collection: 'reviews',
+      id: review.id,
+      data: {
+        publicMeasure: 'removed',
+        publicComment: null,
+        publicNotice: null,
+        moderationReason: 'The review contains privacy-sensitive details that could identify another patient.',
+        moderatedAt,
+        moderatedBy: moderator.id,
+      } as unknown as Review,
+      user: platformUser,
+      overrideAccess: true,
+      depth: 0,
+    })
+
+    const reviewVersions = await payload.findVersions({
+      collection: 'reviews',
+      where: { parent: { equals: review.id } },
+      user: platformUser,
+      overrideAccess: false,
+      depth: 0,
+      pagination: false,
+    })
+    expect(reviewVersions.docs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          version: expect.objectContaining({
+            publicMeasure: 'removed',
+            moderatedAt,
+            moderatedBy: moderator.id,
+          }),
+        }),
+      ]),
+    )
+
+    const upheld = await payload.update({
+      collection: 'reviewAppeals',
+      id: appeal.id,
+      data: finalSnapshot,
+      user: platformUser,
+      overrideAccess: true,
+      context: { trustedReviewWorkflowSeed: true },
+      depth: 0,
+    })
+
+    expect(upheld).toMatchObject({
+      status: 'upheld',
+      decidedAt,
+    })
+    expect(Date.parse(appeal.createdAt)).toBeLessThan(Date.parse(moderatedAt))
+    expect(Date.parse(moderatedAt)).toBeLessThan(Date.parse(upheld.decidedAt!))
+  }, 60000)
 })

--- a/tests/unit/collections/reviewCommandTransactions.test.ts
+++ b/tests/unit/collections/reviewCommandTransactions.test.ts
@@ -1,11 +1,29 @@
 import type { PayloadRequest } from 'payload'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   ReviewCommandTransactionUnavailableError,
   runReviewCommandTransaction,
 } from '@/collections/reviews/commandTransaction'
 import { reviewModerationPostHandler, reviewWithdrawPostHandler } from '@/collections/reviews/endpoints'
+
+type ReviewRevalidationDispatchArgs = {
+  readonly doc: unknown
+  readonly previousDoc?: unknown
+  readonly req: PayloadRequest
+}
+
+const hookMocks = vi.hoisted(() => ({
+  dispatchReviewChangeRevalidation: vi.fn(async (_args: ReviewRevalidationDispatchArgs) => undefined),
+}))
+
+vi.mock('@/hooks/revalidateClinicSurfaces', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/hooks/revalidateClinicSurfaces')>()
+  return {
+    ...original,
+    dispatchReviewChangeRevalidation: hookMocks.dispatchReviewChangeRevalidation,
+  }
+})
 
 const serializableFailure = (): Error =>
   new Error('transaction failed', {
@@ -34,6 +52,11 @@ const deferred = <Value = void>() => {
   })
   return { promise, resolve }
 }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hookMocks.dispatchReviewChangeRevalidation.mockResolvedValue(undefined)
+})
 
 describe('review command transaction control', () => {
   it('retries serialization failures in fresh serializable read-write transactions', async () => {
@@ -121,6 +144,7 @@ describe('review command endpoint concurrency', () => {
     const releaseModeration = deferred()
     const stagedReviews = new Map<string, Record<string, unknown>>()
     const committedWrites: string[] = []
+    const lifecycle: string[] = []
     let transactionSequence = 0
     let committedReview: Record<string, unknown> = {
       id: 42,
@@ -135,6 +159,7 @@ describe('review command endpoint concurrency', () => {
 
     const beginTransaction = vi.fn(async () => `tx-${++transactionSequence}`)
     const commitTransaction = vi.fn(async (transactionID: string) => {
+      lifecycle.push(`commit:${transactionID}`)
       if (transactionID === 'tx-1') throw serializableFailure()
 
       const staged = stagedReviews.get(transactionID)
@@ -159,12 +184,23 @@ describe('review command endpoint concurrency', () => {
 
       return snapshot
     })
-    const update = vi.fn(async ({ data, req }: { data: Record<string, unknown>; req: PayloadRequest }) => {
-      const transactionID = String(req.transactionID)
-      const staged = { ...committedReview, ...data }
-      stagedReviews.set(transactionID, staged)
-      return staged
-    })
+    const update = vi.fn(
+      async ({
+        context,
+        data,
+        req,
+      }: {
+        context?: Record<string, unknown>
+        data: Record<string, unknown>
+        req: PayloadRequest
+      }) => {
+        expect(context).toEqual({ disableRevalidate: true })
+        const transactionID = String(req.transactionID)
+        const staged = { ...committedReview, ...data }
+        stagedReviews.set(transactionID, staged)
+        return staged
+      },
+    )
     const logger = { error: vi.fn() }
     const payload = {
       db: { beginTransaction, commitTransaction, rollbackTransaction },
@@ -180,16 +216,29 @@ describe('review command endpoint concurrency', () => {
         user,
       }) as unknown as PayloadRequest
 
-    const moderation = reviewModerationPostHandler(
-      request(
-        { collection: 'platformStaff', id: 11 },
-        { measure: 'removed', reason: 'Moderation based on the stale active state.' },
-      ),
+    hookMocks.dispatchReviewChangeRevalidation.mockImplementation(async ({ req }) => {
+      expect(req.transactionID).toBeUndefined()
+      lifecycle.push('dispatch')
+    })
+
+    const moderationReq = request(
+      { collection: 'platformStaff', id: 11 },
+      { measure: 'removed', reason: 'Moderation based on the stale active state.' },
     )
+    const withdrawalReq = request({ collection: 'patients', id: 7 }, {})
+
+    const moderation = reviewModerationPostHandler(moderationReq)
     await firstModerationRead.promise
 
-    const withdrawalResponse = await reviewWithdrawPostHandler(request({ collection: 'patients', id: 7 }, {}))
+    const withdrawalResponse = await reviewWithdrawPostHandler(withdrawalReq)
     expect(withdrawalResponse.status).toBe(200)
+    expect(hookMocks.dispatchReviewChangeRevalidation).toHaveBeenCalledOnce()
+    expect(hookMocks.dispatchReviewChangeRevalidation).toHaveBeenCalledWith({
+      doc: expect.objectContaining({ withdrawalState: 'withdrawn' }),
+      previousDoc: expect.objectContaining({ withdrawalState: 'active' }),
+      req: withdrawalReq,
+    })
+    expect(lifecycle.indexOf('commit:tx-2')).toBeLessThan(lifecycle.indexOf('dispatch'))
 
     releaseModeration.resolve()
     const moderationResponse = await moderation
@@ -203,8 +252,14 @@ describe('review command endpoint concurrency', () => {
       withdrawalState: 'withdrawn',
     })
     expect(committedWrites).toEqual(['withdrawal'])
-    expect(beginTransaction).toHaveBeenCalledTimes(3)
-    expect(findByID).toHaveBeenCalledTimes(3)
+    expect(hookMocks.dispatchReviewChangeRevalidation).toHaveBeenCalledOnce()
+
+    const repeatedWithdrawal = await reviewWithdrawPostHandler(request({ collection: 'patients', id: 7 }, {}))
+    expect(repeatedWithdrawal.status).toBe(200)
+    expect(hookMocks.dispatchReviewChangeRevalidation).toHaveBeenCalledOnce()
+
+    expect(beginTransaction).toHaveBeenCalledTimes(4)
+    expect(findByID).toHaveBeenCalledTimes(4)
     expect(update).toHaveBeenCalledTimes(2)
     expect(rollbackTransaction).toHaveBeenCalledWith('tx-1')
     expect(logger.error).not.toHaveBeenCalled()
@@ -238,6 +293,7 @@ describe('review command endpoint concurrency', () => {
     expect(commitTransaction).not.toHaveBeenCalled()
     expect(update).not.toHaveBeenCalled()
     expect(logger.error).toHaveBeenCalledOnce()
+    expect(hookMocks.dispatchReviewChangeRevalidation).not.toHaveBeenCalled()
   })
 
   it('maps exhausted serialization retries to unavailable', async () => {
@@ -271,5 +327,6 @@ describe('review command endpoint concurrency', () => {
     expect(commitTransaction).not.toHaveBeenCalled()
     expect(logger.error).toHaveBeenCalledOnce()
     expect(req.transactionID).toBeUndefined()
+    expect(hookMocks.dispatchReviewChangeRevalidation).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/collections/reviewCommandTransactions.test.ts
+++ b/tests/unit/collections/reviewCommandTransactions.test.ts
@@ -1,0 +1,275 @@
+import type { PayloadRequest } from 'payload'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  ReviewCommandTransactionUnavailableError,
+  runReviewCommandTransaction,
+} from '@/collections/reviews/commandTransaction'
+import { reviewModerationPostHandler, reviewWithdrawPostHandler } from '@/collections/reviews/endpoints'
+
+const serializableFailure = (): Error =>
+  new Error('transaction failed', {
+    cause: new Error('driver failed', { cause: { code: '40001' } }),
+  })
+
+const transactionRequest = ({
+  beginTransaction = vi.fn(async () => 'tx-1'),
+  commitTransaction = vi.fn(async () => undefined),
+  rollbackTransaction = vi.fn(async () => undefined),
+}: {
+  beginTransaction?: ReturnType<typeof vi.fn>
+  commitTransaction?: ReturnType<typeof vi.fn>
+  rollbackTransaction?: ReturnType<typeof vi.fn>
+} = {}) =>
+  ({
+    payload: {
+      db: { beginTransaction, commitTransaction, rollbackTransaction },
+    },
+  }) as unknown as PayloadRequest
+
+const deferred = <Value = void>() => {
+  let resolve!: (value: Value | PromiseLike<Value>) => void
+  const promise = new Promise<Value>((resolver) => {
+    resolve = resolver
+  })
+  return { promise, resolve }
+}
+
+describe('review command transaction control', () => {
+  it('retries serialization failures in fresh serializable read-write transactions', async () => {
+    const transactionIDs = ['tx-1', 'tx-2', 'tx-3']
+    const beginTransaction = vi.fn(async () => transactionIDs.shift() ?? null)
+    const commitTransaction = vi.fn(async () => undefined)
+    const rollbackTransaction = vi.fn(async () => undefined)
+    const req = transactionRequest({ beginTransaction, commitTransaction, rollbackTransaction })
+    const seenTransactionIDs: unknown[] = []
+
+    const result = await runReviewCommandTransaction(req, async () => {
+      seenTransactionIDs.push(req.transactionID)
+      if (seenTransactionIDs.length < 3) throw serializableFailure()
+      return 'committed'
+    })
+
+    expect(result).toBe('committed')
+    expect(seenTransactionIDs).toEqual(['tx-1', 'tx-2', 'tx-3'])
+    expect(beginTransaction).toHaveBeenCalledTimes(3)
+    expect(beginTransaction).toHaveBeenCalledWith({
+      accessMode: 'read write',
+      isolationLevel: 'serializable',
+    })
+    expect(rollbackTransaction.mock.calls).toEqual([['tx-1'], ['tx-2']])
+    expect(commitTransaction).toHaveBeenCalledOnce()
+    expect(commitTransaction).toHaveBeenCalledWith('tx-3')
+    expect(req.transactionID).toBeUndefined()
+  })
+
+  it('rolls back once and does not retry a non-serialization database failure', async () => {
+    const beginTransaction = vi.fn(async () => 'tx-1')
+    const commitTransaction = vi.fn(async () => undefined)
+    const rollbackTransaction = vi.fn(async () => undefined)
+    const req = transactionRequest({ beginTransaction, commitTransaction, rollbackTransaction })
+    const databaseFailure = Object.assign(new Error('constraint failed'), { code: '23505' })
+
+    await expect(
+      runReviewCommandTransaction(req, async () => {
+        throw databaseFailure
+      }),
+    ).rejects.toBe(databaseFailure)
+
+    expect(beginTransaction).toHaveBeenCalledOnce()
+    expect(commitTransaction).not.toHaveBeenCalled()
+    expect(rollbackTransaction).toHaveBeenCalledWith('tx-1')
+    expect(req.transactionID).toBeUndefined()
+  })
+
+  it('stops after three serialization failures and rolls every attempt back', async () => {
+    let sequence = 0
+    const beginTransaction = vi.fn(async () => `tx-${++sequence}`)
+    const commitTransaction = vi.fn(async () => undefined)
+    const rollbackTransaction = vi.fn(async () => undefined)
+    const req = transactionRequest({ beginTransaction, commitTransaction, rollbackTransaction })
+
+    await expect(
+      runReviewCommandTransaction(req, async () => {
+        throw serializableFailure()
+      }),
+    ).rejects.toMatchObject({ cause: { cause: { code: '40001' } } })
+
+    expect(beginTransaction).toHaveBeenCalledTimes(3)
+    expect(commitTransaction).not.toHaveBeenCalled()
+    expect(rollbackTransaction.mock.calls).toEqual([['tx-1'], ['tx-2'], ['tx-3']])
+    expect(req.transactionID).toBeUndefined()
+  })
+
+  it('rejects a pre-existing transaction without taking ownership of it', async () => {
+    const beginTransaction = vi.fn(async () => 'tx-1')
+    const req = transactionRequest({ beginTransaction })
+    req.transactionID = 'outer-transaction'
+
+    await expect(runReviewCommandTransaction(req, async () => 'unused')).rejects.toBeInstanceOf(
+      ReviewCommandTransactionUnavailableError,
+    )
+
+    expect(beginTransaction).not.toHaveBeenCalled()
+    expect(req.transactionID).toBe('outer-transaction')
+  })
+})
+
+describe('review command endpoint concurrency', () => {
+  it('keeps withdrawal terminal when it commits before stale moderation', async () => {
+    const firstModerationRead = deferred()
+    const releaseModeration = deferred()
+    const stagedReviews = new Map<string, Record<string, unknown>>()
+    const committedWrites: string[] = []
+    let transactionSequence = 0
+    let committedReview: Record<string, unknown> = {
+      id: 42,
+      patient: 7,
+      publicComment: null,
+      publicMeasure: 'none',
+      publicNotice: null,
+      withdrawalSource: null,
+      withdrawalState: 'active',
+      withdrawnAt: null,
+    }
+
+    const beginTransaction = vi.fn(async () => `tx-${++transactionSequence}`)
+    const commitTransaction = vi.fn(async (transactionID: string) => {
+      if (transactionID === 'tx-1') throw serializableFailure()
+
+      const staged = stagedReviews.get(transactionID)
+      if (staged) {
+        committedReview = staged
+        committedWrites.push(staged.withdrawalState === 'withdrawn' ? 'withdrawal' : 'moderation')
+        stagedReviews.delete(transactionID)
+      }
+    })
+    const rollbackTransaction = vi.fn(async (transactionID: string) => {
+      stagedReviews.delete(transactionID)
+    })
+    const findByID = vi.fn(async ({ disableErrors, req }: { disableErrors?: boolean; req: PayloadRequest }) => {
+      expect(disableErrors).toBe(true)
+      const transactionID = String(req.transactionID)
+      const snapshot = { ...committedReview }
+
+      if (transactionID === 'tx-1') {
+        firstModerationRead.resolve()
+        await releaseModeration.promise
+      }
+
+      return snapshot
+    })
+    const update = vi.fn(async ({ data, req }: { data: Record<string, unknown>; req: PayloadRequest }) => {
+      const transactionID = String(req.transactionID)
+      const staged = { ...committedReview, ...data }
+      stagedReviews.set(transactionID, staged)
+      return staged
+    })
+    const logger = { error: vi.fn() }
+    const payload = {
+      db: { beginTransaction, commitTransaction, rollbackTransaction },
+      findByID,
+      logger,
+      update,
+    }
+    const request = (user: { collection: 'patients' | 'platformStaff'; id: number }, body: Record<string, unknown>) =>
+      ({
+        json: vi.fn(async () => body),
+        payload,
+        routeParams: { id: 42 },
+        user,
+      }) as unknown as PayloadRequest
+
+    const moderation = reviewModerationPostHandler(
+      request(
+        { collection: 'platformStaff', id: 11 },
+        { measure: 'removed', reason: 'Moderation based on the stale active state.' },
+      ),
+    )
+    await firstModerationRead.promise
+
+    const withdrawalResponse = await reviewWithdrawPostHandler(request({ collection: 'patients', id: 7 }, {}))
+    expect(withdrawalResponse.status).toBe(200)
+
+    releaseModeration.resolve()
+    const moderationResponse = await moderation
+
+    expect(moderationResponse.status).toBe(409)
+    await expect(moderationResponse.json()).resolves.toEqual({
+      error: { code: 'REVIEW_WITHDRAWN' },
+    })
+    expect(committedReview).toMatchObject({
+      publicMeasure: 'none',
+      withdrawalState: 'withdrawn',
+    })
+    expect(committedWrites).toEqual(['withdrawal'])
+    expect(beginTransaction).toHaveBeenCalledTimes(3)
+    expect(findByID).toHaveBeenCalledTimes(3)
+    expect(update).toHaveBeenCalledTimes(2)
+    expect(rollbackTransaction).toHaveBeenCalledWith('tx-1')
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('maps a database read failure to unavailable instead of not found', async () => {
+    const beginTransaction = vi.fn(async () => 'tx-1')
+    const commitTransaction = vi.fn(async () => undefined)
+    const rollbackTransaction = vi.fn(async () => undefined)
+    const logger = { error: vi.fn() }
+    const update = vi.fn()
+    const req = {
+      json: vi.fn(async () => ({ measure: 'none', reason: 'No public change.' })),
+      payload: {
+        db: { beginTransaction, commitTransaction, rollbackTransaction },
+        findByID: vi.fn(async () => {
+          throw Object.assign(new Error('database unavailable'), { code: '08006' })
+        }),
+        logger,
+        update,
+      },
+      routeParams: { id: 42 },
+      user: { collection: 'platformStaff', id: 11 },
+    } as unknown as PayloadRequest
+
+    const response = await reviewModerationPostHandler(req)
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({ error: { code: 'UNAVAILABLE' } })
+    expect(rollbackTransaction).toHaveBeenCalledWith('tx-1')
+    expect(commitTransaction).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledOnce()
+  })
+
+  it('maps exhausted serialization retries to unavailable', async () => {
+    let transactionSequence = 0
+    const beginTransaction = vi.fn(async () => `tx-${++transactionSequence}`)
+    const commitTransaction = vi.fn(async () => undefined)
+    const rollbackTransaction = vi.fn(async () => undefined)
+    const update = vi.fn(async () => {
+      throw serializableFailure()
+    })
+    const logger = { error: vi.fn() }
+    const req = {
+      json: vi.fn(async () => ({ measure: 'none', reason: 'No public change.' })),
+      payload: {
+        db: { beginTransaction, commitTransaction, rollbackTransaction },
+        findByID: vi.fn(async () => ({ id: 42, publicMeasure: 'none', withdrawalState: 'active' })),
+        logger,
+        update,
+      },
+      routeParams: { id: 42 },
+      user: { collection: 'platformStaff', id: 11 },
+    } as unknown as PayloadRequest
+
+    const response = await reviewModerationPostHandler(req)
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({ error: { code: 'UNAVAILABLE' } })
+    expect(beginTransaction).toHaveBeenCalledTimes(3)
+    expect(update).toHaveBeenCalledTimes(3)
+    expect(rollbackTransaction).toHaveBeenCalledTimes(3)
+    expect(commitTransaction).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledOnce()
+    expect(req.transactionID).toBeUndefined()
+  })
+})

--- a/tests/unit/collections/reviewCommandTransactions.test.ts
+++ b/tests/unit/collections/reviewCommandTransactions.test.ts
@@ -296,6 +296,53 @@ describe('review command endpoint concurrency', () => {
     expect(hookMocks.dispatchReviewChangeRevalidation).not.toHaveBeenCalled()
   })
 
+  it('keeps a committed command successful when post-commit revalidation fails', async () => {
+    const beginTransaction = vi.fn(async () => 'tx-1')
+    const commitTransaction = vi.fn(async () => undefined)
+    const rollbackTransaction = vi.fn(async () => undefined)
+    const logger = { error: vi.fn() }
+    const review = {
+      id: 42,
+      patient: 7,
+      publicComment: null,
+      publicMeasure: 'none',
+      publicNotice: null,
+      withdrawalSource: null,
+      withdrawalState: 'active',
+      withdrawnAt: null,
+    }
+    const update = vi.fn(async ({ data }: { data: Record<string, unknown> }) => ({ ...review, ...data }))
+    const req = {
+      json: vi.fn(async () => ({ measure: 'none', reason: 'No public change.' })),
+      payload: {
+        db: { beginTransaction, commitTransaction, rollbackTransaction },
+        findByID: vi.fn(async () => review),
+        logger,
+        update,
+      },
+      routeParams: { id: 42 },
+      user: { collection: 'platformStaff', id: 11 },
+    } as unknown as PayloadRequest
+    const revalidationFailure = new Error('cache unavailable')
+    hookMocks.dispatchReviewChangeRevalidation.mockRejectedValueOnce(revalidationFailure)
+
+    const response = await reviewModerationPostHandler(req)
+
+    expect(response.status).toBe(200)
+    expect(beginTransaction).toHaveBeenCalledOnce()
+    expect(update).toHaveBeenCalledOnce()
+    expect(commitTransaction).toHaveBeenCalledOnce()
+    expect(commitTransaction).toHaveBeenCalledWith('tx-1')
+    expect(rollbackTransaction).not.toHaveBeenCalled()
+    expect(hookMocks.dispatchReviewChangeRevalidation).toHaveBeenCalledOnce()
+    expect(logger.error).toHaveBeenCalledOnce()
+    expect(logger.error).toHaveBeenCalledWith(
+      { err: revalidationFailure, event: 'review_publication.post_commit_revalidation_failed' },
+      'Review publication post-commit revalidation failed',
+    )
+    expect(req.transactionID).toBeUndefined()
+  })
+
   it('maps exhausted serialization retries to unavailable', async () => {
     let transactionSequence = 0
     const beginTransaction = vi.fn(async () => `tx-${++transactionSequence}`)

--- a/tests/unit/hooks/revalidateClinicRelatedCollections.test.ts
+++ b/tests/unit/hooks/revalidateClinicRelatedCollections.test.ts
@@ -3,6 +3,7 @@ import { revalidatePath, revalidateTag } from 'next/cache'
 import type { PayloadRequest } from 'payload'
 
 import {
+  dispatchReviewChangeRevalidation,
   revalidateClinicTreatmentChange,
   revalidateMedicalSpecialtyChange,
   revalidateReviewResponseChange,
@@ -98,22 +99,54 @@ describe('clinic related collection revalidation hooks', () => {
     )
   })
 
-  it('skips duplicate review revalidation for hook-triggered average updates before relation reads', async () => {
-    const req = buildReq({ skipHooks: true })
+  it.each([{ disableRevalidate: true }, { skipHooks: true }])(
+    'skips review hook revalidation before relation reads for context %o',
+    async (context) => {
+      const req = buildReq(context)
 
-    await revalidateReviewChange({
-      collection: { slug: 'reviews' } as unknown as ReviewChangeArgs['collection'],
-      context: req.context,
-      data: {},
-      doc: { id: 300, clinic: 12, status: 'approved' },
-      operation: 'update',
-      previousDoc: undefined,
+      await revalidateReviewChange({
+        collection: { slug: 'reviews' } as unknown as ReviewChangeArgs['collection'],
+        context: req.context,
+        data: {},
+        doc: { id: 300, clinic: 12, status: 'approved' },
+        operation: 'update',
+        previousDoc: undefined,
+        req,
+      } as ReviewChangeArgs)
+
+      expect(req.payload.findByID).not.toHaveBeenCalled()
+      expect(getPathCalls()).toEqual([])
+      expect(getTagCalls()).toEqual([])
+    },
+  )
+
+  it('directly dispatches review revalidation even when the hook path is disabled', async () => {
+    const req = buildReq({ disableRevalidate: true })
+    const publicFields = {
+      id: 301,
+      clinic: 12,
+      status: 'approved',
+      publicMeasure: 'none',
+      reviewDate: '2026-08-08T10:00:00.000Z',
+      starRating: 5,
+      comment: 'Visible review text',
+    }
+
+    await dispatchReviewChangeRevalidation({
+      doc: { ...publicFields, withdrawalState: 'withdrawn' },
+      previousDoc: { ...publicFields, withdrawalState: 'active' },
       req,
-    } as ReviewChangeArgs)
+    })
 
-    expect(req.payload.findByID).not.toHaveBeenCalled()
-    expect(getPathCalls()).toEqual([])
-    expect(getTagCalls()).toEqual([])
+    expect(getPathCalls()).toEqual(['/clinics/berlin-health'])
+    expect(getTagCalls()).toEqual(
+      expect.arrayContaining([
+        'entity:reviews:301',
+        'collection:reviews',
+        'surface:clinic-detail:12',
+        'surface:listing-comparison',
+      ]),
+    )
   })
 
   it.each([


### PR DESCRIPTION
## Management summary

### Deutsch

Moderationsentscheidungen und Autorenrückzüge können sich bei gleichzeitiger Bearbeitung nicht mehr widersprechen. Zudem bilden die Demo-Daten bestätigte Einsprüche nur noch dann ab, wenn die dazugehörige öffentliche Maßnahme separat und nachvollziehbar protokolliert wurde.

### English

Moderation decisions and author withdrawals can no longer conflict when processed concurrently. Demo data now also records upheld appeals only when the corresponding public action has been logged separately and audibly.

## What changed

- Executes review moderation, author withdrawal, and withdrawal correction as serializable Payload-managed command transactions with bounded retries for PostgreSQL serialization conflicts.
- Preserves Payload Local API writes, native review versions, hooks, audit fields, aggregate updates, and cache revalidation while making each read-check-write sequence atomic.
- Defers the existing Review cache-owner dispatch until after commit, suppresses invalidation from rolled-back attempts, and treats post-commit revalidation as best-effort without retrying an already persisted command.
- Stops mapping database read failures to `404`; unavailable infrastructure now returns the existing private `503 UNAVAILABLE` contract.
- Enforces the separately audited review-moderation prerequisite for trusted upheld-appeal seed snapshots without enabling the normal interactive transition graph for seed imports.
- Adds a deterministic privacy-removal seed snapshot between appeal submission and decision, including platform actor and timestamp ordering.

## Points to review

| Priority | Files / paths                                                                                                                  | Why focus here                                                          | Reviewer should verify                                                                                                  | Evidence                                                       |
| -------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| P1       | `src/collections/reviews/commandTransaction.ts`, `src/collections/reviews/endpoints.ts`                                        | Concurrency and rollback determine whether withdrawal remains terminal. | Serializable retries, request transaction ownership, error mapping, and continued use of Payload Local API are correct. | Focused transaction/race tests, `pnpm check`, production build |
| P1       | `src/collections/reviewWorkflow.ts`, `src/endpoints/seed/data/demo/reviewModerations.json`, `src/endpoints/seed/utils/plan.ts` | Trusted seed data must not bypass the audit invariant.                  | An upheld snapshot requires moderation strictly after appeal submission and the seed order preserves that history.      | Lifecycle and data-integrity tests                             |

## Validation

- [x] `pnpm format`: completed successfully
- [x] `pnpm check`: completed successfully
- [x] `pnpm build`: completed successfully with `PAYLOAD_SECRET=dev-secret`
- [x] Focused tests: 31 tests passed across transaction, race, commit-bound revalidation, seed-integrity, appeal-lifecycle, and review-publication suites
- [ ] UI/mobile QA: not applicable; no UI or public rendering changed
- [x] Security/privacy review: isolated Security and Cache Architecture reviews completed; all `6/10` findings were fixed and both final re-reviews reported no remaining findings at `5/10` or higher
- [x] Migration/schema check: no schema change, migration, or generated Payload type update required
- [x] Documentation/instructions check: seed ordering documented; test sense-check passed with existing repository-wide warnings only

## Risk and rollout

This is the lower layer of a two-PR atomic stack. It changes command transaction behavior and trusted demo data but introduces no schema or environment change. If PostgreSQL serialization conflicts persist through three attempts, the command fails closed with `503 UNAVAILABLE`. The stack must be merged atomically with the bounded publication-history follow-up.

## Development

Closes #1642
