### PR TITLE
chore(deps): simplify dependency overrides

### DIFF
--- a/docs/security/overrides.md
+++ b/docs/security/overrides.md
@@ -9,23 +9,53 @@ JSON does not support comments, so we keep the rationale and evidence here for r
 
 ## Entries
 
-### esbuild (esbuild@<=0.24.2 -> pinned >=0.25.0)
-- Reason: `@payloadcms/db-postgres` still brings a `drizzle-kit` path that can resolve vulnerable esbuild versions without the override.
+### undici (`undici` -> `^7.28.0`)
+- Reason: `payload@3.86.0` declares `undici@7.28.0`. A fresh resolution without the override restores that vulnerable version, while the override resolves the graph to `undici@7.29.0`.
 - References:
+  - https://registry.npmjs.org/payload/3.86.0
+  - https://github.com/advisories/GHSA-8xcm-r25x-g524
+  - https://github.com/advisories/GHSA-4cwx-7wf7-3272
+  - https://github.com/advisories/GHSA-m8rv-5g2x-5cg5
+  - https://github.com/advisories/GHSA-jr45-8vmc-qm54
+  - https://github.com/advisories/GHSA-v3r7-h72x-cjcm
+
+### @modelcontextprotocol/sdk (`@modelcontextprotocol/sdk` -> `1.26.0`)
+- Reason: `mcp-handler@1.1.0` declares an exact `@modelcontextprotocol/sdk@1.26.0` peer. Removing the pin resolves another path to `1.27.1` and produces an unmet peer warning.
+- References:
+  - https://registry.npmjs.org/mcp-handler/1.1.0
+
+### esbuild (`esbuild@<0.28.1` -> `0.28.1`)
+- Reason: `@esbuild-kit/core-utils@3.3.2` declares `esbuild@~0.18.20`. Without the range override, the graph restores vulnerable `esbuild@0.18.20` and resolves Vite's esbuild peer to an unsupported `0.25.12`.
+- References:
+  - https://registry.npmjs.org/@esbuild-kit/core-utils/3.3.2
+  - https://registry.npmjs.org/vite/8.1.0
   - https://github.com/advisories/GHSA-67mh-4wv8-2f99
 
-### hono (hono@<4.12.21 -> pinned >=4.12.21)
-- Reason: `@payloadcms/plugin-mcp` and `shadcn` both bring `@modelcontextprotocol/sdk` paths that resolve vulnerable Hono versions without the override.
+### @hono/node-server (`@hono/node-server@<2.0.5` -> `>=2.0.5`)
+- Reason: `@modelcontextprotocol/sdk@1.26.0` declares `@hono/node-server@^1.19.9`. Removing the override restores vulnerable `1.19.17`; the override resolves the graph to `2.1.0`.
 - References:
-  - https://github.com/advisories/GHSA-2gcr-mfcq-wcc3
-  - https://github.com/advisories/GHSA-3hrh-pfw6-9m5x
-  - https://github.com/advisories/GHSA-xrhx-7g5j-rcj5
-  - https://github.com/advisories/GHSA-f577-qrjj-4474
+  - https://registry.npmjs.org/@modelcontextprotocol/sdk/1.26.0
+  - https://github.com/advisories/GHSA-frvp-7c67-39w9
 
-### postcss (postcss@<8.5.10 -> pinned >=8.5.10)
-- Reason: `next@16.2.6` declares `postcss@8.4.31`; the override keeps all lockfile PostCSS resolutions on the patched 8.5 line.
+### postcss (`postcss@<8.5.23` -> `8.5.23`)
+- Reason: `next@16.2.11` declares `postcss@8.4.31`. Removing the override restores that version and four known advisories; the override keeps the graph on the patched `8.5.23` line.
 - References:
+  - https://registry.npmjs.org/next/16.2.11
   - https://github.com/advisories/GHSA-qx2v-qp2m-jg93
+  - https://github.com/advisories/GHSA-6g55-p6wh-862q
+  - https://github.com/advisories/GHSA-r28c-9q8g-f849
+  - https://github.com/advisories/GHSA-fxqj-rqcc-2cmp
+
+### brace-expansion (`brace-expansion@<5.0.9` -> `5.0.9`)
+- Reason: the patched `minimatch@3.1.5` compatibility path uses the current `brace-expansion` API. Removing the override resolves `brace-expansion@1.1.18` and makes ESLint fail with `TypeError: expand is not a function`.
+- References:
+  - https://registry.npmjs.org/brace-expansion/5.0.9
+
+### sharp (`sharp@<0.35.0` -> `0.35.3`)
+- Reason: `next@16.2.11` declares optional `sharp@^0.34.5`. Removing the override restores vulnerable `0.34.5`; the override resolves production paths to `0.35.3`.
+- References:
+  - https://registry.npmjs.org/next/16.2.11
+  - https://github.com/advisories/GHSA-f88m-g3jw-g9cj
 
 ## Temporary audit-ci exceptions
 

