### PR TITLE
fix: reconcile existing review appeal seeds

### DIFF
--- a/src/endpoints/seed/utils/plan.ts
+++ b/src/endpoints/seed/utils/plan.ts
@@ -458,7 +458,7 @@ export const demoPlan: SeedPlanStep[] = [
     context: { trustedReviewWorkflowSeed: true },
     reqUserStableId: 'seed-platform-admin',
     atomicGroup: 'review-moderation-history',
-    upsertPolicy: { skipIfVersionMatches: true },
+    upsertPolicy: { reconcileByUniqueFields: ['review'], skipIfVersionMatches: true },
     mapping: [
       {
         sourceField: 'reviewStableId',
@@ -493,7 +493,7 @@ export const demoPlan: SeedPlanStep[] = [
     context: { trustedReviewWorkflowSeed: true },
     reqUserStableId: 'seed-platform-admin',
     atomicGroup: 'review-moderation-history',
-    upsertPolicy: { skipIfCurrentMatches: true },
+    upsertPolicy: { reconcileByUniqueFields: ['review'], skipIfCurrentMatches: true },
     mapping: [
       {
         sourceField: 'reviewStableId',

--- a/tests/data-integrity/endpoints/seed/reviewWorkflowSnapshots.test.ts
+++ b/tests/data-integrity/endpoints/seed/reviewWorkflowSnapshots.test.ts
@@ -60,10 +60,16 @@ describe('review workflow seed plan', () => {
 
   it('keeps intermediate snapshots version-idempotent and terminal snapshots current', () => {
     const historySteps = [
-      { name: 'review-appeals-initial-history', upsertPolicy: { skipIfVersionMatches: true } },
+      {
+        name: 'review-appeals-initial-history',
+        upsertPolicy: { reconcileByUniqueFields: ['review'], skipIfVersionMatches: true },
+      },
       { name: 'review-moderations-initial-history', upsertPolicy: { skipIfVersionMatches: true } },
       { name: 'review-moderations-final-state', upsertPolicy: { skipIfCurrentMatches: true } },
-      { name: 'review-appeals-final-state', upsertPolicy: { skipIfCurrentMatches: true } },
+      {
+        name: 'review-appeals-final-state',
+        upsertPolicy: { reconcileByUniqueFields: ['review'], skipIfCurrentMatches: true },
+      },
     ]
 
     expect(historySteps.map(({ name }) => demoPlan.find((step) => step.name === name))).toEqual(

--- a/tests/integration/seedReviewWorkflow.integration.test.ts
+++ b/tests/integration/seedReviewWorkflow.integration.test.ts
@@ -443,7 +443,8 @@ describe.sequential('demo review workflow seed integration', () => {
   let centralClinicId: number
   let clinicStaffId: number | string
   let clinicUser: Awaited<ReturnType<typeof asClinicScopedPayloadUser>>
-  let reconciledResponseId: number | string | null = null
+  const reconciledAppealIds: Array<number | string> = []
+  const reconciledResponseIds: Array<number | string> = []
   const createdStaffIds: Array<number | string> = []
   const slugPrefix = testSlug('seedReviewWorkflow.integration.test.ts')
 
@@ -454,14 +455,10 @@ describe.sequential('demo review workflow seed integration', () => {
 
   afterAll(async () => {
     try {
-      if (reconciledResponseId !== null) {
-        await cleanupTrackedDocs(payload, [
-          {
-            collection: 'reviewResponses',
-            ids: [reconciledResponseId],
-          },
-        ])
-      }
+      await cleanupTrackedDocs(payload, [
+        { collection: 'reviewAppeals', ids: reconciledAppealIds },
+        { collection: 'reviewResponses', ids: reconciledResponseIds },
+      ])
       await cleanupSeedReviewWorkflow(payload)
     } finally {
       await cleanupTrackedUsers(payload, { staffIds: createdStaffIds })
@@ -694,8 +691,8 @@ describe.sequential('demo review workflow seed integration', () => {
     expect(relationId(persistedClinicStaff.clinic)).toBe(centralClinicId)
   }, 180_000)
 
-  it('reconciles a pre-existing response for a seed review without replacing its audit identity', async () => {
-    const [reviewResult, responseResult] = await Promise.all([
+  it('reconciles pre-existing workflow records without replacing their audit identities', async () => {
+    const [review03Result, review05Result, responseResult, appeal03Result, appeal05Result] = await Promise.all([
       payload.find({
         collection: 'reviews',
         depth: 0,
@@ -704,31 +701,73 @@ describe.sequential('demo review workflow seed integration', () => {
         where: { stableId: { equals: 'seed-review-izmir-coast-03' } },
       }),
       payload.find({
+        collection: 'reviews',
+        depth: 0,
+        limit: 1,
+        overrideAccess: true,
+        where: { stableId: { equals: 'seed-review-izmir-coast-05' } },
+      }),
+      payload.find({
         collection: 'reviewResponses',
         depth: 0,
         limit: 1,
         overrideAccess: true,
         where: { stableId: { equals: 'seed-review-response-izmir-coast-03' } },
       }),
+      payload.find({
+        collection: 'reviewAppeals',
+        depth: 0,
+        limit: 1,
+        overrideAccess: true,
+        where: { stableId: { equals: 'seed-review-appeal-izmir-coast-03' } },
+      }),
+      payload.find({
+        collection: 'reviewAppeals',
+        depth: 0,
+        limit: 1,
+        overrideAccess: true,
+        where: { stableId: { equals: 'seed-review-appeal-izmir-coast-05' } },
+      }),
     ])
-    const review = reviewResult.docs[0]
+    const review03 = review03Result.docs[0]
+    const review05 = review05Result.docs[0]
     const seededResponse = responseResult.docs[0]
-    if (!review || !seededResponse) {
-      throw new Error('Expected the central review and its seeded response')
+    const seededAppeal03 = appeal03Result.docs[0]
+    const seededAppeal05 = appeal05Result.docs[0]
+    if (!review03 || !review05 || !seededResponse || !seededAppeal03 || !seededAppeal05) {
+      throw new Error('Expected the central reviews and their seeded workflow records')
     }
 
-    await payload.delete({
-      collection: 'reviewResponses',
-      id: seededResponse.id,
-      context: { disableRevalidate: true },
-      overrideAccess: true,
-    })
+    await Promise.all([
+      payload.delete({
+        collection: 'reviewResponses',
+        id: seededResponse.id,
+        context: { disableRevalidate: true },
+        overrideAccess: true,
+      }),
+      payload.delete({
+        collection: 'reviewAppeals',
+        id: seededAppeal03.id,
+        context: { disableRevalidate: true },
+        overrideAccess: true,
+      }),
+      payload.delete({
+        collection: 'reviewAppeals',
+        id: seededAppeal05.id,
+        context: { disableRevalidate: true },
+        overrideAccess: true,
+      }),
+    ])
 
     const submittedBody = 'This clinic-authored response existed before the non-destructive demo seed was retried.'
+    const submittedAppeal03Details =
+      'This clinic-authored appeal existed before the non-destructive demo seed was retried.'
+    const submittedAppeal05Details =
+      'This second clinic-authored appeal verifies reconciliation through the versioned history step.'
     const existingResponse = await payload.create({
       collection: 'reviewResponses',
       data: {
-        review: review.id,
+        review: review03.id,
         pendingResponse: {
           body: submittedBody,
         },
@@ -737,23 +776,65 @@ describe.sequential('demo review workflow seed integration', () => {
       overrideAccess: false,
       user: clinicUser,
     })
-    reconciledResponseId = existingResponse.id
-    const existingStableId = existingResponse.stableId
+    reconciledResponseIds.push(existingResponse.id)
+    const existingAppeal03 = await payload.create({
+      collection: 'reviewAppeals',
+      data: {
+        review: review03.id,
+        reason: 'other',
+        details: submittedAppeal03Details,
+      } as unknown as ReviewAppeal,
+      depth: 0,
+      overrideAccess: false,
+      user: clinicUser,
+    })
+    reconciledAppealIds.push(existingAppeal03.id)
+    const existingAppeal05 = await payload.create({
+      collection: 'reviewAppeals',
+      data: {
+        review: review05.id,
+        reason: 'privacy_concern',
+        details: submittedAppeal05Details,
+      } as unknown as ReviewAppeal,
+      depth: 0,
+      overrideAccess: false,
+      user: clinicUser,
+    })
+    reconciledAppealIds.push(existingAppeal05.id)
+    const existingResponseStableId = existingResponse.stableId
+    const existingAppeal03StableId = existingAppeal03.stableId
+    const existingAppeal05StableId = existingAppeal05.stableId
 
     const result = await runDemoSeeds(payload)
     expect(result.failures).toEqual([])
 
-    const reconciledResult = await payload.find({
-      collection: 'reviewResponses',
-      depth: 0,
-      overrideAccess: true,
-      pagination: false,
-      where: { review: { equals: review.id } },
-    })
-    expect(reconciledResult.docs).toHaveLength(1)
-    expect(reconciledResult.docs[0]).toMatchObject({
+    const [reconciledResponseResult, reconciledAppeal03Result, reconciledAppeal05Result] = await Promise.all([
+      payload.find({
+        collection: 'reviewResponses',
+        depth: 0,
+        overrideAccess: true,
+        pagination: false,
+        where: { review: { equals: review03.id } },
+      }),
+      payload.find({
+        collection: 'reviewAppeals',
+        depth: 0,
+        overrideAccess: true,
+        pagination: false,
+        where: { review: { equals: review03.id } },
+      }),
+      payload.find({
+        collection: 'reviewAppeals',
+        depth: 0,
+        overrideAccess: true,
+        pagination: false,
+        where: { review: { equals: review05.id } },
+      }),
+    ])
+    expect(reconciledResponseResult.docs).toHaveLength(1)
+    expect(reconciledResponseResult.docs[0]).toMatchObject({
       id: existingResponse.id,
-      stableId: existingStableId,
+      stableId: existingResponseStableId,
       moderationStatus: 'approved',
       publishedResponse: {
         body: 'Thank you for describing the consultation. We are glad the written plan made the treatment options easier to compare.',
@@ -761,26 +842,78 @@ describe.sequential('demo review workflow seed integration', () => {
         isBlocked: false,
       },
     })
-
-    const firstVersions = await payload.findVersions({
-      collection: 'reviewResponses',
-      depth: 0,
-      overrideAccess: true,
-      pagination: false,
-      where: { parent: { equals: existingResponse.id } },
+    expect(reconciledAppeal03Result.docs).toHaveLength(1)
+    expect(reconciledAppeal03Result.docs[0]).toMatchObject({
+      id: existingAppeal03.id,
+      stableId: existingAppeal03StableId,
+      reason: 'other',
+      details: 'The clinic asks Platform Support to review the written consultation summary.',
+      status: 'submitted',
     })
-    expect(firstVersions.docs.some(({ version }) => version.pendingResponse?.body === submittedBody)).toBe(true)
+    expect(reconciledAppeal05Result.docs).toHaveLength(1)
+    expect(reconciledAppeal05Result.docs[0]).toMatchObject({
+      id: existingAppeal05.id,
+      stableId: existingAppeal05StableId,
+      reason: 'privacy_concern',
+      status: 'upheld',
+      decisionReason: 'The appeal is upheld for one narrow wording concern; a redacted review remains public.',
+    })
+
+    const [firstResponseVersions, firstAppeal03Versions, firstAppeal05Versions] = await Promise.all([
+      payload.findVersions({
+        collection: 'reviewResponses',
+        depth: 0,
+        overrideAccess: true,
+        pagination: false,
+        where: { parent: { equals: existingResponse.id } },
+      }),
+      payload.findVersions({
+        collection: 'reviewAppeals',
+        depth: 0,
+        overrideAccess: true,
+        pagination: false,
+        where: { parent: { equals: existingAppeal03.id } },
+      }),
+      payload.findVersions({
+        collection: 'reviewAppeals',
+        depth: 0,
+        overrideAccess: true,
+        pagination: false,
+        where: { parent: { equals: existingAppeal05.id } },
+      }),
+    ])
+    expect(firstResponseVersions.docs.some(({ version }) => version.pendingResponse?.body === submittedBody)).toBe(true)
+    expect(firstAppeal03Versions.docs.some(({ version }) => version.details === submittedAppeal03Details)).toBe(true)
+    expect(firstAppeal05Versions.docs.some(({ version }) => version.details === submittedAppeal05Details)).toBe(true)
 
     const repeatedResult = await runDemoSeeds(payload)
     expect(repeatedResult.failures).toEqual([])
 
-    const repeatedVersions = await payload.findVersions({
-      collection: 'reviewResponses',
-      depth: 0,
-      overrideAccess: true,
-      pagination: false,
-      where: { parent: { equals: existingResponse.id } },
-    })
-    expect(repeatedVersions.docs).toEqual(firstVersions.docs)
+    const [repeatedResponseVersions, repeatedAppeal03Versions, repeatedAppeal05Versions] = await Promise.all([
+      payload.findVersions({
+        collection: 'reviewResponses',
+        depth: 0,
+        overrideAccess: true,
+        pagination: false,
+        where: { parent: { equals: existingResponse.id } },
+      }),
+      payload.findVersions({
+        collection: 'reviewAppeals',
+        depth: 0,
+        overrideAccess: true,
+        pagination: false,
+        where: { parent: { equals: existingAppeal03.id } },
+      }),
+      payload.findVersions({
+        collection: 'reviewAppeals',
+        depth: 0,
+        overrideAccess: true,
+        pagination: false,
+        where: { parent: { equals: existingAppeal05.id } },
+      }),
+    ])
+    expect(repeatedResponseVersions.docs).toEqual(firstResponseVersions.docs)
+    expect(repeatedAppeal03Versions.docs).toEqual(firstAppeal03Versions.docs)
+    expect(repeatedAppeal05Versions.docs).toEqual(firstAppeal05Versions.docs)
   }, 180_000)
 })


### PR DESCRIPTION
## Management summary

### Deutsch

Der nicht-destruktive Demo-Seed kann die zentrale Review-Demo-Klinik nun auch dann vollständig herstellen, wenn dort bereits regulär eingereichte Einsprüche vorhanden sind. Bestehende Einsprüche behalten ihre interne Identität und ihren Audit-Verlauf, während der reproduzierbare Demo-Zustand zuverlässig hergestellt wird.

### English

The non-destructive demo seed can now fully prepare the central review demo clinic even when regular appeals already exist there. Existing appeals retain their internal identity and audit history while the reproducible demo state is restored reliably.

## What changed

- Reconcile both intermediate and final review-appeal seed steps through the schema-unique `review` relationship when the fixture `stableId` is absent.
- Preserve the existing appeal ID and `stableId`; Payload-native versions retain the clinic-submitted state before the synthetic demo workflow is applied.
- Extend the central workflow integration regression to cover the observed final-only appeal collision, the versioned initial-to-final path, and an unchanged second demo run. This follows the equivalent response reconciliation introduced in #1694 and keeps the central matrix from #1690 intact.

## Points to review

| Priority | Files / paths | Why focus here | Reviewer should verify | Evidence |
| -------- | ------------- | -------------- | ---------------------- | -------- |
| P1 | `src/endpoints/seed/utils/plan.ts` | Existing non-seed appeals occupy the schema-unique review relationship. | Reconciliation is limited to the unique `review` field and preserves both version-idempotent intermediate and current terminal policies. | Data-integrity contract: 16/16 passed. |
| P1 | `tests/integration/seedReviewWorkflow.integration.test.ts` | The fix must preserve existing audit identity and history across retries. | Final-only and versioned appeal paths preserve ID, `stableId`, clinic-authored versions, and exact second-run history. | Real Payload/Postgres integration: 4/4 passed. |

## Validation

- [x] `pnpm format`: passed under Node 24.19.0 and pnpm 10.28.2.
- [x] `pnpm check`: passed, including lint, route type generation, Payload type check, and TypeScript.
- [x] `pnpm build`: passed with `PAYLOAD_SECRET=dev-secret`; the known non-fatal missing local Supabase environment log remained unchanged.
- [x] Focused tests: review workflow data-integrity contract 16/16; real Payload/Postgres workflow integration 4/4; `pnpm tests:sense-check` passed.
- [ ] UI/mobile QA: not applicable; no UI or frontend behavior changed.
- [x] Security/privacy review: isolated security and cache-architecture reviews found no issue at or above 5/10; the two 3/10 hardening/efficiency notes do not affect correctness or freshness.
- [x] Migration/schema check: no schema, migration, or generated Payload type change.
- [x] Documentation/instructions check: no documentation or instruction change required; tests remain the canonical demo-data contract.

## Risk and rollout

The change is limited to non-production demo seeding. A matching existing appeal is updated to the synthetic demo state without replacing its record identity; Payload-native versions retain the earlier clinic-submitted state. Cache classification remains `public-cached` with the existing `disableRevalidate` writes and terminal seed flush; no tag, path, owner, or invalidation semantics changed. Rollback is the single commit.

## Development

Closes #1702
