### PR TITLE
docs: document review moderation process

### DIFF
--- a/docs/review-modification-process.md
+++ b/docs/review-modification-process.md
@@ -1,62 +1,178 @@
 # Review Modification Process
 
-## Overview
+## Purpose and Policy Boundary
 
-Once patients submit reviews, they cannot edit or delete them directly. All review modifications must go through Platform Staff to maintain review integrity and prevent abuse.
+This document describes the implemented technical process for review corrections, clinic responses, clinic appeals,
+public moderation, and author withdrawal. It does not define which statements require a policy intervention. The
+internal Trust Core remains the source of truth for those decisions and must be consulted without duplicating
+its private contents here.
 
-## Process Flow
+findmydoc is not an evidence platform. Review workflows must not request or store proof uploads, passage-level or
+evidence fields, raw medical records, screenshots, or personally identifiable information about third parties.
+`ReviewAppeals.details` is a short description of the clinic's objection, limited to 10-2000 characters. An external
+case or file reference is not required.
 
-```mermaid
-flowchart TD
-    A[Patient submits review] --> B[Review status: 'pending']
-    B --> C[Platform Staff moderates]
-    C --> D{Review approved?}
-    D -->|Yes| E[Status: 'approved'<br/>Review published]
-    D -->|No| F[Status: 'rejected'<br/>Review not published]
-    
-    E --> G[Patient wants to modify review]
-    G --> H[Patient contacts Platform Support]
-    H --> I[Platform Staff evaluates request]
-    I --> J{Valid modification request?}
-    
-    J -->|Yes| K[Platform Staff makes approved changes]
-    J -->|No| L[Request denied with explanation]
-    
-    K --> M[Changes logged in audit trail]
-    M --> N[Patient notified of changes]
+## Domain Contract
 
-    style A fill:#e1f5fe
-    style E fill:#c8e6c9
-    style F fill:#ffcdd2
-    style K fill:#fff3e0
-    style L fill:#ffcdd2
-```
+| Record | Implemented responsibility |
+| --- | --- |
+| `Reviews` | Stores the author's original `comment`, approval `status`, public moderation projection, withdrawal state, and unlimited native Payload versions. |
+| `ReviewResponses` | Stores one moderated clinic-response workflow per approved review, with separate pending and published projections and unlimited native versions. |
+| `ReviewAppeals` | Stores at most one non-public clinic appeal per approved review, its decision lifecycle, and unlimited native versions. |
 
-## Rules
+The three review concerns are independent:
 
-1. **No Patient Editing/Deleting**: Once submitted, patients cannot edit or delete reviews directly (create-only for patients)
-2. **Platform Staff Only**: Only Platform Staff can modify or delete reviews
-3. **Support Process**: Patients contact support for legitimate correction requests
-4. **Audit Trail**: All changes are logged with timestamps and staff member ID; audit fields are system-controlled (immutable by clients)
-5. **Visibility**: Non-platform users can only read reviews with status `approved`
+- `status` is the existing approval state: `pending | approved | rejected`.
+- `publicMeasure` controls the public treatment of an approved review:
+  `none | context | redaction | placeholder | removed`.
+- `withdrawalState` records whether the author withdrawal is `active | withdrawn`.
 
-## Valid Modification Requests
+An appeal decision does not set either of the other states. In particular, `upheld` does not automatically reject,
+remove, redact, or otherwise change a review or its clinic response.
 
-- Factual errors (wrong treatment date, procedure name)
-- Typos or grammatical mistakes
-- Privacy concerns (removing personal information)
-- Updated medical outcomes
+## Roles and Tenant Scope
 
-## Invalid Modification Requests
+| Principal | Review access and actions |
+| --- | --- |
+| Anonymous caller | Reads only approved, active public review projections and eligible published clinic responses. |
+| Patient | Creates a review that is forced to the authenticated patient and `pending`; reads the same public projection as an anonymous caller; can withdraw only their own review. Patients cannot directly update, delete, or read review versions. |
+| Clinic staff | Reads approved reviews for the currently assigned clinic, including sanitized moderation and withdrawal state; manages only that clinic's response and appeal workflows; reads tenant-scoped response and appeal versions and the sanitized review publication history. Clinic staff cannot moderate or withdraw reviews. |
+| Platform staff | Reads all review states and raw history; performs ordinary Review updates, public moderation, verified author withdrawal recording, withdrawal corrections, response workflow management, and appeal submission or decisions. Review deletion is platform-only and uses Payload soft delete. |
 
-- Rating changes without factual basis
-- Retaliation against clinic/doctor
-- Changes under pressure from healthcare providers
-- Emotional changes without valid reason
+For response and appeal writes, the clinic is derived from the related review and checked against the authenticated
+clinic assignment. A clinic or actor supplied by a client is not authoritative. Cross-tenant workflow reads are
+filtered, and the review publication-history endpoint returns `404` for an assigned clinic that does not own the
+review.
 
-## Technical Implementation
+## Submission and Approval
 
