### PR TITLE
feat: add clinic dashboard treatment contract

### DIFF
--- a/docs/integrations/clinic-dashboard-api.md
+++ b/docs/integrations/clinic-dashboard-api.md
@@ -21,9 +21,9 @@ durable architecture documentation, not an execution plan. The contract does not
 Payload CORS origins, a Dashboard database, service-role credentials, public cache behavior, or clinic login UI to the
 website.
 
-Payload exposes the private bootstrap contract and the persistent clinic-profile draft workflow. The Clinic Dashboard
-session and BFF runtime are implemented in the Dashboard repository; trusted preview and production rollout evidence
-remain pending.
+Payload exposes the private bootstrap contract, the persistent clinic-profile draft workflow, and the focused clinic
+treatment contract. The Clinic Dashboard session and BFF runtime are implemented in the Dashboard repository; trusted
+preview and production rollout evidence remain pending.
 
 ## Boundary and Ownership
 
@@ -169,6 +169,63 @@ plain text is stored as canonical rich-text paragraphs.
 Draft read, create, update, and discard do not mutate `clinics` and do not trigger public revalidation. Publish checks
 and writes the clinic plus draft deletion in one database transaction. It then dispatches the existing clinic-surface
 revalidation event after commit.
+
+## Clinic Treatment Contract
+
+The treatment capability uses one focused custom Payload endpoint rather than generic collection REST:
+
+| Method and route | Result |
+| --- | --- |
+| `GET /api/clinic-dashboard/treatments` | Returns the assigned clinic's complete treatment snapshot and the central treatment catalogue. |
+| `POST /api/clinic-dashboard/treatments` | Creates one inactive offering for an existing central treatment. |
+| `PATCH /api/clinic-dashboard/treatments` | Updates only EUR price and active state after an optimistic revision check. |
+
+Every request repeats bootstrap authorization, requires `clinic-treatments:view` for reads or
+`clinic-treatments:edit` for writes, and derives the clinic from the approved `clinicStaff` assignment. No request
+accepts a clinic ID. The endpoint returns purpose-specific DTOs and does not expose generic Payload query, depth,
+relationship, or collection response semantics.
+
+```ts
+type ClinicTreatmentMasterDTO = {
+  descriptionText: string
+  id: string
+  name: string
+}
+
+type ClinicTreatmentOfferingDTO = {
+  active: boolean
+  id: string
+  priceEUR: number
+  revision: string
+  treatment: ClinicTreatmentMasterDTO
+}
+
+type ClinicTreatmentSnapshotDTO = {
+  catalogue: ClinicTreatmentMasterDTO[]
+  offerings: ClinicTreatmentOfferingDTO[]
+}
+```
+
+Create accepts only `{ treatmentId, priceEUR }`; Payload assigns the authenticated clinic and stores `active: false`.
+The offering can be activated only by a later update. Update accepts
+`{ offeringId, expectedRevision, priceEUR, active }`. `revision` is the offering's ISO `updatedAt` value. Payload finds
+the offering by both ID and assigned clinic and compares the expected revision inside a serializable transaction.
+Serialization failures are retried; a retry observes the newer revision and returns a conflict instead of overwriting
+it. Treatment name and plain-text description remain projections of the central Treatment record and are never
+writable through this endpoint.
+
+Invalid request structure returns `400 CLINIC_TREATMENT_INVALID_INPUT`; a missing or unavailable master treatment
+returns `422 CLINIC_TREATMENT_INVALID_INPUT`; a foreign or missing clinic offering returns
+`404 CLINIC_TREATMENT_NOT_FOUND`; a duplicate clinic/treatment pair or stale revision returns
+`409 CLINIC_TREATMENT_CONFLICT`. Authentication and temporary-service errors reuse the stable Clinic Dashboard error
+codes. Every response is private-live with `Cache-Control: private, no-store`, `Pragma: no-cache`, `Expires: 0`, and
+`Vary: Authorization`.
+
+Clinic-treatment writes retain the existing `clinictreatments` hook behavior. Transactional updates suppress the hook's
+in-transaction invalidation and dispatch the same related-clinic plan once after commit, preventing an invalidated
+public cache from refilling against pre-commit data. Public clinic detail and listing comparison reads remain
+`public-cached`; the existing event, cache-policy entries, tags, planner owner, and bounded public paths remain
+authoritative. The private Dashboard endpoint adds no cache class, tag, surface, or invalidation owner.
 
 ## Dashboard-facing Route Semantics
 

