### PR TITLE
test(storybooks): stabilize HeaderNav interactions

### DIFF
--- a/src/stories/templates/HeaderNav.stories.tsx
+++ b/src/stories/templates/HeaderNav.stories.tsx
@@ -69,6 +69,12 @@ const manyNavItems: HeaderNavItem[] = [
   { href: '/faq', label: 'FAQ', newTab: false },
 ]
 
+const resetDesktopDropdown = async (trigger: HTMLElement) => {
+  await userEvent.unhover(trigger)
+  await userEvent.click(trigger.ownerDocument.body)
+  await waitFor(() => expect(trigger).toHaveAttribute('aria-expanded', 'false'))
+}
+
 /** Default flat navigation items without submenus. */
 export const Default: Story = {
   args: {
@@ -109,8 +115,8 @@ export const DesktopNeutralSubmenu: Story = {
     const trigger = canvas.getByRole('button', { name: 'Clinics' })
     const firstLevelLink = canvas.getByRole('link', { name: 'Stories' })
 
-    // Trigger should start in the collapsed state.
-    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    // Storybook can preserve browser pointer or focus state between stories.
+    await resetDesktopDropdown(trigger)
 
     // Focusing the trigger should open the submenu.
     trigger.focus()
@@ -140,7 +146,8 @@ export const DesktopHoverTolerance: Story = {
 
     if (!dropdownContainer) throw new Error('Missing dropdown container')
 
-    trigger.focus()
+    await resetDesktopDropdown(trigger)
+    await userEvent.hover(trigger)
     await waitFor(() => expect(trigger).toHaveAttribute('aria-expanded', 'true'))
     await waitFor(() => expect(canvas.getByRole('link', { name: 'All Clinics' })).toBeInTheDocument())
 
@@ -149,6 +156,8 @@ export const DesktopHoverTolerance: Story = {
     // Menu should not close synchronously on mouseout; it should still be visible immediately after.
     expect(canvas.getByRole('link', { name: 'All Clinics' })).toBeInTheDocument()
 
+    // Move the actual user-event pointer away so a previous hover cannot reopen the dropdown.
+    await userEvent.unhover(dropdownContainer)
     await waitFor(() => expect(canvas.queryByRole('link', { name: 'All Clinics' })).not.toBeInTheDocument())
   },
 }

--- a/src/stories/templates/HeaderNav.stories.tsx
+++ b/src/stories/templates/HeaderNav.stories.tsx
@@ -71,7 +71,9 @@ const manyNavItems: HeaderNavItem[] = [
 
 const resetDesktopDropdown = async (trigger: HTMLElement) => {
   await userEvent.unhover(trigger)
-  await userEvent.click(trigger.ownerDocument.body)
+  trigger.focus()
+  await userEvent.keyboard('{Escape}')
+  trigger.blur()
   await waitFor(() => expect(trigger).toHaveAttribute('aria-expanded', 'false'))
 }
 


### PR DESCRIPTION
## Management summary

### Deutsch

Die automatisierte Qualitätsprüfung der Website läuft zuverlässiger und blockiert fachlich unabhängige Änderungen nicht mehr durch instabile Navigationstests.

### English

The website quality checks now run more reliably and no longer block unrelated changes because of unstable navigation tests.

## What changed

- Reset browser pointer and focus state through the dropdown's Escape and blur handlers before asserting desktop behavior.
- Drive the hover-tolerance scenario through Storybook's user-event pointer state so the menu can close deterministically.
- Keep production HeaderNav behavior unchanged; this PR only adjusts its interaction stories.

## Points to review

| Priority | Files / paths                                      | Why focus here                                  | Reviewer should verify                                                | Evidence                                                   |
| -------- | -------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------- |
| P2       | `src/stories/templates/HeaderNav.stories.tsx`      | Pointer and focus state previously leaked into interaction assertions. | The reset preserves the intended focus and delayed-hover-close checks. | 20 repeated focused runs and the full 958-test Storybook suite passed. |

## Validation

- [x] `pnpm format`: passed under Node.js 24.19.0 and pnpm 10.28.2.
- [x] `pnpm check`: passed; existing test sense-check warnings only.
- [ ] `pnpm build`: not applicable; this changes a Storybook interaction file only.
- [x] Focused tests: HeaderNav Storybook file passed 20 consecutive runs; full Storybook coverage run passed 958/958 tests.
- [ ] UI/mobile QA: not applicable; no production UI behavior changed.
- [ ] Security/privacy review: not applicable; no runtime, data, access, or privacy path changed.
- [ ] Migration/schema check: not applicable; no Payload schema or migration changed.
- [x] Documentation/instructions check: `pnpm stories:governance:check` passed for 109 story files and 6 MDX docs.

## Risk and rollout

No production runtime, data, configuration, or migration changes. Rollback is the single story-file commit.

## Development

Closes #1679