-- **Create Access**: Patients and Platform Staff
-- **Update/Delete Access**: Platform Staff only
-- **Audit Fields**: `lastEditedAt`, `editedBy` (set automatically on update by Platform)
-- **Status Control**: Only Platform Staff can approve/reject reviews
+Patients and platform staff can create reviews. Patient creation always derives the patient from the authenticated
+principal and forces `status=pending`. Platform staff controls ordinary Review updates, including approval or
+rejection. Only approved reviews can enter the clinic response or appeal workflows.
+
+Public output requires an approved, non-deleted, active review and a public measure other than `removed`. A pending or
+rejected review is not public, regardless of its moderation fields.
+
+## Verified Author Corrections
+
+Patients do not edit a submitted review directly. A patient requests a correction through support, and platform staff
+must verify that the request came from the review author.
+
+The only permitted process that changes the original `comment` is such a verified author correction. Platform staff
+applies it through the platform-only Review update. Payload records the previous and updated text as native versions,
+and the Review edit hook records `lastEditedAt`, `editedBy`, and `editedByName`.
+
+Platform, legal, or clinic moderation must not overwrite `comment`. The dedicated moderation command writes only the
+public projection and its audit fields. A redaction therefore stores a separate readable `publicComment`; context adds
+a separate notice; placeholder and removal hide text without replacing the original. Withdrawal also leaves
+`comment` unchanged.
+
+## Clinic Response Workflow
+
+Each approved review can have one `ReviewResponses` record:
+
+1. Assigned clinic staff submits or edits `pendingResponse`.
+2. Platform staff can also create or manage the workflow when required.
+3. An already approved response remains public while a revision is pending.
+4. Platform staff sets `moderationStatus` to `approved`, `rejected`, or `blocked`.
+5. Approval publishes the pending response. Rejection discards the pending replacement but retains an existing
+   published response. Blocking hides the published response.
+
+A published, non-blocked response is public only while its parent review remains approved, active, and readable under
+`none`, `context`, or `redaction`. It is hidden when the parent Review is rejected, soft-deleted, withdrawn, or assigned
+`placeholder` or `removed`.
+
+## Clinic Appeal Workflow
+
+Each approved review can have at most one `ReviewAppeals` record for its lifetime:
+
+1. Assigned clinic staff, or platform staff recording the submission, selects a reason and submits the short `details`
+   description.
+2. The clinic submission is immutable after creation.
+3. Platform staff moves the appeal through `submitted -> under_review -> upheld | dismissed` and provides a
+   `decisionReason` for a terminal decision.
+4. Before an appeal can become `upheld`, platform staff must record a separate public moderation action after the
+   appeal was submitted. `none` is the explicit decision that no public change is required.
+5. The terminal appeal update changes only the appeal. It does not create a Review or ReviewResponse version and does
+   not alter either record's public state.
+
+The appeal's `under_review` state is private workflow data. It is never rendered as a public review status.
+
+## Public Moderation Measures
+
+The following table assumes `status=approved`, `withdrawalState=active`, and no soft deletion. “Public author” means
+the first-name and last-initial snapshot only when the patient opted into that display.
+
+| Measure | Public review output | Stars, count, date, and public author | Published clinic response |
+| --- | --- | --- | --- |
+| `none` | Original `comment` | Included | Visible when independently approved and non-blocked |
+| `context` | Original `comment` plus a factual operator-provided `publicNotice` | Included | Visible when independently approved and non-blocked |
+| `redaction` | Separate readable `publicComment` plus the fixed factual removal notice | Included | Visible when independently approved and non-blocked |
+| `placeholder` | Fixed neutral notice; no review text | Included | Hidden |
+| `removed` | Review omitted without a placeholder | Excluded | Hidden |
+
+Redaction produces ordinary readable text, not black bars. Placeholder is an operationally temporary measure for cases
+where no coherent text can remain visible while the final measure is completed. It is not a public `under_review`
+state; platform staff must replace it with the final measure. The current command contract does not schedule or expire
+placeholders automatically.
+
+The moderation command records the internal reason, platform actor, and timestamp. It preserves the Review's
+`comment`, star rating, approval status, review date, and author preference. A withdrawn review rejects further
+moderation until platform staff corrects an erroneous withdrawal.
+
+Current collection reads apply the same visibility boundary:
+
+- Platform staff can read all states, raw text, internal reasons, and audit actors.
+- Assigned clinic staff can read approved rows for their clinic, including removed and withdrawn rows, but receives
+  only sanitized moderation and withdrawal fields. Raw `comment` is available only for active `none` or `context`
+  reviews; patient identity, internal reasons, named actors, and hidden text are omitted.
+- Patients and anonymous callers receive only approved, active `none | context | redaction | placeholder` rows. They
+  receive the public projection only; removed and withdrawn rows are absent.
+
+## Author Withdrawal
+
+Withdrawal is a dedicated state change, not review deletion or text editing:
+
+1. The owning patient can invoke the withdrawal command for their own review. An unrelated patient receives no
+   confirmation that the review exists.
+2. Platform staff can document a verified author request and must provide an internal reason.
+3. Repeating an already completed withdrawal is idempotent and creates no additional version.
+4. Withdrawal removes the review, star contribution, clinic response, and any future published patient additions from
+   public output without a placeholder.
+5. The command appends the withdrawal state and audit to native history. It does not overwrite the original `comment`,
+   change the existing public measure, or delete the Review record and its versions.
+
+Withdrawal is terminal until platform staff uses the audited withdrawal-correction command. That correction restores
+`withdrawalState=active` and preserves the existing public measure; it does not rewrite the review.
+
+## Versioning and Audit
+
+- `Reviews`, `ReviewResponses`, and `ReviewAppeals` retain unlimited native Payload versions. Version restoration is
+  disabled for all three collections.
+- Raw Review versions are platform-only. Assigned clinic staff use the sanitized publication-history endpoint, which
+  reveals historical public text, notices, and author name only when they exactly match the currently safe public
+  projection. Removed or withdrawn current state exposes no historical text.
+- Response and appeal versions are readable by platform staff and by clinic staff for their assigned clinic. Public
+  and patient principals cannot read them.
+- Response and appeal mutations record action, timestamp, actor type, and an optional actor relation. Account erasure
+  can clear the personal actor relation from current and version records while the non-personal action audit remains.
+- Moderation records `moderationReason`, `moderatedAt`, and `moderatedBy`. Withdrawal records state, source, internal
+  reason, time, and actor. These fields are not part of public output.
+- Response and appeal deletion through normal collection access is disabled. Review deletion remains the separate
+  platform-only soft-delete path and is not used for author withdrawal.
+
+## Endpoint Boundary
+
+The process uses these purpose-specific Review endpoints in addition to standard access-controlled Payload collection
+reads and workflow writes:
+
+| Endpoint | Process role |
+| --- | --- |
+| `POST /api/reviews/:id/moderation` | Platform-only public measure command. |
+| `POST /api/reviews/:id/withdraw` | Owning-patient or platform-documented author withdrawal command. |
+| `POST /api/reviews/:id/withdrawal-correction` | Platform-only correction of an erroneous withdrawal state. |
+| `GET /api/reviews/:id/publication-history` | Private, no-store history for platform staff or the currently assigned clinic, with tenant and current-safety filtering. |
+
+Request shapes, response DTOs, pagination, error codes, standard collection-read projections, and the Clinic Dashboard
+BFF boundary are defined once in the
+[Clinic Dashboard API contract](./integrations/clinic-dashboard-api.md#review-publication-response-and-appeal-upstream-contract).

--- a/docs/review-modification-process.md
+++ b/docs/review-modification-process.md
@@ -117,7 +117,7 @@ the first-name and last-initial snapshot only when the patient opted into that d
 | --- | --- | --- | --- |
 | `none` | Original `comment` | Included | Visible when independently approved and non-blocked |
 | `context` | Original `comment` plus a factual operator-provided `publicNotice` | Included | Visible when independently approved and non-blocked |
-| `redaction` | Separate readable `publicComment` plus the fixed factual removal notice | Included | Visible when independently approved and non-blocked |
+| `redaction` | Separate readable `publicComment` plus the fixed removal notice | Included | Visible when independently approved and non-blocked |
 | `placeholder` | Fixed neutral notice; no review text | Included | Hidden |
 | `removed` | Review omitted without a placeholder | Excluded | Hidden |
 
@@ -126,9 +126,17 @@ where no coherent text can remain visible while the final measure is completed. 
 state; platform staff must replace it with the final measure. The current command contract does not schedule or expire
 placeholders automatically.
 
-The moderation command records the internal reason, platform actor, and timestamp. It preserves the Review's
-`comment`, star rating, approval status, review date, and author preference. A withdrawn review rejects further
-moderation until platform staff corrects an erroneous withdrawal.
+For `redaction`, platform staff supplies `publicComment`, while the moderation command leaves the stored original
+`comment` unchanged. The backend does not compare `publicComment` with `comment`; it therefore does not guarantee that
+the public text is deletion-only or that it preserves the meaning of the original. Before selecting `redaction`, the
+operator must compare both texts and confirm that only the necessary passages were removed and that the remaining
+content does not distort the original statement.
+
+The moderation process stores no passage selection, text diff, evidence field, or proof for that decision. The fixed
+public removal notice is an operator-responsible statement, not the result of automated text analysis. The moderation
+command records the internal reason, platform actor, and timestamp. It preserves the Review's `comment`, star rating,
+approval status, review date, and author preference. A withdrawn review rejects further moderation until platform
+staff corrects an erroneous withdrawal.
 
 Current collection reads apply the same visibility boundary:
 

--- a/docs/review-modification-process.md
+++ b/docs/review-modification-process.md
@@ -37,7 +37,7 @@ remove, redact, or otherwise change a review or its clinic response.
 | Anonymous caller | Reads only approved, active public review projections and eligible published clinic responses. |
 | Patient | Creates a review that is forced to the authenticated patient and `pending`; reads the same public projection as an anonymous caller; can withdraw only their own review. Patients cannot directly update, delete, or read review versions. |
 | Clinic staff | Reads approved reviews for the currently assigned clinic, including sanitized moderation and withdrawal state; manages only that clinic's response and appeal workflows; reads tenant-scoped response and appeal versions and the sanitized review publication history. Clinic staff cannot moderate or withdraw reviews. |
-| Platform staff | Reads all review states and raw history; performs ordinary Review updates, public moderation, verified author withdrawal recording, withdrawal corrections, response workflow management, and appeal submission or decisions. Review deletion is platform-only and uses Payload soft delete. |
+| Platform staff | Reads all review states and raw history; performs ordinary Review updates, public moderation, records author withdrawal after external support verification, corrects withdrawal state, manages response workflows, and submits or decides appeals. Review deletion is platform-only and uses Payload soft delete. |
 
 For response and appeal writes, the clinic is derived from the related review and checked against the authenticated
 clinic assignment. A clinic or actor supplied by a client is not authoritative. Cross-tenant workflow reads are
@@ -55,17 +55,27 @@ rejected review is not public, regardless of its moderation fields.
 
 ## Verified Author Corrections
 
-Patients do not edit a submitted review directly. A patient requests a correction through support, and platform staff
-must verify that the request came from the review author.
+### Operator Policy
 
-The only permitted process that changes the original `comment` is such a verified author correction. Platform staff
-applies it through the platform-only Review update. Payload records the previous and updated text as native versions,
-and the Review edit hook records `lastEditedAt`, `editedBy`, and `editedByName`.
+Patients do not edit a submitted review directly. A patient requests a correction through support, and platform staff
+verifies outside the Website backend that the request came from the review author. Only that externally verified
+request permits an operator to change the original `comment`.
 
 Platform, legal, or clinic moderation must not overwrite `comment`. The dedicated moderation command writes only the
 public projection and its audit fields. A redaction therefore stores a separate readable `publicComment`; context adds
 a separate notice; placeholder and removal hide text without replacing the original. Withdrawal also leaves
 `comment` unchanged.
+
+### Technical Guarantee
+
+Platform staff applies an author correction through the ordinary platform-only Review update. Payload records the
+previous and updated text as native versions, and the Review edit hook records `lastEditedAt`, `editedBy`, and
+`editedByName`.
+
+The Website backend has no dedicated author-correction command, verification flag, stored verification evidence, or
+purpose field for that update. The edit metadata establishes which platform account made an update and when; it does
+not prove that the author approved the change or that the update was used for an author correction. External support
+verification and correct operator use therefore remain policy obligations.
 
 ## Clinic Response Workflow
 
@@ -123,11 +133,14 @@ moderation until platform staff corrects an erroneous withdrawal.
 Current collection reads apply the same visibility boundary:
 
 - Platform staff can read all states, raw text, internal reasons, and audit actors.
-- Assigned clinic staff can read approved rows for their clinic, including removed and withdrawn rows, but receives
-  only sanitized moderation and withdrawal fields. Raw `comment` is available only for active `none` or `context`
-  reviews; patient identity, internal reasons, named actors, and hidden text are omitted.
+- Assigned clinic staff current reads retain approved rows for their clinic even when `publicMeasure=removed` or
+  `withdrawalState=withdrawn`. They can read the stored `publicMeasure`, `publicComment`, and `publicNotice` when
+  present, plus `moderatedAt`, `withdrawalState`, `withdrawalSource`, and `withdrawnAt`. Those stored fields do
+  not mean that the row or projection is still public. Raw `comment` is available only for active `none` or
+  `context` reviews; it is not readable for redaction, placeholder, removal, or withdrawal. Patient identity,
+  internal reasons, and named audit actors are also omitted.
 - Patients and anonymous callers receive only approved, active `none | context | redaction | placeholder` rows. They
-  receive the public projection only; removed and withdrawn rows are absent.
+  receive the public projection only. Removed and withdrawn rows are absent in full.
 
 ## Author Withdrawal
 
@@ -135,12 +148,14 @@ Withdrawal is a dedicated state change, not review deletion or text editing:
 
 1. The owning patient can invoke the withdrawal command for their own review. An unrelated patient receives no
    confirmation that the review exists.
-2. Platform staff can document a verified author request and must provide an internal reason.
+2. Platform staff may document an author withdrawal only after support has verified the request outside the Website
+   backend. The platform request must include an internal reason, but the backend stores no verification proof.
 3. Repeating an already completed withdrawal is idempotent and creates no additional version.
 4. Withdrawal removes the review, star contribution, clinic response, and any future published patient additions from
    public output without a placeholder.
-5. The command appends the withdrawal state and audit to native history. It does not overwrite the original `comment`,
-   change the existing public measure, or delete the Review record and its versions.
+5. The command appends source, actor, time, reason, and withdrawal state to native history. Those fields establish who
+   recorded the state change and when; they do not prove an externally verified author request. The command does not
+   overwrite the original `comment`, change the existing public measure, or delete the Review record and its versions.
 
 Withdrawal is terminal until platform staff uses the audited withdrawal-correction command. That correction restores
 `withdrawalState=active` and preserves the existing public measure; it does not rewrite the review.
@@ -156,8 +171,9 @@ Withdrawal is terminal until platform staff uses the audited withdrawal-correcti
   and patient principals cannot read them.
 - Response and appeal mutations record action, timestamp, actor type, and an optional actor relation. Account erasure
   can clear the personal actor relation from current and version records while the non-personal action audit remains.
-- Moderation records `moderationReason`, `moderatedAt`, and `moderatedBy`. Withdrawal records state, source, internal
-  reason, time, and actor. These fields are not part of public output.
+- Moderation records `moderationReason`, `moderatedAt`, and `moderatedBy`. A platform Review update records general
+  `lastEdited*` metadata, and withdrawal records state, source, internal reason, time, and actor. These audit fields
+  are not part of public output and do not establish author verification or the operator's purpose.
 - Response and appeal deletion through normal collection access is disabled. Review deletion remains the separate
   platform-only soft-delete path and is not used for author withdrawal.
 

--- a/scripts/test-sense-check.mjs
+++ b/scripts/test-sense-check.mjs
@@ -98,7 +98,7 @@ function hasDataIntegritySignal(source) {
     /@\/endpoints\/seed\/data\//u,
     /src\/endpoints\/seed\/data\//u,
     /readFileSync\([^)]*seed/u,
-    /readFileSync\([\s\S]{0,240}?['"][^'"]*docs\/[^'"]+\.md['"]/u,
+    /readFileSync\(\s*['"](?:[^'"]*\/)?docs\/[^'"]+\.md['"]\s*(?:,|\))/u,
     /medicalSpecialt(?:y|ies).*\.json/u,
   ].some((pattern) => pattern.test(source))
 }

--- a/scripts/test-sense-check.mjs
+++ b/scripts/test-sense-check.mjs
@@ -98,6 +98,7 @@ function hasDataIntegritySignal(source) {
     /@\/endpoints\/seed\/data\//u,
     /src\/endpoints\/seed\/data\//u,
     /readFileSync\([^)]*seed/u,
+    /readFileSync\([\s\S]{0,240}?['"][^'"]*docs\/[^'"]+\.md['"]/u,
     /medicalSpecialt(?:y|ies).*\.json/u,
   ].some((pattern) => pattern.test(source))
 }

--- a/tests/data-integrity/docs/reviewModificationProcess.test.ts
+++ b/tests/data-integrity/docs/reviewModificationProcess.test.ts
@@ -9,6 +9,8 @@ type MarkdownSection = {
   title: string
 }
 
+type MarkdownTableRecord = Record<string, string>
+
 const parseSections = (source: string): MarkdownSection[] => {
   const headings = [...source.matchAll(/^## (.+)$/gmu)]
 
@@ -65,6 +67,62 @@ const parseTable = (section: string): string[][] =>
     )
     .filter((row) => !row.every((cell) => /^-+$/u.test(cell)))
 
+const parseTableRecords = (section: string): MarkdownTableRecord[] => {
+  const [headers, ...rows] = parseTable(section)
+  if (!headers) throw new Error('Missing Markdown table')
+
+  return rows.map(
+    (row) =>
+      Object.fromEntries(headers.map((header, index) => [header, row[index] ?? ''])) as MarkdownTableRecord,
+  )
+}
+
+const parseTopLevelBullets = (section: string): string[] => {
+  const bullets: string[] = []
+  let activeIndex: number | undefined
+
+  for (const line of section.split('\n')) {
+    if (line.startsWith('- ')) {
+      bullets.push(line.slice(2))
+      activeIndex = bullets.length - 1
+      continue
+    }
+
+    if (line.trim() === '') {
+      activeIndex = undefined
+      continue
+    }
+
+    if (activeIndex !== undefined) {
+      bullets[activeIndex] = `${bullets[activeIndex]} ${line.trim()}`
+    }
+  }
+
+  return bullets.map(normalizeWhitespace)
+}
+
+const getBullet = (section: string, prefix: string): string => {
+  const bullet = parseTopLevelBullets(section).find((candidate) => candidate.startsWith(prefix))
+  if (!bullet) throw new Error(`Missing documentation bullet: ${prefix}`)
+  return bullet
+}
+
+const getSentence = (source: string, marker: string): string => {
+  const sentence = (source.match(/[^.]+(?:\.|$)/gu) ?? []).find((candidate) =>
+    candidate.toLowerCase().includes(marker.toLowerCase()),
+  )
+  if (!sentence) throw new Error(`Missing documentation sentence: ${marker}`)
+  return normalizeWhitespace(sentence)
+}
+
+const extractCodeTerms = (value: string): string[] =>
+  [...value.matchAll(/`([^`]+)`/gu)].flatMap((match) =>
+    (match[1] ?? '')
+      .split('|')
+      .map((term) => term.trim())
+      .filter(Boolean),
+  )
+
 describe('review modification process documentation contract', () => {
   it('keeps approval, public treatment, and withdrawal as separate state machines', () => {
     const domainContract = getSection('Domain Contract')
@@ -84,32 +142,196 @@ describe('review modification process documentation contract', () => {
     expect(independenceSignals.filter((signal) => normalizedContract.includes(signal))).toEqual(independenceSignals)
   })
 
-  it('defines public behavior for every supported moderation measure', () => {
-    const rows = parseTable(getSection('Public Moderation Measures')).slice(1)
-    const measures = rows.map((row) => row[0]?.match(/^`([^`]+)`$/u)?.[1])
+  it('binds each moderation measure to its public text, rating, and response behavior', () => {
+    const rows = parseTableRecords(getSection('Public Moderation Measures'))
+    const measures = Object.fromEntries(
+      rows.map((row) => {
+        const measure = extractCodeTerms(row.Measure ?? '')[0]
+        if (!measure) throw new Error('Missing public moderation measure')
 
-    expect(measures).toEqual(['none', 'context', 'redaction', 'placeholder', 'removed'])
-    expect(rows.every((row) => row.length === 4 && row.every(Boolean))).toBe(true)
+        const output = normalizeWhitespace(row['Public review output'] ?? '').toLowerCase()
+        const fields = extractCodeTerms(row['Public review output'] ?? '')
+        const outputMode = fields.includes('publicComment')
+          ? 'redacted'
+          : fields.includes('publicNotice')
+            ? 'context'
+            : fields.includes('comment')
+              ? 'original'
+              : output.includes('no review text')
+                ? 'notice-only'
+                : output.includes('omitted')
+                  ? 'omitted'
+                  : 'unknown'
+        const notice = output.includes('fixed removal notice')
+          ? 'removal'
+          : output.includes('fixed neutral notice')
+            ? 'neutral'
+            : output.includes('factual') && fields.includes('publicNotice')
+              ? 'context'
+              : 'none'
+
+        return [
+          measure,
+          {
+            fields,
+            metadata: normalizeWhitespace(row['Stars, count, date, and public author'] ?? '').toLowerCase(),
+            notice,
+            outputMode,
+            response: normalizeWhitespace(row['Published clinic response'] ?? '')
+              .toLowerCase()
+              .startsWith('visible')
+              ? 'visible'
+              : normalizeWhitespace(row['Published clinic response'] ?? '').toLowerCase().startsWith('hidden')
+                ? 'hidden'
+                : 'unknown',
+          },
+        ]
+      }),
+    )
+
+    expect(measures).toEqual({
+      context: {
+        fields: ['comment', 'publicNotice'],
+        metadata: 'included',
+        notice: 'context',
+        outputMode: 'context',
+        response: 'visible',
+      },
+      none: {
+        fields: ['comment'],
+        metadata: 'included',
+        notice: 'none',
+        outputMode: 'original',
+        response: 'visible',
+      },
+      placeholder: {
+        fields: [],
+        metadata: 'included',
+        notice: 'neutral',
+        outputMode: 'notice-only',
+        response: 'hidden',
+      },
+      redaction: {
+        fields: ['publicComment'],
+        metadata: 'included',
+        notice: 'removal',
+        outputMode: 'redacted',
+        response: 'visible',
+      },
+      removed: {
+        fields: [],
+        metadata: 'excluded',
+        notice: 'none',
+        outputMode: 'omitted',
+        response: 'hidden',
+      },
+    })
   })
 
-  it('keeps publication history read-only, private, tenant-scoped, and visibility-filtered', () => {
-    const endpointRows = parseTable(getSection('Endpoint Boundary')).slice(1)
-    const historyRows = endpointRows.filter((row) => row[0]?.includes('/publication-history'))
-    const methods = historyRows.map((row) => row[0]?.match(/`([A-Z]+)\s/u)?.[1])
-    const endpointRole = normalizeWhitespace(historyRows[0]?.[1] ?? '').toLowerCase()
-    const endpointSignals = ['private', 'no-store', 'platform staff', 'currently assigned clinic', 'tenant', 'current-safety']
+  it('keeps dashboard history and current reads private, read-only, and current-safe', () => {
+    const endpointRows = parseTableRecords(getSection('Endpoint Boundary'))
+    const historyEndpoint = endpointRows.find((row) => (row.Endpoint ?? '').includes('/publication-history'))
+    if (!historyEndpoint) throw new Error('Missing publication-history endpoint')
 
-    expect(methods).toEqual(['GET'])
-    expect(endpointSignals.filter((signal) => endpointRole.includes(signal))).toEqual(endpointSignals)
+    const [method, endpointPath] = extractCodeTerms(historyEndpoint.Endpoint ?? '')[0]?.split(/\s+/u) ?? []
+    const endpointRole = normalizeWhitespace(historyEndpoint['Process role'] ?? '').toLowerCase()
+    expect({
+      cache: endpointRole.includes('no-store') ? 'no-store' : 'unspecified',
+      endpointPath,
+      method,
+      principals: ['platform staff', 'currently assigned clinic'].filter((principal) =>
+        endpointRole.includes(principal),
+      ),
+      scope: ['tenant', 'current-safety'].filter((constraint) => endpointRole.includes(constraint)),
+    }).toEqual({
+      cache: 'no-store',
+      endpointPath: '/api/reviews/:id/publication-history',
+      method: 'GET',
+      principals: ['platform staff', 'currently assigned clinic'],
+      scope: ['tenant', 'current-safety'],
+    })
 
-    const versioning = normalizeWhitespace(getSection('Versioning and Audit')).toLowerCase()
-    const visibilitySignals = [
-      'sanitized publication-history endpoint',
+    const moderationSection = getSection('Public Moderation Measures')
+    const clinicCurrentRead = getBullet(moderationSection, 'Assigned clinic staff current reads')
+    const retainedRows = getSentence(clinicCurrentRead, 'retain approved rows')
+    expect(extractCodeTerms(retainedRows)).toEqual(['publicMeasure=removed', 'withdrawalState=withdrawn'])
+
+    const readableProjectionFields = getSentence(clinicCurrentRead, 'They can read')
+    expect(extractCodeTerms(readableProjectionFields)).toEqual([
+      'publicMeasure',
+      'publicComment',
+      'publicNotice',
+      'moderatedAt',
+      'withdrawalState',
+      'withdrawalSource',
+      'withdrawnAt',
+    ])
+
+    const projectionVisibility = getSentence(clinicCurrentRead, 'do not mean')
+    expect(
+      ['stored fields', 'row or projection', 'still public'].filter((signal) =>
+        projectionVisibility.toLowerCase().includes(signal),
+      ),
+    ).toEqual(['stored fields', 'row or projection', 'still public'])
+
+    const rawCommentVisibility = getSentence(clinicCurrentRead, 'available only')
+    expect(extractCodeTerms(rawCommentVisibility)).toEqual(['comment', 'none', 'context'])
+    expect(
+      ['active', 'not readable', 'redaction', 'placeholder', 'removal', 'withdrawal'].filter((signal) =>
+        rawCommentVisibility.toLowerCase().includes(signal),
+      ),
+    ).toEqual(['active', 'not readable', 'redaction', 'placeholder', 'removal', 'withdrawal'])
+
+    const omittedClinicData = getSentence(clinicCurrentRead, 'also omitted')
+    expect(
+      ['patient identity', 'internal reasons', 'named audit actors'].filter((field) =>
+        omittedClinicData.toLowerCase().includes(field),
+      ),
+    ).toEqual(['patient identity', 'internal reasons', 'named audit actors'])
+
+    const publicCurrentRead = getBullet(moderationSection, 'Patients and anonymous callers')
+    const eligiblePublicRows = getSentence(publicCurrentRead, 'receive only approved')
+    expect(extractCodeTerms(eligiblePublicRows)).toEqual(['none', 'context', 'redaction', 'placeholder'])
+    expect(
+      ['approved', 'active'].filter((state) => eligiblePublicRows.toLowerCase().includes(state)),
+    ).toEqual(['approved', 'active'])
+
+    const publicProjection = getSentence(publicCurrentRead, 'public projection only')
+    expect(publicProjection.toLowerCase().includes('public projection only')).toBe(true)
+
+    const absentPublicRows = getSentence(publicCurrentRead, 'absent in full')
+    expect(
+      ['removed', 'withdrawn', 'absent in full'].filter((state) =>
+        absentPublicRows.toLowerCase().includes(state),
+      ),
+    ).toEqual(['removed', 'withdrawn', 'absent in full'])
+
+    const reviewHistory = getBullet(getSection('Versioning and Audit'), 'Raw Review versions')
+    const rawVersionAccess = getSentence(reviewHistory, 'platform-only')
+    expect(
+      ['raw review versions', 'platform-only'].filter((signal) =>
+        rawVersionAccess.toLowerCase().includes(signal),
+      ),
+    ).toEqual(['raw review versions', 'platform-only'])
+
+    const safeClinicHistory = getSentence(reviewHistory, 'currently safe public projection')
+    expect(
+      ['assigned clinic staff', 'sanitized publication-history', 'exactly match', 'currently safe public projection'].filter(
+        (signal) => safeClinicHistory.toLowerCase().includes(signal),
+      ),
+    ).toEqual([
+      'assigned clinic staff',
+      'sanitized publication-history',
+      'exactly match',
       'currently safe public projection',
-      'removed or withdrawn current state',
-      'no historical text',
-    ]
-    expect(visibilitySignals.filter((signal) => versioning.includes(signal))).toEqual(visibilitySignals)
+    ])
+
+    const hiddenHistory = getSentence(reviewHistory, 'no historical text')
+    expect(
+      ['removed', 'withdrawn', 'no historical text'].filter((signal) =>
+        hiddenHistory.toLowerCase().includes(signal),
+      ),
+    ).toEqual(['removed', 'withdrawn', 'no historical text'])
   })
 
   it('references the Trust Core only at the policy boundary and forbids evidence storage', () => {

--- a/tests/data-integrity/docs/reviewModificationProcess.test.ts
+++ b/tests/data-integrity/docs/reviewModificationProcess.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+const processDocument = readFileSync('docs/review-modification-process.md', 'utf8')
+
+type MarkdownSection = {
+  body: string
+  title: string
+}
+
+const parseSections = (source: string): MarkdownSection[] => {
+  const headings = [...source.matchAll(/^## (.+)$/gmu)]
+
+  return headings.map((heading, index) => {
+    const start = (heading.index ?? 0) + heading[0].length
+    const end = headings[index + 1]?.index ?? source.length
+
+    return {
+      body: source.slice(start, end).trim(),
+      title: (heading[1] ?? '').trim(),
+    }
+  })
+}
+
+const sections = parseSections(processDocument)
+
+const getSection = (title: string): string => {
+  const section = sections.find((candidate) => candidate.title === title)
+  if (!section) throw new Error(`Missing documentation section: ${title}`)
+  return section.body
+}
+
+const normalizeWhitespace = (value: string): string => value.replace(/\s+/gu, ' ').trim()
+
+const extractCodeUnion = (section: string, field: string): string[] => {
+  const lines = section.split('\n')
+  const start = lines.findIndex((line) => line.startsWith(`- \`${field}\``))
+  if (start < 0) throw new Error(`Missing state definition for ${field}`)
+
+  const definition = []
+  for (let index = start; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (line === undefined) break
+    if (index > start && (line === '' || line.startsWith('- `'))) break
+    definition.push(line)
+  }
+
+  const union = [...definition.join(' ').matchAll(/`([^`]+\|[^`]+)`/gu)][0]?.[1]
+  if (!union) throw new Error(`Missing state values for ${field}`)
+
+  return union.split('|').map((value) => value.trim())
+}
+
+const parseTable = (section: string): string[][] =>
+  section
+    .split('\n')
+    .filter((line) => line.trim().startsWith('|'))
+    .map((line) =>
+      line
+        .trim()
+        .slice(1, -1)
+        .split('|')
+        .map((cell) => cell.trim()),
+    )
+    .filter((row) => !row.every((cell) => /^-+$/u.test(cell)))
+
+describe('review modification process documentation contract', () => {
+  it('keeps approval, public treatment, and withdrawal as separate state machines', () => {
+    const domainContract = getSection('Domain Contract')
+
+    expect({
+      publicMeasure: extractCodeUnion(domainContract, 'publicMeasure'),
+      status: extractCodeUnion(domainContract, 'status'),
+      withdrawalState: extractCodeUnion(domainContract, 'withdrawalState'),
+    }).toEqual({
+      publicMeasure: ['none', 'context', 'redaction', 'placeholder', 'removed'],
+      status: ['pending', 'approved', 'rejected'],
+      withdrawalState: ['active', 'withdrawn'],
+    })
+
+    const independenceSignals = ['independent', 'appeal decision', 'does not set']
+    const normalizedContract = normalizeWhitespace(domainContract).toLowerCase()
+    expect(independenceSignals.filter((signal) => normalizedContract.includes(signal))).toEqual(independenceSignals)
+  })
+
+  it('defines public behavior for every supported moderation measure', () => {
+    const rows = parseTable(getSection('Public Moderation Measures')).slice(1)
+    const measures = rows.map((row) => row[0]?.match(/^`([^`]+)`$/u)?.[1])
+
+    expect(measures).toEqual(['none', 'context', 'redaction', 'placeholder', 'removed'])
+    expect(rows.every((row) => row.length === 4 && row.every(Boolean))).toBe(true)
+  })
+
+  it('keeps publication history read-only, private, tenant-scoped, and visibility-filtered', () => {
+    const endpointRows = parseTable(getSection('Endpoint Boundary')).slice(1)
+    const historyRows = endpointRows.filter((row) => row[0]?.includes('/publication-history'))
+    const methods = historyRows.map((row) => row[0]?.match(/`([A-Z]+)\s/u)?.[1])
+    const endpointRole = normalizeWhitespace(historyRows[0]?.[1] ?? '').toLowerCase()
+    const endpointSignals = ['private', 'no-store', 'platform staff', 'currently assigned clinic', 'tenant', 'current-safety']
+
+    expect(methods).toEqual(['GET'])
+    expect(endpointSignals.filter((signal) => endpointRole.includes(signal))).toEqual(endpointSignals)
+
+    const versioning = normalizeWhitespace(getSection('Versioning and Audit')).toLowerCase()
+    const visibilitySignals = [
+      'sanitized publication-history endpoint',
+      'currently safe public projection',
+      'removed or withdrawn current state',
+      'no historical text',
+    ]
+    expect(visibilitySignals.filter((signal) => versioning.includes(signal))).toEqual(visibilitySignals)
+  })
+
+  it('references the Trust Core only at the policy boundary and forbids evidence storage', () => {
+    expect(sections.filter((section) => /\bTrust Core\b/u.test(section.body)).map((section) => section.title)).toEqual([
+      'Purpose and Policy Boundary',
+    ])
+
+    const policyBoundary = normalizeWhitespace(getSection('Purpose and Policy Boundary')).toLowerCase()
+    const boundarySignals = ['source of truth', 'without duplicating', 'must not request or store', 'proof uploads', 'evidence fields']
+    expect(boundarySignals.filter((signal) => policyBoundary.includes(signal))).toEqual(boundarySignals)
+  })
+})

--- a/tests/tooling/scripts/test-sense-check.test.ts
+++ b/tests/tooling/scripts/test-sense-check.test.ts
@@ -157,4 +157,21 @@ describe('runTestSenseCheck', () => {
 
     expect(runTestSenseCheck({ rootDir }).ok).toBe(true)
   })
+
+  it('recognizes documentation contracts in the data-integrity suite', () => {
+    const rootDir = createTempRepo({
+      'tests/data-integrity/docs/reviewModificationProcess.test.ts': [
+        "import { readFileSync } from 'node:fs'",
+        "import { describe, expect, it } from 'vitest'",
+        "const processDocument = readFileSync('docs/review-modification-process.md', 'utf8')",
+        "describe('review process contract', () => {",
+        "  it('defines review states', () => {",
+        '    expect(processDocument.match(/publicMeasure/gu)?.length ?? 0).toBeGreaterThan(0)',
+        '  })',
+        '})',
+      ].join('\n'),
+    })
+
+    expect(runTestSenseCheck({ rootDir })).toMatchObject({ failures: [], ok: true })
+  })
 })

--- a/tests/tooling/scripts/test-sense-check.test.ts
+++ b/tests/tooling/scripts/test-sense-check.test.ts
@@ -174,4 +174,27 @@ describe('runTestSenseCheck', () => {
 
     expect(runTestSenseCheck({ rootDir })).toMatchObject({ failures: [], ok: true })
   })
+
+  it('rejects unrelated reads followed by a documentation path literal', () => {
+    const rootDir = createTempRepo({
+      'tests/data-integrity/docs/unrelatedRead.test.ts': [
+        "import { readFileSync } from 'node:fs'",
+        "import { describe, expect, it } from 'vitest'",
+        "const readme = readFileSync('README.md', 'utf8')",
+        "const unusedContractPath = 'docs/review-modification-process.md'",
+        "describe('unrelated file', () => {",
+        "  it('has content', () => {",
+        '    expect(readme.length + unusedContractPath.length).toBeGreaterThan(0)',
+        '  })',
+        '})',
+      ].join('\n'),
+    })
+
+    expect(runTestSenseCheck({ rootDir })).toMatchObject({
+      failures: [
+        'tests/data-integrity/docs/unrelatedRead.test.ts: Data-integrity tests must exercise seed fixtures or repository data contracts.',
+      ],
+      ok: false,
+    })
+  })
 })


### PR DESCRIPTION
## Management summary

### Deutsch

Der Umgang mit Bewertungen ist jetzt einheitlich und nachvollziehbar beschrieben: Einsprüche, öffentliche Maßnahmen
und der Rückzug durch Verfassende bleiben getrennt, sensible Inhalte werden nicht als Beweismaterial gesammelt, und
die Sichtbarkeit von Text, Sternen und Klinikantworten folgt klaren Regeln. Bei gekürzten Bewertungstexten ist zudem
transparent festgehalten, dass Mitarbeitende die sinnwahrende Entfernung selbst prüfen müssen und das Backend diese
Prüfung derzeit nicht übernimmt.

### English

The handling of reviews is now described consistently and transparently: appeals, public measures, and author
withdrawal remain separate, sensitive content is not collected as evidence, and the visibility of text, ratings, and
clinic responses follows clear rules. For shortened review text, the documentation also makes clear that staff must
verify the meaning-preserving removal themselves because the backend does not currently perform that check.

## What changed

- Replaced the outdated platform-only edit overview with the implemented Review, ReviewResponse, and ReviewAppeal
  contract.
- Documented role and clinic-tenant boundaries, native versioning, audit behavior, public visibility, response and
  appeal lifecycles, moderation measures, verified author corrections, and author withdrawal.
- Clarified the redaction boundary: the moderation command preserves the original `comment`, platform staff supplies
  `publicComment`, and the backend neither compares both texts nor guarantees deletion-only or meaning-preserving
  output. The operator owns that check, and no passage selection, diff, evidence field, or proof is stored.
- Separated external support verification policy from backend audit guarantees: general edit and withdrawal metadata
  records actor and time but does not prove author approval or operator purpose.
- Clarified that assigned-clinic current reads can retain stored public-projection fields for removed or withdrawn
  rows even though public and patient reads omit those rows completely.
- Kept policy authority in the internal Trust Core without duplicating or exposing its private source.
- Defined the non-evidence boundary for appeal descriptions and linked the existing Clinic Dashboard API contract for
  request, response, pagination, and error details.
- Added focused data-integrity coverage for the separate state machines, supported public measures, private read-only
  publication history, current-safe visibility filtering, and the Trust Core non-evidence boundary. The test-sense
  classifier now recognizes data-integrity tests backed by repository Markdown contracts.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `docs/review-modification-process.md` — moderation, correction, and appeal sections | The wording governs privacy-sensitive operator behavior and must distinguish manual policy duties from backend guarantees. | Verify redaction leaves the original `comment` unchanged, the current lack of automatic deletion-only and semantic validation is explicit, the non-evidence scope is intact, and appeal decisions remain separate from public measures. | Compared with the Review moderation endpoint, public projection, update hook, withdrawal endpoint, `ReviewAppeals.ts`, `reviewWorkflow.ts`, and lifecycle tests. |
| P1 | `docs/review-modification-process.md` — visibility, withdrawal, and audit sections | Public absence and tenant-scoped current-read field visibility are different contracts. | Verify removed and withdrawn reviews are absent publicly while assigned-clinic reads retain approved rows and stored public-projection fields without exposing raw `comment`, internal reasons, patient identity, or named actors. | Compared with `publicProjection.ts`, `endpoints.ts`, `scopeFilters.ts`, Review field access, public mappers, rating queries, and publication tests. |
| P2 | `tests/data-integrity/docs/reviewModificationProcess.test.ts` and test-sense tooling | The focused contract test must protect stable technical boundaries without freezing prose. | Verify the assertions cover domain values, endpoint shape, visibility, and non-evidence ownership while the classifier recognizes the real Markdown dependency. | Focused Vitest runs passed: 4 data-integrity tests and 8 test-sense tooling tests. |
| P2 | `docs/review-modification-process.md` — endpoint boundary | Detailed API contracts should remain single-sourced. | Verify the process summary is sufficient and the relative Clinic Dashboard contract link resolves to the owned upstream section. | `pnpm docs:check` passed for 109 files. |

## Validation

- [x] `pnpm format`: Passed after the focused contract-test changes.
- [x] `pnpm check`: Passed under Node 24 and pnpm 10.
- [ ] `pnpm build`: Not run; documentation, tests, and test tooling do not change build output.
- [x] Focused tests: The review-process data-integrity test passed 4/4, the test-sense tooling suite passed 8/8,
  `pnpm tests:sense-check` passed for the changed files, and `pnpm docs:check` passed for 109 documentation files.
- [ ] UI/mobile QA: Not applicable; no UI or frontend behavior changed.
- [ ] Security/privacy review: No separate specialist reviewer was run. No access, authentication, or runtime behavior
  changed; privacy-related claims were checked directly against the current access and public-projection code and are
  covered by the focused documentation contract test.
- [ ] Migration/schema check: Not applicable; no schema, migration, seed, or generated type changed.
- [x] Documentation/instructions check: Root, `docs/AGENTS.md`, and `tests/AGENTS.md` instructions were applied,
  the complete diff was reviewed, and the linked API contract exists.

## Risk and rollout

Documentation and test-only. The main risk is contract drift; the focused test now checks the stable state, endpoint,
visibility, and non-evidence boundaries without reproducing the policy source or storing evidence. There are no
runtime, data, configuration, environment, migration, deployment, or rollback requirements. Reverting these
documentation and test commits restores the previous state.

## Development

Closes #1668