--- a/src/endpoints/clinicDashboardTreatments.ts
+++ b/src/endpoints/clinicDashboardTreatments.ts
@@ -1,0 +1,152 @@
+import type { PayloadHandler, PayloadRequest } from 'payload'
+import type { ZodType } from 'zod'
+
+import { resolveClinicDashboardBootstrap } from '@/features/clinicDashboard/bootstrap'
+import type { ClinicDashboardCapability } from '@/features/clinicDashboard/bootstrap'
+import {
+  clinicTreatmentCreateInputSchema,
+  clinicTreatmentUpdateInputSchema,
+} from '@/features/clinicDashboard/treatments/contracts'
+import {
+  ClinicTreatmentServiceError,
+  createClinicTreatment,
+  readClinicTreatmentSnapshot,
+  updateClinicTreatment,
+} from '@/features/clinicDashboard/treatments/service'
+import { toLoggedError } from '@/utilities/logging/shared'
+import { CLINIC_DASHBOARD_ERROR_CODES, clinicDashboardPrivateJsonResponse } from './clinicDashboardBootstrap'
+
+export const CLINIC_TREATMENT_ERROR_CODES = {
+  conflict: 'CLINIC_TREATMENT_CONFLICT',
+  invalidInput: 'CLINIC_TREATMENT_INVALID_INPUT',
+  notFound: 'CLINIC_TREATMENT_NOT_FOUND',
+} as const
+
+type AuthorizedClinic =
+  | { ok: true; clinicId: string }
+  | {
+      ok: false
+      response: Response
+    }
+
+const authorizeClinic = async (
+  req: PayloadRequest,
+  requiredCapability: ClinicDashboardCapability,
+): Promise<AuthorizedClinic> => {
+  const result = await resolveClinicDashboardBootstrap(req)
+
+  switch (result.status) {
+    case 'success':
+      return result.data.capabilities.includes(requiredCapability)
+        ? { ok: true, clinicId: result.data.clinic.id }
+        : {
+            ok: false,
+            response: clinicDashboardPrivateJsonResponse(
+              { error: { code: CLINIC_DASHBOARD_ERROR_CODES.accessDenied } },
+              403,
+            ),
+          }
+    case 'access-denied':
+      return {
+        ok: false,
+        response: clinicDashboardPrivateJsonResponse(
+          { error: { code: CLINIC_DASHBOARD_ERROR_CODES.accessDenied } },
+          403,
+        ),
+      }
+    case 'unavailable':
+      return {
+        ok: false,
+        response: clinicDashboardPrivateJsonResponse(
+          { error: { code: CLINIC_DASHBOARD_ERROR_CODES.temporarilyUnavailable } },
+          503,
+        ),
+      }
+    case 'unauthorized':
+      return {
+        ok: false,
+        response: clinicDashboardPrivateJsonResponse(
+          { error: { code: CLINIC_DASHBOARD_ERROR_CODES.unauthorized } },
+          401,
+        ),
+      }
+  }
+}
+
+const readBody = async <T>(req: PayloadRequest, schema: ZodType<T>): Promise<T | Response> => {
+  const body = typeof req.json === 'function' ? await req.json().catch(() => undefined) : undefined
+  const parsed = schema.safeParse(body)
+  return parsed.success
+    ? parsed.data
+    : clinicDashboardPrivateJsonResponse({ error: { code: CLINIC_TREATMENT_ERROR_CODES.invalidInput } }, 400)
+}
+
+const serviceErrorResponse = (error: ClinicTreatmentServiceError): Response => {
+  switch (error.kind) {
+    case 'conflict':
+      return clinicDashboardPrivateJsonResponse({ error: { code: CLINIC_TREATMENT_ERROR_CODES.conflict } }, 409)
+    case 'invalid-input':
+      return clinicDashboardPrivateJsonResponse({ error: { code: CLINIC_TREATMENT_ERROR_CODES.invalidInput } }, 422)
+    case 'not-found':
+      return clinicDashboardPrivateJsonResponse({ error: { code: CLINIC_TREATMENT_ERROR_CODES.notFound } }, 404)
+    case 'unavailable':
+      return clinicDashboardPrivateJsonResponse(
+        { error: { code: CLINIC_DASHBOARD_ERROR_CODES.temporarilyUnavailable } },
+        503,
+      )
+  }
+}
+
+const unexpectedErrorResponse = (req: PayloadRequest, error: unknown, operation: string): Response => {
+  req.payload.logger.error(
+    {
+      err: toLoggedError(error),
+      event: `clinic_dashboard.treatments.${operation}_failed`,
+    },
+    'Clinic Dashboard treatment operation failed',
+  )
+  return clinicDashboardPrivateJsonResponse(
+    { error: { code: CLINIC_DASHBOARD_ERROR_CODES.temporarilyUnavailable } },
+    503,
+  )
+}
+
+export const clinicDashboardTreatmentsGetHandler: PayloadHandler = async (req) => {
+  const authorization = await authorizeClinic(req, 'clinic-treatments:view')
+  if (!authorization.ok) return authorization.response
+
+  try {
+    return clinicDashboardPrivateJsonResponse(await readClinicTreatmentSnapshot(req, authorization.clinicId), 200)
+  } catch (error: unknown) {
+    if (error instanceof ClinicTreatmentServiceError) return serviceErrorResponse(error)
+    return unexpectedErrorResponse(req, error, 'read')
+  }
+}
+
+export const clinicDashboardTreatmentsPostHandler: PayloadHandler = async (req) => {
+  const authorization = await authorizeClinic(req, 'clinic-treatments:edit')
+  if (!authorization.ok) return authorization.response
+  const input = await readBody(req, clinicTreatmentCreateInputSchema)
+  if (input instanceof Response) return input
+
+  try {
+    return clinicDashboardPrivateJsonResponse(await createClinicTreatment(req, authorization.clinicId, input), 201)
+  } catch (error: unknown) {
+    if (error instanceof ClinicTreatmentServiceError) return serviceErrorResponse(error)
+    return unexpectedErrorResponse(req, error, 'create')
+  }
+}
+
+export const clinicDashboardTreatmentsPatchHandler: PayloadHandler = async (req) => {
+  const authorization = await authorizeClinic(req, 'clinic-treatments:edit')
+  if (!authorization.ok) return authorization.response
+  const input = await readBody(req, clinicTreatmentUpdateInputSchema)
+  if (input instanceof Response) return input
+
+  try {
+    return clinicDashboardPrivateJsonResponse(await updateClinicTreatment(req, authorization.clinicId, input), 200)
+  } catch (error: unknown) {
+    if (error instanceof ClinicTreatmentServiceError) return serviceErrorResponse(error)
+    return unexpectedErrorResponse(req, error, 'update')
+  }
+}

--- a/src/features/clinicDashboard/treatments/contracts.ts
+++ b/src/features/clinicDashboard/treatments/contracts.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod'
+
+const identifierSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9_-]+$/u)
+const priceEURSchema = z
+  .number()
+  .finite()
+  .nonnegative()
+  .refine((value) => Math.abs(value * 100 - Math.round(value * 100)) <= 1e-8)
+const revisionSchema = z.string().datetime({ offset: true })
+
+export const clinicTreatmentCreateInputSchema = z
+  .object({
+    priceEUR: priceEURSchema,
+    treatmentId: identifierSchema,
+  })
+  .strict()
+
+export const clinicTreatmentUpdateInputSchema = z
+  .object({
+    active: z.boolean(),
+    expectedRevision: revisionSchema,
+    offeringId: identifierSchema,
+    priceEUR: priceEURSchema,
+  })
+  .strict()
+
+export type ClinicTreatmentCreateInput = z.infer<typeof clinicTreatmentCreateInputSchema>
+export type ClinicTreatmentUpdateInput = z.infer<typeof clinicTreatmentUpdateInputSchema>
+
+export type ClinicTreatmentMasterDTO = {
+  descriptionText: string
+  id: string
+  name: string
+}
+
+export type ClinicTreatmentOfferingDTO = {
+  active: boolean
+  id: string
+  priceEUR: number
+  revision: string
+  treatment: ClinicTreatmentMasterDTO
+}
+
+export type ClinicTreatmentSnapshotDTO = {
+  catalogue: ClinicTreatmentMasterDTO[]
+  offerings: ClinicTreatmentOfferingDTO[]
+}