--- a/package.json
+++ b/package.json
@@ -189,18 +189,11 @@
     "overrides": {
       "undici": "^7.28.0",
       "@modelcontextprotocol/sdk": "1.26.0",
-      "esbuild": "0.28.1",
       "esbuild@<0.28.1": "0.28.1",
-      "esbuild@<=0.24.2": ">=0.25.0",
       "@hono/node-server@<2.0.5": ">=2.0.5",
-      "hono@<4.12.34": ">=4.12.34",
       "postcss@<8.5.23": "8.5.23",
-      "js-yaml@<4.3.1": "4.3.1",
-      "nanoid@<3.3.17": "3.3.17",
       "brace-expansion@<5.0.9": "5.0.9",
-      "sharp@<0.35.0": "0.35.3",
-      "fast-uri@<3.1.5": "3.1.5",
-      "payload@3.85.1>tsx": "4.21.0"
+      "sharp@<0.35.0": "0.35.3"
     },
     "patchedDependencies": {
       "minimatch@3.1.5": "patches/minimatch@3.1.5.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,18 +7,11 @@ settings:
 overrides:
   undici: ^7.28.0
   '@modelcontextprotocol/sdk': 1.26.0
-  esbuild: 0.28.1
   esbuild@<0.28.1: 0.28.1
-  esbuild@<=0.24.2: '>=0.25.0'
   '@hono/node-server@<2.0.5': '>=2.0.5'
-  hono@<4.12.34: '>=4.12.34'
   postcss@<8.5.23: 8.5.23
-  js-yaml@<4.3.1: 4.3.1
-  nanoid@<3.3.17: 3.3.17
   brace-expansion@<5.0.9: 5.0.9
   sharp@<0.35.0: 0.35.3
-  fast-uri@<3.1.5: 3.1.5
-  payload@3.85.1>tsx: 4.21.0
 
 patchedDependencies:
   minimatch@3.1.5:
@@ -1200,7 +1193,7 @@ packages:
     resolution: {integrity: sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.34'
+      hono: ^4
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -3074,7 +3067,7 @@ packages:
   '@storybook/csf-plugin@10.5.5':
     resolution: {integrity: sha512-/euibhRFqklYCZqUseokojmfYcQpXshVY2QmA1qCuxMz9SzVFD3iSTw+aFLTxpsJGGdcZJk8fnm/rEthLzZ9jA==}
     peerDependencies:
-      esbuild: '>=0.25.0'
+      esbuild: 0.28.1
       rollup: '*'
       storybook: ^10.5.5
       vite: '*'
@@ -4655,7 +4648,7 @@ packages:
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
-      esbuild: '>=0.25.0'
+      esbuild: 0.28.1
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}


### PR DESCRIPTION
## Management summary

### Deutsch

Die Abhängigkeitsverwaltung enthält nur noch aktuell notwendige Sonderregeln. Das reduziert künftige Wartungs- und Update-Risiken, ohne bestehende Sicherheits- oder Kompatibilitätsschutzmaßnahmen zu schwächen.

### English

Dependency management now contains only currently necessary exception rules. This reduces future maintenance and upgrade risk without weakening existing security or compatibility protections.

## What changed

- Removed seven overrides that a fresh pnpm resolution proved redundant, overlapping, or non-matching: the global and narrower duplicate esbuild rules, unscoped Hono, js-yaml, nanoid, fast-uri, and the stale Payload 3.85.1 selector.
- Retained seven rules with reproduced security, peer compatibility, or runtime requirements: undici, MCP SDK, the remaining esbuild range, Hono Node server, PostCSS, brace-expansion, and sharp.
- Regenerated and deduplicated the lockfile with pnpm 10.28.2 and updated `docs/security/overrides.md` to match the current manifest.
- Official evidence: [undici advisories](https://github.com/advisories/GHSA-4cwx-7wf7-3272), [esbuild advisory](https://github.com/advisories/GHSA-67mh-4wv8-2f99), [Hono Node server advisory](https://github.com/advisories/GHSA-frvp-7c67-39w9), [PostCSS advisories](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp), [sharp advisory](https://github.com/advisories/GHSA-f88m-g3jw-g9cj), [mcp-handler peer manifest](https://registry.npmjs.org/mcp-handler/1.1.0), and [Next.js parent manifest](https://registry.npmjs.org/next/16.2.11).

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `package.json`, `pnpm-lock.yaml` | These files determine the deployed transitive dependency graph. | Confirm each removed rule is absent and every retained security or compatibility path still resolves to the documented version. | Fresh per-rule lockfile resolutions, `pnpm deps:dedupe:check`, `pnpm deps:audit`, `pnpm check`, and `pnpm build` passed. |
| P2 | `docs/security/overrides.md` | The prior rationale no longer matched the manifest. | Confirm all seven remaining rules have one current reason and primary evidence. | `pnpm docs:check` passed. |

## Reviewer gate

- Reviewed diff: Full PR diff and conflict-free merge result against the current `origin/main`
- Reviewer set: `security_reviewer`
- Result: Completed with no findings; no reviewer block for Ready or auto-merge
- Open, fixed, deferred, or excepted decisions: None

## Validation

- [x] `pnpm format`: Passed.
- [x] `pnpm check`: Passed. The existing test-sense warnings remain non-blocking.
- [x] `pnpm build`: Passed, including postbuild sitemap generation. Static generation logged the existing missing local `NEXT_PUBLIC_SUPABASE_URL` condition without failing the build.
- [x] Focused tests: `pnpm install --frozen-lockfile`, `pnpm deps:dedupe:check`, and `pnpm deps:audit` passed. The direct low-threshold audit still reports the existing DOMPurify moderate advisory and two temporarily allowlisted image-size high advisories; no new advisory was introduced.
- [ ] UI/mobile QA: Not applicable; no UI changes.
- [x] Security/privacy review: Authorized `security_reviewer` completed against current `origin/main` with no findings.
- [ ] Migration/schema check: Not applicable; no schema or migration changes.
- [x] Documentation/instructions check: `pnpm docs:check` passed; no instruction sources changed.

## Risk and rollout

Low. The removed rules resolve through parent-declared ranges, and full repository validation passed. Rollback is a revert of commit `468dd668` if an unexpected dependency integration issue appears.

## Development

Closes #1671
