### PR TITLE
fix: reconcile existing review response seeds

### DIFF
--- a/src/endpoints/seed/utils/plan.ts
+++ b/src/endpoints/seed/utils/plan.ts
@@ -440,7 +440,7 @@ export const demoPlan: SeedPlanStep[] = [
     fileName: 'reviewResponses',
     context: { trustedReviewWorkflowSeed: true },
     reqUserStableId: 'seed-platform-admin',
-    upsertPolicy: { skipIfCurrentMatches: true },
+    upsertPolicy: { reconcileByUniqueFields: ['review'], skipIfCurrentMatches: true },
     mapping: [
       {
         sourceField: 'reviewStableId',

--- a/src/endpoints/seed/utils/upsert.ts
+++ b/src/endpoints/seed/utils/upsert.ts
@@ -1,4 +1,4 @@
-import type { CollectionSlug, Payload, PayloadRequest } from 'payload'
+import type { CollectionSlug, Payload, PayloadRequest, Where } from 'payload'
 import { resolveS3StorageBucket } from '@/plugins/storageConfig'
 
 export type UpsertResult = {
@@ -9,6 +9,7 @@ export type UpsertResult = {
 }
 
 export type SeedUpsertPolicy = {
+  reconcileByUniqueFields?: string[]
   recreateUploadOnRelationDrift?: string[]
   skipIfCurrentMatches?: boolean
   skipIfVersionMatches?: boolean
@@ -453,7 +454,7 @@ export async function upsertByStableId<T extends Record<string, unknown>>(
   }
 
   const stableId = data.stableId
-  const existing = await payload.find({
+  let existing = await payload.find({
     collection,
     ...(options?.policy?.skipIfCurrentMatches ? { depth: 0 } : {}),
     where: { stableId: { equals: stableId } },
@@ -464,6 +465,35 @@ export async function upsertByStableId<T extends Record<string, unknown>>(
     trash: true,
     overrideAccess: true,
   })
+
+  const reconciliationFields = options?.policy?.reconcileByUniqueFields ?? []
+  let reconciledByUniqueFields = false
+
+  if (existing.totalDocs === 0 && reconciliationFields.length > 0) {
+    const clauses = reconciliationFields.map((field): Where => {
+      const value = data[field]
+      if (value === null || typeof value === 'undefined' || value === '') {
+        throw new Error(`Missing ${field} for ${collection} seed reconciliation`)
+      }
+
+      return { [field]: { equals: value } }
+    })
+
+    existing = await payload.find({
+      collection,
+      depth: 0,
+      where: clauses.length === 1 ? clauses[0] : { and: clauses },
+      limit: 2,
+      trash: true,
+      overrideAccess: true,
+    })
+
+    if (existing.totalDocs > 1) {
+      throw new Error(`Multiple ${collection} documents match the configured seed reconciliation fields`)
+    }
+
+    reconciledByUniqueFields = existing.totalDocs === 1
+  }
 
   const operationContext = {
     disableRevalidate: true,
@@ -526,8 +556,21 @@ export async function upsertByStableId<T extends Record<string, unknown>>(
     }
   }
 
-  const current = existing.docs[0] as { id: string | number; deletedAt?: unknown; slug?: unknown }
+  const current = existing.docs[0] as {
+    id: string | number
+    deletedAt?: unknown
+    slug?: unknown
+    stableId?: unknown
+  }
   const nextData: Record<string, unknown> = { ...data }
+
+  if (reconciledByUniqueFields) {
+    if (typeof current.stableId !== 'string' || current.stableId.length === 0) {
+      throw new Error(`Cannot reconcile ${collection} document without its existing stableId`)
+    }
+
+    nextData.stableId = current.stableId
+  }
 
   // If found doc is trashed, restore it by clearing deletedAt.
   if (current.deletedAt) {

--- a/tests/data-integrity/endpoints/seed/reviewWorkflowSnapshots.test.ts
+++ b/tests/data-integrity/endpoints/seed/reviewWorkflowSnapshots.test.ts
@@ -77,7 +77,9 @@ describe('review workflow seed plan', () => {
     )
 
     expect(demoPlan.find((step) => step.name === 'review-response-states')).toEqual(
-      expect.objectContaining({ upsertPolicy: { skipIfCurrentMatches: true } }),
+      expect.objectContaining({
+        upsertPolicy: { reconcileByUniqueFields: ['review'], skipIfCurrentMatches: true },
+      }),
     )
   })
 

--- a/tests/integration/seedReviewWorkflow.integration.test.ts
+++ b/tests/integration/seedReviewWorkflow.integration.test.ts
@@ -443,6 +443,7 @@ describe.sequential('demo review workflow seed integration', () => {
   let centralClinicId: number
   let clinicStaffId: number | string
   let clinicUser: Awaited<ReturnType<typeof asClinicScopedPayloadUser>>
+  let reconciledResponseId: number | string | null = null
   const createdStaffIds: Array<number | string> = []
   const slugPrefix = testSlug('seedReviewWorkflow.integration.test.ts')
 
@@ -453,6 +454,14 @@ describe.sequential('demo review workflow seed integration', () => {
 
   afterAll(async () => {
     try {
+      if (reconciledResponseId !== null) {
+        await cleanupTrackedDocs(payload, [
+          {
+            collection: 'reviewResponses',
+            ids: [reconciledResponseId],
+          },
+        ])
+      }
       await cleanupSeedReviewWorkflow(payload)
     } finally {
       await cleanupTrackedUsers(payload, { staffIds: createdStaffIds })
@@ -683,5 +692,95 @@ describe.sequential('demo review workflow seed integration', () => {
       overrideAccess: true,
     })
     expect(relationId(persistedClinicStaff.clinic)).toBe(centralClinicId)
+  }, 180_000)
+
+  it('reconciles a pre-existing response for a seed review without replacing its audit identity', async () => {
+    const [reviewResult, responseResult] = await Promise.all([
+      payload.find({
+        collection: 'reviews',
+        depth: 0,
+        limit: 1,
+        overrideAccess: true,
+        where: { stableId: { equals: 'seed-review-izmir-coast-03' } },
+      }),
+      payload.find({
+        collection: 'reviewResponses',
+        depth: 0,
+        limit: 1,
+        overrideAccess: true,
+        where: { stableId: { equals: 'seed-review-response-izmir-coast-03' } },
+      }),
+    ])
+    const review = reviewResult.docs[0]
+    const seededResponse = responseResult.docs[0]
+    if (!review || !seededResponse) {
+      throw new Error('Expected the central review and its seeded response')
+    }
+
+    await payload.delete({
+      collection: 'reviewResponses',
+      id: seededResponse.id,
+      context: { disableRevalidate: true },
+      overrideAccess: true,
+    })
+
+    const submittedBody = 'This clinic-authored response existed before the non-destructive demo seed was retried.'
+    const existingResponse = await payload.create({
+      collection: 'reviewResponses',
+      data: {
+        review: review.id,
+        pendingResponse: {
+          body: submittedBody,
+        },
+      } as unknown as ReviewResponse,
+      depth: 0,
+      overrideAccess: false,
+      user: clinicUser,
+    })
+    reconciledResponseId = existingResponse.id
+    const existingStableId = existingResponse.stableId
+
+    const result = await runDemoSeeds(payload)
+    expect(result.failures).toEqual([])
+
+    const reconciledResult = await payload.find({
+      collection: 'reviewResponses',
+      depth: 0,
+      overrideAccess: true,
+      pagination: false,
+      where: { review: { equals: review.id } },
+    })
+    expect(reconciledResult.docs).toHaveLength(1)
+    expect(reconciledResult.docs[0]).toMatchObject({
+      id: existingResponse.id,
+      stableId: existingStableId,
+      moderationStatus: 'approved',
+      publishedResponse: {
+        body: 'Thank you for describing the consultation. We are glad the written plan made the treatment options easier to compare.',
+        approvedAt: '2026-01-24T10:00:00.000Z',
+        isBlocked: false,
+      },
+    })
+
+    const firstVersions = await payload.findVersions({
+      collection: 'reviewResponses',
+      depth: 0,
+      overrideAccess: true,
+      pagination: false,
+      where: { parent: { equals: existingResponse.id } },
+    })
+    expect(firstVersions.docs.some(({ version }) => version.pendingResponse?.body === submittedBody)).toBe(true)
+
+    const repeatedResult = await runDemoSeeds(payload)
+    expect(repeatedResult.failures).toEqual([])
+
+    const repeatedVersions = await payload.findVersions({
+      collection: 'reviewResponses',
+      depth: 0,
+      overrideAccess: true,
+      pagination: false,
+      where: { parent: { equals: existingResponse.id } },
+    })
+    expect(repeatedVersions.docs).toEqual(firstVersions.docs)
   }, 180_000)
 })

--- a/tests/unit/endpoints/seed/resolvers-upsert-reset.test.ts
+++ b/tests/unit/endpoints/seed/resolvers-upsert-reset.test.ts
@@ -218,6 +218,91 @@ describe('upsertByStableId', () => {
     expect(findVersions).not.toHaveBeenCalled()
     expect(update).not.toHaveBeenCalled()
   })
+
+  it('reconciles a review response by its unique review while preserving the existing stable ID', async () => {
+    find.mockResolvedValueOnce({ totalDocs: 0, docs: [] }).mockResolvedValueOnce({
+      totalDocs: 1,
+      docs: [
+        {
+          id: 'existing-response-id',
+          stableId: 'generated-response-id',
+          review: 'review-id',
+          moderationStatus: 'pending',
+        },
+      ],
+    })
+    update.mockResolvedValue({ id: 'existing-response-id' })
+
+    const result = await upsertByStableId(
+      payload,
+      'reviewResponses',
+      {
+        stableId: 'seed-review-response-id',
+        review: 'review-id',
+        moderationStatus: 'approved',
+      },
+      {
+        policy: {
+          reconcileByUniqueFields: ['review'],
+          skipIfCurrentMatches: true,
+        },
+      },
+    )
+
+    expect(result).toEqual({ created: false, updated: true })
+    expect(find).toHaveBeenNthCalledWith(2, {
+      collection: 'reviewResponses',
+      depth: 0,
+      where: { review: { equals: 'review-id' } },
+      limit: 2,
+      trash: true,
+      overrideAccess: true,
+    })
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'reviewResponses',
+        id: 'existing-response-id',
+        data: {
+          stableId: 'generated-response-id',
+          review: 'review-id',
+          moderationStatus: 'approved',
+        },
+      }),
+    )
+  })
+
+  it('skips a reconciled review response when its current workflow snapshot matches', async () => {
+    find.mockResolvedValueOnce({ totalDocs: 0, docs: [] }).mockResolvedValueOnce({
+      totalDocs: 1,
+      docs: [
+        {
+          id: 'existing-response-id',
+          stableId: 'generated-response-id',
+          review: 'review-id',
+          moderationStatus: 'approved',
+        },
+      ],
+    })
+
+    const result = await upsertByStableId(
+      payload,
+      'reviewResponses',
+      {
+        stableId: 'seed-review-response-id',
+        review: 'review-id',
+        moderationStatus: 'approved',
+      },
+      {
+        policy: {
+          reconcileByUniqueFields: ['review'],
+          skipIfCurrentMatches: true,
+        },
+      },
+    )
+
+    expect(result).toEqual({ created: false, updated: false })
+    expect(update).not.toHaveBeenCalled()
+  })
 })
 
 describe('resetCollections', () => {


### PR DESCRIPTION
## Management summary

### Deutsch

Der nicht-destruktive Preview-Demo-Seed kann jetzt einen bereits vorhandenen Klinik-Response übernehmen, statt an der eindeutigen Review-Zuordnung abzubrechen. Bestehender Audit-Verlauf und interne Identität bleiben erhalten, während der vorgesehene Demo-Zustand zuverlässig hergestellt wird.

### English

The non-destructive preview demo seed can now adopt an existing clinic response instead of failing on the unique review assignment. Existing audit history and internal identity are preserved while the intended demo state is restored reliably.

## What changed

- Added an opt-in seed upsert fallback that resolves an existing document through configured unique relationship fields when the canonical seed stable ID is absent.
- Applied the fallback only to review response workflow seeds through their unique `review` relationship.
- Preserved the existing document ID and immutable stable ID while the trusted seed updates the current workflow snapshot.
- Added focused unit, data-contract, and real Payload integration coverage for reconciliation, native version retention, retry completion, and repeat-run idempotency.
- Follow-up to #1690 and #1669.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `src/endpoints/seed/utils/upsert.ts` | Existing preview data is reconciled through a second lookup. | The fallback is opt-in, fail-closed for missing/ambiguous fields, and preserves immutable identity. | Focused unit tests, real Payload integration test, security review |
| P1 | `src/endpoints/seed/utils/plan.ts` | Trusted review response seeds enable the fallback. | Only the unique `review` relationship is used and production/demo guards remain unchanged. | Data-integrity contract, security review |
| P1 | `tests/integration/seedReviewWorkflow.integration.test.ts` | The regression depends on existing native workflow history. | The test proves no duplicate workflow, preserved audit identity/history, complete retry, and idempotent repeat. | Local integration suite 4/4, cache review 36/36 |

## Validation

- [x] `pnpm format`: passed under Node 24 and pnpm 10.
- [x] `pnpm check`: passed; existing sense-check warnings only.
- [x] `pnpm build`: passed with the known non-fatal local Supabase environment log during static generation.
- [x] Focused tests: 32 unit/data-integrity tests and 4 real Payload integration tests passed; cache reviewer independently repeated all 36.
- [ ] UI/mobile QA: not applicable; no UI or frontend files changed.
- [x] Security/privacy review: no findings at or above 5/10; one 3/10 future-hardening note for generic policy reuse.
- [x] Migration/schema check: no schema, generated type, or migration change.
- [x] Documentation/instructions check: no documentation change required; tests remain the canonical demo-seed contract.

## Risk and rollout

Scope is limited to the non-production demo seed. Production demo seeding remains fail-closed. Cache review found no issue at or above 5/10; a no-op retry may still perform a freshness-safe terminal invalidation. After merge and Preview deployment, retry unfinished jobs without reset; never use the reset action. Reverting this PR restores the previous lookup behavior, while any already reconciled response remains a valid audited workflow record.

## Development

Closes #1693