--- a/src/features/clinicDashboard/treatments/service.ts
+++ b/src/features/clinicDashboard/treatments/service.ts
@@ -1,0 +1,261 @@
+import type { PayloadRequest } from 'payload'
+
+import { richTextToPlainText } from '@/features/clinicDashboard/profile/richText'
+import { dispatchClinicTreatmentChangeRevalidation } from '@/hooks/revalidateClinicSurfaces'
+import type { Clinictreatment, Treatment } from '@/payload-types'
+import type {
+  ClinicTreatmentCreateInput,
+  ClinicTreatmentMasterDTO,
+  ClinicTreatmentOfferingDTO,
+  ClinicTreatmentSnapshotDTO,
+  ClinicTreatmentUpdateInput,
+} from './contracts'
+
+export type ClinicTreatmentServiceErrorKind = 'conflict' | 'invalid-input' | 'not-found' | 'unavailable'
+
+export class ClinicTreatmentServiceError extends Error {
+  constructor(
+    readonly kind: ClinicTreatmentServiceErrorKind,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'ClinicTreatmentServiceError'
+  }
+}
+
+type RelationId = number | string
+
+const relationId = (value: unknown): RelationId | null => {
+  if (typeof value === 'number' && Number.isSafeInteger(value)) return value
+  if (typeof value === 'string' && value.trim()) return value.trim()
+  if (value && typeof value === 'object' && 'id' in value) return relationId((value as { id?: unknown }).id)
+  return null
+}
+
+const payloadId = (value: string): RelationId => {
+  if (!/^[1-9]\d*$/u.test(value)) return value
+  const numeric = Number(value)
+  return Number.isSafeInteger(numeric) ? numeric : value
+}
+
+const numericClinicId = (clinicId: RelationId): number => {
+  const numeric = typeof clinicId === 'number' ? clinicId : Number(clinicId)
+  if (!Number.isSafeInteger(numeric) || numeric <= 0) {
+    throw new ClinicTreatmentServiceError('unavailable', 'The assigned clinic identity is invalid.')
+  }
+  return numeric
+}
+
+const duplicateConstraint = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') return false
+  const record = error as { code?: unknown; cause?: { code?: unknown }; message?: unknown }
+  return (
+    record.code === '23505' ||
+    record.cause?.code === '23505' ||
+    (typeof record.message === 'string' && /duplicate|unique/iu.test(record.message))
+  )
+}
+
+const masterDTO = (treatment: Treatment): ClinicTreatmentMasterDTO => ({
+  descriptionText: richTextToPlainText(treatment.description),
+  id: String(treatment.id),
+  name: treatment.name.trim(),
+})
+
+const offeringDTO = (offering: Clinictreatment, clinicId: RelationId): ClinicTreatmentOfferingDTO => {
+  if (String(relationId(offering.clinic)) !== String(clinicId) || typeof offering.treatment !== 'object') {
+    throw new ClinicTreatmentServiceError('unavailable', 'Clinic treatment relationships are unavailable.')
+  }
+
+  return {
+    active: offering.active,
+    id: String(offering.id),
+    priceEUR: offering.price,
+    revision: offering.updatedAt,
+    treatment: masterDTO(offering.treatment),
+  }
+}
+
+const MAX_TRANSACTION_ATTEMPTS = 3
+
+const isSerializationFailure = (error: unknown): boolean => {
+  const visited = new Set<unknown>()
+  let current = error
+
+  while (current !== null && typeof current !== 'undefined' && !visited.has(current)) {
+    visited.add(current)
+    if (typeof current !== 'object' && typeof current !== 'function') return false
+    const record = current as Record<string, unknown>
+    if (record.code === '40001' || record.sqlState === '40001' || record.sqlstate === '40001') return true
+    current = record.cause
+  }
+
+  return false
+}
+
+const runSerializableTransaction = async <Result>(
+  req: PayloadRequest,
+  command: () => Promise<Result>,
+): Promise<Result> => {
+  if (typeof req.transactionID !== 'undefined') {
+    throw new ClinicTreatmentServiceError('unavailable', 'Treatment updates cannot join another transaction.')
+  }
+
+  for (let attempt = 1; attempt <= MAX_TRANSACTION_ATTEMPTS; attempt += 1) {
+    let transactionID: null | number | string = null
+
+    try {
+      transactionID = await req.payload.db.beginTransaction({
+        accessMode: 'read write',
+        isolationLevel: 'serializable',
+      })
+      if (transactionID === null) {
+        throw new ClinicTreatmentServiceError('unavailable', 'A database transaction could not be started.')
+      }
+
+      req.transactionID = transactionID
+      const result = await command()
+      await req.payload.db.commitTransaction(transactionID)
+      return result
+    } catch (error: unknown) {
+      if (transactionID !== null) await req.payload.db.rollbackTransaction(transactionID)
+      if (isSerializationFailure(error)) {
+        if (attempt < MAX_TRANSACTION_ATTEMPTS) continue
+        throw new ClinicTreatmentServiceError('conflict', 'The clinic treatment changed.')
+      }
+      throw error
+    } finally {
+      if (transactionID !== null && req.transactionID === transactionID) delete req.transactionID
+    }
+  }
+
+  throw new ClinicTreatmentServiceError('conflict', 'The clinic treatment changed.')
+}
+
+export const readClinicTreatmentSnapshot = async (
+  req: PayloadRequest,
+  clinicId: RelationId,
+): Promise<ClinicTreatmentSnapshotDTO> => {
+  const [offerings, catalogue] = await Promise.all([
+    req.payload.find({
+      collection: 'clinictreatments',
+      depth: 1,
+      limit: 1_000,
+      overrideAccess: true,
+      pagination: false,
+      req,
+      where: { clinic: { equals: clinicId } },
+    }),
+    req.payload.find({
+      collection: 'treatments',
+      depth: 0,
+      limit: 1_000,
+      overrideAccess: true,
+      pagination: false,
+      req,
+      sort: 'name',
+    }),
+  ])
+
+  return {
+    catalogue: catalogue.docs.map(masterDTO),
+    offerings: offerings.docs.map((offering) => offeringDTO(offering, clinicId)),
+  }
+}
+
+export const createClinicTreatment = async (
+  req: PayloadRequest,
+  clinicId: RelationId,
+  input: ClinicTreatmentCreateInput,
+): Promise<ClinicTreatmentOfferingDTO> => {
+  try {
+    const treatment = await req.payload.findByID({
+      collection: 'treatments',
+      depth: 0,
+      id: payloadId(input.treatmentId),
+      overrideAccess: true,
+      req,
+    })
+    if (!treatment.name.trim()) {
+      throw new ClinicTreatmentServiceError('invalid-input', 'The selected treatment is unavailable.')
+    }
+
+    const offering = await req.payload.create({
+      collection: 'clinictreatments',
+      data: {
+        active: false,
+        clinic: numericClinicId(clinicId),
+        price: input.priceEUR,
+        treatment: treatment.id,
+      },
+      depth: 1,
+      overrideAccess: true,
+      req,
+    })
+    return offeringDTO(offering, clinicId)
+  } catch (error: unknown) {
+    if (error instanceof ClinicTreatmentServiceError) throw error
+    if (duplicateConstraint(error)) {
+      throw new ClinicTreatmentServiceError('conflict', 'The clinic already offers this treatment.')
+    }
+    if (error && typeof error === 'object' && 'status' in error && error.status === 404) {
+      throw new ClinicTreatmentServiceError('invalid-input', 'The selected treatment is unavailable.')
+    }
+    throw error
+  }
+}
+
+export const updateClinicTreatment = async (
+  req: PayloadRequest,
+  clinicId: RelationId,
+  input: ClinicTreatmentUpdateInput,
+): Promise<ClinicTreatmentOfferingDTO> => {
+  const result = await runSerializableTransaction(req, async () => {
+    const existing = await req.payload.find({
+      collection: 'clinictreatments',
+      depth: 0,
+      limit: 1,
+      overrideAccess: true,
+      pagination: false,
+      req,
+      where: {
+        and: [{ id: { equals: payloadId(input.offeringId) } }, { clinic: { equals: clinicId } }],
+      },
+    })
+    const current = existing.docs[0]
+    if (!current) throw new ClinicTreatmentServiceError('not-found', 'The clinic treatment does not exist.')
+    if (current.updatedAt !== input.expectedRevision) {
+      throw new ClinicTreatmentServiceError('conflict', 'The clinic treatment changed.')
+    }
+
+    const result = await req.payload.update({
+      collection: 'clinictreatments',
+      context: { disableRevalidate: true },
+      data: { active: input.active, price: input.priceEUR },
+      depth: 1,
+      overrideAccess: true,
+      req,
+      where: {
+        and: [
+          { id: { equals: current.id } },
+          { clinic: { equals: clinicId } },
+          { updatedAt: { equals: input.expectedRevision } },
+        ],
+      },
+    })
+    const updated = result.docs[0]
+    if (!updated || result.docs.length !== 1) {
+      throw new ClinicTreatmentServiceError('conflict', 'The clinic treatment changed.')
+    }
+
+    return { current, updated }
+  })
+
+  await dispatchClinicTreatmentChangeRevalidation({
+    doc: result.updated,
+    previousDoc: result.current,
+    req,
+  })
+
+  return offeringDTO(result.updated, clinicId)
+}

