### PR TITLE
fix(collections): paginate review publication history

### DIFF
--- a/docs/integrations/clinic-dashboard-api.md
+++ b/docs/integrations/clinic-dashboard-api.md
@@ -237,29 +237,50 @@ Payload REST:
 
 Clinic staff must not use the raw version routes because an older version can contain text that a later redaction,
 removal, or withdrawal makes unsafe. The clinic-safe fallback is
-`GET /api/reviews/<reviewId>/publication-history`. It returns platform staff any review, or the currently assigned
-clinic only when the current review remains approved and not physically deleted:
+`GET /api/reviews/<reviewId>/publication-history?limit=25&cursor=<opaque>`. It returns platform staff any available
+review, or the currently assigned clinic only when the current review remains approved and not physically deleted:
 
 ```ts
-type ReviewPublicationHistoryDTO = {
-  reviewId: number | string
-  versions: Array<{
-    id: number | string | null
-    recordedAt: string | null
-    status: "pending" | "approved" | "rejected"
-    starRating: number
-    reviewDate: string
-    publicAuthorName: string | null
-    publicMeasure: "none" | "context" | "redaction" | "placeholder" | "removed"
-    withdrawalState: "active" | "withdrawn"
-    withdrawalSource: "patient" | "platform" | null
-    withdrawnAt: string | null
-    publicText: string | null
-    publicNotice: string | null
-    actorType: "patient" | "platform_staff" | "system"
-  }>
+type ReviewPublicationHistoryResponseDTO = {
+  data: {
+    reviewId: number | string
+    versions: Array<{
+      id: number | string | null
+      recordedAt: string | null
+      status: "pending" | "approved" | "rejected"
+      starRating: number
+      reviewDate: string
+      publicAuthorName: string | null
+      publicMeasure: "none" | "context" | "redaction" | "placeholder" | "removed"
+      withdrawalState: "active" | "withdrawn"
+      withdrawalSource: "patient" | "platform" | null
+      withdrawnAt: string | null
+      publicText: string | null
+      publicNotice: string | null
+      actorType: "patient" | "platform_staff" | "system"
+    }>
+    pagination: {
+      limit: number
+      hasNextPage: boolean
+      nextCursor: string | null
+    }
+  }
 }
 ```
+
+The route uses keyset pagination ordered by native version `createdAt DESC, id DESC`. `limit` defaults to `25` and
+accepts only integers from `1` through `100`. There are no page numbers, offsets, or total counts. When
+`hasNextPage=true`, the caller sends the returned opaque `nextCursor` unchanged with the same review ID; the final page
+returns `nextCursor=null`. The cursor is versioned and bound to both the route review and the current review revision.
+It never supplies or overrides authorization scope.
+
+Authorization and clinic-tenant hiding run before query validation. Missing authentication returns
+`401 UNAUTHORIZED`; authenticated principals other than platform or clinic staff receive `403 FORBIDDEN`; a missing,
+physically deleted, non-approved clinic review, or review from another clinic returns `404 NOT_FOUND`. Unknown query
+parameters, repeated parameters, an invalid `limit`, a malformed cursor, or a cursor from another review return
+`400 INVALID_INPUT`. A review update after a cursor was issued returns `409 HISTORY_CHANGED`; the
+`clinic-dashboard#106` reader must discard that cursor and its accumulated pages, then restart from the first page.
+Infrastructure failures return `503 UNAVAILABLE`.
 
 `publicText`, `publicNotice`, and `publicAuthorName` are gated by the current review state across the entire history. A
 historical value is returned only when it exactly matches the currently safe public projection; superseded text,

--- a/src/collections/reviews/endpoints.ts
+++ b/src/collections/reviews/endpoints.ts
@@ -1,4 +1,4 @@
-import type { PayloadHandler, PayloadRequest } from 'payload'
+import type { PayloadHandler, PayloadRequest, Where } from 'payload'
 import { z } from 'zod'
 
 import type { Review } from '@/payload-types'