--- a/src/features/clinicDashboard/treatments/service.ts
+++ b/src/features/clinicDashboard/treatments/service.ts
@@ -62,8 +62,15 @@ const masterDTO = (treatment: Treatment): ClinicTreatmentMasterDTO => ({
   name: treatment.name.trim(),
 })
 
-const offeringDTO = (offering: Clinictreatment, clinicId: RelationId): ClinicTreatmentOfferingDTO => {
-  if (String(relationId(offering.clinic)) !== String(clinicId) || typeof offering.treatment !== 'object') {
+const offeringDTO = (
+  offering: Clinictreatment,
+  clinicId: RelationId,
+  treatment: Treatment,
+): ClinicTreatmentOfferingDTO => {
+  if (
+    String(relationId(offering.clinic)) !== String(clinicId) ||
+    String(relationId(offering.treatment)) !== String(treatment.id)
+  ) {
     throw new ClinicTreatmentServiceError('unavailable', 'Clinic treatment relationships are unavailable.')
   }
 
@@ -72,7 +79,55 @@ const offeringDTO = (offering: Clinictreatment, clinicId: RelationId): ClinicTre
     id: String(offering.id),
     priceEUR: offering.price,
     revision: offering.updatedAt,
-    treatment: masterDTO(offering.treatment),
+    treatment: masterDTO(treatment),
+  }
+}
+
+const SNAPSHOT_PAGE_SIZE = 100
+
+const readAllClinicOfferings = async (req: PayloadRequest, clinicId: RelationId): Promise<Clinictreatment[]> => {
+  const docs: Clinictreatment[] = []
+  let page = 1
+
+  while (true) {
+    const result = await req.payload.find({
+      collection: 'clinictreatments',
+      depth: 0,
+      limit: SNAPSHOT_PAGE_SIZE,
+      overrideAccess: true,
+      page,
+      req,
+      where: { clinic: { equals: clinicId } },
+    })
+    docs.push(...result.docs)
+    if (!result.hasNextPage) return docs
+    if (typeof result.nextPage !== 'number' || result.nextPage <= page) {
+      throw new ClinicTreatmentServiceError('unavailable', 'Clinic treatments could not be loaded completely.')
+    }
+    page = result.nextPage
+  }
+}
+
+const readAllTreatments = async (req: PayloadRequest): Promise<Treatment[]> => {
+  const docs: Treatment[] = []
+  let page = 1
+
+  while (true) {
+    const result = await req.payload.find({
+      collection: 'treatments',
+      depth: 0,
+      limit: SNAPSHOT_PAGE_SIZE,
+      overrideAccess: true,
+      page,
+      req,
+      sort: 'name',
+    })
+    docs.push(...result.docs)
+    if (!result.hasNextPage) return docs
+    if (typeof result.nextPage !== 'number' || result.nextPage <= page) {
+      throw new ClinicTreatmentServiceError('unavailable', 'The treatment catalogue could not be loaded completely.')
+    }
+    page = result.nextPage
   }
 }
 
@@ -136,30 +191,18 @@ export const readClinicTreatmentSnapshot = async (
   req: PayloadRequest,
   clinicId: RelationId,
 ): Promise<ClinicTreatmentSnapshotDTO> => {
-  const [offerings, catalogue] = await Promise.all([
-    req.payload.find({
-      collection: 'clinictreatments',
-      depth: 1,
-      limit: 1_000,
-      overrideAccess: true,
-      pagination: false,
-      req,
-      where: { clinic: { equals: clinicId } },
-    }),
-    req.payload.find({
-      collection: 'treatments',
-      depth: 0,
-      limit: 1_000,
-      overrideAccess: true,
-      pagination: false,
-      req,
-      sort: 'name',
-    }),
-  ])
+  const [offerings, catalogue] = await Promise.all([readAllClinicOfferings(req, clinicId), readAllTreatments(req)])
+  const treatmentsById = new Map(catalogue.map((treatment) => [String(treatment.id), treatment]))
 
   return {
-    catalogue: catalogue.docs.map(masterDTO),
-    offerings: offerings.docs.map((offering) => offeringDTO(offering, clinicId)),
+    catalogue: catalogue.map(masterDTO),
+    offerings: offerings.map((offering) => {
+      const treatment = treatmentsById.get(String(relationId(offering.treatment)))
+      if (!treatment) {
+        throw new ClinicTreatmentServiceError('unavailable', 'Clinic treatment relationships are unavailable.')
+      }
+      return offeringDTO(offering, clinicId, treatment)
+    }),
   }
 }
 
@@ -188,11 +231,11 @@ export const createClinicTreatment = async (
         price: input.priceEUR,
         treatment: treatment.id,
       },
-      depth: 1,
+      depth: 0,
       overrideAccess: true,
       req,
     })
-    return offeringDTO(offering, clinicId)
+    return offeringDTO(offering, clinicId, treatment)
   } catch (error: unknown) {
     if (error instanceof ClinicTreatmentServiceError) throw error
     if (duplicateConstraint(error)) {
@@ -227,12 +270,23 @@ export const updateClinicTreatment = async (
     if (current.updatedAt !== input.expectedRevision) {
       throw new ClinicTreatmentServiceError('conflict', 'The clinic treatment changed.')
     }
+    const treatmentId = relationId(current.treatment)
+    if (treatmentId === null) {
+      throw new ClinicTreatmentServiceError('unavailable', 'Clinic treatment relationships are unavailable.')
+    }
+    const treatment = await req.payload.findByID({
+      collection: 'treatments',
+      depth: 0,
+      id: treatmentId,
+      overrideAccess: true,
+      req,
+    })
 
     const result = await req.payload.update({
       collection: 'clinictreatments',
       context: { disableRevalidate: true },
       data: { active: input.active, price: input.priceEUR },
-      depth: 1,
+      depth: 0,
       overrideAccess: true,
       req,
       where: {
@@ -248,7 +302,7 @@ export const updateClinicTreatment = async (
       throw new ClinicTreatmentServiceError('conflict', 'The clinic treatment changed.')
     }
 
-    return { current, updated }
+    return { current, treatment, updated }
   })
 
   await dispatchClinicTreatmentChangeRevalidation({
@@ -257,5 +311,5 @@ export const updateClinicTreatment = async (
     req,
   })
 
-  return offeringDTO(result.updated, clinicId)
+  return offeringDTO(result.updated, clinicId, result.treatment)
 }

--- a/src/hooks/revalidateClinicSurfaces.ts
+++ b/src/hooks/revalidateClinicSurfaces.ts
@@ -317,10 +317,24 @@ const revalidateRelatedClinicSurface = async (
 export const revalidateClinicTreatmentChange: CollectionAfterChangeHook = async ({ doc, previousDoc, req }) => {
   if (isRevalidationDisabled(req)) return doc
 
+  await dispatchClinicTreatmentChangeRevalidation({ doc, previousDoc, req })
+
+  return doc
+}
+
+export const dispatchClinicTreatmentChangeRevalidation = async ({
+  doc,
+  previousDoc,
+  req,
+}: {
+  doc: unknown
+  previousDoc?: unknown
+  req: PayloadRequest
+}): Promise<void> => {
   const current = doc as RevalidatableDoc
   const previous = previousDoc as RevalidatableDoc | undefined
 
-  return revalidateRelatedClinicSurface({
+  dispatchRelatedClinicSurfaceRevalidation({
     collection: 'clinictreatments',
     currentClinics: [await resolveClinicIdentity(req, current.clinic)].filter(isClinicIdentity),
     previousClinics: [await resolveClinicIdentity(req, previous?.clinic)].filter(isClinicIdentity),

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -13,6 +13,11 @@ import {
   clinicDashboardProfileGetHandler,
   clinicDashboardProfilePublishPostHandler,
 } from './endpoints/clinicDashboardProfile'
+import {
+  clinicDashboardTreatmentsGetHandler,
+  clinicDashboardTreatmentsPatchHandler,
+  clinicDashboardTreatmentsPostHandler,
+} from './endpoints/clinicDashboardTreatments'
 import { seedPostHandler, seedGetHandler, seedAdvanceHandler, seedRetryHandler } from './endpoints/seed/seedEndpoint'
 import { seedChunkTask } from './endpoints/seed/tasks/seedChunkTask'
 import { fileURLToPath } from 'url'
@@ -128,6 +133,21 @@ export default buildConfig({
       path: '/clinic-dashboard/profile/publish',
       method: 'post',
       handler: clinicDashboardProfilePublishPostHandler as PayloadHandler,
+    },
+    {
+      path: '/clinic-dashboard/treatments',
+      method: 'get',
+      handler: clinicDashboardTreatmentsGetHandler as PayloadHandler,
+    },
+    {
+      path: '/clinic-dashboard/treatments',
+      method: 'post',
+      handler: clinicDashboardTreatmentsPostHandler as PayloadHandler,
+    },
+    {
+      path: '/clinic-dashboard/treatments',
+      method: 'patch',
+      handler: clinicDashboardTreatmentsPatchHandler as PayloadHandler,
     },
     { path: '/seed', method: 'post', handler: seedPostHandler as PayloadHandler },
     { path: '/seed', method: 'get', handler: seedGetHandler as PayloadHandler },

--- a/tests/integration/clinicDashboardTreatments.concurrency.test.ts
+++ b/tests/integration/clinicDashboardTreatments.concurrency.test.ts
@@ -1,0 +1,108 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { createLocalReq, getPayload, type Payload } from 'payload'
+
+import config from '@payload-config'
+import { updateClinicTreatment } from '@/features/clinicDashboard/treatments/service'
+import { buildRichText } from '../fixtures/richText'
+import { createClinicFixture } from '../fixtures/createClinicFixture'
+import { ensureBaseline } from '../fixtures/ensureBaseline'
+import { testSlug } from '../fixtures/testSlug'
+
+vi.mock('@payloadcms/storage-s3', () => ({
+  s3Storage: () => (incomingConfig: unknown) => incomingConfig,
+}))
+
+describe('Clinic Dashboard treatment concurrency', () => {
+  let payload: Payload
+  let clinicId: number
+  let doctorId: number
+  let offeringId: number
+  let treatmentId: number
+  const name = `${testSlug('clinicDashboardTreatments.concurrency.test.ts')}-treatment`
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    await ensureBaseline(payload)
+
+    const [cityResult, specialtyResult] = await Promise.all([
+      payload.find({ collection: 'cities', depth: 0, limit: 1, overrideAccess: true }),
+      payload.find({ collection: 'medical-specialties', depth: 0, limit: 1, overrideAccess: true }),
+    ])
+    const city = cityResult.docs[0]
+    const specialty = specialtyResult.docs[0]
+    if (!city || !specialty) throw new Error('Expected baseline city and medical specialty')
+    const fixture = await createClinicFixture(payload, city.id, { slugPrefix: name })
+    clinicId = fixture.clinic.id
+    doctorId = fixture.doctor.id
+
+    const treatment = await payload.create({
+      collection: 'treatments',
+      data: {
+        description: buildRichText('Concurrency test treatment'),
+        medicalSpecialty: specialty.id,
+        name,
+      },
+      depth: 0,
+      overrideAccess: true,
+    })
+    treatmentId = treatment.id
+
+    const offering = await payload.create({
+      collection: 'clinictreatments',
+      data: {
+        active: false,
+        clinic: clinicId,
+        price: 100,
+        treatment: treatment.id,
+      },
+      depth: 0,
+      overrideAccess: true,
+    })
+    offeringId = offering.id
+  }, 60_000)
+
+  afterAll(async () => {
+    if (!payload) return
+    if (offeringId) await payload.delete({ collection: 'clinictreatments', id: offeringId, overrideAccess: true })
+    if (doctorId) await payload.delete({ collection: 'doctors', id: doctorId, overrideAccess: true })
+    if (clinicId) await payload.delete({ collection: 'clinics', id: clinicId, overrideAccess: true })
+    if (treatmentId) await payload.delete({ collection: 'treatments', id: treatmentId, overrideAccess: true })
+  })
+
+  it('allows only one of two updates that start from the same revision', async () => {
+    const initial = await payload.findByID({
+      collection: 'clinictreatments',
+      depth: 0,
+      id: offeringId,
+      overrideAccess: true,
+    })
+    const [firstReq, secondReq] = await Promise.all([createLocalReq({}, payload), createLocalReq({}, payload)])
+
+    const results = await Promise.allSettled([
+      updateClinicTreatment(firstReq, clinicId, {
+        active: true,
+        expectedRevision: initial.updatedAt,
+        offeringId: String(initial.id),
+        priceEUR: 110,
+      }),
+      updateClinicTreatment(secondReq, clinicId, {
+        active: true,
+        expectedRevision: initial.updatedAt,
+        offeringId: String(initial.id),
+        priceEUR: 120,
+      }),
+    ])
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1)
+    const rejected = results.find((result) => result.status === 'rejected')
+    expect(rejected).toMatchObject({ reason: { kind: 'conflict' }, status: 'rejected' })
+
+    const stored = await payload.findByID({
+      collection: 'clinictreatments',
+      depth: 0,
+      id: offeringId,
+      overrideAccess: true,
+    })
+    expect([110, 120]).toContain(stored.price)
+  })
+})

--- a/tests/unit/endpoints/clinicDashboardTreatments.test.ts
+++ b/tests/unit/endpoints/clinicDashboardTreatments.test.ts
@@ -1,0 +1,132 @@
+import type { PayloadRequest } from 'payload'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  clinicDashboardTreatmentsGetHandler,
+  clinicDashboardTreatmentsPatchHandler,
+  clinicDashboardTreatmentsPostHandler,
+} from '@/endpoints/clinicDashboardTreatments'
+import { ClinicTreatmentServiceError } from '@/features/clinicDashboard/treatments/service'
+
+const mocks = vi.hoisted(() => ({
+  bootstrap: vi.fn(),
+  create: vi.fn(),
+  read: vi.fn(),
+  update: vi.fn(),
+}))
+
+vi.mock('@/features/clinicDashboard/bootstrap', () => ({
+  resolveClinicDashboardBootstrap: mocks.bootstrap,
+}))
+
+vi.mock('@/features/clinicDashboard/treatments/service', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/features/clinicDashboard/treatments/service')>()
+  return {
+    ...original,
+    createClinicTreatment: mocks.create,
+    readClinicTreatmentSnapshot: mocks.read,
+    updateClinicTreatment: mocks.update,
+  }
+})
+
+const offering = {
+  active: false,
+  id: 'offering-1',
+  priceEUR: 100,
+  revision: '2026-08-13T10:00:00.000Z',
+  treatment: { descriptionText: 'Description', id: 'treatment-1', name: 'Treatment' },
+}
+
+const request = (body?: unknown) =>
+  ({
+    headers: new Headers({ authorization: 'Bearer token' }),
+    json: vi.fn(async () => body),
+    payload: { logger: { error: vi.fn() } },
+  }) as unknown as PayloadRequest
+
+describe('Clinic Dashboard treatment endpoints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.bootstrap.mockResolvedValue({
+      status: 'success',
+      data: {
+        capabilities: [
+          'clinic-profile:view',
+          'clinic-profile:edit',
+          'clinic-treatments:view',
+          'clinic-treatments:edit',
+        ],
+        clinic: { id: '42', name: 'Assigned clinic' },
+      },
+    })
+    mocks.read.mockResolvedValue({ catalogue: [offering.treatment], offerings: [offering] })
+    mocks.create.mockResolvedValue(offering)
+    mocks.update.mockResolvedValue({ ...offering, active: true })
+  })
+
+  it('returns only the server-assigned clinic snapshot with private-live headers', async () => {
+    const response = await clinicDashboardTreatmentsGetHandler(request())
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('private, no-store')
+    expect(response.headers.get('vary')).toBe('Authorization')
+    expect(mocks.read).toHaveBeenCalledWith(expect.anything(), '42')
+  })
+
+  it('creates a treatment inactive without accepting caller-controlled active state', async () => {
+    const response = await clinicDashboardTreatmentsPostHandler(request({ priceEUR: 100, treatmentId: 'treatment-1' }))
+
+    expect(response.status).toBe(201)
+    expect(mocks.create).toHaveBeenCalledWith(expect.anything(), '42', {
+      priceEUR: 100,
+      treatmentId: 'treatment-1',
+    })
+
+    const rejected = await clinicDashboardTreatmentsPostHandler(
+      request({ active: true, priceEUR: 100, treatmentId: 'treatment-1' }),
+    )
+    expect(rejected.status).toBe(400)
+    expect(mocks.create).toHaveBeenCalledOnce()
+  })
+
+  it('requires an expected revision for updates and maps conflicts to 409', async () => {
+    const input = {
+      active: true,
+      expectedRevision: offering.revision,
+      offeringId: offering.id,
+      priceEUR: 120,
+    }
+    const response = await clinicDashboardTreatmentsPatchHandler(request(input))
+    expect(response.status).toBe(200)
+    expect(mocks.update).toHaveBeenCalledWith(expect.anything(), '42', input)
+
+    mocks.update.mockRejectedValueOnce(new ClinicTreatmentServiceError('conflict', 'changed'))
+    const conflict = await clinicDashboardTreatmentsPatchHandler(request(input))
+    expect(conflict.status).toBe(409)
+    await expect(conflict.json()).resolves.toEqual({ error: { code: 'CLINIC_TREATMENT_CONFLICT' } })
+  })
+
+  it('reuses bootstrap authorization failures without calling the service', async () => {
+    mocks.bootstrap.mockResolvedValue({ status: 'access-denied' })
+    const response = await clinicDashboardTreatmentsGetHandler(request())
+
+    expect(response.status).toBe(403)
+    expect(mocks.read).not.toHaveBeenCalled()
+  })
+
+  it('requires the method-specific treatment capability', async () => {
+    mocks.bootstrap.mockResolvedValue({
+      status: 'success',
+      data: {
+        capabilities: ['clinic-treatments:view'],
+        clinic: { id: '42', name: 'Assigned clinic' },
+      },
+    })
+
+    expect((await clinicDashboardTreatmentsGetHandler(request())).status).toBe(200)
+    expect(
+      (await clinicDashboardTreatmentsPostHandler(request({ priceEUR: 100, treatmentId: 'treatment-1' }))).status,
+    ).toBe(403)
+    expect(mocks.create).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/features/clinicDashboard/treatments/service.test.ts
+++ b/tests/unit/features/clinicDashboard/treatments/service.test.ts
@@ -1,0 +1,158 @@
+import type { PayloadRequest } from 'payload'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  ClinicTreatmentServiceError,
+  createClinicTreatment,
+  updateClinicTreatment,
+} from '@/features/clinicDashboard/treatments/service'
+
+const transactions = vi.hoisted(() => ({
+  begin: vi.fn(async () => 'tx-1'),
+  commit: vi.fn(async () => undefined),
+  rollback: vi.fn(async () => undefined),
+}))
+
+const cache = vi.hoisted(() => ({ dispatch: vi.fn(async () => undefined) }))
+
+vi.mock('@/hooks/revalidateClinicSurfaces', () => ({
+  dispatchClinicTreatmentChangeRevalidation: cache.dispatch,
+}))
+
+const treatment = {
+  description: null,
+  id: 8,
+  name: 'Treatment',
+}
+const offering = {
+  active: false,
+  clinic: 7,
+  id: 9,
+  price: 100,
+  treatment,
+  updatedAt: '2026-08-13T10:00:00.000Z',
+}
+
+const request = (overrides: Record<string, unknown> = {}) =>
+  ({
+    payload: {
+      create: vi.fn(async () => offering),
+      db: {
+        beginTransaction: transactions.begin,
+        commitTransaction: transactions.commit,
+        rollbackTransaction: transactions.rollback,
+      },
+      find: vi.fn(async () => ({ docs: [offering] })),
+      findByID: vi.fn(async () => treatment),
+      update: vi.fn(async () => ({
+        docs: [{ ...offering, active: true, updatedAt: '2026-08-13T10:01:00.000Z' }],
+      })),
+      ...overrides,
+    },
+  }) as unknown as PayloadRequest
+
+describe('Clinic Dashboard treatment service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    transactions.begin.mockResolvedValue('tx-1')
+    transactions.commit.mockResolvedValue(undefined)
+  })
+
+  it('always creates new clinic treatments inactive for the server-derived clinic', async () => {
+    const req = request()
+
+    await createClinicTreatment(req, 7, { priceEUR: 100, treatmentId: '8' })
+
+    expect(req.payload.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'clinictreatments',
+        data: { active: false, clinic: 7, price: 100, treatment: 8 },
+      }),
+    )
+  })
+
+  it('does not update an offering outside the server-derived clinic', async () => {
+    const update = vi.fn()
+    const req = request({ find: vi.fn(async () => ({ docs: [] })), update })
+
+    await expect(
+      updateClinicTreatment(req, 7, {
+        active: true,
+        expectedRevision: offering.updatedAt,
+        offeringId: '99',
+        priceEUR: 120,
+      }),
+    ).rejects.toEqual(expect.objectContaining<Partial<ClinicTreatmentServiceError>>({ kind: 'not-found' }))
+    expect(update).not.toHaveBeenCalled()
+    expect(transactions.rollback).toHaveBeenCalledOnce()
+  })
+
+  it('updates only the expected clinic-scoped revision and rejects stale writes', async () => {
+    const req = request()
+
+    await updateClinicTreatment(req, 7, {
+      active: true,
+      expectedRevision: offering.updatedAt,
+      offeringId: '9',
+      priceEUR: 120,
+    })
+
+    expect(req.payload.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: { disableRevalidate: true },
+        data: { active: true, price: 120 },
+        where: {
+          and: [{ id: { equals: 9 } }, { clinic: { equals: 7 } }, { updatedAt: { equals: offering.updatedAt } }],
+        },
+      }),
+    )
+    expect(transactions.begin).toHaveBeenCalledWith({
+      accessMode: 'read write',
+      isolationLevel: 'serializable',
+    })
+    expect(transactions.commit).toHaveBeenCalledOnce()
+    expect(cache.dispatch).toHaveBeenCalledAfter(transactions.commit)
+    expect(cache.dispatch).toHaveBeenCalledWith({
+      doc: expect.objectContaining({ active: true }),
+      previousDoc: offering,
+      req,
+    })
+
+    const stale = request({ find: vi.fn(async () => ({ docs: [{ ...offering, updatedAt: 'later' }] })) })
+    await expect(
+      updateClinicTreatment(stale, 7, {
+        active: true,
+        expectedRevision: offering.updatedAt,
+        offeringId: '9',
+        priceEUR: 120,
+      }),
+    ).rejects.toEqual(expect.objectContaining<Partial<ClinicTreatmentServiceError>>({ kind: 'conflict' }))
+    expect(stale.payload.update).not.toHaveBeenCalled()
+    expect(cache.dispatch).toHaveBeenCalledOnce()
+  })
+
+  it('retries serialization failures and turns a newly stale revision into a conflict', async () => {
+    const changed = { ...offering, updatedAt: '2026-08-13T10:01:00.000Z' }
+    const find = vi
+      .fn()
+      .mockResolvedValueOnce({ docs: [offering] })
+      .mockResolvedValueOnce({ docs: [changed] })
+    const req = request({ find })
+    transactions.begin.mockResolvedValueOnce('tx-1').mockResolvedValueOnce('tx-2')
+    transactions.commit.mockRejectedValueOnce(Object.assign(new Error('serialization failure'), { code: '40001' }))
+
+    await expect(
+      updateClinicTreatment(req, 7, {
+        active: true,
+        expectedRevision: offering.updatedAt,
+        offeringId: '9',
+        priceEUR: 120,
+      }),
+    ).rejects.toEqual(expect.objectContaining<Partial<ClinicTreatmentServiceError>>({ kind: 'conflict' }))
+
+    expect(transactions.begin).toHaveBeenCalledTimes(2)
+    expect(transactions.rollback).toHaveBeenCalledTimes(2)
+    expect(req.payload.update).toHaveBeenCalledOnce()
+    expect(cache.dispatch).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/features/clinicDashboard/treatments/service.test.ts
+++ b/tests/unit/features/clinicDashboard/treatments/service.test.ts
@@ -4,8 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   ClinicTreatmentServiceError,
   createClinicTreatment,
+  readClinicTreatmentSnapshot,
   updateClinicTreatment,
 } from '@/features/clinicDashboard/treatments/service'
+import { canonicalizeDescriptionText } from '@/features/clinicDashboard/profile/richText'
 
 const transactions = vi.hoisted(() => ({
   begin: vi.fn(async () => 'tx-1'),
@@ -69,6 +71,33 @@ describe('Clinic Dashboard treatment service', () => {
         data: { active: false, clinic: 7, price: 100, treatment: 8 },
       }),
     )
+  })
+
+  it('returns complete paginated snapshots with full treatment descriptions', async () => {
+    const describedTreatment = {
+      ...treatment,
+      description: canonicalizeDescriptionText('Complete description'),
+    }
+    const secondTreatment = { ...treatment, id: 10, name: 'Second treatment' }
+    const find = vi.fn(async ({ collection, page }: { collection: string; page: number }) => {
+      if (collection === 'clinictreatments') {
+        return { docs: [{ ...offering, treatment: treatment.id }], hasNextPage: false, nextPage: null }
+      }
+      if (page === 1) {
+        return { docs: [describedTreatment], hasNextPage: true, nextPage: 2 }
+      }
+      return { docs: [secondTreatment], hasNextPage: false, nextPage: null }
+    })
+    const req = request({ find })
+
+    const snapshot = await readClinicTreatmentSnapshot(req, 7)
+
+    expect(snapshot.catalogue).toEqual([
+      { descriptionText: 'Complete description', id: '8', name: 'Treatment' },
+      { descriptionText: '', id: '10', name: 'Second treatment' },
+    ])
+    expect(snapshot.offerings[0]?.treatment.descriptionText).toBe('Complete description')
+    expect(find).toHaveBeenCalledWith(expect.objectContaining({ collection: 'treatments', page: 2 }))
   })
 
   it('does not update an offering outside the server-derived clinic', async () => {

--- a/tests/unit/hooks/revalidateClinicSurfaces.test.ts
+++ b/tests/unit/hooks/revalidateClinicSurfaces.test.ts
@@ -2,7 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { revalidatePath, revalidateTag } from 'next/cache'
 import type { PayloadRequest } from 'payload'
 
-import { revalidateClinicChange, revalidateClinicDelete } from '@/hooks/revalidateClinicSurfaces'
+import {
+  dispatchClinicTreatmentChangeRevalidation,
+  revalidateClinicChange,
+  revalidateClinicDelete,
+} from '@/hooks/revalidateClinicSurfaces'
 import { createMockReq } from '../helpers/testHelpers'
 
 type ClinicDoc = {
@@ -88,5 +92,20 @@ describe('clinic surface revalidation hooks', () => {
 
     expect(getPathCalls()).toEqual([])
     expect(getTagCalls()).toEqual([])
+  })
+
+  it('dispatches an explicit post-commit treatment plan despite the hook suppression context', async () => {
+    const clinic = { id: 12, slug: 'berlin-health', status: 'approved' as const }
+    const req = buildReq({ disableRevalidate: true })
+
+    await dispatchClinicTreatmentChangeRevalidation({
+      doc: { clinic, id: 99 },
+      previousDoc: { clinic, id: 99 },
+      req,
+    })
+
+    expect(getPathCalls()).toEqual(['/clinics/berlin-health'])
+    expect(getTagCalls()).toContain('surface:clinic-detail:12')
+    expect(getTagCalls()).toContain('surface:listing-comparison')
   })
 })


### PR DESCRIPTION
## Management summary

### Deutsch

Klinikmitarbeiter können Behandlungsangebote künftig zuverlässig über das Klinik-Dashboard verwalten. Neue Angebote starten sicher inaktiv, parallele Änderungen überschreiben sich nicht unbemerkt und öffentliche Klinikansichten werden erst nach einer erfolgreichen Speicherung aktualisiert.

### English

Clinic staff can reliably manage treatment offerings through the clinic dashboard. New offerings start inactive, concurrent changes cannot silently overwrite each other, and public clinic views are refreshed only after a successful save.

## What changed

- Added one purpose-specific Payload endpoint for the assigned clinic's treatment snapshot, inactive creation, and revision-protected updates.
- Reused the existing dashboard bootstrap authorization with method-specific treatment capabilities and server-derived clinic identity.
- Added strict request and response contracts with stable private error semantics; generic Payload collection query and relationship shapes are no longer part of the cross-repository contract.
- Serialized updates with retry-aware conflict handling, then dispatched the existing clinic-surface revalidation plan after commit.
- Documented the shared Dashboard contract, cache behavior, error mapping, and rollout boundary.
- Added endpoint, service, cache, and real PostgreSQL concurrency coverage.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| --- | --- | --- | --- | --- |
| P1 | `src/endpoints/clinicDashboardTreatments.ts`, `src/features/clinicDashboard/treatments/` | These files establish the authenticated tenant and write boundary used by the separate clinic-dashboard application. | The clinic is always derived from bootstrap, method capabilities are exact, create cannot set active state, and foreign or stale updates fail closed. | Focused endpoint/service tests, full unit suite, dedicated security review, and a real PostgreSQL concurrency test pass. |
| P1 | `src/features/clinicDashboard/treatments/service.ts`, `src/hooks/revalidateClinicSurfaces.ts` | Public treatment price and availability depend on commit ordering and existing cache invalidation semantics. | Hook invalidation is suppressed inside the transaction and the same existing related-clinic plan runs once after commit. | Cache architecture review and explicit post-commit revalidation regression test pass. |
| P2 | `docs/integrations/clinic-dashboard-api.md` | This is the durable cross-repository compatibility boundary. | DTOs, allowed fields, revisions, errors, privacy headers, and cache behavior match the endpoint implementation. | Documentation consistency check passes and the Dashboard documentation was updated in its paired PR. |

## Reviewer gate

- Reviewed diff: final Website treatment contract against `origin/main`.
- Reviewer set: security and cache architecture.
- Result: both reviewers reported findings; all findings were fixed and explicitly re-verified with no remaining issues.
- Open, fixed, deferred, or excepted decisions: fixed serializable lost-update protection and post-commit cache invalidation; none open or deferred.

## Validation

- [x] `pnpm format`: passed.
- [x] `pnpm check`: passed, including lint, generated route types, Payload type gate, and TypeScript.
- [x] `pnpm build`: passed; the local development build emitted the existing missing Supabase URL log while still completing successfully.
- [x] Focused tests: endpoint, service, revalidation, and real PostgreSQL concurrent-update tests passed; full unit suite passed with 2,510 tests.
- [x] UI/mobile QA: not applicable; no Website UI changed.
- [x] Security/privacy review: dedicated reviewer re-verified tenant isolation, strict input, private responses, and serializable conflict behavior with no findings remaining.
- [x] Migration/schema check: no schema or migration change.
- [x] Documentation/instructions check: integration documentation and docs consistency check passed.

## Risk and rollout

The clinic-dashboard consumer must use this focused endpoint before its treatment PR merges. No new environment variables, schema changes, cache classes, tags, surfaces, or deployment changes are introduced. Rollback is a normal application rollback; the endpoint is additive.

## Development

Closes #1695