@@ -46,7 +46,7 @@ const withdrawalInputSchema = z.object({ reason: z.string().trim().min(1).max(20
 const correctionInputSchema = z.object({ reason: z.string().trim().min(1).max(2000) }).strict()
 
 type ReviewCommandErrorCode =
-  'FORBIDDEN' | 'INVALID_INPUT' | 'NOT_FOUND' | 'REVIEW_WITHDRAWN' | 'UNAUTHORIZED' | 'UNAVAILABLE'
+  'FORBIDDEN' | 'HISTORY_CHANGED' | 'INVALID_INPUT' | 'NOT_FOUND' | 'REVIEW_WITHDRAWN' | 'UNAUTHORIZED' | 'UNAVAILABLE'
 
 const privateJsonResponse = (body: unknown, status: number): Response =>
   Response.json(body, { status, headers: PRIVATE_HEADERS })
@@ -315,6 +315,73 @@ type ReviewVersionRecord = {
   version?: Review
 }
 
+const PUBLICATION_HISTORY_DEFAULT_LIMIT = 25
+const PUBLICATION_HISTORY_MAX_LIMIT = 100
+const PUBLICATION_HISTORY_CURSOR_VERSION = 1
+const PUBLICATION_HISTORY_MAX_CURSOR_LENGTH = 2048
+
+const publicationHistoryCursorIdSchema = z.union([z.string().min(1), z.number().int().safe()])
+const publicationHistoryCursorSchema = z
+  .object({
+    version: z.literal(PUBLICATION_HISTORY_CURSOR_VERSION),
+    reviewId: publicationHistoryCursorIdSchema,
+    reviewRevision: z.string().datetime({ offset: true }),
+    createdAt: z.string().datetime({ offset: true }),
+    id: publicationHistoryCursorIdSchema,
+  })
+  .strict()
+
+type PublicationHistoryCursor = z.infer<typeof publicationHistoryCursorSchema>
+
+type PublicationHistoryQuery = {
+  cursor: PublicationHistoryCursor | null
+  limit: number
+}
+
+const decodePublicationHistoryCursor = (value: string): PublicationHistoryCursor | null => {
+  if (value.length > PUBLICATION_HISTORY_MAX_CURSOR_LENGTH || !/^[A-Za-z0-9_-]+$/.test(value)) return null
+
+  try {
+    const decoded = Buffer.from(value, 'base64url')
+    if (decoded.toString('base64url') !== value) return null
+
+    const parsed = publicationHistoryCursorSchema.safeParse(JSON.parse(decoded.toString('utf8')))
+    return parsed.success ? parsed.data : null
+  } catch {
+    return null
+  }
+}
+
+const encodePublicationHistoryCursor = (cursor: PublicationHistoryCursor): string =>
+  Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url')
+
+const parsePublicationHistoryQuery = (req: PayloadRequest): PublicationHistoryQuery | null => {
+  for (const key of req.searchParams.keys()) {
+    if (key !== 'limit' && key !== 'cursor') return null
+  }
+
+  const limitValues = req.searchParams.getAll('limit')
+  const cursorValues = req.searchParams.getAll('cursor')
+  if (limitValues.length > 1 || cursorValues.length > 1) return null
+
+  const rawLimit = limitValues[0]
+  const limit = rawLimit === undefined ? PUBLICATION_HISTORY_DEFAULT_LIMIT : Number(rawLimit)
+  if (
+    (rawLimit !== undefined && !/^(?:[1-9]|[1-9][0-9]|100)$/.test(rawLimit)) ||
+    !Number.isInteger(limit) ||
+    limit < 1 ||
+    limit > PUBLICATION_HISTORY_MAX_LIMIT
+  ) {
+    return null
+  }
+
+  const rawCursor = cursorValues[0]
+  const cursor = rawCursor === undefined ? null : decodePublicationHistoryCursor(rawCursor)
+  if (rawCursor !== undefined && cursor === null) return null
+
+  return { cursor, limit }
+}
+
 type PublicationHistoryActorType = 'patient' | 'platform_staff' | 'system'
 
 const publicationHistoryActorType = (version: Review): PublicationHistoryActorType => {
@@ -407,23 +474,75 @@ export const reviewPublicationHistoryGetHandler: PayloadHandler = async (req) =>
       if (clinicId === null || !sameId(review.clinic, clinicId)) return errorResponse('NOT_FOUND', 404)
     }
 
+    const query = parsePublicationHistoryQuery(req)
+    if (!query) return errorResponse('INVALID_INPUT', 400)
+    if (query.cursor && !sameId(query.cursor.reviewId, review.id)) {
+      return errorResponse('INVALID_INPUT', 400)
+    }
+    if (query.cursor && query.cursor.reviewRevision !== review.updatedAt) {
+      return errorResponse('HISTORY_CHANGED', 409)
+    }
+
+    const where: Where = query.cursor
+      ? {
+          and: [
+            { parent: { equals: id } },
+            {
+              or: [
+                { createdAt: { less_than: query.cursor.createdAt } },
+                {
+                  and: [{ createdAt: { equals: query.cursor.createdAt } }, { id: { less_than: query.cursor.id } }],
+                },
+              ],
+            },
+          ],
+        }
+      : { parent: { equals: id } }
+
     const versions = await req.payload.findVersions({
       collection: 'reviews',
-      where: { parent: { equals: id } },
+      where,
       depth: 0,
+      limit: query.limit + 1,
       pagination: false,
-      sort: '-createdAt',
+      sort: ['-createdAt', '-id'],
       overrideAccess: true,
       req,
     })
+
+    const pageRecords = (versions.docs as ReviewVersionRecord[]).slice(0, query.limit)
+    const mappedVersions = pageRecords.map((version) => mapHistoryVersion(version, review))
+    if (mappedVersions.some((version) => version === null)) {
+      throw new Error('Review publication history contains an invalid native version record')
+    }
+
+    const hasNextPage = versions.docs.length > query.limit
+    const lastRecord = pageRecords.at(-1)
+    let nextCursor: string | null = null
+    if (hasNextPage) {
+      const cursor = publicationHistoryCursorSchema.safeParse({
+        version: PUBLICATION_HISTORY_CURSOR_VERSION,
+        reviewId: review.id,
+        reviewRevision: review.updatedAt,
+        createdAt: lastRecord?.createdAt,
+        id: lastRecord?.id,
+      })
+      if (!cursor.success) {
+        throw new Error('Review publication history cannot create a cursor for the native version record')
+      }
+      nextCursor = encodePublicationHistoryCursor(cursor.data)
+    }
 
     return privateJsonResponse(
       {
         data: {
           reviewId: review.id,
-          versions: (versions.docs as ReviewVersionRecord[])
-            .map((version) => mapHistoryVersion(version, review))
-            .filter((version) => version !== null),
+          versions: mappedVersions,
+          pagination: {
+            limit: query.limit,
+            hasNextPage,
+            nextCursor,
+          },
         },
       },
       200,

--- a/tests/integration/reviews.publication.test.ts
+++ b/tests/integration/reviews.publication.test.ts
@@ -86,10 +86,18 @@ describe('review public moderation and author withdrawal', () => {
     await cleanupTestEntities(payload, 'clinics', slugPrefix)
   })
 
-  const endpointRequest = async (user: TypedUser | null | undefined, id: number | string, body?: unknown) => {
+  const endpointRequest = async (
+    user: TypedUser | null | undefined,
+    id: number | string,
+    body?: unknown,
+    query = '',
+  ) => {
     const req = await createLocalReq({ ...(user ? { user } : {}) }, payload)
     req.routeParams = { id }
     req.json = async () => body
+    for (const [key, value] of new URLSearchParams(query)) {
+      req.searchParams.append(key, value)
+    }
     return req
   }
 
@@ -332,6 +340,91 @@ describe('review public moderation and author withdrawal', () => {
       expect.arrayContaining(['none', 'context', 'redaction', 'placeholder', 'removed']),
     )
     expect(versions.docs.every((version) => version.version.comment === platformRead.comment)).toBe(true)
+  }, 60000)
+
+  it('paginates native history without overlap or gaps and invalidates cursors after a review change', async () => {
+    const { review, platformUser, ownClinicUser } = await createScenario('history-pagination')
+
+    for (const sequence of [1, 2, 3, 4, 5]) {
+      const response = await reviewModerationPostHandler(
+        await endpointRequest(platformUser, review.id, {
+          measure: 'context',
+          reason: `Audit history pagination fixture ${sequence}.`,
+          publicNotice: `Verified context ${sequence}.`,
+        }),
+      )
+      expect(response.status).toBe(200)
+    }
+
+    const nativeVersions = await payload.findVersions({
+      collection: 'reviews',
+      where: { parent: { equals: review.id } },
+      limit: 100,
+      pagination: false,
+      sort: ['-createdAt', '-id'],
+      overrideAccess: true,
+      depth: 0,
+    })
+    const expectedIds = nativeVersions.docs.map((version) => relationId(version.id))
+    expect(expectedIds.length).toBeGreaterThan(2)
+
+    const deliveredIds: Array<number | string | null> = []
+    let cursor: string | null = null
+    let pageCount = 0
+
+    do {
+      const query = new URLSearchParams({ limit: '2' })
+      if (cursor) query.set('cursor', cursor)
+      const response = await reviewPublicationHistoryGetHandler(
+        await endpointRequest(ownClinicUser, review.id, undefined, query.toString()),
+      )
+      expect(response.status).toBe(200)
+      expect(response.headers.get('cache-control')).toContain('private, no-store')
+
+      const body = (await response.json()) as {
+        data: {
+          pagination: { hasNextPage: boolean; limit: number; nextCursor: string | null }
+          versions: Array<{ id: number | string | null }>
+        }
+      }
+      expect(body.data.pagination.limit).toBe(2)
+      expect(body.data.pagination.hasNextPage).toBe(body.data.pagination.nextCursor !== null)
+      deliveredIds.push(...body.data.versions.map((version) => version.id))
+      cursor = body.data.pagination.nextCursor
+      pageCount += 1
+      expect(pageCount).toBeLessThanOrEqual(expectedIds.length)
+    } while (cursor)
+
+    expect(deliveredIds).toEqual(expectedIds)
+    expect(new Set(deliveredIds).size).toBe(deliveredIds.length)
+
+    const firstPageResponse = await reviewPublicationHistoryGetHandler(
+      await endpointRequest(ownClinicUser, review.id, undefined, 'limit=1'),
+    )
+    const firstPage = (await firstPageResponse.json()) as {
+      data: { pagination: { nextCursor: string | null } }
+    }
+    expect(firstPage.data.pagination.nextCursor).toEqual(expect.any(String))
+
+    const changed = await reviewModerationPostHandler(
+      await endpointRequest(platformUser, review.id, {
+        measure: 'context',
+        reason: 'This creates a newer review revision.',
+        publicNotice: 'Verified context after pagination.',
+      }),
+    )
+    expect(changed.status).toBe(200)
+
+    const staleCursorResponse = await reviewPublicationHistoryGetHandler(
+      await endpointRequest(
+        ownClinicUser,
+        review.id,
+        undefined,
+        new URLSearchParams({ limit: '1', cursor: String(firstPage.data.pagination.nextCursor) }).toString(),
+      ),
+    )
+    expect(staleCursorResponse.status).toBe(409)
+    await expect(staleCursorResponse.json()).resolves.toEqual({ error: { code: 'HISTORY_CHANGED' } })
   }, 60000)
 
   it('withdraws idempotently, enforces ownership and terminal state, and exposes only tenant-safe history', async () => {

--- a/tests/unit/collections/reviewPublicationHistoryPagination.test.ts
+++ b/tests/unit/collections/reviewPublicationHistoryPagination.test.ts
@@ -1,0 +1,287 @@
+import type { PayloadRequest } from 'payload'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Review } from '@/payload-types'
+import { reviewPublicationHistoryGetHandler } from '@/collections/reviews/endpoints'
+
+const clinicAssignmentMocks = vi.hoisted(() => ({
+  getUserAssignedClinicId: vi.fn(async () => 7 as number | null),
+}))
+
+vi.mock('@/access/utils/getClinicAssignment', () => clinicAssignmentMocks)
+
+const REVIEW_REVISION = '2026-08-08T10:00:00.000Z'
+
+const platformUser = { collection: 'platformStaff', id: 11 } as const
+const clinicUser = { collection: 'clinicStaff', id: 12 } as const
+const patientUser = { collection: 'patients', id: 13 } as const
+
+const currentReview = (overrides: Partial<Review> = {}): Review =>
+  ({
+    id: 42,
+    clinic: 7,
+    comment: 'Care was excellent.',
+    publicAuthorName: 'Maya K.',
+    publicMeasure: 'none',
+    publicNotice: null,
+    publicComment: null,
+    reviewDate: '2026-08-01T00:00:00.000Z',
+    starRating: 5,
+    status: 'approved',
+    updatedAt: REVIEW_REVISION,
+    withdrawalSource: null,
+    withdrawalState: 'active',
+    withdrawnAt: null,
+    ...overrides,
+  }) as Review
+
+const versionRecord = (id: number, secondsBeforeRevision: number) => {
+  const createdAt = new Date(Date.parse(REVIEW_REVISION) - secondsBeforeRevision * 1000).toISOString()
+  return {
+    id,
+    createdAt,
+    updatedAt: createdAt,
+    version: currentReview({ updatedAt: createdAt }),
+  }
+}
+
+const createHarness = ({
+  review = currentReview(),
+  versionDocs = [],
+}: {
+  review?: Review | null
+  versionDocs?: Array<ReturnType<typeof versionRecord>>
+} = {}) => {
+  const findByID = vi.fn(async (_args: unknown) => review)
+  const findVersions = vi.fn(async (_args: unknown) => ({ docs: versionDocs }))
+  const logger = { error: vi.fn() }
+  const payload = { findByID, findVersions, logger }
+
+  const request = ({
+    query = '',
+    routeId = 42,
+    user = platformUser as unknown,
+  }: {
+    query?: string
+    routeId?: number | string
+    user?: unknown
+  } = {}) =>
+    ({
+      payload,
+      routeParams: { id: routeId },
+      searchParams: new URLSearchParams(query),
+      user,
+    }) as unknown as PayloadRequest
+
+  return { findByID, findVersions, logger, payload, request }
+}
+
+const responseData = async (response: Response) =>
+  (await response.json()) as {
+    data: {
+      pagination: { hasNextPage: boolean; limit: number; nextCursor: string | null }
+      reviewId: number | string
+      versions: Array<{ id: number | string | null }>
+    }
+  }
+
+const decodeCursor = (cursor: string): Record<string, unknown> =>
+  JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as Record<string, unknown>
+
+const encodeCursor = (cursor: Record<string, unknown>): string =>
+  Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  clinicAssignmentMocks.getUserAssignedClinicId.mockResolvedValue(7)
+})
+
+describe('review publication history pagination', () => {
+  it.each([
+    { expectedInternalLimit: 26, expectedLimit: 25, query: '', versionCount: 26 },
+    { expectedInternalLimit: 101, expectedLimit: 100, query: 'limit=100', versionCount: 101 },
+  ])(
+    'bounds $expectedLimit returned versions with one-record lookahead',
+    async ({ expectedInternalLimit, expectedLimit, query, versionCount }) => {
+      const records = Array.from({ length: versionCount }, (_, index) => versionRecord(versionCount - index, index))
+      const { findVersions, request } = createHarness({ versionDocs: records })
+
+      const response = await reviewPublicationHistoryGetHandler(request({ query }))
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('cache-control')).toContain('private, no-store')
+      const body = await responseData(response)
+      expect(body.data.versions).toHaveLength(expectedLimit)
+      expect(body.data.pagination).toMatchObject({
+        limit: expectedLimit,
+        hasNextPage: true,
+      })
+      expect(body.data.pagination.nextCursor).toEqual(expect.any(String))
+      expect(findVersions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collection: 'reviews',
+          limit: expectedInternalLimit,
+          pagination: false,
+          sort: ['-createdAt', '-id'],
+        }),
+      )
+      expect(findVersions.mock.calls[0]?.[0]).not.toHaveProperty('page')
+    },
+  )
+
+  it('walks stable keyset pages without overlap or gaps and ends with a null cursor', async () => {
+    const records = [
+      versionRecord(105, 0),
+      versionRecord(104, 1),
+      versionRecord(103, 2),
+      versionRecord(102, 3),
+      versionRecord(101, 4),
+    ]
+    const { findVersions, request } = createHarness()
+    findVersions
+      .mockResolvedValueOnce({ docs: records.slice(0, 3) })
+      .mockResolvedValueOnce({ docs: records.slice(2, 5) })
+      .mockResolvedValueOnce({ docs: records.slice(4, 5) })
+
+    const first = await responseData(await reviewPublicationHistoryGetHandler(request({ query: 'limit=2' })))
+    const second = await responseData(
+      await reviewPublicationHistoryGetHandler(
+        request({ query: `limit=2&cursor=${encodeURIComponent(String(first.data.pagination.nextCursor))}` }),
+      ),
+    )
+    const third = await responseData(
+      await reviewPublicationHistoryGetHandler(
+        request({ query: `limit=2&cursor=${encodeURIComponent(String(second.data.pagination.nextCursor))}` }),
+      ),
+    )
+
+    const deliveredIds = [...first.data.versions, ...second.data.versions, ...third.data.versions].map(
+      (version) => version.id,
+    )
+    expect(deliveredIds).toEqual([105, 104, 103, 102, 101])
+    expect(new Set(deliveredIds).size).toBe(deliveredIds.length)
+    expect(third.data.pagination).toEqual({ limit: 2, hasNextPage: false, nextCursor: null })
+
+    const firstCursor = decodeCursor(String(first.data.pagination.nextCursor))
+    expect(findVersions.mock.calls[1]?.[0]).toMatchObject({
+      limit: 3,
+      pagination: false,
+      sort: ['-createdAt', '-id'],
+      where: {
+        and: [
+          { parent: { equals: 42 } },
+          {
+            or: [
+              { createdAt: { less_than: firstCursor.createdAt } },
+              {
+                and: [{ createdAt: { equals: firstCursor.createdAt } }, { id: { less_than: firstCursor.id } }],
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
+  it('returns HISTORY_CHANGED when the review revision changes after issuing a cursor', async () => {
+    const { findByID, findVersions, request } = createHarness({
+      versionDocs: [versionRecord(3, 0), versionRecord(2, 1)],
+    })
+    const first = await responseData(await reviewPublicationHistoryGetHandler(request({ query: 'limit=1' })))
+    findByID.mockResolvedValueOnce(currentReview({ updatedAt: '2026-08-08T10:01:00.000Z' }))
+    findVersions.mockClear()
+
+    const response = await reviewPublicationHistoryGetHandler(
+      request({ query: `limit=1&cursor=${encodeURIComponent(String(first.data.pagination.nextCursor))}` }),
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({ error: { code: 'HISTORY_CHANGED' } })
+    expect(findVersions).not.toHaveBeenCalled()
+  })
+
+  it('rejects unknown, repeated, out-of-range, decimal, malformed, and foreign inputs', async () => {
+    const validCursor = {
+      version: 1,
+      reviewId: 42,
+      reviewRevision: REVIEW_REVISION,
+      createdAt: '2026-08-08T09:59:59.000Z',
+      id: 41,
+    }
+    const malformedShape = encodeCursor({ ...validCursor, unexpected: true })
+    const foreignCursor = encodeCursor({ ...validCursor, reviewId: 999 })
+    const unsupportedVersion = encodeCursor({ ...validCursor, version: 2 })
+    const { findVersions, request } = createHarness()
+    const queries = [
+      'unknown=true',
+      'limit=1&limit=1',
+      `cursor=${encodeURIComponent(encodeCursor(validCursor))}&cursor=${encodeURIComponent(encodeCursor(validCursor))}`,
+      'limit=0',
+      'limit=101',
+      'limit=1.5',
+      'cursor=not.base64url',
+      `cursor=${'a'.repeat(2049)}`,
+      `cursor=${encodeURIComponent(`${encodeCursor(validCursor)}=`)}`,
+      `cursor=${encodeURIComponent(malformedShape)}`,
+      `cursor=${encodeURIComponent(unsupportedVersion)}`,
+      `cursor=${encodeURIComponent(foreignCursor)}`,
+    ]
+
+    for (const query of queries) {
+      const response = await reviewPublicationHistoryGetHandler(request({ query }))
+      expect(response.status, query).toBe(400)
+      await expect(response.json()).resolves.toEqual({ error: { code: 'INVALID_INPUT' } })
+    }
+
+    expect(findVersions).not.toHaveBeenCalled()
+  })
+
+  it('authorizes and hides tenant state before validating query input', async () => {
+    const anonymous = createHarness()
+    expect(
+      (await reviewPublicationHistoryGetHandler(anonymous.request({ query: 'unknown=true', user: null }))).status,
+    ).toBe(401)
+    expect(anonymous.findByID).not.toHaveBeenCalled()
+
+    const wrongRole = createHarness()
+    expect(
+      (await reviewPublicationHistoryGetHandler(wrongRole.request({ query: 'unknown=true', user: patientUser })))
+        .status,
+    ).toBe(403)
+    expect(wrongRole.findByID).not.toHaveBeenCalled()
+
+    const missing = createHarness({ review: null })
+    expect((await reviewPublicationHistoryGetHandler(missing.request({ query: 'unknown=true' }))).status).toBe(404)
+
+    clinicAssignmentMocks.getUserAssignedClinicId.mockResolvedValueOnce(99)
+    const foreignTenant = createHarness()
+    expect(
+      (await reviewPublicationHistoryGetHandler(foreignTenant.request({ query: 'unknown=true', user: clinicUser })))
+        .status,
+    ).toBe(404)
+    expect(foreignTenant.findVersions).not.toHaveBeenCalled()
+
+    const pending = createHarness({ review: currentReview({ status: 'pending' }) })
+    expect(
+      (await reviewPublicationHistoryGetHandler(pending.request({ query: 'unknown=true', user: clinicUser }))).status,
+    ).toBe(404)
+    expect(pending.findVersions).not.toHaveBeenCalled()
+
+    const deleted = createHarness({ review: currentReview({ deletedAt: '2026-08-08T10:02:00.000Z' }) })
+    expect(
+      (await reviewPublicationHistoryGetHandler(deleted.request({ query: 'unknown=true', user: clinicUser }))).status,
+    ).toBe(404)
+    expect(deleted.findVersions).not.toHaveBeenCalled()
+  })
+
+  it('maps history infrastructure failures to UNAVAILABLE', async () => {
+    const { findVersions, logger, request } = createHarness()
+    findVersions.mockRejectedValueOnce(new Error('database unavailable'))
+
+    const response = await reviewPublicationHistoryGetHandler(request())
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({ error: { code: 'UNAVAILABLE' } })
+    expect(logger.error).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Management summary

### Deutsch

Kliniken können den freigegebenen Änderungsverlauf einer Patientenbewertung zuverlässig und schrittweise abrufen, ohne frühere vertrauliche oder inzwischen entfernte Inhalte zu sehen. Auch bei langen Verläufen bleibt der Abruf begrenzt und konsistent; ändert sich die Bewertung währenddessen, beginnt die Anzeige kontrolliert neu.

### English

Clinics can reliably load an approved patient review's change history in bounded steps without seeing confidential or subsequently removed content. Long histories remain bounded and consistent, and if the review changes during retrieval, the reader restarts in a controlled way.

## What changed

- Replaced the unbounded clinic-safe publication-history read with strict cursor-based keyset pagination ordered by native review version creation time and ID.
- Bound every cursor to the route review and its current revision; stale cursors return `409 HISTORY_CHANGED` so read-only consumers restart without combining different history snapshots.
- Preserved authorization and tenant hiding before query validation, rejected malformed or ambiguous query input, and kept every response private and non-cacheable.
- Documented the complete paginated response, error contract, limits, and restart behavior for `clinic-dashboard#106`.
- Added focused unit and database-backed integration coverage for limits, cursor traversal, malformed input, tenant separation, stale histories, and infrastructure errors.

## Points to review

| Priority | Files / paths                                                      | Why focus here                                                                              | Reviewer should verify                                                                                                           | Evidence                                                                             |
| -------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| P1       | `src/collections/reviews/endpoints.ts` publication-history handler | The cursor is part of a tenant-scoped privacy boundary and controls a native-version query. | Authorization and tenant hiding precede parsing; cursor tampering cannot widen scope; query size and result size remain bounded. | 7 focused unit tests and 3 database-backed publication integration tests pass.       |
| P1       | `src/collections/reviews/endpoints.ts` keyset predicate            | Concurrent review changes must not produce mixed or incomplete audit pages.                 | The `createdAt DESC, id DESC` predicate matches the sort and a revision change produces `409 HISTORY_CHANGED`.                   | Unit traversal plus native-version integration traversal and stale-cursor test pass. |
| P2       | `docs/integrations/clinic-dashboard-api.md`                        | This is the read-only integration contract for the dependent dashboard issue.               | Response wrapping, pagination fields, errors, visibility, and restart semantics match runtime behavior.                          | Documentation reviewed against focused tests and implementation.                     |

## Validation

- [x] `pnpm format`: completed successfully.
- [x] `pnpm check`: completed successfully, including lint, type generation, Payload type consistency, and TypeScript.
- [x] `pnpm build`: completed successfully with `PAYLOAD_SECRET=dev-secret`.
- [x] Focused tests: 7 unit tests in `reviewPublicationHistoryPagination.test.ts` and 3 database-backed tests in `reviews.publication.test.ts`; `pnpm tests:sense-check` also passed with repository-wide pre-existing advisory warnings only.
- [x] UI/mobile QA: not applicable; this PR changes only a private API read contract, tests, and integration documentation.
- [x] Security/privacy review: isolated Security and Cache Architecture reviews completed; neither reported a finding at `5/10` or higher.
- [x] Migration/schema check: no schema or generated Payload type change; no migration required.
- [x] Documentation/instructions check: updated the existing `clinic-dashboard#106` contract and followed the applicable collection, test, and documentation instructions.

## Risk and rollout

This is the top layer of a two-PR atomic stack and depends on the transactional command invariants in #1663. Consumers must treat cursors as opaque and restart from page one after `409 HISTORY_CHANGED`; the contract intentionally exposes no offsets or total count. The route remains private-live with no public cache impact and requires no data migration or environment change.

## Development

Closes #1642
